### PR TITLE
fix: Update worker binary to deadline-worker-agent where necessary

### DIFF
--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -23,7 +23,7 @@ def install() -> None:
 
     arg_parser = get_argument_parser()
     args = arg_parser.parse_args(namespace=ParsedCommandLineArguments)
-    worker_agent_program = Path(sysconfig.get_path("scripts")) / "deadline_worker_agent"
+    worker_agent_program = Path(sysconfig.get_path("scripts")) / "deadline-worker-agent"
 
     cmd = [
         "sudo",

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -125,7 +125,7 @@ def expected_cmd(
         "--user",
         parsed_args.user,
         "--worker-agent-program",
-        os.path.join(sysconfig.get_path("scripts"), "deadline_worker_agent"),
+        os.path.join(sysconfig.get_path("scripts"), "deadline-worker-agent"),
     ]
     if parsed_args.group is not None:
         expected_cmd.extend(("--group", parsed_args.group))

--- a/testing_containers/posix_ldap_multiuser/run_agent.sh
+++ b/testing_containers/posix_ldap_multiuser/run_agent.sh
@@ -12,7 +12,7 @@ python -m venv .venv
 source .venv/bin/activate
 pip install /code/dist/deadline_worker_agent-*-py3-none-any.whl
 
-deadline_worker_agent \
+deadline-worker-agent \
     --allow-instance-profile \
     --posix-job-user jobuser:sharedgroup \
     --no-shutdown \

--- a/testing_containers/posix_ldap_multiuser/term_agent.sh
+++ b/testing_containers/posix_ldap_multiuser/term_agent.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-pkill --signal term -f deadline_worker_agent
+pkill --signal term -f deadline-worker-agent

--- a/testing_containers/posix_local_multiuser/run_agent.sh
+++ b/testing_containers/posix_local_multiuser/run_agent.sh
@@ -12,7 +12,7 @@ python -m venv .venv
 source .venv/bin/activate
 pip install /code/dist/deadline_worker_agent-*-py3-none-any.whl
 
-deadline_worker_agent \
+deadline-worker-agent \
     --allow-instance-profile \
     --posix-job-user jobuser:sharedgroup \
     --no-shutdown \

--- a/testing_containers/posix_local_multiuser/term_agent.sh
+++ b/testing_containers/posix_local_multiuser/term_agent.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-pkill --signal term -f deadline_worker_agent
+pkill --signal term -f deadline-worker-agent


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Worker agent fails to start in the service. We identified that it's trying to run the binary deadline_worker_agent instead of deadline-worker-agent.

### What was the solution? (How)

Correct occurrences from deadline_worker_agent to deadline-worker-agent.

### What is the impact of this change?

We're one step closer to a working service again.

### How was this change tested?

Not tested.

### Was this change documented?

No

### Is this a breaking change?

It's an unbreaking change.