### PR TITLE
revert!: schema version workaround and template version for integ tests 

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -9,7 +9,7 @@ test = "pytest {args:test/unit} --numprocesses=auto"
 # Don't pass --numprocesses here so that tests run sequentially.
 # pytest-xdist does not allow live output of stdout, meaning integ tests only show output after the test is done
 # See: https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers
-integ-test = "pytest test/integ"
+integ-test = "pytest --no-cov test/integ"
 typing = "mypy {args:src test}"
 style = [
   "ruff {args:.}",

--- a/src/deadline_worker_agent/sessions/job_entities/environment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/environment_details.py
@@ -44,7 +44,17 @@ class EnvironmentDetails:
             If the environment's Open Job Description schema version not unsupported
         """
 
-        schema_version = SchemaVersion(environment_details_data["schemaVersion"])
+        # TODO - Remove from here
+        env_schema_version = environment_details_data["schemaVersion"]
+        if env_schema_version not in ("jobtemplate-2023-09", "2022-09-01"):
+            UnsupportedSchema(env_schema_version)
+        # Note: 2023-09 & 2022-09-01 are identical as far as the worker agent is concerned.
+        schema_version = SchemaVersion.v2023_09
+        # -- to here once the migration to the new schema version is complete
+
+        # TODO - Put this back in once the migration to the new schema version is complete.
+        # schema_version = SchemaVersion(environment_details_data["schemaVersion"])
+        # --
 
         if schema_version == SchemaVersion.v2023_09:
             environment = parse_model(

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -204,7 +204,17 @@ class JobDetails:
             or None
         )
 
-        schema_version = SchemaVersion(job_details_data["schemaVersion"])
+        # TODO - Remove from here
+        job_schema_version = job_details_data["schemaVersion"]
+        if job_schema_version not in ("jobtemplate-2023-09", "2022-09-01"):
+            UnsupportedSchema(job_schema_version)
+        # Note: 2023-09 & 2022-09-01 are identical as far as the worker agent is concerned.
+        schema_version = SchemaVersion.v2023_09
+        # -- to here once the migration to the new schema version is complete
+
+        # TODO - Put this back in once the migration to the new schema version is complete.
+        # schema_version = SchemaVersion(job_details_data["schemaVersion"])
+        # --
 
         if schema_version != SchemaVersion.v2023_09:
             raise UnsupportedSchema(schema_version.value)

--- a/src/deadline_worker_agent/sessions/job_entities/step_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/step_details.py
@@ -47,7 +47,17 @@ class StepDetails:
             If the environment's Open Job Description schema version not unsupported
         """
 
-        schema_version = SchemaVersion(step_details_data["schemaVersion"])
+        # TODO - Remove from here
+        step_schema_version = step_details_data["schemaVersion"]
+        if step_schema_version not in ("jobtemplate-2023-09", "2022-09-01"):
+            UnsupportedSchema(step_schema_version)
+        # Note: 2023-09 & 2022-09-01 are identical as far as the worker agent is concerned.
+        schema_version = SchemaVersion.v2023_09
+        # -- to here once the migration to the new schema version is complete
+
+        # TODO - Put this back in once the migration to the new schema version is complete.
+        # schema_version = SchemaVersion(environment_details_data["schemaVersion"])
+        # --
 
         if schema_version == SchemaVersion.v2023_09:
             step_script = parse_model(model=StepScript_2023_09, obj=step_details_data["template"])

--- a/test/integ/test_job_submissions.py
+++ b/test/integ/test_job_submissions.py
@@ -43,7 +43,7 @@ class TestJobSubmissions:
             queue=queue,
             priority=98,
             template={
-                "specificationVersion": "jobtemplate-2023-09",
+                "specificationVersion": "2022-09-01",
                 "name": "Sleep Job",
                 "steps": [
                     {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Integ tests are not ready to use the latest version of the job templates, we will also still require the workaround that allows use of both template versions in the worker.

### What was the solution? (How)
roll back to previous version

### What is the impact of this change?
Submissions Integ Tests run

### How was this change tested?
```
hatch run lint
hatch run test
```

### Was this change documented?
no

### Is this a breaking change?
Yes, a new version will need to be released to add the workaround back in.