### PR TITLE
fix: set RunStepTaskAction end time to asset sync completion time

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
+++ b/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
@@ -127,8 +127,6 @@ class SyncInputJobAttachmentsAction(SessionActionDefinition):
             )
         except Exception as e:
             session.logger.exception(e)
-            # We need to directly complete the action. Other actions rely on the Open Job Description session's
-            # callback to complete the action
             action_status = ActionStatus(
                 state=ActionState.FAILED,
                 fail_message=str(e),

--- a/src/deadline_worker_agent/sessions/log_config.py
+++ b/src/deadline_worker_agent/sessions/log_config.py
@@ -198,7 +198,7 @@ class LogConfiguration:
         if not (log_group := self.options.get(LOG_CONFIG_OPTION_GROUP_NAME_KEY, None)):
             raise KeyError(f'No "{LOG_CONFIG_OPTION_GROUP_NAME_KEY}" in logConfiguration.options')
         elif not (log_stream := self.options.get(LOG_CONFIG_OPTION_STREAM_NAME_KEY, None)):
-            raise KeyError('No "{LOG_CONFIG_OPTION_STREAM_NAME_KEY}" in logConfiguration.options')
+            raise KeyError(f'No "{LOG_CONFIG_OPTION_STREAM_NAME_KEY}" in logConfiguration.options')
 
         return CloudWatchHandler(
             log_group_name=log_group,

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -962,14 +962,17 @@ class Session:
         ):
             # Synchronizing job output attachments is currently bundled together with the
             # RunStepTaskAction. The synchronization happens after the task run succeeds, and both
-            # must be successful in order to mark the action as SUCCEEDED.
+            # must be successful in order to mark the action as SUCCEEDED. The time when
+            # the action is completed should be the moment when the sunchronization have
+            # been finished.
             try:
                 self._sync_asset_outputs(current_action=current_action)
+                now = datetime.now(tz=timezone.utc)
             except Exception as e:
                 # Log and fail the task run action if we are unable to sync output job
                 # attachments
                 fail_message = f"Failed to sync job output attachments for {current_action.definition.human_readable()}: {e}"
-                logger.warning(fail_message)
+                self.logger.warning(fail_message)
                 action_status = ActionStatus(state=ActionState.FAILED, fail_message=fail_message)
                 is_unsuccessful = True
 
@@ -1083,7 +1086,7 @@ class Session:
         from .actions import RunStepTaskAction
 
         assert isinstance(current_action.definition, RunStepTaskAction)
-        self._asset_sync.sync_outputs(
+        upload_summary_statistics = self._asset_sync.sync_outputs(
             s3_settings=s3_settings,
             attachments=attachments,
             queue_id=self._queue_id,
@@ -1096,6 +1099,9 @@ class Session:
             storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules_dict,
             on_uploading_files=partial(self._notifier_callback, current_action),
         )
+
+        ASSET_SYNC_LOGGER.info(f"Summary Statistics for file uploads:\n{upload_summary_statistics}")
+
         ASSET_SYNC_LOGGER.info("Finished syncing outputs using Job Attachments")
 
     def run_task(

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -29,6 +29,7 @@ from openjd.sessions import (
 
 from deadline_worker_agent.api_models import EnvironmentAction, TaskRunAction
 from deadline_worker_agent.sessions import Session
+from deadline_worker_agent.sessions import session as session_module
 from deadline_worker_agent.sessions.session import (
     CurrentAction,
     SessionActionStatus,
@@ -1087,7 +1088,14 @@ class TestSessionActionUpdatedImpl:
             end_time=action_complete_time,
         )
 
-        with patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs:
+        def mock_now(*arg, **kwarg) -> datetime:
+            return action_complete_time
+
+        with patch.object(session_module, "datetime") as mock_datetime, patch.object(
+            session, "_sync_asset_outputs"
+        ) as mock_sync_asset_outputs:
+            mock_datetime.now.side_effect = mock_now
+
             # Assert that reporting the action update happens AFTER syncing the output job
             # attachments.
             def sync_asset_outputs_side_effect(*, current_action: CurrentAction) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The end time of the RunStepTaskAction was not being recorded accurately when it involved a job output sync at the end. This led to an issue in the Portal when fetching Session logs with a too-early timestamp caused Job Attachment-related logs to be missing.

### What was the solution? (How)
- Modified the `_action_updated_impl` to ensure the end time reflects the moment the output sync completes.
- Switched from using Worker logger (`logger`) to the Session logger(`self.logger`) for logging the fail message when an exception occurs during output syncing.

### What is the impact of this change?
Ensures that Job Attachment-related logs are not missing in the Portal's Session logs page.

### How was this change tested?
- `hatch run lint` and `hatch run test`
- Performed end-to-end tests (job submission --> running CMF worker), and made sure that, when a job involved output sync, the end time of the RunTask action was after (or same as) the time that syncing outputs was done (when "Finished syncing outputs using Job Attachments" was logged in CloudWatch log stream.) For example,
  - Before updating the action end time:
    - `TASK_RUN` Session Action's `endedAt`: "2023-10-16T02:**21:58.332**000+00:00"
    - Session log: (Note that the log "Finished syncing outputs ... " is timestamped at 58.396, whereas the endedAt for the session action is earlier (before the sync actually started.) This will lead to the missing of any subsequent logs on the Portals' log page.)
  ```
  2023-10-15T21:21:58.332-05:00 Output files created successfully.
  2023-10-15T21:21:58.333-05:00 Started syncing outputs using Job Attachments
  2023-10-15T21:21:58.346-05:00 Uploading output manifest to rootPrefix/Manifests/farm-c4f398146fd94e23bfe82c11357a9e94/queue-2390491842ca476ea483c3b9c29a3612/job-6057670ab9e74eeeb6d632755cd7a814/step-519c41b6eabc4036b56e86eba1871f6c/task-519c41b6eabc4036b56e86eba1871f6c-1/2023-10-16T02:21:58.006534Z_sessionaction-ea4390710955439eb51ffe0a122d95fb-2/dd620bb19abcb3be62a189f368bb3dd3_output.xxh128
  2023-10-15T21:21:58.396-05:00 Finished syncing outputs using Job Attachments
  ```

  - After updating the action end time:
    - `TASK_RUN` Session Action's `endedAt`: "2023-10-16T02:**11:00.829**000+00:00",
    - Session log:
  ```
  2023-10-15T21:11:00.733-05:00 Output files created successfully.
  2023-10-15T21:11:00.733-05:00 Started syncing outputs using Job Attachments
  2023-10-15T21:11:00.761-05:00 Uploading output manifest to rootPrefix/Manifests/farm-c4f398146fd94e23bfe82c11357a9e94/queue-2390491842ca476ea483c3b9c29a3612/job-6057670ab9e74eeeb6d632755cd7a814/step-519c41b6eabc4036b56e86eba1871f6c/task-519c41b6eabc4036b56e86eba1871f6c-0/2023-10-16T02:11:00.409143Z_sessionaction-235f3cea29054d0eb1ee65b3252fdc68-1/dd620bb19abcb3be62a189f368bb3dd3_output.xxh128
  2023-10-15T21:11:00.829-05:00 Finished syncing outputs using Job Attachments
  ```

### Was this change documented?
No.

### Is this a breaking change?
No.
