### PR TITLE
chore: misconfiguration in integration canary

### DIFF
--- a/.github/workflows/release_integration_canary.yml
+++ b/.github/workflows/release_integration_canary.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 */1 * * *'
 
 jobs:
-  Release Integration Canary:
+  ReleaseIntegrationCanary:
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: release
-    steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Release integ canary has syntax errors

### What was the solution? (How)
Remove extra step, jobIDs should not have spaces.

### What is the impact of this change?
Fix canary

### How was this change tested?
```
hatch run lint
hatch run test
```

### Was this change documented?
No

### Is this a breaking change?
No