### PR TITLE
feat: update to the new job schema

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,7 @@ This contains an impementation of the Worker Agent's scheduler. This works with 
 
 ### `src/deadline_worker_agent/sessions`
 
-This contains the logic and APIs for managing the life-cycle of a Worker session. The primary class contained in this package, the `Session` class, is responsible for taking actions from the `SessionActionQueue` and running them within the OpenJobIO session.
+This contains the logic and APIs for managing the life-cycle of a Worker session. The primary class contained in this package, the `Session` class, is responsible for taking actions from the `SessionActionQueue` and running them within the Open Job Description session.
 
 ### `src/deadline_worker_agent/sessions/actions`
 

--- a/docs/worker_api_contract.md
+++ b/docs/worker_api_contract.md
@@ -101,7 +101,7 @@ Workflow before proceeding.
         that the Worker cannot start the Session Action if either:
             * The Session Action is a type that is not understood by the Worker Agent (e.g. a new type
             added in the future);
-            * The Session Action uses an OpenJobIO version that the Worker Agent doesn't understand; or
+            * The Session Action uses an Open Job Description version that the Worker Agent doesn't understand; or
             * Otherwise unable to be run by the Worker Agent (e.g. compatibility reasons, or failures
             in a `AssumeQueueRoleForWorker` request).
         4. Any other updates as dictated by a Worker-Initiated Drain workflow.

