### PR TITLE
api: support both 'sourceOS' and 'sourcePathFormat'

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -222,8 +222,12 @@ class ManifestProperties(TypedDict):
 
 
 class PathMappingRule(TypedDict):
-    sourceOS: str
+    # TODO: remove sourceOS and make sourcePathFormat required
+    sourceOS: NotRequired[str]
     """The operating system family (posix/windows) associated with the source path"""
+
+    sourcePathFormat: NotRequired[str]
+    """The path format associated with the source path (windows vs posix)"""
 
     sourcePath: str
     """The path we're looking to change"""

--- a/src/deadline_worker_agent/boto_mock.py
+++ b/src/deadline_worker_agent/boto_mock.py
@@ -265,7 +265,13 @@ class DeadlineClient:
                             },
                             "pathMappingRules": [
                                 {
+                                    # TODO: remove once sourceOS is removed from response
                                     "sourceOS": "windows",
+                                    "sourcePath": "C:/windows/path",
+                                    "destinationPath": "/linux/path",
+                                },
+                                {
+                                    "sourcePathFormat": "windows",
                                     "sourcePath": "C:/windows/path",
                                     "destinationPath": "/linux/path",
                                 },

--- a/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
@@ -2,18 +2,15 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from pathlib import PurePath, PurePosixPath, PureWindowsPath
 from typing import Any, cast
 
-from openjobio.sessions import Parameter, ParameterType, PathMappingOS
-from openjobio.sessions import PathMappingRule as OJIOPathMappingRule
+from openjobio.sessions import Parameter, ParameterType
 from deadline.job_attachments.utils import AssetLoadingMethod
 
 from ...api_models import (
     FloatParameter,
     IntParameter,
     JobAttachmentDetailsData,
-    PathMappingRule,
     PathParameter,
     StringParameter,
 )
@@ -47,34 +44,6 @@ def parameters_data_to_list(
             # TODO - PATH parameter types
             raise ValueError(f"Parameter {name} -- unknown form in API response: {str(value)}")
     return result
-
-
-def path_mapping_api_model_to_ojio(
-    path_mapping_rules: list[PathMappingRule],
-) -> list[OJIOPathMappingRule]:
-    """Converts path_mapping_rules from a BatchGetJobEntity response
-    to the format expected by OJIO. effectively camelCase to snake_case"""
-    rules: list[OJIOPathMappingRule] = []
-    for api_rule in path_mapping_rules:
-        source_os: PathMappingOS = (
-            PathMappingOS.WINDOWS
-            if api_rule["sourceOS"].lower() == "windows"
-            else PathMappingOS.POSIX
-        )
-        source_path: PurePath = (
-            PureWindowsPath(api_rule["sourcePath"])
-            if source_os == PathMappingOS.WINDOWS
-            else PurePosixPath(api_rule["sourcePath"])
-        )
-        destination_path: PurePath = PurePath(api_rule["destinationPath"])
-        rules.append(
-            OJIOPathMappingRule(
-                source_os=source_os,
-                source_path=source_path,
-                destination_path=destination_path,
-            )
-        )
-    return rules
 
 
 @dataclass(frozen=True)

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from os import chmod
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from logging import getLogger, LoggerAdapter
@@ -820,6 +820,22 @@ class Session:
         ASSET_SYNC_LOGGER.info(
             f"Summary Statistics for file downloads:\n{download_summary_statistics}"
         )
+
+        # TODO: remove path_mapping_rule workaround once deadline-cloud and openjobio are both upgraded
+        source_path_format_key = "source_path_format"
+        source_os_key = "source_os"
+        use_source_path_format = any(
+            f.name == source_path_format_key for f in fields(PathMappingRule)
+        )
+        for rule in path_mapping_rules:
+            if use_source_path_format:
+                if source_os_key in rule:
+                    rule[source_path_format_key] = rule[source_os_key]
+                    del rule[source_os_key]
+            else:
+                if source_path_format_key in rule:
+                    rule[source_os_key] = rule[source_path_format_key]
+                    del rule[source_path_format_key]
 
         job_attachment_path_mappings = [
             PathMappingRule.from_dict(rule) for rule in path_mapping_rules

--- a/test/unit/sessions/test_job_entities.py
+++ b/test/unit/sessions/test_job_entities.py
@@ -105,7 +105,7 @@ class TestJobEntity:
             pytest.param(
                 [
                     {
-                        "sourceOS": "windows",
+                        "sourcePathFormat": "windows",
                         "sourcePath": "C:/windows/path",
                         "destinationPath": "/linux/path",
                     }
@@ -115,17 +115,18 @@ class TestJobEntity:
             pytest.param(
                 [
                     {
+                        # TODO: swap to sourcePathFormat once sourceOS removed
                         "sourceOS": "windows",
                         "sourcePath": "Z:/artist/windows/path",
                         "destinationPath": "/mnt/worker/windows/path",
                     },
                     {
-                        "sourceOS": "posix",
+                        "sourcePathFormat": "posix",
                         "sourcePath": "/artist/linux",
                         "destinationPath": "/mnt/worker/linux",
                     },
                     {
-                        "sourceOS": "posix",
+                        "sourcePathFormat": "posix",
                         "sourcePath": "/artist/linux/path",
                         "destinationPath": "/mnt/worker/linux/path",
                     },

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -579,6 +579,48 @@ class TestSessionSyncAssetInputs:
                 else:
                     session.sync_asset_inputs(cancel=cancel, **args)  # type: ignore[arg-type]
 
+    def test_job_attachments_path_mapping_rules_compatibility(
+        self,
+        session: Session,
+        mock_asset_sync: MagicMock,
+    ):
+        """
+        Tests that the path mapping rules received from job_attachments's sync_inputs
+        can use both the older 'source_os' and the newer 'source_path_format' based
+        on whatever fields are required in openjobio's PathMappingRule
+
+        Remove this test once both openjobio and job_attachments both use source_path_format
+        """
+        # GIVEN
+        mock_sync_inputs: MagicMock = mock_asset_sync.sync_inputs
+        path_mapping_rules = [
+            {
+                # TODO: remove sourceOS once removed
+                "source_os": "windows",
+                "source_path": "Z:/artist/windows/path",
+                "destination_path": "/mnt/worker/windows/path",
+            },
+            {
+                "source_path_format": "posix",
+                "source_path": "/artist/linux",
+                "destination_path": "/mnt/worker/linux",
+            },
+        ]
+        mock_sync_inputs.return_value = ({}, path_mapping_rules)
+        cancel = Event()
+
+        sync_asset_inputs_args = {
+            "job_attachment_details": JobAttachmentDetails(
+                manifests=[],
+                asset_loading_method=AssetLoadingMethod.PRELOAD,
+            )
+        }
+
+        with (patch.object(session, "_recursive_change_fs_group", return_value=()),):
+            # WHEN / THEN
+            session.sync_asset_inputs(cancel=cancel, **sync_asset_inputs_args)  # type: ignore[arg-type]
+            # No errors on generating path mapping rules - success!
+
 
 class TestSessionInnerRun:
     """Test cases for Session._run()"""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We're changing path mapping rules to use `source_path_format` instead of `source_os` to be less confusing

### What was the solution? (How)

Support both while the service and job attachments use a mixture of old/new fields.

### What is the impact of this change?

The worker agent is resilient to the api change!

### How was this change tested?

Added tests, ensured they failed, then added changes

```
hatch run fmt
hatch run lint
hatch build
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

Nope!