### PR TITLE
feat: Basic Windows support

### DIFF
--- a/src/deadline_worker_agent/aws_credentials/aws_configs.py
+++ b/src/deadline_worker_agent/aws_credentials/aws_configs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import stat
-
+import os
 import logging
 from abc import ABC, abstractmethod
 from configparser import ConfigParser
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Optional
 from openjd.sessions import PosixSessionUser, SessionUser
 from subprocess import run, DEVNULL, PIPE, STDOUT
+from ..set_windows_permissions import set_user_restricted_path_permissions
 
 __all__ = [
     "AWSConfig",
@@ -28,8 +29,12 @@ def _run_cmd_as(*, user: PosixSessionUser, cmd: list[str]) -> None:
 
 def _setup_parent_dir(*, dir_path: Path, owner: SessionUser | None = None) -> None:
     if owner is None:
-        create_perms: int = stat.S_IRWXU
-        dir_path.mkdir(mode=create_perms, exist_ok=True)
+        if os.name == "posix":
+            create_perms: int = stat.S_IRWXU
+            dir_path.mkdir(mode=create_perms, exist_ok=True)
+        else:
+            dir_path.mkdir(exist_ok=True)
+            set_user_restricted_path_permissions(dir_path.name)
     else:
         assert isinstance(owner, PosixSessionUser)
         _run_cmd_as(user=owner, cmd=["mkdir", "-p", str(dir_path)])

--- a/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
+++ b/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
@@ -91,8 +91,6 @@ class QueueBoto3Session(BaseBoto3Session):
         interrupt_event: Event,
         worker_persistence_dir: Path,
     ) -> None:
-        if os.name != "posix":
-            raise NotImplementedError("Windows not supported.")
         super().__init__()
 
         self._deadline_client = deadline_client
@@ -110,7 +108,11 @@ class QueueBoto3Session(BaseBoto3Session):
         self._credentials_filename = (
             "aws_credentials"  # note: .json extension added by JSONFileCache
         )
-        self._credentials_process_script_path = self._credential_dir / "get_aws_credentials.sh"
+
+        if os.name == "posix":
+            self._credentials_process_script_path = self._credential_dir / "get_aws_credentials.sh"
+        else:
+            self._credentials_process_script_path = self._credential_dir / "get_aws_credentials.cmd"
 
         self._aws_config = AWSConfig(self._os_user)
         self._aws_credentials = AWSCredentials(self._os_user)
@@ -321,9 +323,14 @@ class QueueBoto3Session(BaseBoto3Session):
         Generates the bash script which generates the credentials as JSON output on STDOUT.
         This script will be used by the installed credential process.
         """
-        return ("#!/bin/bash\nset -eu\ncat {0}\n").format(
-            (self._credential_dir / self._credentials_filename).with_suffix(".json")
-        )
+        if os.name == "posix":
+            return ("#!/bin/bash\nset -eu\ncat {0}\n").format(
+                (self._credential_dir / self._credentials_filename).with_suffix(".json")
+            )
+        else:
+            return ('@echo off\ntype "{0}"\n').format(
+                (self._credential_dir / self._credentials_filename).with_suffix(".json")
+            )
 
     def _uninstall_credential_process(self) -> None:
         """

--- a/src/deadline_worker_agent/aws_credentials/worker_boto3_session.py
+++ b/src/deadline_worker_agent/aws_credentials/worker_boto3_session.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
-import os
 import logging
 from typing import Any, cast
 
@@ -34,8 +33,6 @@ class WorkerBoto3Session(BaseBoto3Session):
         config: Configuration,
         worker_id: str,
     ) -> None:
-        if os.name != "posix":
-            raise NotImplementedError("Windows not supported.")
         super().__init__()
 
         self._bootstrap_session = bootstrap_session

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -54,7 +54,8 @@ from .session_cleanup import SessionUserCleanupManager
 from .session_queue import SessionActionQueue, SessionActionStatus
 from ..startup.config import ImpersonationOverrides
 from ..utils import MappingWithCallbacks
-
+from ..set_windows_permissions import set_user_restricted_path_permissions
+import subprocess
 
 logger = LOGGER
 
