### PR TITLE
chore(api)!: rename jobsRunAs to jobRunAsUser

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -240,7 +240,7 @@ class PosixUser(TypedDict):
     """The posix group name associated with session file ownership"""
 
 
-class JobsRunAs(TypedDict):
+class JobRunAsUser(TypedDict):
     posix: PosixUser
     # TODO: windows support
 
@@ -249,7 +249,11 @@ class JobDetailsData(JobDetailsIdentifierFields):
     jobAttachmentSettings: NotRequired[JobAttachmentQueueSettings]
     """The queue's job attachment settings"""
 
-    jobsRunAs: NotRequired[JobsRunAs | None]
+    # TODO: remove once service no longer sends this
+    jobsRunAs: NotRequired[JobRunAsUser | None]
+    """Deprecated: The queue's info on how to run the job processes (ie. posix user/group)"""
+
+    jobRunAsUser: NotRequired[JobRunAsUser | None]
     """The queue's info on how to run the job processes (ie. posix user/group)"""
 
     logGroupName: str

--- a/src/deadline_worker_agent/boto/shim.py
+++ b/src/deadline_worker_agent/boto/shim.py
@@ -254,7 +254,14 @@ class DeadlineClient:
                                 "rootPrefix": "my-queue",
                             },
                             "logGroupName": "/aws/deadline/queue-abc",
+                            # TODO: remove once service no longer sends this
                             "jobsRunAs": {
+                                "posix": {
+                                    "user": "",
+                                    "group": "",
+                                }
+                            },
+                            "jobRunAsUser": {
                                 "posix": {
                                     "user": "job-user",
                                     "group": "job-group",

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -704,11 +704,11 @@ class WorkerScheduler:
             logger.debug(f"[{new_session_id}] Assigned actions")
 
             os_user: Optional[SessionUser] = None
-            if job_details.jobs_run_as and not self._impersonation.inactive:
+            if job_details.job_run_as_user and not self._impersonation.inactive:
                 if os.name != "posix":
                     # TODO: windows support
                     raise NotImplementedError(f"{os.name} is not supported")
-                os_user = job_details.jobs_run_as.posix
+                os_user = job_details.job_run_as_user.posix
 
             if self._impersonation.posix_job_user is not None:
                 os_user = self._impersonation.posix_job_user

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -27,7 +27,7 @@ from deadline_worker_agent.api_models import HostProperties, IpAddresses
 from deadline_worker_agent.sessions.job_entities.job_details import (
     JobAttachmentSettings,
     JobDetails,
-    JobsRunAs,
+    JobRunAsUser,
 )
 from deadline_worker_agent.sessions.job_entities.job_attachment_details import (
     JobAttachmentDetails,
@@ -238,12 +238,12 @@ def job_parameters() -> list[Parameter]:
 
 
 @pytest.fixture
-def jobs_run_as() -> JobsRunAs | None:
+def job_run_as_user() -> JobRunAsUser | None:
     """The OS user/group associated with the job's queue"""
     # TODO: windows support
     if os.name != "posix":
         raise NotImplementedError(f"{os.name} is not supported")
-    return JobsRunAs(posix=PosixSessionUser(user="job-user", group="job-user"))
+    return JobRunAsUser(posix=PosixSessionUser(user="job-user", group="job-user"))
 
 
 @pytest.fixture
@@ -257,14 +257,14 @@ def job_details(
     queue_job_attachment_settings: JobAttachmentSettings,
     job_parameters: list[Parameter],
     log_group_name: str,
-    jobs_run_as: JobsRunAs | None,
+    job_run_as_user: JobRunAsUser | None,
     path_mapping_rules: list[PathMappingRule],
     schema_version: SchemaVersion,
 ) -> JobDetails:
     return JobDetails(
         job_attachment_settings=queue_job_attachment_settings,
         parameters=job_parameters,
-        jobs_run_as=jobs_run_as,
+        job_run_as_user=job_run_as_user,
         path_mapping_rules=path_mapping_rules,
         log_group_name=log_group_name,
         schema_version=schema_version,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `jobsRunAs` property in the API is being renamed in the service to `jobRunAsUser`, so the worker agent needs to follow suit.

### What was the solution? (How)

The Worker agent uses the following priority order when reading the serivce response:
1. `jobRunAsUser` if it exists in the api response, otherwise
1. `jobsRunAs`, otherwise
1. `None`

### What is the impact of this change?

Worker Agent works with new API shape.

### How was this change tested?

```
hatch run fmt
hatch run lint
hatch build
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

Yes.