### PR TITLE
fix: ensure we update job attachments action no matter what

### DIFF
--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -240,9 +240,8 @@ class Session:
             try:
                 self._cleanup()
             except Exception as error:
-                logger.exception(error)
-                logger.error(
-                    "Unexpected exception while performing cleanup of Session %s.", self._id
+                logger.exception(
+                    f"Unexpected exception while performing cleanup of Session {self._id}: {error}."
                 )
             finally:
                 self._stopped_running.set()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Worker in closed-beta was crashing before marking a job attachments sync action as failed:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/concurrent/futures/_base.py", line 330, in _invoke_callbacks
    callback(self)
  File "/usr/local/lib/python3.9/site-packages/bealine_worker_agent/sessions/actions/sync_input_job_attachments.py", line 140, in _on_done
    session.logger.exception(e)
  File "/usr/local/lib/python3.9/logging/__init__.py", line 1829, in exception
    self.log(ERROR, msg, *args, exc_info=exc_info, **kwargs)
  File "/usr/local/lib/python3.9/logging/__init__.py", line 1844, in log
    self.logger.log(level, msg, *args, **kwargs)
  File "/usr/local/lib/python3.9/logging/__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "/usr/local/lib/python3.9/logging/__init__.py", line 1589, in _log
    self.handle(record)
  File "/usr/local/lib/python3.9/logging/__init__.py", line 1598, in handle
    if (not self.disabled) and self.filter(record):
  File "/usr/local/lib/python3.9/logging/__init__.py", line 806, in filter
    result = f.filter(record)
  File "/usr/local/lib/python3.9/site-packages/openjobio/processing/_action_filter.py", line 130, in filter
    match = filter_matcher.match(record.msg)
TypeError: expected string or bytes-like object
```

This is because our ojio filter expects the `record.msg` to be a `str`, but in reality that filter should be co-ercing the value into a string before using it in a regex.

### What was the solution? (How)

Newer worker agents have a newer OJIO version that fixes this: https://github.com/casillas2/openjobio/commit/4cba955dfdac38278ff5895fa5c0591f6dbe7550#diff-bfd9934f32ccd128ff1bbb4c62771fbd25e2b739950bca6a4e80bf5163c568f1R130-R133

We also moved to a try/except/finally clause to ensure that the update action happens

### What is the impact of this change?

worker agent doesn't stall out indefinitely since it'll actually mark the action as FAILED.

### How was this change tested?

```
hatch run fmt
hatch run lint
hatch build
hatch run test
```

Looks like there's no test for this specifically though... if I get some time, I'll add one.

### Was this change documented?

N/A

### Is this a breaking change?

No