@@ -220,7 +221,7 @@ class WorkerScheduler:
         The Worker begins by hydrating its assigned work using the UpdateWorkerSchedule API.
 
         The scheduler then enters a loop of processing assigned actions - creating and deleting
-        Worker sessions as required. If no actions are assigned, the Worke idles for 5 seconds.
+        Worker sessions as required. If no actions are assigned, the Worker idles for 5 seconds.
         If any action completes, finishes cancelation, or if the Worker is done idling, an
         UpdateWorkerSchedule API request is made with any relevant changes specified in the request.
 
@@ -628,8 +629,12 @@ class WorkerScheduler:
             if self._worker_logs_dir:
                 queue_log_dir = self._queue_log_dir_path(queue_id=session_spec["queueId"])
                 try:
-                    queue_log_dir.mkdir(mode=stat.S_IRWXU, exist_ok=True)
-                except OSError:
+                    if os.name == "posix":
+                        queue_log_dir.mkdir(mode=stat.S_IRWXU, exist_ok=True)
+                    else:
+                        queue_log_dir.mkdir(exist_ok=True)
+                        set_user_restricted_path_permissions(queue_log_dir.name)
+                except (OSError, subprocess.CalledProcessError):
                     error_msg = (
                         f"Failed to create local session log directory on worker: {queue_log_dir}"
                     )

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -106,7 +106,7 @@ def job_run_as_user_api_model_to_worker_agent(
         )
     else:
         # TODO: windows support
-        raise NotImplementedError(f"{os.name} is not supported")
+        return None
 
     return job_run_as_user
 

--- a/src/deadline_worker_agent/set_windows_permissions.py
+++ b/src/deadline_worker_agent/set_windows_permissions.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from typing import Optional
+import subprocess
+import getpass
+
+
+def set_user_restricted_path_permissions(path: str, username: Optional[str] = None):
+    """
+    Set permissions for a specified file or directory (and any child objects)
+    to give full control only to the specified user.
+
+    Args:
+        path (str): The path of the file or directory for which permissions will be set.
+        username (str, optional): The username for whom permissions will be granted. If none is
+                        provided the current username will be used.
+
+    Example:
+        path = "C:\\example_directory_or_file"
+        username = "a_username"
+        set_user_restricted_path_permissions(path, username)
+    """
+
+    if not username:
+        username = getpass.getuser()
+
+    subprocess.run(
+        [
+            "icacls",
+            path,
+            # Remove any existing permissions
+            "/inheritance:r",
+            # OI - Contained objects will inherit
+            # CI - Sub-directories will inherit
+            # F  - Full control
+            "/grant",
+            ("{0}:(OI)(CI)(F)").format(username),
+            "/T",  # Apply recursively for directories
+        ],
+        check=True,
+    )

--- a/src/deadline_worker_agent/startup/config.py
+++ b/src/deadline_worker_agent/startup/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import logging as _logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -131,7 +132,7 @@ class Configuration:
 
         settings = WorkerSettings(**settings_kwargs)
 
-        if settings.posix_job_user is not None:
+        if os.name == "posix" and settings.posix_job_user is not None:
             user, group = self._get_user_and_group_from_posix_job_user(settings.posix_job_user)
             self.impersonation = ImpersonationOverrides(
                 inactive=not settings.impersonation,

--- a/src/deadline_worker_agent/startup/config_file.py
+++ b/src/deadline_worker_agent/startup/config_file.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Optional
 import sys
+import os
 
 from pydantic import BaseModel, BaseSettings, Field
 
@@ -20,6 +21,7 @@ from .capabilities import Capabilities
 DEFAULT_CONFIG_PATH: dict[str, Path] = {
     "darwin": Path("/etc/amazon/deadline/worker.toml"),
     "linux": Path("/etc/amazon/deadline/worker.toml"),
+    "win32": Path(os.path.expandvars(r"%PROGRAMDATA%/Amazon/Deadline/Config/worker.toml")),
 }
 
 

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -50,9 +50,14 @@ def detect_system_capabilities() -> Capabilities:
         "linux": "linux",
         "windows": "windows",
     }
