### PR TITLE
feat: log session action completion events

### DIFF
--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -997,6 +997,9 @@ class Session:
             # UpdateWorkerSchedule request if so.
             self._current_action = None
 
+        completed_status = OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS.get(
+            action_status.state, None
+        )
         self._report_action_update(
             SessionActionStatus(
                 id=current_action.definition.id,
@@ -1004,10 +1007,15 @@ class Session:
                 start_time=current_action.start_time,
                 end_time=now if action_status.state != ActionState.RUNNING else None,
                 update_time=now if action_status.state == ActionState.RUNNING else None,
-                completed_status=OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS.get(
-                    action_status.state, None
-                ),
+                completed_status=completed_status,
             )
+        )
+        logger.info(
+            "[%s] Action %s: %s completed as %s",
+            self.id,
+            current_action.definition.id,
+            current_action.definition.human_readable(),
+            completed_status,
         )
 
     def _sync_asset_outputs(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Session action completion events were not being logged

### What was the solution? (How)

Added logic for logging session action completion events.

### What is the impact of this change?

All session and session action lifecycle events are now emitted

### How was this change tested?

*   Automated unit tests were added
*   Manual end-to-end testing

### Was this change documented?

No

### Is this a breaking change?

No