### PR TITLE
feat!: session lifecycle log improvements

### DIFF
--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1192,7 +1192,7 @@ class TestSessionActionUpdatedImpl:
 
         # THEN
         mock_mod_logger.info.assert_called_once_with(
-            "[%s] Action %s: %s completed as %s",
+            "[%s] [%s] (%s): Action completed as %s",
             session.id,
             current_action.definition.id,
             current_action.definition.human_readable(),
@@ -1216,7 +1216,7 @@ class TestSessionActionUpdatedImpl:
 
         # THEN
         mock_mod_logger.info.assert_called_once_with(
-            "[%s] Action %s: %s completed as %s",
+            "[%s] [%s] (%s): Action completed as %s",
             session.id,
             current_action.definition.id,
             current_action.definition.human_readable(),
@@ -1240,7 +1240,7 @@ class TestSessionActionUpdatedImpl:
 
         # THEN
         mock_mod_logger.info.assert_called_once_with(
-            "[%s] Action %s: %s completed as %s",
+            "[%s] [%s] (%s): Action completed as %s",
             session.id,
             current_action.definition.id,
             current_action.definition.human_readable(),
@@ -1303,7 +1303,10 @@ class TestStartCancelingCurrentAction:
 
         # THEN
         logger_info.assert_called_once_with(
-            "[%s] Canceling action %s", session.id, current_action.definition.id
+            "[%s] [%s] (%s): Canceling action",
+            session.id,
+            current_action.definition.id,
+            current_action.definition.human_readable(),
         )
 
 
@@ -1627,7 +1630,7 @@ class TestSessionStartAction:
 
         # THEN
         logger_info.assert_called_once_with(
-            "[%s] Running action %s: %s",
+            "[%s] [%s] (%s): Starting action",
             session.id,
             run_step_task_action.id,
             run_step_task_action.human_readable(),
@@ -1651,5 +1654,9 @@ class TestSessionStartAction:
         )
         assert session._current_action is None
         logger_warn.assert_called_once_with(
-            "[%s] Error starting action %s: %s", session.id, run_step_task_action.id, exception
+            "[%s] [%s] (%s): Error starting action: %s",
+            session.id,
+            run_step_task_action.id,
+            run_step_task_action.human_readable(),
+            exception,
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent logs for session lifecycle events was ad-hoc and inconsistent

The previous PR (#49) was intended to include changes that were missed. That PR description has since been edited to reflect the actual changes made.

### What was the solution? (How)

Made the logging message formatting structure consistent. The format for session events is:

```
[<SESSION_ID>] [<SESSIONACTION_ID>] (<SESSIONACTION_HUMAN_READABLE>): <MSG>
```

Where:

*   `<SESSION_ID>` &mdash; The unique identifier for the session
*   `<SESSIONACTION_ID>` &mdash; The unique identifier for the session action
*   `<SESSIONACTION_HUMAN_READABLE>` &mdash; A more human-friendly representation of the session action that denotes the job model entity that the action definition belongs to
*   `<MSG>` &mdash; The event message

An example of the new session log is:

```txt
2023-10-06 05:13:47,039 INFO [deadline_worker_agent.sessions.session] [session-6a7080641d5440c78a5f379b287c2b71]: Session started
2023-10-06 05:13:47,142 INFO [deadline_worker_agent.sessions.session] [session-6a7080641d5440c78a5f379b287c2b71] [sessionaction-6a7080641d5440c78a5f379b287c2b71-0] (environment[STEP:step-e404e034a52846809db3ec250ea82f48:myenv].enter()): Starting action
2023-10-06 05:13:47,150 INFO [deadline_worker_agent.sessions.session] [session-6a7080641d5440c78a5f379b287c2b71] [sessionaction-6a7080641d5440c78a5f379b287c2b71-0] (environment[STEP:step-e404e034a52846809db3ec250ea82f48:myenv].enter()): Action completed as SUCCEEDED
2023-10-06 05:13:47,251 INFO [deadline_worker_agent.sessions.session] [session-6a7080641d5440c78a5f379b287c2b71] [sessionaction-6a7080641d5440c78a5f379b287c2b71-1] (step[step-e404e034a52846809db3ec250ea82f48].run()): Starting action
2023-10-06 05:14:32,379 INFO [deadline_worker_agent.sessions.session] [session-6a7080641d5440c78a5f379b287c2b71] [sessionaction-6a7080641d5440c78a5f379b287c2b71-1] (step[step-e404e034a52846809db3ec250ea82f48].run()): Action completed as SUCCEEDED
2023-10-06 05:14:32,852 INFO [deadline_worker_agent.sessions.session] [session-6a7080641d5440c78a5f379b287c2b71] [sessionaction-6a7080641d5440c78a5f379b287c2b71-2] (environment[STEP:step-e404e034a52846809db3ec250ea82f48:myenv].exit()): Starting action
2023-10-06 05:14:32,861 INFO [deadline_worker_agent.sessions.session] [session-6a7080641d5440c78a5f379b287c2b71] [sessionaction-6a7080641d5440c78a5f379b287c2b71-2] (environment[STEP:step-e404e034a52846809db3ec250ea82f48:myenv].exit()): Action completed as SUCCEEDED
2023-10-06 05:14:33,043 INFO [deadline_worker_agent.sessions.session] [session-6a7080641d5440c78a5f379b287c2b71]: Session complete
```

### What is the impact of this change?

*   Logging is more structured and internally consistent and easy to filter with basic text searches
*   Since identifiers are fixed length, the log messages for session lifecycle events align vertically unless word-wrapping

### How was this change tested?

*   Automated unit tests were added and updated
*   Manual end-to-end testing

### Was this change documented?

No

### Is this a breaking change?

Yes, log formatting has changed