+    platform_machine = platform.machine().lower()
+    python_machine_to_openjd_cpu_arch = {"x86_64": "x86_64", "amd64": "x86_64"}
     if openjd_os_family := python_system_to_openjd_os_family.get(platform_system):
         attributes[AttributeCapabilityName("attr.worker.os.family")] = [openjd_os_family]
-    attributes[AttributeCapabilityName("attr.worker.cpu.arch")] = [platform.machine()]
+    if openjd_cpu_arch := python_machine_to_openjd_cpu_arch.get(platform_machine):
+        attributes[AttributeCapabilityName("attr.worker.cpu.arch")] = [openjd_cpu_arch]
+    else:
+        raise NotImplementedError(f"{platform_machine} not supported")
     amounts[AmountCapabilityName("amount.worker.vcpu")] = float(psutil.cpu_count())
     amounts[AmountCapabilityName("amount.worker.memory")] = float(psutil.virtual_memory().total) / (
         1024.0**2

--- a/src/deadline_worker_agent/startup/settings.py
+++ b/src/deadline_worker_agent/startup/settings.py
@@ -11,14 +11,20 @@ from pydantic.env_settings import SettingsSourceCallable
 from .capabilities import Capabilities
 from .config_file import ConfigFile
 
+import os
+
 
 # Default path for the worker's logs.
 DEFAULT_POSIX_WORKER_LOGS_DIR = Path("/var/log/amazon/deadline")
+DEFAULT_WINDOWS_WORKER_LOGS_DIR = Path(os.path.expandvars(r"%PROGRAMDATA%/Amazon/Deadline/Logs"))
 # Default path for the worker persistence directory.
 # The persistence directory is expected to be located on a file-system that is local to the Worker
 # Node. The Worker's ID and credentials are persisted and these should not be accessible by other
 # Worker Nodes.
 DEFAULT_POSIX_WORKER_PERSISTENCE_DIR = Path("/var/lib/deadline")
+DEFAULT_WINDOWS_WORKER_PERSISTENCE_DIR = Path(
+    os.path.expandvars(r"%PROGRAMDATA%/Amazon/Deadline/Cache")
+)
 
 
 class WorkerSettings(BaseSettings):
@@ -84,8 +90,14 @@ class WorkerSettings(BaseSettings):
     capabilities: Capabilities = Field(
         default_factory=lambda: Capabilities(amounts={}, attributes={})
     )
-    worker_logs_dir: Path = DEFAULT_POSIX_WORKER_LOGS_DIR
-    worker_persistence_dir: Path = DEFAULT_POSIX_WORKER_PERSISTENCE_DIR
+    worker_logs_dir: Path = (
+        DEFAULT_WINDOWS_WORKER_LOGS_DIR if os.name == "nt" else DEFAULT_POSIX_WORKER_LOGS_DIR
+    )
+    worker_persistence_dir: Path = (
+        DEFAULT_WINDOWS_WORKER_PERSISTENCE_DIR
+        if os.name == "nt"
+        else DEFAULT_POSIX_WORKER_PERSISTENCE_DIR
+    )
     local_session_logs: bool = True
     host_metrics_logging: bool = True
     host_metrics_logging_interval_seconds: float = 60

--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import signal
+import os
 import sys
 import traceback
 from contextlib import nullcontext
@@ -121,8 +122,10 @@ class Worker:
 
         signal.signal(signal.SIGTERM, self._signal_handler)
         signal.signal(signal.SIGINT, self._signal_handler)
-        # TODO: Remove this once WA is stable or put behind a debug flag
-        signal.signal(signal.SIGUSR1, self._output_thread_stacks)
+
+        if os.name == "posix":
+            # TODO: Remove this once WA is stable or put behind a debug flag
+            signal.signal(signal.SIGUSR1, self._output_thread_stacks)  # type: ignore
 
     def _signal_handler(self, signum: int, frame: FrameType | None = None) -> None:
         """
@@ -147,7 +150,7 @@ class Worker:
         This signal is designated for application-defined behaviors. In our case, we want to output
         stack traces for all running threads.
         """
-        if signum in (signal.SIGUSR1,):
+        if signum in (signal.SIGUSR1,):  # type: ignore
             logger.info(f"Received signal {signum}. Initiating application shutdown.")
             # OUTPUT STACK TRACE FOR ALL THREADS
             print("\n*** STACKTRACE - START ***\n", file=sys.stderr)
@@ -169,7 +172,7 @@ class Worker:
 
     @property
     def sessions(self) -> WorkerSessionCollection:
-        raise NotImplementedError("Worker.sessions property not implemeneted")
+        raise NotImplementedError("Worker.sessions property not implemented")
 
     def run(self) -> None:
         """Runs the main Worker loop for processing sessions."""
@@ -388,9 +391,10 @@ class Worker:
                     )
                     return None
                 logger.info(f"Spot {action} happening at {shutdown_time}")
