### PR TITLE
fix!: remove old schema workaround

### DIFF
--- a/src/deadline_worker_agent/sessions/job_entities/environment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/environment_details.py
@@ -44,17 +44,7 @@ class EnvironmentDetails:
             If the environment's Open Job Description schema version not unsupported
         """
 
-        # TODO - Remove from here
-        env_schema_version = environment_details_data["schemaVersion"]
-        if env_schema_version not in ("jobtemplate-2023-09", "2022-09-01"):
-            UnsupportedSchema(env_schema_version)
-        # Note: 2023-09 & 2022-09-01 are identical as far as the worker agent is concerned.
-        schema_version = SchemaVersion.v2023_09
-        # -- to here once the migration to the new schema version is complete
-
-        # TODO - Put this back in once the migration to the new schema version is complete.
-        # schema_version = SchemaVersion(environment_details_data["schemaVersion"])
-        # --
+        schema_version = SchemaVersion(environment_details_data["schemaVersion"])
 
         if schema_version == SchemaVersion.v2023_09:
             environment = parse_model(

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -206,17 +206,7 @@ class JobDetails:
             or None
         )
 
-        # TODO - Remove from here
-        job_schema_version = job_details_data["schemaVersion"]
-        if job_schema_version not in ("jobtemplate-2023-09", "2022-09-01"):
-            UnsupportedSchema(job_schema_version)
-        # Note: 2023-09 & 2022-09-01 are identical as far as the worker agent is concerned.
-        schema_version = SchemaVersion.v2023_09
-        # -- to here once the migration to the new schema version is complete
-
-        # TODO - Put this back in once the migration to the new schema version is complete.
-        # schema_version = SchemaVersion(job_details_data["schemaVersion"])
-        # --
+        schema_version = SchemaVersion(job_details_data["schemaVersion"])
 
         if schema_version != SchemaVersion.v2023_09:
             raise UnsupportedSchema(schema_version.value)

--- a/src/deadline_worker_agent/sessions/job_entities/step_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/step_details.py
@@ -47,17 +47,7 @@ class StepDetails:
             If the environment's Open Job Description schema version not unsupported
         """
 
-        # TODO - Remove from here
-        step_schema_version = step_details_data["schemaVersion"]
-        if step_schema_version not in ("jobtemplate-2023-09", "2022-09-01"):
-            UnsupportedSchema(step_schema_version)
-        # Note: 2023-09 & 2022-09-01 are identical as far as the worker agent is concerned.
-        schema_version = SchemaVersion.v2023_09
-        # -- to here once the migration to the new schema version is complete
-
-        # TODO - Put this back in once the migration to the new schema version is complete.
-        # schema_version = SchemaVersion(environment_details_data["schemaVersion"])
-        # --
+        schema_version = SchemaVersion(step_details_data["schemaVersion"])
 
         if schema_version == SchemaVersion.v2023_09:
             step_script = parse_model(model=StepScript_2023_09, obj=step_details_data["template"])


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

We added a workaround to the agent that would allow it to handle both old job template schema as well as new. This was for a transitory period while the service updated to the new schema. That transition has now been completed, and it's time to remove the workaround.

### What was the solution? (How)

Remove the workaround.

### What is the impact of this change?

The last vestige of the old schema is removed, and the agent no longer can be used against old versions of the service.

### How was this change tested?

Just running our unit tests.

### Was this change documented?

N/A

### Is this a breaking change?

Yes, technically.