### PR TITLE
fix: use the proper entity key variable

### DIFF
--- a/src/deadline_worker_agent/sessions/job_entities/job_entities.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_entities.py
@@ -267,7 +267,7 @@ class JobEntities:
                 # InternalServerException, ValidationException, ResourceNotFoundException,
 
                 failed_entity_key = self._entity_key(failed_entity)
-                entity_record = self._entity_record_map[entity_key]
+                entity_record = self._entity_record_map[failed_entity_key]
                 entity_record.error = failed_entity_value
                 logger.info(
                     f"BatchGetJobEntity request: {failed_entity_key} failed due to {failed_entity_value['code']}: {failed_entity_value['message']}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We were using a wrong and uninitialized variable when there were no successful entities

```
[session-8f546ac52c3e4b978b46ca5240e67d35] Entity {'jobDetails': {'jobId': 'job-685679cbca4a4bc39c6244304992058a'}} failed in an unrecoverable way: local variable 'entity_key' referenced before assignment
```

### What was the solution? (How)

use the right one...

### What is the impact of this change?

BatchGetJobEntity errors properly get reported by the worker agent

### How was this change tested?

Tested in gamma and got the actual underlying error message

```
{'sessionaction-a4fd90b02c9d457fa528d44c7df6b182-0': {'startedAt': datetime.datetime(2023, 9, 1, 23, 9, 13, 96713, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'progressMessage': "Entity {'jobDetails': {'jobId': 'job-92b1831b602447bdbd58704df51f5691'}} failed with: ConflictException Storage profiles and file systems not found", 'endedAt': datetime.datetime(2023, 9, 1, 23, 9, 13, 96713, tzinfo=datetime.timezone.utc)}, 'sessionaction-a4fd90b02c9d457fa528d44c7df6b182-1': {'startedAt': datetime.datetime(2023, 9, 1, 23, 9, 13, 96713, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'progressMessage': "Entity {'jobDetails': {'jobId': 'job-92b1831b602447bdbd58704df51f5691'}} failed with: ConflictException Storage profiles and file systems not found", 'endedAt': datetime.datetime(2023, 9, 1, 23, 9, 13, 96713, tzinfo=datetime.timezone.utc)}}
```

ran

```
hatch run fmt
hatch run lint
hatch build
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

Fixing!