--- a/hatch_version_hook.py
+++ b/hatch_version_hook.py
@@ -46,9 +46,7 @@ class CustomBuildHook(BuildHookInterface):
       "_version.py",
     ]
     destinations = [
-      "src/openjobio",
-      "src/openjobio_adaptor_runtime",
-      "src/openjobio_adaptor_runtime_client",
+      "src/deadline-cloud-worker-agent",
     ]
     [[tool.hatch.build.hooks.custom.copy_map]]
     sources = [
@@ -56,9 +54,7 @@ class CustomBuildHook(BuildHookInterface):
       "something_else_the_tests_need.ini",
     ]
     destinations = [
-      "test/openjobio",
-      "test/openjobio_adaptor_runtime",
-      "test/openjobio_adaptor_runtime_client",
+      "test/deadline-cloud-worker-agent",
     ]
     ```
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
     "deadline == 0.18.*",
-    "openjobio == 0.8.*",
+    "openjd == 0.10.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",
     "typing_extensions ~= 4.5",
@@ -106,7 +106,7 @@ line-length = 100
 known-first-party = [
   "deadline_worker_agent",
   "deadline",
-  "openjobio",
+  "openjd",
 ]
 
 [tool.black]

--- a/scripts/submit_jobs/asset_example/template.json
+++ b/scripts/submit_jobs/asset_example/template.json
@@ -1,10 +1,15 @@
 {
-    "specificationVersion": "2022-09-01",
+    "specificationVersion": "jobtemplate-2023-09",
     "name": "AssetsExample",
-    "parameters": [
+    "parameterDefinitions": [
         {
             "name": "DataDir",
-            "type": "PATH"
+            "type": "PATH",
+            "dataFlow": "INOUT",
+            "userInterface": {
+                "label": "Input/Output Directory",
+                "control": "CHOOSE_DIRECTORY"
+            }
         }
     ],
     "steps": [
@@ -25,7 +30,7 @@
                     }
                 ]
             },
-            "environments": [
+            "stepEnvironments": [
                 {
                     "name": "myenv",
                     "script": {

--- a/scripts/submit_jobs/asset_example/template_uihint.yaml
+++ b/scripts/submit_jobs/asset_example/template_uihint.yaml
@@ -1,8 +1,0 @@
-parameters:
-- name: DataDir
-  uiHint:
-    label: Input/Output Directory
-    ojioFutureType: PATH
-    controlType: CHOOSE_DIRECTORY
-    assetReference: INOUT
-    

--- a/scripts/submit_jobs/sleep/sleep_job.json
+++ b/scripts/submit_jobs/sleep/sleep_job.json
@@ -1,7 +1,7 @@
 {
-    "specificationVersion": "2022-09-01",
+    "specificationVersion": "jobtemplate-2023-09",
     "name": "Longsleep",
-    "parameters": [
+    "parameterDefinitions": [
         {
             "name": "duration",
             "type": "INT",
@@ -25,11 +25,11 @@
                         "name": "runScript",
                         "type": "TEXT",
                         "runnable": true,
-                        "data": "#!/usr/bin/env python3\n\nimport signal\nimport sys\nimport time\n\nprint(sys.argv)\nif len(sys.argv) < 2:\n    print(\"ERROR: Expected arg for number of seconds\")\n    sys.exit(1)\nelif len(sys.argv) > 2:\n    print(\"ERROR: Unexpected number of arguments\")\n    sys.exit(1)\n\n\ntry:\n    seconds = int(sys.argv[1])\nexcept Exception as e:\n    print(f'ERROR: could not parse number from \"{sys.argv[1]}\"')\n    sys.exit(1)\n\nif seconds <= 0:\n    print(\"ERROR: Invalid \")\n\n\ndef signal_handler(sig_num, frame):\n    print(f\"Trapped signal {sig_num}\")\n    sys.stdout.flush()\n\n    if sig_num in (signal.SIGINT, signal.SIGTERM):\n        print(\"CANCELLED\")\n        sys.stdout.flush()\n        sys.exit(1)\n\nif sys.platform.startswith(\"win\"):\n    signal.signal(signal.SIGINT, signal_handler)\nelse:\n    signal.signal(signal.SIGTERM, signal_handler)\n\n\nprogress_inc = 100 / float(seconds)\nprogress = 0.0\n\nprint(f\"Waiting {seconds}...\")\n\nfor i in range(seconds):\n    time.sleep(1)\n    progress += progress_inc\n    print(f\"openjobio_progress: {progress}\")\n    sys.stdout.flush()\n\nprint(\"done.\")\n"
+                        "data": "#!/usr/bin/env python3\n\nimport signal\nimport sys\nimport time\n\nprint(sys.argv)\nif len(sys.argv) < 2:\n    print(\"ERROR: Expected arg for number of seconds\")\n    sys.exit(1)\nelif len(sys.argv) > 2:\n    print(\"ERROR: Unexpected number of arguments\")\n    sys.exit(1)\n\n\ntry:\n    seconds = int(sys.argv[1])\nexcept Exception as e:\n    print(f'ERROR: could not parse number from \"{sys.argv[1]}\"')\n    sys.exit(1)\n\nif seconds <= 0:\n    print(\"ERROR: Invalid \")\n\n\ndef signal_handler(sig_num, frame):\n    print(f\"Trapped signal {sig_num}\")\n    sys.stdout.flush()\n\n    if sig_num in (signal.SIGINT, signal.SIGTERM):\n        print(\"CANCELLED\")\n        sys.stdout.flush()\n        sys.exit(1)\n\nif sys.platform.startswith(\"win\"):\n    signal.signal(signal.SIGINT, signal_handler)\nelse:\n    signal.signal(signal.SIGTERM, signal_handler)\n\n\nprogress_inc = 100 / float(seconds)\nprogress = 0.0\n\nprint(f\"Waiting {seconds}...\")\n\nfor i in range(seconds):\n    time.sleep(1)\n    progress += progress_inc\n    print(f\"openjd_progress: {progress}\")\n    sys.stdout.flush()\n\nprint(\"done.\")\n"
                     }
                 ]
             },
-            "environments": [
+            "stepEnvironments": [
                 {
                     "name": "myenv",
                     "script": {

--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -133,7 +133,7 @@ class StepDetailsIdentifier(TypedDict):
 
 class StepDetailsData(StepDetailsIdentifierFields):
     schemaVersion: str
-    """The OpenJobIO schema version that corresponds to the template"""
+    """The Open Job Description schema version that corresponds to the template"""
 
     template: dict[str, Any]
     """The template of the step"""
@@ -260,7 +260,7 @@ class JobDetailsData(JobDetailsIdentifierFields):
     """The name of the CloudWatch Log Group containing the Worker session's Log Stream"""
 
     schemaVersion: str
-    """The OpenJobIO job template schema version"""
+    """The Open Job Description job template schema version"""
 
     parameters: NotRequired[
         dict[str, StringParameter | PathParameter | IntParameter | FloatParameter | str]
@@ -297,7 +297,7 @@ class EnvironmentDetailsIdentifier(TypedDict):
 
 class EnvironmentDetailsData(EnvironmentDetailsIdentifierFields):
     schemaVersion: str
-    """The OpenJobIO schema version"""
+    """The Open Job Description schema version"""
     template: dict[str, Any]
     """The template of the environment."""
 

--- a/src/deadline_worker_agent/aws_credentials/aws_configs.py
+++ b/src/deadline_worker_agent/aws_credentials/aws_configs.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from configparser import ConfigParser
 from pathlib import Path
 from typing import Optional
-from openjobio.sessions import PosixSessionUser, SessionUser
+from openjd.sessions import PosixSessionUser, SessionUser
 from subprocess import run, DEVNULL, PIPE, STDOUT
 
 __all__ = [

--- a/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
+++ b/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
@@ -11,7 +11,7 @@ import stat
 from threading import Event
 
 from botocore.utils import JSONFileCache
-from openjobio.sessions import PosixSessionUser, SessionUser
+from openjd.sessions import PosixSessionUser, SessionUser
 
 from ..boto_mock import DeadlineClient
 
@@ -31,9 +31,9 @@ _logger = logging.getLogger(__name__)
 
 class QueueBoto3Session(BaseBoto3Session):
     """A Boto3 Session that contains Queue Role AWS Credentials for use by:
-    1. Any service Session Action run within an OpenJobIO Session; and
-    2. The Worker when performing actions on behalf of a service Session Action for an OpenJobIO
-       Session.
+    1. Any service Session Action run within an Open Job Description Session; and
+    2. The Worker when performing actions on behalf of a service Session Action for
+       an Open Job Description Session.
 
     When created, this Session:
     1. Installs an AWS Credentials Process in the ~/.aws of the given os_user, or the current user if

--- a/src/deadline_worker_agent/boto_mock.py
+++ b/src/deadline_worker_agent/boto_mock.py
@@ -251,7 +251,7 @@ class DeadlineClient:
                     {
                         "jobDetails": {
                             "jobId": "job-21432d89b44a46cbaaeb2f1d5254e548",
-                            "schemaVersion": "2022-09-01",
+                            "schemaVersion": "jobtemplate-2023-09",
                             "jobAttachmentSettings": {
                                 "s3BucketName": "asset-bucket",
                                 "rootPrefix": "my-queue",
@@ -291,7 +291,7 @@ class DeadlineClient:
                         "stepDetails": {
                             "jobId": "job-abac",
                             "stepId": "step-a50bcbf7a86848dabc46480db936b4a7",
-                            "schemaVersion": "2022-09-01",
+                            "schemaVersion": "jobtemplate-2023-09",
                             "template": {},
                             "dependencies": [],
                         },
@@ -300,7 +300,7 @@ class DeadlineClient:
                         "environmentDetails": {
                             "environmentId": "env1",
                             "jobId": "job-21432d89b44a46cbaaeb2f1d5254e548",
-                            "schemaVersion": "2022-09-01",
+                            "schemaVersion": "jobtemplate-2023-09",
                             "template": {
                                 "name": "foo",
                                 "script": {},

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -226,7 +226,7 @@
 #
 #       <VENDOR>
 #           An optional namespace that indicates the capabilitiy is specific to a particular
-#           OpenJobIO-compatable render farm management system.
+#           Open Job Description-compatable render farm management system.
 #       <NAME>
 #           A name for the amount capability
 #       <VALUE>
@@ -255,7 +255,7 @@
 #
 #       <VENDOR>
 #           An optional namespace that indicates the capabilitiy is specific to a particular
-#           OpenJobIO-compatable render farm component.
+#           Open Job Description-compatable render farm component.
 #       <NAME>
 #           A name for the attribute capability
 #       <VALUE>

--- a/src/deadline_worker_agent/log_sync/loggers.py
+++ b/src/deadline_worker_agent/log_sync/loggers.py
@@ -4,5 +4,5 @@ from logging import getLogger as _getLogger
 
 logger = _getLogger(__name__.rsplit(".", maxsplit=1)[0])
 
-OJIO_ACTION_OUTPUT_LOGGER = _getLogger("openjobio.processing.action_output")
+OPENJD_ACTION_OUTPUT_LOGGER = _getLogger("openjd.processing.action_output")
 ROOT_LOGGER = _getLogger("root")

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -19,9 +19,9 @@ import logging
 import os
 import stat
 
-from openjobio.sessions import ActionState, ActionStatus, SessionUser
-from openjobio.sessions import LOG as OJIO_SESSION_LOG
-from openjobio.sessions import ActionState, ActionStatus
+from openjd.sessions import ActionState, ActionStatus, SessionUser
+from openjd.sessions import LOG as OPENJD_SESSION_LOG
+from openjd.sessions import ActionState, ActionStatus
 from deadline.job_attachments.asset_sync import AssetSync
 from botocore.exceptions import ClientError
 
@@ -88,8 +88,8 @@ class SchedulerSession:
 @dataclass(frozen=True)
 class QueueAwsCredentials:
     """This holds the AWS Credentials for a particular Queue to use for all actions
-    performed on behalf of the OpenJobIO Session for Jobs from that Queue. This
-    includes:
+    performed on behalf of the Open Job Description Session for Jobs from that Queue.
+    This includes:
     1. all Job Attachments behaviors; and
     2. things done by the running SessionActions' subprocesses.
 
@@ -656,7 +656,7 @@ class WorkerScheduler:
 
             try:
                 log_config = LogConfiguration.from_boto(
-                    loggers=[OJIO_SESSION_LOG, JOB_ATTACHMENTS_LOGGER],
+                    loggers=[OPENJD_SESSION_LOG, JOB_ATTACHMENTS_LOGGER],
                     log_configuration=session_spec["logConfiguration"],
                     session_log_file=session_log_file,
                 )

--- a/src/deadline_worker_agent/scheduler/session_action_status.py
+++ b/src/deadline_worker_agent/scheduler/session_action_status.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from openjobio.sessions import ActionStatus
+from openjd.sessions import ActionStatus
 
 if TYPE_CHECKING:
     from ..api_models import CompletedActionStatus

--- a/src/deadline_worker_agent/scheduler/session_cleanup.py
+++ b/src/deadline_worker_agent/scheduler/session_cleanup.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 from threading import Lock
 
-from openjobio.sessions import SessionUser, PosixSessionUser
+from openjd.sessions import SessionUser, PosixSessionUser
 
 from .log import LOGGER
 from ..sessions import Session

--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -8,8 +8,8 @@ from logging import getLogger
 from threading import Event
 from typing import Any, Callable, Iterable, Generic, Literal, TypeVar, TYPE_CHECKING, cast
 
-from openjobio.model import UnsupportedSchema
-from openjobio.sessions import ActionState, ActionStatus
+from openjd.model import UnsupportedSchema
+from openjd.sessions import ActionState, ActionStatus
 
 from ..api_models import (
     EnvironmentAction as EnvironmentActionApiModel,
@@ -209,7 +209,7 @@ class SessionActionQueue:
                 end_time=timestamp,
                 # TODO: This is semantically incorrect, but status.state is a required field. We
                 # only need this to communicate the message. In the future, we may want to remove
-                # the "status" field from OJIO here and hoist the fields we care about up to the
+                # the "status" field from Open Job Description here and hoist the fields we care about up to the
                 # SessionActionStatus class.
                 status=ActionStatus(
                     state=ActionState.FAILED,
@@ -313,7 +313,7 @@ class SessionActionQueue:
         Raises
         ------
             JobEntityUnsupportedSchemaError:
-                When the details for an OjioAction have a schema that the Worker Agent
+                When the details for an OpenjdAction have a schema that the Worker Agent
                 does not support. Allows the action to gracefully report the failure
                 to the service.
 

--- a/src/deadline_worker_agent/sessions/actions/__init__.py
+++ b/src/deadline_worker_agent/sessions/actions/__init__.py
@@ -3,14 +3,14 @@
 from .action_definition import SessionActionDefinition
 from .enter_env import EnterEnvironmentAction
 from .exit_env import ExitEnvironmentAction
-from .ojio_action import OjioAction
+from .openjd_action import OpenjdAction
 from .run_step_task import RunStepTaskAction
 from .sync_input_job_attachments import SyncInputJobAttachmentsAction
 
 __all__ = [
     "EnterEnvironmentAction",
     "ExitEnvironmentAction",
-    "OjioAction",
+    "OpenjdAction",
     "RunStepTaskAction",
     "SessionActionDefinition",
     "SyncInputJobAttachmentsAction",

--- a/src/deadline_worker_agent/sessions/actions/action_definition.py
+++ b/src/deadline_worker_agent/sessions/actions/action_definition.py
@@ -92,7 +92,7 @@ class SessionActionDefinition(ABC):
         and hyphens.
 
         PARAM_NAME and PARAM_VALUE describe the parameters to the action. The allowable values for
-        are inherited from OpenJobIO step parameter spaces.
+        are inherited from Open Job Description step parameter spaces.
 
         For example:
 

--- a/src/deadline_worker_agent/sessions/actions/enter_env.py
+++ b/src/deadline_worker_agent/sessions/actions/enter_env.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 from concurrent.futures import Executor
 from typing import Any, TYPE_CHECKING
 
-from openjobio.sessions import EnvironmentIdentifier
+from openjd.sessions import EnvironmentIdentifier
 
 from ..job_entities import EnvironmentDetails
-from .ojio_action import OjioAction
+from .openjd_action import OpenjdAction
 
 if TYPE_CHECKING:
     from ...api_models import EnvironmentAction
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from .action_definition import SessionActionDefinition
 
 
-class EnterEnvironmentAction(OjioAction):
+class EnterEnvironmentAction(OpenjdAction):
     """Action to enter an environment within a Worker session
 
     Parameters
@@ -23,7 +23,7 @@ class EnterEnvironmentAction(OjioAction):
     id : str
         A unique identifier for the session action
     job_env_id : str
-        A unique identifier for the environment within the OpenJobIO job
+        A unique identifier for the environment within the Open Job Description job
     environment_details : EnvironmentDetails
         The environment details
     """

--- a/src/deadline_worker_agent/sessions/actions/exit_env.py
+++ b/src/deadline_worker_agent/sessions/actions/exit_env.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 from concurrent.futures import Executor
 from typing import TYPE_CHECKING, Any
 
-from .ojio_action import OjioAction
+from .openjd_action import OpenjdAction
 
 if TYPE_CHECKING:
     from ..session import Session
 
 
-class ExitEnvironmentAction(OjioAction):
+class ExitEnvironmentAction(OpenjdAction):
     """Action to exit an environment within a Worker session
 
     Parameters

--- a/src/deadline_worker_agent/sessions/actions/openjd_action.py
+++ b/src/deadline_worker_agent/sessions/actions/openjd_action.py
@@ -8,8 +8,8 @@ from .action_definition import SessionActionDefinition
 from ..errors import CancelationError
 
 
-class OjioAction(SessionActionDefinition):
-    """Common base class for OpenJobIO session actions"""
+class OpenjdAction(SessionActionDefinition):
+    """Common base class for Open Job Description session actions"""
 
     _current_action_cancel_sent = False
 

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 from concurrent.futures import Executor
 from typing import Any, TYPE_CHECKING
 
-from openjobio.sessions import Parameter
+from openjd.sessions import Parameter
 
-from .ojio_action import OjioAction
+from .openjd_action import OpenjdAction
 
 if TYPE_CHECKING:
     from ..job_entities import StepDetails
     from ..session import Session
 
 
-class RunStepTaskAction(OjioAction):
+class RunStepTaskAction(OpenjdAction):
     """Action to run a step's task within a Worker session
 
     Parameters

--- a/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
+++ b/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
@@ -13,7 +13,7 @@ from threading import Event
 from typing import Any, TYPE_CHECKING, Optional
 
 from deadline.job_attachments.errors import AssetSyncCancelledError
-from openjobio.sessions import ActionState, ActionStatus
+from openjd.sessions import ActionState, ActionStatus
 
 from ..session import Session
 
@@ -127,14 +127,14 @@ class SyncInputJobAttachmentsAction(SessionActionDefinition):
             )
         except Exception as e:
             session.logger.exception(e)
-            # We need to directly complete the action. Other actions rely on the OpenJobIO session's
+            # We need to directly complete the action. Other actions rely on the Open Job Description session's
             # callback to complete the action
             action_status = ActionStatus(
                 state=ActionState.FAILED,
                 fail_message=str(e),
             )
         finally:
-            # We need to directly complete the action. Other actions rely on the OpenJobIO session's
+            # We need to directly complete the action. Other actions rely on the Open Job Description session's
             # callback to complete the action
             session.update_action(action_status=action_status)
 

--- a/src/deadline_worker_agent/sessions/errors.py
+++ b/src/deadline_worker_agent/sessions/errors.py
@@ -53,7 +53,7 @@ class JobEntityUnsupportedSchemaError(SessionActionError):
     def __init__(self, action_id: str, schema_version: str):
         self.schema_version = schema_version
         self.message = (
-            f"Worker Agent: {version} does not support OpenJobIO Schema Version {self.schema_version}. "
+            f"Worker Agent: {version} does not support Open Job Description Schema Version {self.schema_version}. "
             f"Consider upgrading to a newer Worker Agent."
         )
         super().__init__(action_id=action_id, message=self.message)

--- a/src/deadline_worker_agent/sessions/job_entities/environment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/environment_details.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, cast
 
-from openjobio.model import parse_model, SchemaVersion, UnsupportedSchema
-from openjobio.model.v2022_09_01 import Environment as Environment_2022_09_01
-from openjobio.sessions import EnvironmentModel
+from openjd.model import parse_model, SchemaVersion, UnsupportedSchema
+from openjd.model.v2023_09 import Environment as Environment_2023_09
+from openjd.sessions import EnvironmentModel
 
 from ...api_models import EnvironmentDetailsData
 from .job_entity_type import JobEntityType
@@ -41,12 +41,24 @@ class EnvironmentDetails:
         Raises
         ------
         RuntimeError:
-            If the environment's OpenJobIO schema version not unsupported
+            If the environment's Open Job Description schema version not unsupported
         """
-        schema_version = SchemaVersion(environment_details_data["schemaVersion"])
-        if schema_version == SchemaVersion.v2022_09_01:
+
+        # TODO - Remove from here
+        env_schema_version = environment_details_data["schemaVersion"]
+        if env_schema_version not in ("jobtemplate-2023-09", "2022-09-01"):
+            UnsupportedSchema(env_schema_version)
+        # Note: 2023-09 & 2022-09-01 are identical as far as the worker agent is concerned.
+        schema_version = SchemaVersion.v2023_09
+        # -- to here once the migration to the new schema version is complete
+
+        # TODO - Put this back in once the migration to the new schema version is complete.
+        # schema_version = SchemaVersion(environment_details_data["schemaVersion"])
+        # --
+
+        if schema_version == SchemaVersion.v2023_09:
             environment = parse_model(
-                model=Environment_2022_09_01, obj=environment_details_data["template"]
+                model=Environment_2023_09, obj=environment_details_data["template"]
             )
         else:
             raise UnsupportedSchema(schema_version.value)

--- a/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, cast
 
-from openjobio.sessions import Parameter, ParameterType
+from openjd.sessions import Parameter, ParameterType
 from deadline.job_attachments.utils import AssetLoadingMethod
 
 from ...api_models import (
@@ -107,7 +107,7 @@ class JobAttachmentDetails:
         Raises
         ------
         RuntimeError:
-            If the environment's OpenJobIO schema version not unsupported
+            If the environment's Open Job Description schema version not unsupported
         """
 
         return JobAttachmentDetails(

--- a/src/deadline_worker_agent/sessions/job_entities/step_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/step_details.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, cast
 
-from openjobio.model import parse_model, SchemaVersion, UnsupportedSchema
-from openjobio.model.v2022_09_01 import StepScript as StepScript_2022_09_01
-from openjobio.sessions import StepScriptModel
+from openjd.model import parse_model, SchemaVersion, UnsupportedSchema
+from openjd.model.v2023_09 import StepScript as StepScript_2023_09
+from openjd.sessions import StepScriptModel
 
 from ...api_models import StepDetailsData
 from .job_entity_type import JobEntityType
@@ -21,7 +21,7 @@ class StepDetails:
     """The JobEntityType handled by this class"""
 
     script: StepScriptModel
-    """The step's OpenJobIO script"""
+    """The step's Open Job Description script"""
 
     dependencies: list[str] = field(default_factory=list)
     """The dependencies (a list of IDs) that the step depends on"""
@@ -44,15 +44,23 @@ class StepDetails:
         Raises
         ------
         RuntimeError:
-            If the environment's OpenJobIO schema version not unsupported
+            If the environment's Open Job Description schema version not unsupported
         """
 
-        schema_version = SchemaVersion(step_details_data["schemaVersion"])
+        # TODO - Remove from here
+        step_schema_version = step_details_data["schemaVersion"]
+        if step_schema_version not in ("jobtemplate-2023-09", "2022-09-01"):
+            UnsupportedSchema(step_schema_version)
+        # Note: 2023-09 & 2022-09-01 are identical as far as the worker agent is concerned.
+        schema_version = SchemaVersion.v2023_09
+        # -- to here once the migration to the new schema version is complete
 
-        if schema_version == SchemaVersion.v2022_09_01:
-            step_script = parse_model(
-                model=StepScript_2022_09_01, obj=step_details_data["template"]
-            )
+        # TODO - Put this back in once the migration to the new schema version is complete.
+        # schema_version = SchemaVersion(environment_details_data["schemaVersion"])
+        # --
+
+        if schema_version == SchemaVersion.v2023_09:
+            step_script = parse_model(model=StepScript_2023_09, obj=step_details_data["template"])
         else:
             raise UnsupportedSchema(schema_version.value)
 

--- a/src/deadline_worker_agent/startup/config.py
+++ b/src/deadline_worker_agent/startup/config.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Sequence, Tuple, cast
 
 from pydantic import ValidationError
 
-from openjobio.sessions import PosixSessionUser, SessionUser
+from openjd.sessions import PosixSessionUser, SessionUser
 
 from ..errors import ConfigurationError
 from .capabilities import Capabilities

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -16,7 +16,7 @@ import shutil
 from pathlib import Path
 
 from botocore.client import Config as BotoClientConfig
-from openjobio.sessions import LOG as OJIO_SESSION_LOG
+from openjd.sessions import LOG as OPENJD_SESSION_LOG
 from pydantic import PositiveFloat
 
 from .._version import __version__
@@ -39,13 +39,13 @@ def detect_system_capabilities() -> Capabilities:
     attributes: dict[AttributeCapabilityName, list[str]] = {}
 
     platform_system = platform.system().lower()
-    python_system_to_ojio_os_family = {
+    python_system_to_openjd_os_family = {
         "darwin": "macos",
         "linux": "linux",
         "windows": "windows",
     }
-    if ojio_os_family := python_system_to_ojio_os_family.get(platform_system):
-        attributes[AttributeCapabilityName("attr.worker.os.family")] = [ojio_os_family]
+    if openjd_os_family := python_system_to_openjd_os_family.get(platform_system):
+        attributes[AttributeCapabilityName("attr.worker.os.family")] = [openjd_os_family]
     attributes[AttributeCapabilityName("attr.worker.cpu.arch")] = [platform.machine()]
     amounts[AmountCapabilityName("amount.worker.vcpu")] = float(psutil.cpu_count())
     amounts[AmountCapabilityName("amount.worker.memory")] = float(psutil.virtual_memory().total) / (
@@ -256,12 +256,12 @@ def _configure_base_logging(worker_logs_dir: Path, verbose: bool) -> logging.Han
         logging.getLogger(logger_name).setLevel(logging.WARNING)
 
     # We don't want the Session logs to appear in the Worker Agent logs, so
-    # set the OpenJobIO library's logger to not propagate.
+    # set the Open Job Description library's logger to not propagate.
     # We do this because the Session log will contain job-specific customer
     # sensitive data. The Worker's log is intended for IT admins that may
     # have different/lesser permissions/access-rights/need-to-know than the
     # folk submitting jobs, so keep the sensitive stuff out of the agent log.
-    OJIO_SESSION_LOG.propagate = False
+    OPENJD_SESSION_LOG.propagate = False
 
     JOB_ATTACHMENTS_LOGGER = logging.getLogger("deadline.job_attachments")
     JOB_ATTACHMENTS_LOGGER.propagate = False

--- a/test/integ/test_job_submissions.py
+++ b/test/integ/test_job_submissions.py
@@ -43,7 +43,7 @@ class TestJobSubmissions:
             queue=queue,
             priority=98,
             template={
-                "specificationVersion": "2022-09-01",
+                "specificationVersion": "jobtemplate-2023-09",
                 "name": "Sleep Job",
                 "steps": [
                     {

--- a/test/unit/aws/deadline/test_batch_get_job_entity.py
+++ b/test/unit/aws/deadline/test_batch_get_job_entity.py
@@ -23,7 +23,7 @@ SAMPLE_RESPONSE: BatchGetJobEntityResponse = {
             "environmentDetails": {
                 "jobId": "job-1234",
                 "environmentId": "env:1234",
-                "schemaVersion": "2022-09-01",
+                "schemaVersion": "jobtemplate-2023-09",
                 "template": {},
             }
         }

--- a/test/unit/aws_credentials/test_aws_configs.py
+++ b/test/unit/aws_credentials/test_aws_configs.py
@@ -13,7 +13,7 @@ from deadline_worker_agent.aws_credentials.aws_configs import (
     _setup_file,
     _setup_parent_dir,
 )
-from openjobio.sessions import PosixSessionUser, SessionUser
+from openjd.sessions import PosixSessionUser, SessionUser
 
 
 @pytest.fixture

--- a/test/unit/aws_credentials/test_queue_boto3_session.py
+++ b/test/unit/aws_credentials/test_queue_boto3_session.py
@@ -19,7 +19,7 @@ from deadline_worker_agent.aws.deadline import (
 )
 import deadline_worker_agent.aws_credentials.queue_boto3_session as queue_boto3_session_mod
 from deadline_worker_agent.aws_credentials.queue_boto3_session import QueueBoto3Session
-from openjobio.sessions import PosixSessionUser, SessionUser
+from openjd.sessions import PosixSessionUser, SessionUser
 
 
 @pytest.fixture(autouse=True)

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -11,8 +11,8 @@ from typing import Generator, Optional
 
 from deadline.job_attachments.models import ManifestProperties, Attachments
 from deadline.job_attachments.utils import AssetLoadingMethod, OperatingSystemFamily
-from openjobio.model import SchemaVersion
-from openjobio.sessions import (
+from openjd.model import SchemaVersion
+from openjd.sessions import (
     Parameter,
     PathMappingRule,
     SessionUser,
@@ -176,8 +176,8 @@ def log_group_name() -> str:
 
 @pytest.fixture
 def schema_version() -> SchemaVersion:
-    """The OpenJobIO schema version"""
-    return SchemaVersion.v2022_09_01
+    """The Open Job Description schema version"""
+    return SchemaVersion.v2023_09
 
 
 @pytest.fixture
@@ -244,7 +244,7 @@ def jobs_run_as() -> JobsRunAs | None:
 
 @pytest.fixture
 def path_mapping_rules() -> list[PathMappingRule] | None:
-    """The path mapping rules to pass to OJIO"""
+    """The path mapping rules to pass to Open Job Description"""
     return []
 
 

--- a/test/unit/log_sync/test_cloudwatch.py
+++ b/test/unit/log_sync/test_cloudwatch.py
@@ -1461,10 +1461,10 @@ class TestCloudWatchHandler:
 @mark.parametrize(
     argnames=("mock_logger"),
     argvalues=(
-        (MagicMock(spec=logger_mod.OJIO_ACTION_OUTPUT_LOGGER)),
+        (MagicMock(spec=logger_mod.OPENJD_ACTION_OUTPUT_LOGGER)),
         (MagicMock(spec=logger_mod.ROOT_LOGGER)),
     ),
-    ids=("OJIO_ACTION_OUTPUT_LOGGER", "ROOT_LOGGER"),
+    ids=("OPENJD_ACTION_OUTPUT_LOGGER", "ROOT_LOGGER"),
 )
 def test_stream_cloudwatch(
     logs_client: MagicMock,

--- a/test/unit/log_sync/test_loggers.py
+++ b/test/unit/log_sync/test_loggers.py
@@ -1,16 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from deadline_worker_agent.log_sync.loggers import OJIO_ACTION_OUTPUT_LOGGER, ROOT_LOGGER, logger
+from deadline_worker_agent.log_sync.loggers import OPENJD_ACTION_OUTPUT_LOGGER, ROOT_LOGGER, logger
 
 
-def test_ojio_action_output_logger() -> None:
+def test_openjd_action_output_logger() -> None:
     """
     Assert that the module is configuring the expected logger. This test combines with downstream
     tests that assert the behavior of configuring this module-level logger variable.
     """
 
     # THEN
-    assert OJIO_ACTION_OUTPUT_LOGGER.name == "openjobio.processing.action_output"
+    assert OPENJD_ACTION_OUTPUT_LOGGER.name == "openjd.processing.action_output"
 
 
 def test_root_logger() -> None:

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -8,7 +8,7 @@ from typing import Generator
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 import time
 
-from openjobio.sessions import ActionState, ActionStatus
+from openjd.sessions import ActionState, ActionStatus
 from botocore.exceptions import ClientError
 import pytest
 

--- a/test/unit/scheduler/test_session_cleanup.py
+++ b/test/unit/scheduler/test_session_cleanup.py
@@ -6,7 +6,7 @@ from typing import Generator
 from unittest.mock import MagicMock, patch
 import subprocess
 
-from openjobio.sessions import SessionUser, PosixSessionUser
+from openjd.sessions import SessionUser, PosixSessionUser
 import pytest
 
 from deadline_worker_agent.scheduler.session_cleanup import (

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, Mock, patch
 from collections import OrderedDict
 
 from deadline.job_attachments.utils import AssetLoadingMethod
-from openjobio.model import SchemaVersion, UnsupportedSchema
-from openjobio.model.v2022_09_01 import (
+from openjd.model import SchemaVersion, UnsupportedSchema
+from openjd.model.v2023_09 import (
     Environment,
     EnvironmentScript,
     EnvironmentActions,
@@ -15,7 +15,7 @@ from openjobio.model.v2022_09_01 import (
     StepScript,
     StepActions,
 )
-from openjobio.sessions import Parameter, ParameterType
+from openjd.sessions import Parameter, ParameterType
 import pytest
 
 from deadline_worker_agent.scheduler.session_queue import (

--- a/test/unit/sessions/actions/test_ojio_action.py
+++ b/test/unit/sessions/actions/test_ojio_action.py
@@ -7,14 +7,14 @@ from unittest.mock import Mock
 from deadline_worker_agent.sessions import Session
 import re
 
-from openjobio.sessions import ActionState, ActionStatus
+from openjd.sessions import ActionState, ActionStatus
 import pytest
 
-from deadline_worker_agent.sessions.actions.ojio_action import OjioAction
+from deadline_worker_agent.sessions.actions.openjd_action import OpenjdAction
 from deadline_worker_agent.sessions.errors import CancelationError
 
 
-class DerivedOjioAction(OjioAction):
+class DerivedOpenjdAction(OpenjdAction):
     def __init__(self, *, id: str) -> None:
         super().__init__(id=id)
         self.start_mock = Mock()
@@ -32,7 +32,7 @@ def session() -> Mock:
 
 
 class TestCancel:
-    """Tests for the OjioAction.cancel() method"""
+    """Tests for the OpenjdAction.cancel() method"""
 
     @pytest.fixture(
         params=(
@@ -49,16 +49,16 @@ class TestCancel:
     def time_limit(self, request: pytest.FixtureRequest) -> timedelta | None:
         return request.param
 
-    def test_calls_ojio_session_cancel_action(
+    def test_calls_openjd_session_cancel_action(
         self,
         session: Mock,
         time_limit: timedelta | None,
     ) -> None:
-        """Tests that when calling OjioAction.cancel(), the session's OpenJobIO session action is
+        """Tests that when calling OpenjdAction.cancel(), the session's Open Job Description session action is
         canceled"""
 
         # GIVEN
-        action = DerivedOjioAction(id="my-id")
+        action = DerivedOpenjdAction(id="my-id")
 
         # WHEN
         action.cancel(session=session, time_limit=time_limit)
@@ -85,11 +85,11 @@ class TestCancel:
         time_limit: timedelta | None,
         action_status: ActionStatus | None,
     ) -> None:
-        """Tests that when calling OjioAction.cancel(), the session's OpenJobIO session action is
+        """Tests that when calling OpenjdAction.cancel(), the session's Open Job Description session action is
         canceled"""
 
         # GIVEN
-        action = DerivedOjioAction(id="my-id")
+        action = DerivedOpenjdAction(id="my-id")
         error_msg = "error msg"
         session._session.cancel_action.side_effect = RuntimeError(error_msg)
         session._session.action_status = action_status

--- a/test/unit/sessions/actions/test_sync_input_job_attachments.py
+++ b/test/unit/sessions/actions/test_sync_input_job_attachments.py
@@ -6,7 +6,7 @@ from typing import Callable, TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 from deadline.job_attachments.errors import AssetSyncCancelledError
-from openjobio.sessions import ActionState, ActionStatus
+from openjd.sessions import ActionState, ActionStatus
 import pytest
 
 from deadline_worker_agent.sessions.actions import SyncInputJobAttachmentsAction

--- a/test/unit/sessions/test_job_entities.py
+++ b/test/unit/sessions/test_job_entities.py
@@ -5,8 +5,8 @@ from typing import Generator
 from unittest.mock import MagicMock, patch
 
 from deadline.job_attachments.utils import AssetLoadingMethod
-from openjobio.model import SchemaVersion
-from openjobio.model.v2022_09_01 import (
+from openjd.model import SchemaVersion
+from openjd.model.v2023_09 import (
     Action,
     Environment,
     EnvironmentActions,
@@ -14,7 +14,7 @@ from openjobio.model.v2022_09_01 import (
     StepActions,
     StepScript,
 )
-from openjobio.sessions import PosixSessionUser
+from openjd.sessions import PosixSessionUser
 
 
 import pytest
@@ -145,7 +145,7 @@ class TestJobEntity:
         job_details_boto = JobDetailsBoto(
             jobDetails={
                 "jobId": job_id,
-                "schemaVersion": "2022-09-01",
+                "schemaVersion": "jobtemplate-2023-09",
                 "logGroupName": "fake-name",
             },
         )
@@ -191,7 +191,7 @@ class TestJobEntity:
                 },
             },
             "logGroupName": "TEST",
-            "schemaVersion": SchemaVersion.v2022_09_01.value,
+            "schemaVersion": SchemaVersion.v2023_09.value,
         }
 
         # WHEN
@@ -245,7 +245,7 @@ class TestJobEntity:
             "jobId": "job-123",
             "jobsRunAs": jobs_run_as_data,
             "logGroupName": "TEST",
-            "schemaVersion": SchemaVersion.v2022_09_01.value,
+            "schemaVersion": SchemaVersion.v2023_09.value,
         }
 
         # WHEN
@@ -261,7 +261,7 @@ class TestJobEntity:
         entity_data: JobDetailsData = {
             "jobId": "job-123",
             "logGroupName": "TEST",
-            "schemaVersion": SchemaVersion.v2022_09_01.value,
+            "schemaVersion": SchemaVersion.v2023_09.value,
         }
 
         # WHEN
@@ -277,7 +277,7 @@ class TestDetails:
         job_details_boto = JobDetailsBoto(
             jobDetails={
                 "jobId": job_id,
-                "schemaVersion": "2022-09-01",
+                "schemaVersion": "jobtemplate-2023-09",
                 "logGroupName": "fake-name",
             },
         )
@@ -286,7 +286,7 @@ class TestDetails:
             "errors": [],
         }
         expected_details = JobDetails(
-            schema_version=SchemaVersion("2022-09-01"),
+            schema_version=SchemaVersion("jobtemplate-2023-09"),
             log_group_name="fake-name",
         )
         deadline_client.batch_get_job_entity.return_value = response
@@ -312,7 +312,7 @@ class TestDetails:
             environmentDetails=EnvironmentDetailsData(
                 jobId=job_id,
                 environmentId=environment_id,
-                schemaVersion="2022-09-01",
+                schemaVersion="jobtemplate-2023-09",
                 template={
                     "name": env_name,
                     "script": {
@@ -392,7 +392,7 @@ class TestDetails:
             stepDetails=StepDetailsData(
                 jobId=job_id,
                 stepId=step_id,
-                schemaVersion="2022-09-01",
+                schemaVersion="jobtemplate-2023-09",
                 template={
                     "actions": {
                         "onRun": {
@@ -465,19 +465,19 @@ class TestCaching:
         expected_job_details: JobDetailsData = {
             "jobId": job_id,
             "logGroupName": "/aws/service/loggroup",
-            "schemaVersion": "2022-09-01",
+            "schemaVersion": "jobtemplate-2023-09",
         }
         expected_environment_details: EnvironmentDetailsData = {
             "jobId": job_id,
             "environmentId": environment_id,
-            "schemaVersion": "2022-09-01",
+            "schemaVersion": "jobtemplate-2023-09",
             # Don't actually need the full template for a test
             "template": {},
         }
         expected_step_details: StepDetailsData = {
             "jobId": job_id,
             "stepId": step_id,
-            "schemaVersion": "2022-09-01",
+            "schemaVersion": "jobtemplate-2023-09",
             # Don't actually need the full template for a test
             "template": {},
         }
@@ -576,7 +576,7 @@ class TestCaching:
         details = EnvironmentDetailsData(
             jobId=job_id,
             environmentId=environment_id,
-            schemaVersion="2022-09-01",
+            schemaVersion="jobtemplate-2023-09",
             template={
                 "name": "TestEnv",
                 "script": {

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -10,7 +10,7 @@ from typing import Generator, Iterable, Literal, Optional
 from unittest.mock import patch, MagicMock, ANY
 
 import pytest
-from openjobio.model.v2022_09_01 import (
+from openjd.model.v2023_09 import (
     Action,
     Environment,
     EnvironmentActions,
@@ -18,7 +18,7 @@ from openjobio.model.v2022_09_01 import (
     StepActions,
     StepScript,
 )
-from openjobio.sessions import (
+from openjd.sessions import (
     ActionState,
     ActionStatus,
     PathMappingOS,
@@ -70,7 +70,7 @@ def session_action_queue() -> MagicMock:
 @pytest.fixture
 def env() -> dict[str, str] | None:
     """A fixture that represents the dictionary of environment variables and their values supplied
-    the OpenJobIO Session initializer"""
+    the Open Job Description Session initializer"""
     return None
 
 
@@ -87,16 +87,16 @@ def action_complete_time() -> datetime:
 
 
 @pytest.fixture
-def mock_ojio_session_cls() -> Generator[MagicMock, None, None]:
-    """Mocks the Worker Agent Session module's import of the OpenJobIO Session class"""
-    with patch.object(session_mod, "OJIOSession") as mock_ojio_session:
-        yield mock_ojio_session
+def mock_openjd_session_cls() -> Generator[MagicMock, None, None]:
+    """Mocks the Worker Agent Session module's import of the Open Job Description Session class"""
+    with patch.object(session_mod, "OPENJDSession") as mock_openjd_session:
+        yield mock_openjd_session
 
 
 @pytest.fixture
-def mock_ojio_session(mock_ojio_session_cls: MagicMock) -> MagicMock:
-    """The mocked OpenJobIO Session class instance"""
-    return mock_ojio_session_cls.return_value
+def mock_openjd_session(mock_openjd_session_cls: MagicMock) -> MagicMock:
+    """The mocked Open Job Description Session class instance"""
+    return mock_openjd_session_cls.return_value
 
 
 @pytest.fixture
@@ -117,7 +117,7 @@ def session(
     env: dict[str, str] | None,
     job_details: JobDetails,
     os_user: SessionUser | None,
-    mock_ojio_session_cls: MagicMock,
+    mock_openjd_session_cls: MagicMock,
     queue_id: str,
     session_action_queue: MagicMock,
     session_id: str,
@@ -205,7 +205,7 @@ def current_action(
     ),
 )
 def failed_action_status(request: pytest.FixtureRequest) -> ActionStatus:
-    """A fixture providing a failed OpenJobIO ActionStatus"""
+    """A fixture providing a failed Open Job Description ActionStatus"""
     return request.param
 
 
@@ -233,7 +233,7 @@ def failed_action_status(request: pytest.FixtureRequest) -> ActionStatus:
     ),
 )
 def succeess_action_status(request: pytest.FixtureRequest) -> ActionStatus:
-    """A fixture providing a successful OpenJobIO ActionStatus"""
+    """A fixture providing a successful Open Job Description ActionStatus"""
     return request.param
 
 
@@ -250,13 +250,13 @@ class TestSessionInit:
     def test_uses_action_updated_callback(
         self,
         session: Session,
-        mock_ojio_session_cls: MagicMock,
+        mock_openjd_session_cls: MagicMock,
     ) -> None:
         """Asserts that the Session.update_action method is called by the callback supplied to the
-        OpenJobIO session initializer."""
+        Open Job Description session initializer."""
         # GIVEN
-        mock_ojio_session_cls.assert_called_once()
-        call = mock_ojio_session_cls.call_args_list[0]
+        mock_openjd_session_cls.assert_called_once()
+        call = mock_openjd_session_cls.call_args_list[0]
         action_status = ActionStatus(state=ActionState.SUCCESS)
 
         # THEN
@@ -314,19 +314,19 @@ class TestSessionInit:
     def test_has_path_mapping_rules(
         self,
         session: Session,
-        mock_ojio_session_cls: MagicMock,
+        mock_openjd_session_cls: MagicMock,
         path_mapping_rules: list[PathMappingRule],
     ):
-        """Ensure that when we have path mapping rules that we're passing them to the OJIO session"""
+        """Ensure that when we have path mapping rules that we're passing them to the Open Job Description session"""
         # GIVEN / WHEN / THEN
         assert session is not None
-        mock_ojio_session_cls.assert_called_once()
+        mock_openjd_session_cls.assert_called_once()
         if path_mapping_rules:
             assert (
-                path_mapping_rules == mock_ojio_session_cls.call_args.kwargs["path_mapping_rules"]
+                path_mapping_rules == mock_openjd_session_cls.call_args.kwargs["path_mapping_rules"]
             )
         else:
-            assert not mock_ojio_session_cls.call_args.kwargs.get("path_mapping_rules", False)
+            assert not mock_openjd_session_cls.call_args.kwargs.get("path_mapping_rules", False)
 
 
 class TestSessionOuterRun:
@@ -588,9 +588,9 @@ class TestSessionSyncAssetInputs:
         """
         Tests that the path mapping rules received from job_attachments's sync_inputs
         can use both the older 'source_os' and the newer 'source_path_format' based
-        on whatever fields are required in openjobio's PathMappingRule
+        on whatever fields are required in openjd's PathMappingRule
 
-        Remove this test once both openjobio and job_attachments both use source_path_format
+        Remove this test once both openjd and job_attachments both use source_path_format
         """
         # GIVEN
         mock_sync_inputs: MagicMock = mock_asset_sync.sync_inputs
@@ -807,19 +807,19 @@ class TestSessionCancelActionsImpl:
     def test_cancels_current_action(
         self,
         session: Session,
-        mock_ojio_session: MagicMock,
+        mock_openjd_session: MagicMock,
         current_action: CurrentAction,
     ) -> None:
         """Asserts that the current action is canceled if cancel_actions() is called with the
         corresponding action ID in the action_ids argument."""
         # GIVEN
-        ojio_cancel_action: MagicMock = mock_ojio_session.cancel_action
+        openjd_cancel_action: MagicMock = mock_openjd_session.cancel_action
 
         # WHEN
         session._cancel_actions_impl(action_ids=[current_action.definition.id])
 
         # THEN
-        ojio_cancel_action.assert_called_once_with(time_limit=None)
+        openjd_cancel_action.assert_called_once_with(time_limit=None)
 
 
 class TestSessionReplaceAssignedActions:
@@ -930,7 +930,7 @@ class TestSessionActionUpdatedImpl:
         failed_action_status: ActionStatus,
         mock_report_action_update: MagicMock,
     ) -> None:
-        """Tests that if a environment enter action fails (the OpenJobIO action), that the action
+        """Tests that if a environment enter action fails (the Open Job Description action), that the action
         failure is returned, and that any pending actions other than ENV_EXITS are marked as FAILED
         with a message that explains that the env enter action failed."""
         # GIVEN
@@ -996,7 +996,7 @@ class TestSessionActionUpdatedImpl:
         failed_action_status: ActionStatus,
         mock_report_action_update: MagicMock,
     ) -> None:
-        """Tests that if a task run fails (the OpenJobIO action), that job attachment output
+        """Tests that if a task run fails (the Open Job Description action), that job attachment output
         sync is not performed, the action failure is returned, and that any pending actions are
         marked as NEVER_ATTEMPTED."""
         # GIVEN
@@ -1061,7 +1061,7 @@ class TestSessionActionUpdatedImpl:
         task_id: str,
         mock_report_action_update: MagicMock,
     ) -> None:
-        """Tests that if a task run succeeds (the OpenJobIO action), that job attachment output
+        """Tests that if a task run succeeds (the Open Job Description action), that job attachment output
         sync is performed, and AFTER that, the action success is returned."""
         # GIVEN
         current_action = CurrentAction(
@@ -1125,7 +1125,7 @@ class TestSessionActionUpdatedImpl:
         task_id: str,
         mock_report_action_update: MagicMock,
     ) -> None:
-        """Tests that if a task run succeeds (the OpenJobIO action), but the job attachment output
+        """Tests that if a task run succeeds (the Open Job Description action), but the job attachment output
         sync fails, the action failure is returned, and any pending actions are marked as
         NEVER_ATTEMPTED."""
         # GIVEN
@@ -1184,7 +1184,7 @@ class TestSessionActionUpdatedImpl:
         mock_sync_asset_outputs.assert_called_once_with(current_action=current_action)
 
 
-@pytest.mark.usefixtures("mock_ojio_session")
+@pytest.mark.usefixtures("mock_openjd_session")
 class TestStartCancelingCurrentAction:
     """Test cases for Session._start_canceling_current_action()"""
 
@@ -1433,21 +1433,21 @@ class TestSessionCleanup:
             message=session._stop_fail_message,
         )
 
-    def test_calls_ojio_cleanup(
+    def test_calls_openjd_cleanup(
         self,
         session: Session,
-        mock_ojio_session: MagicMock,
+        mock_openjd_session: MagicMock,
     ) -> None:
         # GIVEN
-        ojio_session_cleanup: MagicMock = mock_ojio_session.cleanup
+        openjd_session_cleanup: MagicMock = mock_openjd_session.cleanup
 
-        # Mock Session._monitor_action which is used to poll the OJIO session status
+        # Mock Session._monitor_action which is used to poll the Open Job Description session status
         with patch.object(session, "_monitor_action", return_value=[]):
             # WHEN
             session._cleanup()
 
         # THEN
-        ojio_session_cleanup.assert_called_once_with()
+        openjd_session_cleanup.assert_called_once_with()
 
 
 class TestSessionStartAction:

--- a/test/unit/startup/test_config.py
+++ b/test/unit/startup/test_config.py
@@ -10,7 +10,7 @@ from typing import Any, Generator, List, Optional
 import logging
 import pytest
 
-from openjobio.sessions import PosixSessionUser
+from openjd.sessions import PosixSessionUser
 
 from deadline_worker_agent.startup.cli_args import ParsedCommandLineArguments
 from deadline_worker_agent.startup import config as config_mod

--- a/testing_containers/posix_ldap_multiuser/README.md
+++ b/testing_containers/posix_ldap_multiuser/README.md
@@ -1,13 +1,13 @@
 
 ## Build
 ```
