### PR TITLE
feat(session): Log progress messages to Session log during SincInputJobAttachment action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
-    "deadline == 0.18.*",
+    "deadline == 0.22.*",
     "openjd == 0.10.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -761,6 +761,8 @@ class Session:
                     progress=job_upload_status.progress,
                 ),
             )
+            ASSET_SYNC_LOGGER.info(job_upload_status.progressMessage)
+
             return not cancel.is_set()
 
         if not (job_attachment_settings := self._job_details.job_attachment_settings):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
During the 'Sync Input Job Attachments' session action is running, we should provide clearer logs in the Session log to indicate that the action is still running and there is progress being made. So, some sort of a progress or cumulative stats info should be logged to the Session log periodically, maybe at a fixed time frequency (e.g., 1 log / 5 seconds), as syncing inputs is happening. (e.g., "Download rate over the last XX seconds: 54Mb/s")

### What was the solution? (How)
The progress tracker for Job Attachments is modified in [this PR](https://github.com/casillas2/deadline-cloud/pull/33), to provide transfer rate info within its progress message. By invoking a callback, the progress tracker sends a progress message that now includes transfer rate data. So, the worker agent can print out that progress messages into the Session log at some regular intervals.

### What is the impact of this change?
Additional logging into Session log for 'Sync Input Job Attachments' Action

### How was this change tested?
- `hatch run lint && hatch run test && hatch run integ:test`
- Manually run an end-to-end test by submitting a job --> running a CMF worker. Now the Session log has additional log lines as shown below:

![Screenshot 2023-09-11 at 12 22 16 PM](https://github.com/casillas2/deadline-cloud/assets/132245153/db33647d-ccb8-49d7-b510-966562b56f22)

### Was this change documented?
No.

### Is this a breaking change?
No.