### PR TITLE
refactor!: Rename File system options from PRELOAD/ON_DEMAND to COPIED/VIRTUAL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
-    "deadline == 0.29.*",
+    "deadline == 0.30.*",
     "openjd-sessions == 0.2.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",

--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -328,7 +328,7 @@ class Attachments(TypedDict):
     manifests: list[ManifestProperties]
     """A list of all manifests and their configuration"""
 
-    assetLoadingMethod: NotRequired[str]
+    fileSystem: NotRequired[str]
     """Method to use when loading assets required for a job"""
 
 

--- a/src/deadline_worker_agent/boto/shim.py
+++ b/src/deadline_worker_agent/boto/shim.py
@@ -281,7 +281,7 @@ class DeadlineClient:
                             "jobId": "job-21432d89b44a46cbaaeb2f1d5254e548",
                             "attachments": {
                                 "manifests": [],
-                                "assetLoadingMethod": "PRELOAD",
+                                "fileSystem": "COPIED",
                             },
                         },
                     },

--- a/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from openjd.sessions import Parameter, ParameterType
-from deadline.job_attachments.models import AssetLoadingMethod
+from deadline.job_attachments.models import JobAttachmentsFileSystem
 
 from ...api_models import (
     FloatParameter,
@@ -84,7 +84,7 @@ class JobAttachmentDetails:
     Each item in the list specifies its path, required input assets, and output assets.
     """
 
-    asset_loading_method: AssetLoadingMethod = AssetLoadingMethod.PRELOAD
+    job_attachments_file_system: JobAttachmentsFileSystem = JobAttachmentsFileSystem.COPIED
     """Method to use when loading assets required for a job"""
 
     @classmethod
@@ -126,9 +126,9 @@ class JobAttachmentDetails:
                 )
                 for manifest_properties in job_attachments_details_data["attachments"]["manifests"]
             ],
-            asset_loading_method=AssetLoadingMethod(
+            job_attachments_file_system=JobAttachmentsFileSystem(
                 job_attachments_details_data["attachments"].get(
-                    "assetLoadingMethod", AssetLoadingMethod.PRELOAD
+                    "fileSystem", JobAttachmentsFileSystem.COPIED
                 )
             ),
         )
@@ -185,7 +185,7 @@ class JobAttachmentDetails:
                                 Field(key="inputManifestHash", expected_type=str, required=False),
                             ),
                         ),
-                        Field(key="assetLoadingMethod", expected_type=str, required=False),
+                        Field(key="fileSystem", expected_type=str, required=False),
                     ),
                 ),
             ),

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -811,7 +811,7 @@ class Session:
 
         attachments = Attachments(
             manifests=manifest_properties_list,
-            assetLoadingMethod=self._job_attachment_details.asset_loading_method,
+            fileSystem=self._job_attachment_details.job_attachments_file_system,
         )
 
         storage_profiles_path_mapping_rules_dict: dict[str, str] = {
@@ -1070,7 +1070,7 @@ class Session:
 
         attachments = Attachments(
             manifests=manifest_properties_list,
-            assetLoadingMethod=job_attachment_details.asset_loading_method,
+            fileSystem=job_attachment_details.job_attachments_file_system,
         )
 
         storage_profiles_path_mapping_rules_dict: dict[str, str] = {

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -10,7 +10,7 @@ from pytest import FixtureRequest
 from typing import Generator, Optional
 
 from deadline.job_attachments.models import (
-    AssetLoadingMethod,
+    JobAttachmentsFileSystem,
     Attachments,
     ManifestProperties,
     PathFormat,
@@ -215,19 +215,19 @@ def job_attachment_manifest_properties(
 
 
 @pytest.fixture
-def asset_loading_method() -> AssetLoadingMethod:
-    return AssetLoadingMethod.PRELOAD
+def job_attachments_file_system() -> JobAttachmentsFileSystem:
+    return JobAttachmentsFileSystem.COPIED
 
 
 @pytest.fixture
 def job_attachment_details(
     job_attachment_manifest_properties: JobAttachmentManifestProperties,
-    asset_loading_method: AssetLoadingMethod,
+    job_attachments_file_system: JobAttachmentsFileSystem,
 ) -> JobAttachmentDetails | None:
     """Job attachment settings for the job"""
     return JobAttachmentDetails(
         manifests=[job_attachment_manifest_properties],
-        asset_loading_method=asset_loading_method,
+        job_attachments_file_system=job_attachments_file_system,
     )
 
 

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, Mock, patch
 from collections import OrderedDict
 
-from deadline.job_attachments.models import AssetLoadingMethod
+from deadline.job_attachments.models import JobAttachmentsFileSystem
 from openjd.model import SchemaVersion, UnsupportedSchema
 from openjd.model.v2023_09 import (
     Environment,
@@ -170,7 +170,7 @@ class TestSessionActionQueueDequeue:
                 SyncInputJobAttachmentsAction(
                     id="id",
                     job_attachment_details=JobAttachmentDetails(
-                        asset_loading_method=AssetLoadingMethod.PRELOAD,
+                        job_attachments_file_system=JobAttachmentsFileSystem.COPIED,
                         manifests=[],
                     ),
                 ),

--- a/test/unit/sessions/test_job_attachment_details.py
+++ b/test/unit/sessions/test_job_attachment_details.py
@@ -2,11 +2,11 @@
 
 import pytest
 
-from deadline.job_attachments.models import AssetLoadingMethod
+from deadline.job_attachments.models import JobAttachmentsFileSystem
 from deadline_worker_agent.sessions.job_entities.job_attachment_details import JobAttachmentDetails
 
 
-@pytest.mark.parametrize("loading_method", [e.value for e in AssetLoadingMethod])
+@pytest.mark.parametrize("loading_method", [e.value for e in JobAttachmentsFileSystem])
 def test_asset_loading_method(loading_method):
     """Test that the loading method is read from the boto data into JobAttachmentDetails"""
     entity_obj = JobAttachmentDetails.from_boto(
@@ -14,13 +14,13 @@ def test_asset_loading_method(loading_method):
             "jobId": "myjob",
             "attachments": {
                 "manifests": [],
-                "assetLoadingMethod": loading_method,
+                "fileSystem": loading_method,
             },
         },
     )
 
     assert entity_obj is not None
-    assert entity_obj.asset_loading_method == loading_method
+    assert entity_obj.job_attachments_file_system == loading_method
 
 
 def test_asset_loading_method_default():
@@ -35,4 +35,4 @@ def test_asset_loading_method_default():
     )
 
     assert entity_obj is not None
-    assert entity_obj.asset_loading_method == AssetLoadingMethod.PRELOAD
+    assert entity_obj.job_attachments_file_system == JobAttachmentsFileSystem.COPIED

--- a/test/unit/sessions/test_job_entities.py
+++ b/test/unit/sessions/test_job_entities.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
-from deadline.job_attachments.models import AssetLoadingMethod
+from deadline.job_attachments.models import JobAttachmentsFileSystem
 from openjd.model import SchemaVersion
 from openjd.model.v2023_09 import (
     Action,
@@ -464,9 +464,7 @@ class TestDetails:
         details_boto = JobAttachmentDetailsBoto(
             jobAttachmentDetails=JobAttachmentDetailsData(
                 jobId=job_id,
-                attachments=Attachments(
-                    manifests=[], assetLoadingMethod=AssetLoadingMethod.PRELOAD
-                ),
+                attachments=Attachments(manifests=[], fileSystem=JobAttachmentsFileSystem.COPIED),
             )
         )
         response: BatchGetJobEntityResponse = {
@@ -474,7 +472,7 @@ class TestDetails:
             "errors": [],
         }
         expected_details = JobAttachmentDetails(
-            manifests=[], asset_loading_method=AssetLoadingMethod.PRELOAD
+            manifests=[], job_attachments_file_system=JobAttachmentsFileSystem.COPIED
         )
         deadline_client.batch_get_job_entity.return_value = response
         job_entities = JobEntities(

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -45,7 +45,7 @@ from deadline_worker_agent.sessions.job_entities import (
 )
 from deadline.job_attachments.models import (
     Attachments,
-    AssetLoadingMethod,
+    JobAttachmentsFileSystem,
     PosixFileSystemPermissionSettings,
 )
 import deadline_worker_agent.sessions.session as session_mod
@@ -510,17 +510,19 @@ class TestSessionSyncAssetInputs:
         with patch.object(session, "_asset_sync") as mock_asset_sync:
             yield mock_asset_sync
 
-    # This overrides the asset_loading_method fixture in tests/unit/conftest.py which feeds into
+    # This overrides the job_attachments_file_system fixture in tests/unit/conftest.py which feeds into
     # the job_attachment_details fixture
-    @pytest.mark.parametrize("asset_loading_method", [e.value for e in AssetLoadingMethod])
+    @pytest.mark.parametrize(
+        "job_attachments_file_system", [e.value for e in JobAttachmentsFileSystem]
+    )
     def test_asset_loading_method(
         self,
         session: Session,
-        asset_loading_method: AssetLoadingMethod,
+        job_attachments_file_system: JobAttachmentsFileSystem,
         mock_asset_sync: MagicMock,
         job_attachment_details: JobAttachmentDetails,
     ) -> None:
-        """Tests that the asset_loading_method specified in session._job_details is properly passed to the sync_inputs function"""
+        """Tests that the job_attachments_file_system specified in session._job_details is properly passed to the sync_inputs function"""
         # GIVEN
         mock_sync_inputs: MagicMock = mock_asset_sync.sync_inputs
         mock_sync_inputs.return_value = ({}, {})
@@ -539,7 +541,7 @@ class TestSessionSyncAssetInputs:
             session_dir=ANY,
             attachments=Attachments(
                 manifests=ANY,
-                assetLoadingMethod=asset_loading_method,
+                fileSystem=job_attachments_file_system,
             ),
             fs_permission_settings=PosixFileSystemPermissionSettings(
                 os_group="some-group",
@@ -559,7 +561,7 @@ class TestSessionSyncAssetInputs:
                     {
                         "job_attachment_details": JobAttachmentDetails(
                             manifests=[],
-                            asset_loading_method="PRELOAD",
+                            job_attachments_file_system="COPIED",
                         )
                     }
                 ],
@@ -570,7 +572,7 @@ class TestSessionSyncAssetInputs:
                     {
                         "job_attachment_details": JobAttachmentDetails(
                             manifests=[],
-                            asset_loading_method="PRELOAD",
+                            job_attachments_file_system="COPIED",
                         )
                     },
                     {"step_dependencies": ["step-1"]},


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
AssetLoadingMethod variable and its options were renamed in deadline-cloud library. This change is a downstream effect of that.

### What was the solution? (How)
Rename AssetLoadingMethod and its options to new names 

### What is the impact of this change?
This is a downstream change due to changes in deadline-cloud

### How was this change tested?
By running unit tests

### Was this change documented?
N/A

### Is this a breaking change?
Yes