### PR TITLE
chore: remove shell usage in shutdown subprocess

### DIFF
--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -206,12 +206,12 @@ def _system_shutdown(config: Configuration) -> None:
 
     _logger.info("Shutting down the instance")
 
-    shutdown_command = None
+    shutdown_command: list[str]
 
     if sys.platform == "win32":
-        shutdown_command = "shutdown -s"
+        shutdown_command = ["shutdown", "-s"]
     else:
-        shutdown_command = "sudo shutdown now"
+        shutdown_command = ["sudo", "shutdown", "now"]
 
     if config.no_shutdown:
         _logger.debug(
@@ -227,7 +227,6 @@ def _system_shutdown(config: Configuration) -> None:
         shutdown_command,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        shell=True,
     )
     stdout, _ = process.communicate()
     command_output = stdout.decode("utf-8")

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -419,8 +419,8 @@ def test_system_shutdown_called(
 @pytest.mark.parametrize(
     ("expected_platform", "expected_command"),
     (
-        pytest.param("win32", "shutdown -s", id="windows"),
-        pytest.param("linux", "sudo shutdown now", id="linux"),
+        pytest.param("win32", ["shutdown", "-s"], id="windows"),
+        pytest.param("linux", ["sudo", "shutdown", "now"], id="linux"),
     ),
 )
 @patch.object(entrypoint_mod._logger, "info")
@@ -449,7 +449,6 @@ def test_system_shutdown(
     logger_info_mock.assert_any_call("Shutting down the instance")
     subprocess_popen_mock.assert_called_once_with(
         expected_command,
-        shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
@@ -458,8 +457,8 @@ def test_system_shutdown(
 @pytest.mark.parametrize(
     ("expected_platform", "expected_command"),
     (
-        pytest.param("win32", "shutdown -s", id="windows"),
-        pytest.param("linux", "sudo shutdown now", id="linux"),
+        pytest.param("win32", ["shutdown", "-s"], id="windows"),
+        pytest.param("linux", ["sudo", "shutdown", "now"], id="linux"),
     ),
 )
 @patch.object(entrypoint_mod, "_logger")
@@ -495,7 +494,6 @@ def test_system_shutdown_failure(
     logger_mock.info.assert_any_call("Shutting down the instance")
     subprocess_popen_mock.assert_called_once_with(
         expected_command,
-        shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
@@ -509,8 +507,8 @@ def test_system_shutdown_failure(
 @pytest.mark.parametrize(
     ("expected_platform", "expected_command"),
     (
-        pytest.param("win32", "shutdown -s", id="windows"),
-        pytest.param("linux", "sudo shutdown now", id="linux"),
+        pytest.param("win32", ["shutdown", "-s"], id="windows"),
+        pytest.param("linux", ["sudo", "shutdown", "now"], id="linux"),
     ),
 )
 @patch.object(entrypoint_mod._logger, "debug")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When the worker is instructed in a `UpdateWorkerSchedule` API response to shut down the worker host, it launches a subprocess using the `shell=True` argument to `subprocess.Popen`. While the command is hard-coded and does not use user-supplied input, the worker agent code does not require the use of a shell and we should demonstrate best-practices and prevent any future possibility of unquoted shell command exploit.

### What was the solution? (How)

Switch from using a shell command string and `shell=True` to instead provide a list of strings for the command and `shell=False`.

### What is the impact of this change?

The Worker Agent no longer uses a shell command-string when creating a subprocess for shutting down the host. This helps protect against a future potential regression where untrusted input is used to form the command. It also removes the unnecessary overhead for spawning a shell to run the desired command.

### How was this change tested?

Updated the unit tests which now pass.

### Was this change documented?

No

### Is this a breaking change?

No