### PR TITLE
chore: group boto code into subpackage

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,6 +14,10 @@ Files of note include:
 
     `Worker` class implementation containing the main thread's event loop that runs after the Worker has been bootstrapped. This is the original implementation of the Worker Agent that uses `UpdateWorkerSchedule` and `NotifyProgress` which are APIs that are unaware of Worker Sessions.
 
+## `src/deadline_worker_agent/boto`
+
+This contains logic for boto3 and botocore.
+
 ### `src/deadline_worker_agent/startup`
 
 This contains logic for the startup phase in the Worker Agent's lifecycle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ parallel = false
 source_pkgs = [ "deadline_worker_agent" ]
 omit = [
     # the mock boto implementation doesn't require tests
-    "*/boto_mock.py",
+    "*/boto/shim.py",
     # TODO: Remove these once we have session test coverage
     "*/api_models.py",
     "*/errors.py",

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -10,7 +10,7 @@ from botocore.retries.standard import ExponentialBackoff, RetryContext
 from botocore.exceptions import ClientError
 
 from ...startup.config import Configuration
-from ...boto_mock import DeadlineClient
+from ...boto import DeadlineClient
 from ...api_models import (
     AssumeFleetRoleForWorkerResponse,
     AssumeQueueRoleForWorkerResponse,

--- a/src/deadline_worker_agent/aws_credentials/boto3_sessions.py
+++ b/src/deadline_worker_agent/aws_credentials/boto3_sessions.py
@@ -15,7 +15,7 @@ from botocore.credentials import (
 from ..session_events import configure_session_events
 
 
-from ..boto_mock import Session
+from ..boto import Session
 from ..api_models import AwsCredentials
 
 

--- a/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
+++ b/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
@@ -13,7 +13,7 @@ from threading import Event
 from botocore.utils import JSONFileCache
 from openjd.sessions import PosixSessionUser, SessionUser
 
-from ..boto_mock import DeadlineClient
+from ..boto import DeadlineClient
 
 from .temporary_credentials import TemporaryCredentials
 from ..aws.deadline import (

--- a/src/deadline_worker_agent/aws_credentials/worker_boto3_session.py
+++ b/src/deadline_worker_agent/aws_credentials/worker_boto3_session.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 from botocore.utils import JSONFileCache
 
-from ..boto_mock import Session
+from ..boto import Session
 from ..startup.config import Configuration
 from .temporary_credentials import TemporaryCredentials
 from ..aws.deadline import (

--- a/src/deadline_worker_agent/boto/__init__.py
+++ b/src/deadline_worker_agent/boto/__init__.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from .config import DEADLINE_BOTOCORE_CONFIG, OTHER_BOTOCORE_CONFIG
+from .logger import logger
+from .shim import (
+    DeadlineClient,
+    Session,
+)
+
+__all__ = [
+    "DEADLINE_BOTOCORE_CONFIG",
+    "DeadlineClient",
+    "OTHER_BOTOCORE_CONFIG",
+    "Session",
+    "logger",
+]

--- a/src/deadline_worker_agent/boto/config.py
+++ b/src/deadline_worker_agent/boto/config.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from botocore.config import Config
+
+from .._version import __version__ as worker_agent_version
+
+
+DEADLINE_BOTOCORE_CONFIG = Config(
+    user_agent_extra=f"deadline_worker_agent/{worker_agent_version}",
+)
+"""
+Botocore client configuration for Amazon Deadline Cloud. This overrides to:
+    - add deadline-worker-agent version to user User-Agent request header
+"""
+
+OTHER_BOTOCORE_CONFIG = Config(user_agent_extra=f"deadline_worker_agent/{worker_agent_version}")
+"""
+Botocore client configuration for other AWS services. This overrides to:
+    - add deadline-worker-agent version to user User-Agent request header
+"""

--- a/src/deadline_worker_agent/boto/logger.py
+++ b/src/deadline_worker_agent/boto/logger.py
@@ -1,0 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from logging import getLogger
+
+logger = getLogger(__name__.rsplit(".", maxsplit=1)[0])

--- a/src/deadline_worker_agent/boto/shim.py
+++ b/src/deadline_worker_agent/boto/shim.py
@@ -5,14 +5,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from logging import getLogger
 from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 from uuid import uuid4
 
 from boto3 import Session as _Session
 from botocore.session import Session as _BotocoreSession
 
-from .api_models import (
+from ..api_models import (
     AssignedSession,
     AssumeFleetRoleForWorkerResponse,
     AssumeQueueRoleForWorkerResponse,
@@ -27,11 +26,10 @@ from .api_models import (
     UpdateWorkerScheduleResponse,
     WorkerStatus,
 )
+from .logger import logger
 
 if TYPE_CHECKING:
     from .api_models import EntityIdentifier
-
-logger = getLogger(__name__)
 
 
 class DeadlineClient:

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -27,7 +27,7 @@ from botocore.exceptions import ClientError
 
 
 from ..aws_credentials import QueueBoto3Session, AwsCredentialsRefresher
-from ..boto_mock import DeadlineClient, Session as BotoSession
+from ..boto import DeadlineClient, Session as BotoSession
 from ..errors import ServiceShutdown
 from ..sessions import JobEntities, Session
 from ..sessions.actions import SessionActionDefinition

--- a/src/deadline_worker_agent/sessions/job_entities/job_entities.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_entities.py
@@ -28,7 +28,7 @@ from ...aws.deadline import (
     DeadlineRequestUnrecoverableError,
     batch_get_job_entity,
 )
-from ...boto_mock import DeadlineClient
+from ...boto import DeadlineClient
 from .job_attachment_details import JobAttachmentDetails
 from .job_details import JobDetails
 from .job_entity_type import JobEntityType

--- a/src/deadline_worker_agent/sessions/log_config.py
+++ b/src/deadline_worker_agent/sessions/log_config.py
@@ -14,7 +14,7 @@ from ..log_sync.cloudwatch import (
     LOG_CONFIG_OPTION_STREAM_NAME_KEY,
 )
 from ..api_models import LogConfiguration as BotoSessionLogConfiguration
-from ..boto_mock import Session as BotoSession
+from ..boto import Session as BotoSession
 from ..log_sync.cloudwatch import CloudWatchHandler
 
 

--- a/src/deadline_worker_agent/startup/bootstrap.py
+++ b/src/deadline_worker_agent/startup/bootstrap.py
@@ -24,7 +24,7 @@ from ..aws.deadline import (
 from .config import Configuration
 from .host_properties import get_host_properties as _get_host_properties
 from ..api_models import WorkerStatus
-from ..boto_mock import DeadlineClient, Session
+from ..boto import DeadlineClient, Session
 from ..aws_credentials import WorkerBoto3Session
 from ..session_events import configure_session_events
 

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -21,6 +21,7 @@ from pydantic import PositiveFloat
 
 from .._version import __version__
 from ..api_models import WorkerStatus
+from ..aws.deadline import DeadlineRequestError, delete_worker, update_worker
 from ..errors import ServiceShutdown
 from ..log_sync.cloudwatch import stream_cloudwatch_logs
 from ..log_sync.loggers import ROOT_LOGGER, logger as log_sync_logger

--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import boto3
 import requests
 
-from .boto_mock import DeadlineClient
+from .boto import DeadlineClient
 from .errors import ServiceShutdown
 from .scheduler import WorkerScheduler
 from .sessions import Session

--- a/test/unit/boto/test_config.py
+++ b/test/unit/boto/test_config.py
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from botocore.config import Config
+
+from deadline_worker_agent._version import __version__
+import deadline_worker_agent.boto.config as boto_config_mod
+
+
+class TestDeadlineBotocoreConfig:
+    """Tests for deadline_worker_agent.boto.config.DEADLINE_BOTOCORE_CONFIG"""
+
+    def test_sets_user_agent(self) -> None:
+        """Asserts that DEADLINE_BOTOCORE_CONFIG sets the user_agent_extra to identify the worker
+        agent and its version in the format:
+
+            deadline_worker_agent/<VERSION>
+        """
+        # WHEN
+        DEADLINE_BOTOCORE_CONFIG = boto_config_mod.DEADLINE_BOTOCORE_CONFIG
+
+        # THEN
+        assert isinstance(DEADLINE_BOTOCORE_CONFIG, Config)
+        assert DEADLINE_BOTOCORE_CONFIG.user_agent_extra == f"deadline_worker_agent/{__version__}"
+
+
+class TestOtherBotocoreConfig:
+    """Tests for deadline_worker_agent.boto.config.OTHER_BOTOCORE_CONFIG"""
+
+    def test_uses_default_retries(self) -> None:
+        """Asserts that OTHER_BOTOCORE_CONFIG does not configure retries"""
+        # WHEN
+        OTHER_BOTOCORE_CONFIG = boto_config_mod.OTHER_BOTOCORE_CONFIG
+
+        # THEN
+        assert isinstance(OTHER_BOTOCORE_CONFIG, Config)
+        assert hasattr(OTHER_BOTOCORE_CONFIG, "retries") and OTHER_BOTOCORE_CONFIG.retries is None
+
+    def test_sets_user_agent(self) -> None:
+        """Asserts that OTHER_BOTOCORE_CONFIG sets the user_agent_extra to identify the worker
+        agent and its version in the format:
+
+            deadline_worker_agent/<VERSION>
+        """
+        # WHEN
+        OTHER_BOTOCORE_CONFIG = boto_config_mod.OTHER_BOTOCORE_CONFIG
+
+        # THEN
+        assert isinstance(OTHER_BOTOCORE_CONFIG, Config)
+        assert OTHER_BOTOCORE_CONFIG.user_agent_extra == f"deadline_worker_agent/{__version__}"

--- a/test/unit/boto/test_logger.py
+++ b/test/unit/boto/test_logger.py
@@ -1,0 +1,10 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from deadline_worker_agent.boto.logger import logger
+
+
+def test_logger_name() -> None:
+    """Asserts the boto logger name is 'deadline_worker_agent.boto'"""
+
+    # THEN
+    assert logger.name == "deadline_worker_agent.boto"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent code dealing with boto has grown and would benefit with some logical structuring.

### What was the solution? (How)

Create a sub-package `deadline_woker_agent.boto` and migrate all internal boto-related code:

```txt
$ tree src/deadline_worker_agent/boto/
src/deadline_worker_agent/boto/
├── config.py
├── __init__.py
├── logger.py
└── shim.py # formerly boto_mock.py
```

### What is the impact of this change?

The boto code is more structured.

### How was this change tested?

Ran the updated unit tests which all pass. Also ran a end-to-end smoke test of the worker.

### Was this change documented?

A new entry was added in `DEVELOPMENT.md` explaining the `deadline_worker_agent.boto` sub-package.

### Is this a breaking change?

Not technically. The `deadline_worker_agent.boto_mock` module has moved and it formerly contained a module-level Python logger. This module actually contained what could be better described as a ["shim"](https://en.wikipedia.org/wiki/Shim_(computing)). The shim is now contained in the `deadline_worker_agent.boto.shim`.

To make the logging nicer, it now uses the new parent module's logger, so the log events will be emitted from the `deadline_worker_agent.boto` logger.