-                # Spot gives the time in UTC with a trailing Z, but Python can't handle
+                # Spot gives the time in UTC with a trailing Z, but Prior to Python 3.11 Python can't handle
                 # the Z so we strip it
-                shutdown_time = datetime.fromisoformat(shutdown_time[:-1]).astimezone(timezone.utc)
+                shutdown_time = datetime.fromisoformat(shutdown_time[:-1])
+                shutdown_time = shutdown_time.replace(tzinfo=timezone.utc)
                 current_time = datetime.now(timezone.utc)
                 time_delta = shutdown_time - current_time
                 time_delta_seconds = int(time_delta.total_seconds())

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Generator, Optional
 from unittest.mock import MagicMock, patch
-import os
 import sysconfig
 
 import pytest
@@ -288,4 +287,4 @@ def test_unsupported_platform_raises(platform: str, capsys: pytest.CaptureFixtur
     assert raise_ctx.value.code == 1
     capture = capsys.readouterr()
 
-    assert capture.out == f"ERROR: Unsupported platform {platform}{os.linesep}"
+    assert capture.out == f"ERROR: Unsupported platform {platform}\n"

--- a/test/unit/log_sync/test_cloudwatch.py
+++ b/test/unit/log_sync/test_cloudwatch.py
@@ -36,7 +36,7 @@ def mock_module_logger() -> Generator[MagicMock, None, None]:
 class TestCloudWatchLogEventBatch:
     @fixture(autouse=True)
     def now(self) -> datetime:
-        return datetime.fromtimestamp(123)
+        return datetime(2000, 1, 1)
 
     @fixture(autouse=True)
     def datetime_mock(self, now: datetime) -> Generator[MagicMock, None, None]:
@@ -51,7 +51,7 @@ class TestCloudWatchLogEventBatch:
     @fixture
     def event(self, now: datetime) -> PartitionedCloudWatchLogEvent:
         return PartitionedCloudWatchLogEvent(
-            log_event=CloudWatchLogEvent(timestamp=int(now.timestamp()), message="abc"),
+            log_event=CloudWatchLogEvent(timestamp=int(now.timestamp() * 1000), message="abc"),
             size=len("abc".encode("utf-8")),
         )
 
@@ -168,10 +168,12 @@ class TestCloudWatchLogEventBatch:
             datetime_mock: MagicMock,
         ):
             # GIVEN
-            now = datetime.fromtimestamp(1)
+            now = datetime(2000, 1, 1)
             datetime_mock.now.return_value = now
             event = PartitionedCloudWatchLogEvent(
-                log_event=CloudWatchLogEvent(message="abc", timestamp=int(now.timestamp())),
+                log_event=CloudWatchLogEvent(
+                    message="abc", timestamp=(int(now.timestamp()) * 1000)
+                ),
                 size=3,
             )
             batch = CloudWatchLogEventBatch()

--- a/test/unit/scheduler/test_session_cleanup.py
+++ b/test/unit/scheduler/test_session_cleanup.py
@@ -8,6 +8,7 @@ import subprocess
 
 from openjd.sessions import SessionUser, PosixSessionUser
 import pytest