-docker build testing_containers/ldap_sudo_environment -t ojio_ldap_test
+docker build testing_containers/ldap_sudo_environment -t agent_posix_ldap_multiuser
 ```
 
 ## Run Interactive Bash
 To start an interactive bash session:
 ```
-docker run -h ldap.environment.internal --rm -v $(pwd):/code:ro -e PIP_INDEX_URL=${PIP_INDEX_URL} -it --entrypoint bash ojio_ldap_test:latest
+docker run -h ldap.environment.internal --rm -v $(pwd):/code:ro -e PIP_INDEX_URL=${PIP_INDEX_URL} -it --entrypoint bash agent_posix_ldap_multiuser:latest
 ```
 To start the LDAP Server and Client:
 ```

--- a/testing_containers/posix_ldap_multiuser/run_agent.sh
+++ b/testing_containers/posix_ldap_multiuser/run_agent.sh
@@ -10,7 +10,7 @@ cp -r /aws/models/deadline/* .aws/models/deadline/
 
 python -m venv .venv
 source .venv/bin/activate
-pip install /code/dist/deadline_worker_agent-*-py3-none-any.whl
+pip install /code/dist/deadline_cloud_worker_agent-*-py3-none-any.whl
 
 deadline-worker-agent \
     --allow-instance-profile \


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

 The job template schema is being updated for service release. With it, the implementation library is being updated in a breaking way and so the agent code needs to be updated to that revision.

 Furthermore, this needs to be a phased update. The agent needs to support both old and new revisions at the same time. Fortunately, there is nothing changing from the 2022-09-01 revision that is relevant to the agent except for the version string.

### What was the solution? (How)

 Updated the dependency of the template implementation library to the relevant version. Also allow the agent to accept both the new and old revision version string from the service, but treat both values as being the new revision's version string.

 Some TODOs have been left in the code as markers for the changes that
need to happen in the second phase of the update.

### What is the impact of this change?

The agent will continue to function properly one the service is updated to the new schema version, and continues to run if run against the service before it has been updated.

### How was this change tested?

- [X] Unit tests updated and passing.
- [X] Run the agent against the pre-update service, and submitted the sleep job to test running environment enter, environment exit, and task run actions.
- [x] Run the agent against the post-update service, and submitted the sleep job to test running environment enter, environment exit, and task run actions.

### Was this change documented?

Yes, in the template schema.

### Is this a breaking change?

No, actually.