### PR TITLE
feat!: Support Storage Profiles path mapping rules when syncing inputs/outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
-    "deadline == 0.16.*",
+    "deadline == 0.18.*",
     "openjobio == 0.8.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",

--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -222,8 +222,8 @@ class ManifestProperties(TypedDict):
 
 
 class PathMappingRule(TypedDict):
-    # TODO: remove sourceOS and make sourcePathFormat required
-    sourceOS: NotRequired[str]
+    # TODO: remove sourceOs and make sourcePathFormat required
+    sourceOs: NotRequired[str]
     """The operating system family (posix/windows) associated with the source path"""
 
     sourcePathFormat: NotRequired[str]

--- a/src/deadline_worker_agent/boto_mock.py
+++ b/src/deadline_worker_agent/boto_mock.py
@@ -265,8 +265,8 @@ class DeadlineClient:
                             },
                             "pathMappingRules": [
                                 {
-                                    # TODO: remove once sourceOS is removed from response
-                                    "sourceOS": "windows",
+                                    # TODO: remove once sourceOs is removed from response
+                                    "sourceOs": "windows",
                                     "sourcePath": "C:/windows/path",
                                     "destinationPath": "/linux/path",
                                 },

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -65,10 +65,10 @@ def path_mapping_api_model_to_ojio(
     rules: list[OJIOPathMappingRule] = []
     for api_rule in path_mapping_rules:
         api_source_path_format = (
-            # delete sourceOS once removed from api response
+            # delete sourceOs once removed from api response
             api_rule["sourcePathFormat"]
             if "sourcePathFormat" in api_rule
-            else api_rule["sourceOS"]
+            else api_rule["sourceOs"]
         )
         source_path_format: PathMappingOS = (
             PathMappingOS.WINDOWS
@@ -301,8 +301,8 @@ class JobDetails:
                 validate_object(
                     data=path_mapping_rule,
                     fields=(
-                        # TODO: remove sourceOS and make sourcePathFormat required
-                        Field(key="sourceOS", expected_type=str, required=False),
+                        # TODO: remove sourceOs and make sourcePathFormat required
+                        Field(key="sourceOs", expected_type=str, required=False),
                         Field(key="sourcePathFormat", expected_type=str, required=False),
                         Field(key="sourcePath", expected_type=str, required=True),
                         Field(key="destinationPath", expected_type=str, required=True),

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -805,6 +805,11 @@ class Session:
             assetLoadingMethod=self._job_attachment_details.asset_loading_method,
         )
 
+        storage_profiles_path_mapping_rules_dict: dict[str, str] = {
+            str(rule.source_path): str(rule.destination_path)
+            for rule in self._job_details.path_mapping_rules
+        }
+
         # Add path mapping rules for root paths in job attachments
         ASSET_SYNC_LOGGER.info("Syncing inputs using Job Attachments")
         (download_summary_statistics, path_mapping_rules) = self._asset_sync.sync_inputs(
@@ -813,6 +818,7 @@ class Session:
             queue_id=self._queue_id,  # only used for error message
             job_id=self._queue._job_id,  # only used for error message
             session_dir=self._session.working_directory,
+            storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules_dict,
             step_dependencies=step_dependencies,
             on_downloading_files=progress_handler,
         )
@@ -1068,6 +1074,11 @@ class Session:
             assetLoadingMethod=job_attachment_details.asset_loading_method,
         )
 
+        storage_profiles_path_mapping_rules_dict: dict[str, str] = {
+            str(rule.source_path): str(rule.destination_path)
+            for rule in self._job_details.path_mapping_rules
+        }
+
         ASSET_SYNC_LOGGER.info("Started syncing outputs using Job Attachments")
         # avoid circular import
         from .actions import RunStepTaskAction
@@ -1083,6 +1094,7 @@ class Session:
             session_action_id=current_action.definition.id,
             start_time=current_action.start_time.timestamp(),
             session_dir=self._session.working_directory,
+            storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules_dict,
             on_uploading_files=partial(self._notifier_callback, current_action),
         )
         ASSET_SYNC_LOGGER.info("Finished syncing outputs using Job Attachments")

--- a/test/unit/sessions/test_job_entities.py
+++ b/test/unit/sessions/test_job_entities.py
@@ -115,8 +115,8 @@ class TestJobEntity:
             pytest.param(
                 [
                     {
-                        # TODO: swap to sourcePathFormat once sourceOS removed
-                        "sourceOS": "windows",
+                        # TODO: swap to sourcePathFormat once sourceOs removed
+                        "sourceOs": "windows",
                         "sourcePath": "Z:/artist/windows/path",
                         "destinationPath": "/mnt/worker/windows/path",
                     },

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -511,6 +511,7 @@ class TestSessionSyncAssetInputs:
                     manifests=ANY,
                     assetLoadingMethod=asset_loading_method,
                 ),
+                storage_profiles_path_mapping_rules={},
                 step_dependencies=None,
                 on_downloading_files=ANY,
             )
@@ -595,7 +596,7 @@ class TestSessionSyncAssetInputs:
         mock_sync_inputs: MagicMock = mock_asset_sync.sync_inputs
         path_mapping_rules = [
             {
-                # TODO: remove sourceOS once removed
+                # TODO: remove sourceOs once removed
                 "source_os": "windows",
                 "source_path": "Z:/artist/windows/path",
                 "destination_path": "/mnt/worker/windows/path",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Now the JobDetails returned by the BatchGetJobEntities API includes `path_mapping_rules` for Storage Profiles. Especially, if the Storage Profile (ID) set in the Job is different from the Storage Profile (ID) configured in the associated Fleet, then the API will return the mappings of the source path and the destination path between those Storage Profiles. We need to pass this information to Job Attachments library when syncing input/output files so that, if necessary, the download/upload of files can take place at the correct destination path.

### What was the solution? (How)
- Using the JobDetails’ `path_mapping_rules`, which is set in the Worker session, convert it to dictionary of `source_path` -> `destination_path`, and pass it to `sync_inputs` and `sync_outputs` functions in AssetSync.
  - **Note**: The AssetSync’s interface changes are going to be made by [deadline-cloud PR#10](https://github.com/casillas2/deadline-cloud/pull/10). So, once that PR is merged in, this PR will be able to pass the CI checks.
- Additional fixes: `sourceOS` to `sourceOs`

### What is the impact of this change?
We can support Storage Profiles when syncing inputs/outputs.

### How was this change tested?
- `hatch run lint && hatch run test`
- End-to-end test
  - Created a Farm, a Queue, a Fleet (CMF), and two Storage Profiles (SP) - one for Linux, the other for Windows - on my local backend.
    - For each SP, added two FileSystemLocation (FSL) - one for LOCAL type, the other for SHARED type.
    - Make those two SPs available to the Farm and the Queue. For the Fleet, the Linux SP was connected.
  - Specification of the sample job bundle that I used:
    - Defines a few input job attachments. Half of the inputs are relative to the LOCAL-type FSL path, another half is not relative to any of the FSLs’ paths (so that they are grouped with their own dynamic root path.)
    - An output directory is relative to the LOCAL-type FSL path.
    - A simple non-rendering script that has 2 Steps which has 2 Tasks each, and generates one output file per Task.
  - Tested below cases, and confirmed that a flow of job submission via CLI/GUI - worker execution - job donwload via CLI was working.
    1. Submitted a Job from Linux, (so that the job has Linux SP,) and ran a CMF Worker from Linux
    2. Submitted a Job from Windows, (so that the job has Windows SP,) and ran a CMF Worker from Linux
    3. Also, tested the same flow on a Farm, Fleet and Queue that have no involvement with SP, and it worked fine.

### Was this change documented?
No.

### Is this a breaking change?
Yes.
