### PR TITLE
fix: remove the recursive ownership/permissions changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
-    "deadline == 0.23.*",
+    "deadline == 0.25.*",
     "openjd-sessions == 0.2.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",

--- a/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from openjd.sessions import Parameter, ParameterType
-from deadline.job_attachments._utils import AssetLoadingMethod
+from deadline.job_attachments.models import AssetLoadingMethod
 
 from ...api_models import (
     FloatParameter,

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -9,8 +9,12 @@ import pytest
 from pytest import FixtureRequest
 from typing import Generator, Optional
 
-from deadline.job_attachments.models import ManifestProperties, Attachments
-from deadline.job_attachments._utils import AssetLoadingMethod, OperatingSystemFamily
+from deadline.job_attachments.models import (
+    AssetLoadingMethod,
+    Attachments,
+    ManifestProperties,
+    OperatingSystemFamily,
+)
 from openjd.model import SchemaVersion
 from openjd.sessions import (
     Parameter,

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, Mock, patch
 from collections import OrderedDict
 
-from deadline.job_attachments._utils import AssetLoadingMethod
+from deadline.job_attachments.models import AssetLoadingMethod
 from openjd.model import SchemaVersion, UnsupportedSchema
 from openjd.model.v2023_09 import (
     Environment,

--- a/test/unit/sessions/test_job_attachment_details.py
+++ b/test/unit/sessions/test_job_attachment_details.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from deadline.job_attachments._utils import AssetLoadingMethod
+from deadline.job_attachments.models import AssetLoadingMethod
 from deadline_worker_agent.sessions.job_entities.job_attachment_details import JobAttachmentDetails
 
 

--- a/test/unit/sessions/test_job_entities.py
+++ b/test/unit/sessions/test_job_entities.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
-from deadline.job_attachments._utils import AssetLoadingMethod
+from deadline.job_attachments.models import AssetLoadingMethod
 from openjd.model import SchemaVersion
 from openjd.model.v2023_09 import (
     Action,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently as part of the sync job action, the worker agent runs some code to change the group ownership on files in the session directory:
- [Definition](https://github.com/casillas2/deadline-cloud-worker-agent/blob/044f0fa5ce28e9764589373f09c2e07195492764/src/deadline_worker_agent/sessions/session.py#L862)
- Usages: [Usage 1](https://github.com/casillas2/deadline-cloud-worker-agent/blob/044f0fa5ce28e9764589373f09c2e07195492764/src/deadline_worker_agent/sessions/session.py#L860C29-L860C29), [Usage 2](https://github.com/casillas2/deadline-cloud-worker-agent/blob/044f0fa5ce28e9764589373f09c2e07195492764/src/deadline_worker_agent/sessions/session.py#L769)

This was originally only meant to be run against the job attachment owned files/folders (ie. asset roots and all the files within them), however, it's running against all files/folders within the session directory. 

We need to move this code that changes ownership/permissions to Job Attachments library, so that we can perform `chown`/`chmod` only to the attachments (inputs) downloaded from the manifests.

### What was the solution? (How)
- With the change in [deadline-cloud PR#22](https://github.com/casillas2/deadline-cloud/pull/22), the worker agent can now pass an argument for os_group: str, file_mode: int, dir_mode: int, so that Job Attachment library can handle that file system permissions changes. 
- Removed the recursive `chown`/`chmod` from the worker agent.

### What is the impact of this change?
We can remove the custom job attachments specific code from the worker agent, and let job attachments handle it.

### How was this change tested?
- `hatch run lint && hatch run test`
- Run an end-to-end test (submitting a non-rendering job bundle --> running a CMF against my local backend) ensuring that there were no issues/errors in the flow.

### Was this change documented?
No.

### Is this a breaking change?
No.