### PR TITLE
fix: Fixing name mismatch in testing scripts

### DIFF
--- a/testing_containers/posix_local_multiuser/run_agent.sh
+++ b/testing_containers/posix_local_multiuser/run_agent.sh
@@ -10,7 +10,7 @@ cp -r /aws/models/deadline/* .aws/models/deadline/
 
 python -m venv .venv
 source .venv/bin/activate
-pip install /code/dist/deadline_worker_agent-*-py3-none-any.whl
+pip install /code/dist/deadline_cloud_worker_agent-*-py3-none-any.whl
 
 deadline-worker-agent \
     --allow-instance-profile \


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The scripts used to setup a test worker in a container have the wrong name for the pip package to install.

### What was the solution? (How)

Update the name of the package in the test script.

### What is the impact of this change?

You can now launch a test worker in a container again.

### How was this change tested?

Ran the script locally and got a test worker running.

### Was this change documented?

no

### Is this a breaking change?

no