### PR TITLE
feat!: Adds telemetry client calls to worker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
-    "deadline == 0.28.*",
+    "deadline == 0.29.*",
     "openjd-sessions == 0.2.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",

--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -23,7 +23,7 @@ def install() -> None:
 
     arg_parser = get_argument_parser()
     args = arg_parser.parse_args(namespace=ParsedCommandLineArguments)
-    worker_agent_program = Path(sysconfig.get_path("scripts")) / "deadline-worker-agent"
+    scripts_path = Path(sysconfig.get_path("scripts"))
 
     cmd = [
         "sudo",
@@ -36,8 +36,8 @@ def install() -> None:
         args.region,
         "--user",
         args.user,
-        "--worker-agent-program",
-        str(worker_agent_program),
+        "--scripts-path",
+        str(scripts_path),
     ]
     if args.group:
         cmd += ["--group", args.group]
@@ -49,6 +49,8 @@ def install() -> None:
         cmd.append("--allow-shutdown")
     if not args.install_service:
         cmd.append("--no-install-service")
+    if args.telemetry_opt_out:
+        cmd.append("--telemetry-opt-out")
 
     try:
         run(
@@ -72,6 +74,7 @@ class ParsedCommandLineArguments(Namespace):
     service_start: bool
     allow_shutdown: bool
     install_service: bool
+    telemetry_opt_out: bool
 
 
 def get_argument_parser() -> ArgumentParser:  # pragma: no cover
@@ -121,6 +124,11 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
         help="Skips the worker agent systemd service installation",
         action="store_false",
         dest="install_service",
+    )
+    parser.add_argument(
+        "--telemetry-opt-out",
+        help="Opts out of telemetry data collection",
+        action="store_true",
     )
     parser.add_argument(
         "--yes",

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -29,6 +29,12 @@ from ..worker import Worker
 from .bootstrap import bootstrap_worker
 from .capabilities import AmountCapabilityName, AttributeCapabilityName, Capabilities
 from .config import Capabilities, Configuration, ConfigurationError
+from ..aws.deadline import (
+    DeadlineRequestError,
+    delete_worker,
+    update_worker,
+    record_worker_start_event,
+)
 
 __all__ = ["entrypoint"]
 _logger = logging.getLogger(__name__)
@@ -86,6 +92,7 @@ def entrypoint(cli_args: Optional[list[str]] = None) -> None:
         # if customer manually provided the capabilities (to be added in this function)
         # then we default to the customer provided ones
         system_capabilities = detect_system_capabilities()
+        record_worker_start_event(system_capabilities)
         config.capabilities = system_capabilities.merge(config.capabilities)
 
         # Log the configuration

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -73,6 +73,11 @@ def allow_shutdown() -> bool:
 
 
 @pytest.fixture
+def telemetry_opt_out() -> bool:
+    return True
+
+
+@pytest.fixture
 def install_service() -> bool:
     return True
 
@@ -88,6 +93,7 @@ def parsed_args(
     confirmed: bool,
     allow_shutdown: bool,
     install_service: bool,
+    telemetry_opt_out: bool,
 ) -> ParsedCommandLineArguments:
     parsed_args = ParsedCommandLineArguments()
     parsed_args.farm_id = farm_id
@@ -99,6 +105,7 @@ def parsed_args(
     parsed_args.confirmed = confirmed
     parsed_args.allow_shutdown = allow_shutdown
     parsed_args.install_service = install_service
+    parsed_args.telemetry_opt_out = telemetry_opt_out
     return parsed_args
 
 
@@ -131,8 +138,8 @@ def expected_cmd(
         parsed_args.region,
         "--user",
         parsed_args.user,
-        "--worker-agent-program",
-        os.path.join(sysconfig.get_path("scripts"), "deadline-worker-agent"),
+        "--scripts-path",
+        sysconfig.get_path("scripts"),
     ]
     if parsed_args.group is not None:
         expected_cmd.extend(("--group", parsed_args.group))
@@ -142,6 +149,8 @@ def expected_cmd(
         expected_cmd.append("--start")
     if parsed_args.allow_shutdown:
         expected_cmd.append("--allow-shutdown")
+    if parsed_args.telemetry_opt_out:
+        expected_cmd.append("--telemetry-opt-out")
     return expected_cmd
 
 
@@ -216,6 +225,12 @@ class TestInstallRunsCommand:
         params=(True, False),
     )
     def allow_shutdown(self, request: pytest.FixtureRequest) -> bool:
+        return request.param
+
+    @pytest.fixture(
+        params=(True, False),
+    )
+    def telemetry_opt_out(self, request: pytest.FixtureRequest) -> bool:
         return request.param
 
     @pytest.fixture(

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -148,6 +148,12 @@ def block_rich_import() -> Generator[None, None, None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def block_telemetry_client() -> Generator[MagicMock, None, None]:
+    with patch.object(entrypoint_mod, "record_worker_start_event") as telem_mock:
+        yield telem_mock
+
+
 def test_calls_worker_run(
     mock_worker_run: MagicMock,
 ) -> None:


### PR DESCRIPTION
### Note: Depends on https://github.com/casillas2/deadline-cloud/pull/60

### What was the problem/requirement? (What/Why)
We want to gain insights into how our customers use our software.

### What was the solution? (How)
Use the Telemetry Client introduced in the Deadline Cloud Client Library, since it's a requirement for the Worker Agent already. We introduce an installer option to opt out of telemetry collection if customers choose, which calls the client lib to set the config setting.

### What is the impact of this change?
We can now collect simple startup data on Worker machines, so we know what kinds of machines typically get used for worker flows.

Further, the worker installer bash script was updated a bit to refactor the bin directory we search for installed programs, since we need to call the Deadline client lib to set the telemetry opt out option.

### How was this change tested?
- included the changes from https://github.com/casillas2/deadline-cloud/pull/60
- built locally, and confirmed telemetry events were sent to our backend, and ensured none were sent through unit tests
- installed all the packages on a fresh linux EC2 instance, and confirmed that telemetry opt out works as an installer option
```
[ec2-user@ip-172-31-20-107 ~]$ python -m venv /tmp/tmp-env
[ec2-user@ip-172-31-20-107 ~]$ source /tmp/tmp-env/bin/activate
(tmp-env) [ec2-user@ip-172-31-20-107 ~]$ pip install openjd_model-0.1.1-py3-none-any.whl openjd_sessions-0.2.0-py3-none-any.whl deadline-0.28.0.post1+g3f40b9e-py3-none-any.whl deadline_cloud_worker_agent-0.14.1.post4+gcb4fe9f.d20230926-py3-none-any.whl
(tmp-env) [ec2-user@ip-172-31-20-107 ~]$ install-deadline-worker --farm-id $FARM --fleet-id $FLEET --telemetry-opt-out --no-install-service
===========================================================
|      Amazon Deadline Cloud Worker Agent Installer       |
===========================================================

Farm ID: farm-56bc3eb734a24cbf871985aa2221597f
Fleet ID: fleet-3e9ba17545f040cc8d83502b82251242
Region: us-west-2
Worker agent user: deadline-worker-agent
Worker job group: deadline-job-users
Scripts path: /tmp/tmp-env/bin
Worker agent program path: /tmp/tmp-env/bin/deadline-worker-agent
Worker agent program path: /tmp/tmp-env/bin/deadline
Allow worker agent shutdown: no
Start systemd service: no
Telemetry opt-out: yes
Confirm install with the above settings (y/n):y

Worker agent user deadline-worker-agent already exists
Job group deadline-job-users already exists
Worker agent user (deadline-worker-agent) is alread in job group (deadline-job-users)
No prior sudoers shutdown rule at /etc/sudoers.d/deadline-worker-shutdown
Provisioning log directory (/var/log/amazon/deadline)
Done provisioning log directory (/var/log/amazon/deadline)
Provisioning persistence directory (/var/lib/deadline)
Done provisioning persistence directory (/var/lib/deadline)
Provisioning configuration directory (/etc/amazon/deadline)
Done provisioning configuration directory
Configuring farm and fleet
Done configuring farm and fleet
Opting out of telemetry collection
Done
(tmp-env) [ec2-user@ip-172-31-20-107 ~]$ sudo cat /home/deadline-worker-agent/.deadline/config
[telemetry]
opt_out = true
```
### Was this change documented?
N/A

### Is this a breaking change?
Yes, since the installer script interface changed