+import os
 
 from deadline_worker_agent.scheduler.session_cleanup import (
     SessionUserCleanupManager,
@@ -16,6 +17,11 @@ import deadline_worker_agent.scheduler.session_cleanup as session_cleanup_mod
 
 
 class FakeSessionUser(SessionUser):
+    def __init__(self, user: str):
+        self.user = user
+
+
+class WindowsSessionUser(SessionUser):
     def __init__(self, user: str):
         self.user = user
 
@@ -34,8 +40,11 @@ class TestSessionUserCleanupManager:
             yield mock
 
     @pytest.fixture
-    def os_user(self) -> PosixSessionUser:
-        return PosixSessionUser(user="user", group="group")
+    def os_user(self) -> SessionUser:
+        if os.name == "posix":
+            return PosixSessionUser(user="user", group="group")
+        else:
+            return WindowsSessionUser(user="user")
 
     @pytest.fixture
     def session(self, os_user: PosixSessionUser) -> MagicMock:
@@ -45,6 +54,7 @@ class TestSessionUserCleanupManager:
         return session_stub
 
     class TestRegister:
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         def test_registers_session(
             self,
             manager: SessionUserCleanupManager,
@@ -99,6 +109,7 @@ class TestSessionUserCleanupManager:
             user_session_map_lock_mock.__exit__.assert_not_called()
 
     class TestDeregister:
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         def test_deregisters_session(
             self,
             manager: SessionUserCleanupManager,
@@ -119,6 +130,7 @@ class TestSessionUserCleanupManager:
             user_session_map_lock_mock.__enter__.assert_called_once()
             user_session_map_lock_mock.__exit__.assert_called_once()
 
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         def test_deregister_skipped_no_user(
             self,
             manager: SessionUserCleanupManager,
@@ -166,9 +178,10 @@ class TestSessionUserCleanupManager:
             with patch.object(SessionUserCleanupManager, "cleanup_session_user_processes") as mock:
                 yield mock
 
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         def test_calls_cleanup_session_user_processes(
             self,
-            os_user: PosixSessionUser,
+            os_user: SessionUser,
             manager: SessionUserCleanupManager,
             cleanup_session_user_processes_mock: MagicMock,
         ):
@@ -178,9 +191,10 @@ class TestSessionUserCleanupManager:
             # THEN
             cleanup_session_user_processes_mock.assert_called_once_with(os_user)
 
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         def test_skips_cleanup_when_configured_to(
             self,
-            os_user: PosixSessionUser,
+            os_user: SessionUser,
             cleanup_session_user_processes_mock: MagicMock,
         ):
             # GIVEN
@@ -196,27 +210,32 @@ class TestSessionUserCleanupManager:
         @pytest.fixture
         def agent_user(
             self,
-            os_user: PosixSessionUser,
-        ) -> PosixSessionUser:
-            return PosixSessionUser(user=f"agent_{os_user.user}", group=f"agent_{os_user.group}")
+        ) -> SessionUser:
+            if os.name == "posix":
+                return PosixSessionUser(user="agent_user", group="agent_group")
+            else:
+                return WindowsSessionUser(user="user")
 
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         @pytest.fixture(autouse=True)
         def subprocess_check_output_mock(
             self,
-            agent_user: PosixSessionUser,
+            agent_user: SessionUser,
         ) -> Generator[MagicMock, None, None]:
             with patch.object(
                 session_cleanup_mod.subprocess,
                 "check_output",
-                return_value=agent_user.user,
+                return_value=agent_user.user,  # type: ignore
             ) as mock:
                 yield mock
 
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         @pytest.fixture(autouse=True)
         def subprocess_run_mock(self) -> Generator[MagicMock, None, None]:
             with patch.object(session_cleanup_mod.subprocess, "run") as mock:
                 yield mock
 
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         def test_cleans_up_processes(
             self,
             os_user: PosixSessionUser,
@@ -258,6 +277,7 @@ class TestSessionUserCleanupManager:
             assert str(raised_err.value) == "Windows not supported"
             subprocess_run_mock.assert_not_called()
 
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         def test_no_processes_to_clean_up(
             self,
             os_user: PosixSessionUser,
@@ -278,6 +298,7 @@ class TestSessionUserCleanupManager:
                 in caplog.text
             )
 
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         def test_fails_to_clean_up_processes(
             self,
             os_user: PosixSessionUser,
@@ -298,6 +319,7 @@ class TestSessionUserCleanupManager:
             assert f"Failed to stop processes running as '{os_user.user}': {err}" in caplog.text
             assert raised_err.value is err
 
+        @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         def test_skips_if_session_user_is_agent_user(
             self,
             subprocess_run_mock: MagicMock,

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -18,6 +18,7 @@ from openjd.sessions import PosixSessionUser
 
 
 import pytest
+import os
 
 from deadline_worker_agent.api_models import (
     Attachments,
@@ -174,6 +175,7 @@ class TestJobEntity:
             assert job_details.path_mapping_rules not in (None, [])
             assert len(job_details.path_mapping_rules) == len(path_mapping_rules)
 
+    @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
     def test_job_run_as_user(self) -> None:
         """Ensures that if we receive a job_run_as_user field in the response,
         that the created entity has a (Posix) SessionUser created with the
@@ -250,10 +252,11 @@ class TestJobEntity:
 
         # THEN
         assert not hasattr(entity_obj, "jobs_run_as")
-        assert entity_obj.job_run_as_user is not None
-        assert isinstance(entity_obj.job_run_as_user.posix, PosixSessionUser)
-        assert entity_obj.job_run_as_user.posix.user == expected_user
-        assert entity_obj.job_run_as_user.posix.group == expected_group
+        if os.name == "posix":
+            assert entity_obj.job_run_as_user is not None
+            assert isinstance(entity_obj.job_run_as_user.posix, PosixSessionUser)
+            assert entity_obj.job_run_as_user.posix.user == expected_user
+            assert entity_obj.job_run_as_user.posix.group == expected_group
 
     # TODO: remove once service no longer sends jobsRunAs
     def test_only_old_jobs_run_as(self) -> None:
@@ -280,10 +283,11 @@ class TestJobEntity:
 
         # THEN
         assert not hasattr(entity_obj, "jobs_run_as")
-        assert entity_obj.job_run_as_user is not None
-        assert isinstance(entity_obj.job_run_as_user.posix, PosixSessionUser)
-        assert entity_obj.job_run_as_user.posix.user == expected_user
-        assert entity_obj.job_run_as_user.posix.group == expected_group
+        if os.name == "posix":
+            assert entity_obj.job_run_as_user is not None
+            assert isinstance(entity_obj.job_run_as_user.posix, PosixSessionUser)
+            assert entity_obj.job_run_as_user.posix.user == expected_user
+            assert entity_obj.job_run_as_user.posix.group == expected_group
 
     # TODO: remove once service no longer sends jobsRunAs
     def test_only_empty_old_jobs_run_as(self) -> None:

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -10,6 +10,8 @@ from typing import Generator, Iterable, Literal, Optional
 from unittest.mock import patch, MagicMock, ANY
 
 import pytest
+import os
+
 from openjd.model.v2023_09 import (
     Action,
     Environment,
@@ -52,9 +54,12 @@ from deadline.job_attachments.models import (
 import deadline_worker_agent.sessions.session as session_mod
 
 
-@pytest.fixture(params=(PosixSessionUser(user="some-user", group="some-group"),))
-def os_user(request: pytest.FixtureRequest) -> Optional[SessionUser]:
-    return request.param
+@pytest.fixture
+def os_user() -> Optional[SessionUser]:
+    if os.name == "posix":
+        return PosixSessionUser(user="some-user", group="some-group")
+    else:
+        return None
 
 
 @pytest.fixture
@@ -516,6 +521,7 @@ class TestSessionSyncAssetInputs:
     @pytest.mark.parametrize(
         "job_attachments_file_system", [e.value for e in JobAttachmentsFileSystem]
     )
+    @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
     def test_asset_loading_method(
         self,
         session: Session,

--- a/test/unit/startup/test_config.py
+++ b/test/unit/startup/test_config.py
@@ -9,8 +9,9 @@ from unittest.mock import MagicMock, patch
 from typing import Any, Generator, List, Optional
 import logging
 import pytest
+import os
 
-from openjd.sessions import PosixSessionUser
+from openjd.sessions import SessionUser, PosixSessionUser
 
 from deadline_worker_agent.startup.cli_args import ParsedCommandLineArguments
 from deadline_worker_agent.startup import config as config_mod
@@ -73,6 +74,14 @@ def arg_parser(
         get_argument_parser.return_value = arg_parser
         arg_parser.parse_args.return_value = parsed_args
         yield arg_parser
+
+
+@pytest.fixture
+def os_user() -> Optional[SessionUser]:
+    if os.name == "posix":
+        return PosixSessionUser(user="user", group="group")
+    else:
+        return None
 
 
 class TestLoad:
@@ -266,8 +275,18 @@ class TestLoad:
     @pytest.mark.parametrize(
         argnames="worker_logs_dir",
         argvalues=(
-            Path("/foo"),
-            Path("/bar"),
+            pytest.param(
+                Path("/foo"), marks=pytest.mark.skipif(os.name != "posix", reason="Not posix")
+            ),
+            pytest.param(
+                Path("/bar"), marks=pytest.mark.skipif(os.name != "posix", reason="Not posix")
+            ),
+            pytest.param(
+                Path("D:\\foo"), marks=pytest.mark.skipif(os.name != "nt", reason="Not windows")
+            ),
+            pytest.param(
+                Path("D:\\bar"), marks=pytest.mark.skipif(os.name != "nt", reason="Not windows")
+            ),
         ),
     )
     def test_uses_worker_logs_dir(
@@ -289,8 +308,18 @@ class TestLoad:
     @pytest.mark.parametrize(
         argnames="persistence_dir",
         argvalues=(
-            Path("/foo"),
-            Path("/bar"),
+            pytest.param(
+                Path("/foo"), marks=pytest.mark.skipif(os.name != "posix", reason="Not posix")
+            ),
+            pytest.param(
+                Path("/bar"), marks=pytest.mark.skipif(os.name != "posix", reason="Not posix")
+            ),
+            pytest.param(
+                Path("D:\\foo"), marks=pytest.mark.skipif(os.name != "nt", reason="Not windows")
+            ),
+            pytest.param(
+                Path("D:\\bar"), marks=pytest.mark.skipif(os.name != "nt", reason="Not windows")
+            ),
         ),
     )
     def test_uses_worker_persistence_dir(
@@ -598,6 +627,7 @@ class TestInit:
         else:
             assert "impersonation" not in call.kwargs
 
+    @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
     @pytest.mark.parametrize(
         argnames="posix_job_user",
         argvalues=("user:group", None),
@@ -776,8 +806,9 @@ class TestInit:
         argvalues=(
             pytest.param(
                 "user:group",
-                PosixSessionUser(group="group", user="user"),
+                "os_user",
                 id="has-posix-job-user-setting",
+                marks=pytest.mark.skipif(os.name != "posix", reason="Posix-only test."),
             ),
             pytest.param(
                 None,
@@ -792,6 +823,7 @@ class TestInit:
         expected_config_posix_job_user: PosixSessionUser | None,
         parsed_args: ParsedCommandLineArguments,
         mock_worker_settings_cls: MagicMock,
+        request,
     ) -> None:
         """Tests that any parsed_cli_args without a value of None are passed as kwargs when
         creating a WorkerSettings instance"""
@@ -822,9 +854,12 @@ class TestInit:
         assert config.capabilities is mock_worker_settings.capabilities
         assert config.impersonation.inactive == (not mock_worker_settings.impersonation)
         if expected_config_posix_job_user:
+            # TODO: This is needed because we are using a fixture with a parameterized call
+            # but let's revisit whether this can be simplified when Windows impersonation is added
+            posix_user: PosixSessionUser = request.getfixturevalue(expected_config_posix_job_user)
             assert isinstance(config.impersonation.posix_job_user, PosixSessionUser)
-            assert config.impersonation.posix_job_user.group == expected_config_posix_job_user.group
-            assert config.impersonation.posix_job_user.user == expected_config_posix_job_user.user
+            assert config.impersonation.posix_job_user.group == posix_user.group
+            assert config.impersonation.posix_job_user.user == posix_user.user
         else:
             assert config.impersonation.posix_job_user is None
         assert config.worker_logs_dir is mock_worker_settings.worker_logs_dir

--- a/test/unit/startup/test_settings.py
+++ b/test/unit/startup/test_settings.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, Mock, patch
 from typing import Any, Generator, NamedTuple, Type
 import pytest
+import os
 from pathlib import Path
 
 from pydantic import ConstrainedStr
@@ -105,14 +106,18 @@ FIELD_TEST_CASES: list[FieldTestCaseParams] = [
         field_name="worker_logs_dir",
         expected_type=Path,
         expected_required=False,
-        expected_default=Path("/var/log/amazon/deadline"),
+        expected_default=Path("/var/log/amazon/deadline")
+        if os.name == "posix"
+        else Path(os.path.expandvars(r"%PROGRAMDATA%/Amazon/Deadline/Logs")),
         expected_default_factory_return_value=None,
     ),
     FieldTestCaseParams(
         field_name="worker_persistence_dir",
         expected_type=Path,
         expected_required=False,
-        expected_default=Path("/var/lib/deadline"),
+        expected_default=Path("/var/lib/deadline")
+        if os.name == "posix"
+        else Path(os.path.expandvars(r"%PROGRAMDATA%/Amazon/Deadline/Cache")),
         expected_default_factory_return_value=None,
     ),
     FieldTestCaseParams(

--- a/test/unit/test_set_windows_permissions.py
+++ b/test/unit/test_set_windows_permissions.py
@@ -1,0 +1,58 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import unittest
+from unittest.mock import patch
+from deadline_worker_agent.set_windows_permissions import set_user_restricted_path_permissions
+
+
+class TestSetWindowsPermissions(unittest.TestCase):
+    @patch("subprocess.run")
+    @patch("getpass.getuser", return_value="testuser")
+    def test_set_user_restricted_path_permissions_with_default_username(
+        self, mock_getuser, mock_subprocess_run
+    ):
+        # GIVEN
+        path = "C:\\example_directory_or_file"
+
+        # WHEN
+        set_user_restricted_path_permissions(path)
+
+        # THEN
+        expected_command = [
+            "icacls",
+            path,
+            "/inheritance:r",
+            "/grant",
+            "{0}:(OI)(CI)(F)".format("testuser"),
+            "/T",
+        ]
+        mock_subprocess_run.assert_called_once_with(expected_command, check=True)
+        mock_getuser.assert_called_once()
+
+    @patch("subprocess.run")
+    @patch("getpass.getuser")
+    def test_set_user_restricted_path_permissions_with_specific_username(
+        self, mock_getuser, mock_subprocess_run
+    ):
+        # GIVEN
+        path = "C:\\example_directory_or_file"
+        custom_username = "customuser"
+
+        # WHEN
+        set_user_restricted_path_permissions(path, username=custom_username)
+
+        # THEN
+        expected_command = [
+            "icacls",
+            path,
+            "/inheritance:r",
+            "/grant",
+            "{0}:(OI)(CI)(F)".format(custom_username),
+            "/T",
+        ]
+        mock_subprocess_run.assert_called_once_with(expected_command, check=True)
+        mock_getuser.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The DLC worker agent did not start on Windows, and numerous unit tests did not pass. 

### What was the solution? (How)

Numerous small changes related to removing `NotImplemented` exceptions, using more appropriate file paths etc. 

User impersonation is not intended to work in this branch at this time, and several of the changes relate to ensuring tests pass when impersonation is not used. 

**As of 11/6/23 this is targeted at a feature branch, not mainline.** 

### What is the impact of this change?
The worker agent starts, then receives and executes jobs on Windows. 

### How was this change tested?
Submitting jobs to gamma and ensuring they are picked up and executed by a Windows worker. 

### Was this change documented?
No currently. 

### Is this a breaking change?
It is not intended to be. 