### PR TITLE
chore: add jobRunAsUser integration test

### DIFF
--- a/test/integ/test_job_submissions.py
+++ b/test/integ/test_job_submissions.py
@@ -4,32 +4,110 @@ This test module contains tests that verify the Worker agent's behavior by submi
 Deadline Cloud service and checking that the result/output of the jobs is as we expect it.
 """
 
+import boto3
+import botocore.client
+import botocore.config
+import botocore.exceptions
+import dataclasses
+
 import pytest  # noqa: F401
 
 import logging
 
+from typing import Generator
+
 from deadline_test_fixtures import (
     DeadlineClient,
     DeadlineResources,
+    DeadlineWorkerConfiguration,
     Farm,
+    Fleet,
     Job,
+    PosixUser,
     Queue,
+    QueueFleetAssociation,
     TaskStatus,
 )
 
 LOG = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope="session")
+def farm(deadline_resources: DeadlineResources) -> Farm:
+    return deadline_resources.farm
+
+
+@pytest.fixture(scope="session")
+def queue(deadline_resources: DeadlineResources) -> Queue:
+    return deadline_resources.queue
+
+
+@pytest.fixture(scope="session")
+def fleet(deadline_resources: DeadlineResources) -> Fleet:
+    return deadline_resources.fleet
+
+
+@pytest.fixture(scope="session")
+def job_run_as_user() -> PosixUser:
+    return PosixUser(
+        user="job-run-as-user",
+        group="job-run-as-user-group",
+    )
+
+
+@pytest.fixture(scope="session")
+def worker_config(
+    worker_config: DeadlineWorkerConfiguration,
+    job_run_as_user: PosixUser,
+) -> DeadlineWorkerConfiguration:
+    return dataclasses.replace(
+        worker_config,
+        job_users=[
+            *worker_config.job_users,
+            job_run_as_user,
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def queue_with_job_run_as_user(
+    farm: Farm,
+    fleet: Fleet,
+    deadline_client: DeadlineClient,
+    job_run_as_user: PosixUser,
+) -> Generator[Queue, None, None]:
+    queue = Queue.create(
+        client=deadline_client,
+        display_name=f"Queue with jobsRunAsUser {job_run_as_user.user}",
+        farm=farm,
+        raw_kwargs={
+            "jobRunAsUser": {
+                "posix": {
+                    "user": job_run_as_user.user,
+                    "group": job_run_as_user.group,
+                },
+            },
+        },
+    )
+
+    qfa = QueueFleetAssociation.create(
+        client=deadline_client,
+        farm=farm,
+        queue=queue,
+        fleet=fleet,
+    )
+
+    yield queue
+
+    qfa.delete(
+        client=deadline_client,
+        stop_mode="STOP_SCHEDULING_AND_CANCEL_TASKS",
+    )
+    queue.delete(client=deadline_client)
+
+
 @pytest.mark.usefixtures("worker")
-class TestJobSubmissions:
-    @pytest.fixture
-    def farm(self, deadline_resources: DeadlineResources) -> Farm:
-        return deadline_resources.farm
-
-    @pytest.fixture
-    def queue(self, deadline_resources: DeadlineResources) -> Queue:
-        return deadline_resources.queue
-
+class TestJobSubmission:
     def test_success(
         self,
         deadline_client: DeadlineClient,
@@ -59,4 +137,67 @@ class TestJobSubmissions:
         job.wait_until_complete(client=deadline_client)
         LOG.info(f"Job result: {job}")
 
+        assert job.task_run_status == TaskStatus.SUCCEEDED
+
+    def test_jobs_run_as_user(
+        self,
+        deadline_client: DeadlineClient,
+        farm: Farm,
+        queue_with_job_run_as_user: Queue,
+        job_run_as_user: PosixUser,
+    ) -> None:
+        # WHEN
+        job = Job.submit(
+            client=deadline_client,
+            farm=farm,
+            queue=queue_with_job_run_as_user,
+            priority=98,
+            template={
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": "whoami",
+                "steps": [
+                    {
+                        "name": "Step0",
+                        "script": {
+                            "embeddedFiles": [
+                                {
+                                    "name": "whoami",
+                                    "type": "TEXT",
+                                    "runnable": True,
+                                    "data": "\n".join(
+                                        [
+                                            "#!/bin/bash",
+                                            'echo "I am: $(whoami)"',
+                                        ]
+                                    ),
+                                },
+                            ],
+                            "actions": {
+                                "onRun": {
+                                    "command": "{{ Task.File.whoami }}",
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+        )
+
+        # THEN
+        job.wait_until_complete(client=deadline_client)
+
+        # Retrieve job output and verify whoami printed the queue's jobsRunAsUser
+        job_logs = job.get_logs(
+            deadline_client=deadline_client,
+            logs_client=boto3.client(
+                "logs",
+                config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+            ),
+        )
+        full_log = "\n".join(
+            [le.message for _, log_events in job_logs.logs.items() for le in log_events]
+        )
+        assert (
+            f"I am: {job_run_as_user.user}" in full_log
+        ), f"Expected message not found in Job logs. Logs are in CloudWatch log group: {job_logs.log_group_name}"
         assert job.task_run_status == TaskStatus.SUCCEEDED


### PR DESCRIPTION
### Depends on
https://github.com/casillas2/deadline-cloud-test-fixtures/pull/25

### What was the problem/requirement? (What/Why)
We need an integration test verifying the worker respects the `jobRunAsUser` option on queues

### What was the solution? (How)
Add integ test for above

### What is the impact of this change?
We have an integ test for above

### How was this change tested?
Ran the integ test and verified it succeeded (logs below)

### Was this change documented?
No

### Is this a breaking change?
No


### Test logs

#### Test runner logs
```
------------------------------------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------------------------------------
[2023-10-12 18:07:07,035] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] About to call API (Create job in farm farm-09b495690b6049f1b4efde628b935087 and queue queue-f3ca44f264474c5cb01453a46122da8f)
[2023-10-12 18:07:07,512] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] API call succeeded (Create job in farm farm-09b495690b6049f1b4efde628b935087 and queue queue-f3ca44f264474c5cb01453a46122da8f)
[2023-10-12 18:07:07,512] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] Created job: job-ff10e9bb69004d6d928bc9d27278c2b8
[2023-10-12 18:07:07,512] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] About to call API (Fetching job details for job job-ff10e9bb69004d6d928bc9d27278c2b8)
[2023-10-12 18:07:07,618] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] API call succeeded (Fetching job details for job job-ff10e9bb69004d6d928bc9d27278c2b8)
[2023-10-12 18:07:07,618] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] Waiting for job job-ff10e9bb69004d6d928bc9d27278c2b8 to complete
[2023-10-12 18:07:07,619] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] About to call API (Fetching job details for job job-ff10e9bb69004d6d928bc9d27278c2b8)
[2023-10-12 18:07:07,735] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] API call succeeded (Fetching job details for job job-ff10e9bb69004d6d928bc9d27278c2b8)
[2023-10-12 18:07:07,736] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] Job job-ff10e9bb69004d6d928bc9d27278c2b8 not complete
[2023-10-12 18:07:07,736] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] Retrying in 10s...
[2023-10-12 18:07:17,746] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] About to call API (Fetching job details for job job-ff10e9bb69004d6d928bc9d27278c2b8)
[2023-10-12 18:07:17,871] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] API call succeeded (Fetching job details for job job-ff10e9bb69004d6d928bc9d27278c2b8)
[2023-10-12 18:07:17,871] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] Job job-ff10e9bb69004d6d928bc9d27278c2b8 not complete
[2023-10-12 18:07:17,871] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] Retrying in 10s...
[2023-10-12 18:07:27,881] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] About to call API (Fetching job details for job job-ff10e9bb69004d6d928bc9d27278c2b8)
[2023-10-12 18:07:28,005] [test/integ/test_job_submissions.py::TestJobSubmission::test_jobs_run_as_user] API call succeeded (Fetching job details for job job-ff10e9bb69004d6d928bc9d27278c2b8)
PASSED                                                                                                                                        [100%]
```

#### Session logs

```
Session running with no AWS Credentials.
--
Starting Task onRun Action at 2023-10-12T18:07:20Z
Writing embedded files for Task to disk.
Mapping: Task.File.whoami -> /tmp/openjd/session-603e61dc3f464a11ba218467495b65bd_ykgntp5/embedded_fileszrmcosij/tmp09e6vk3s
Wrote: whoami -> /tmp/openjd/session-603e61dc3f464a11ba218467495b65bd_ykgntp5/embedded_fileszrmcosij/tmp09e6vk3s
Wrote the following script to /tmp/openjd/session-603e61dc3f464a11ba218467495b65bd_ykgntp5/tmppupfiij9.sh:#!/bin/sh_term() {  echo 'Caught SIGTERM'  test "${CHILD_PID:-}" != "" && echo "Sending SIGTERM to ${CHILD_PID}" && kill -s TERM "${CHILD_PID}"  wait "${CHILD_PID}"  exit $?}trap _term TERMcd '/tmp/openjd/session-603e61dc3f464a11ba218467495b65bd_ykgntp5'/tmp/openjd/session-603e61dc3f464a11ba218467495b65bd_ykgntp5/embedded_fileszrmcosij/tmp09e6vk3s &CHILD_PID=$!wait "$CHILD_PID"exit $?
Running command sudo -u job-run-as-user -i setsid -w /tmp/openjd/session-603e61dc3f464a11ba218467495b65bd_ykgntp5/tmppupfiij9.sh
Command started as pid: 2454
I am: job-run-as-user
Running command sudo -u job-run-as-user -i setsid -w rm -rf '/tmp/openjd/session-603e61dc3f464a11ba218467495b65bd_ykgntp5/*'
Command started as pid: 2478
```

#### Worker agent logs

```
Synchronizing with service (sending UpdateWorkerSchedule)
--
{'log_type': 'boto_request', 'operation': 'deadline.BatchGetJobEntity', 'params': {}, 'request_url': 'https://scheduling.beta.bealine-dev.us-west-2.amazonaws.com/2023-10-12/farms/farm-09b495690b6049f1b4efde628b935087/fleets/fleet-0a7448a303a14adbbefb60e5dc228340/workers/worker-25bcfb20da3f4b4b83675d309ace98fc/batchGetJobEntity'}
{'log_type': 'boto_response', 'operation': 'deadline.BatchGetJobEntity', 'status_code': 200, 'params': {}}
Fetched jobDetails(job-ff10e9bb69004d6d928bc9d27278c2b8)
Enqueued new action: {'sessionActionId': 'sessionaction-603e61dc3f464a11ba218467495b65bd-0', 'actionType': 'TASK_RUN', 'taskId': 'task-42107de274dd49edb537cc5bd1b21570-0', 'stepId': 'step-42107de274dd49edb537cc5bd1b21570'}
Job has no Queue Role. Not obtaining AWS Credentials for the Session.
Done synchronizing with service
[session-603e61dc3f464a11ba218467495b65bd] logs streamed to CloudWatch target: /aws/deadline/farm-09b495690b6049f1b4efde628b935087/queue-f3ca44f264474c5cb01453a46122da8f/session-603e61dc3f464a11ba218467495b65bd
[session-603e61dc3f464a11ba218467495b65bd] local logs target: /var/log/amazon/deadline/queue-f3ca44f264474c5cb01453a46122da8f/session-603e61dc3f464a11ba218467495b65bd.log
Warming Job Entity Cache
{'log_type': 'boto_request', 'operation': 'deadline.BatchGetJobEntity', 'params': {}, 'request_url': 'https://scheduling.beta.bealine-dev.us-west-2.amazonaws.com/2023-10-12/farms/farm-09b495690b6049f1b4efde628b935087/fleets/fleet-0a7448a303a14adbbefb60e5dc228340/workers/worker-25bcfb20da3f4b4b83675d309ace98fc/batchGetJobEntity'}
{'log_type': 'boto_response', 'operation': 'deadline.BatchGetJobEntity', 'status_code': 200, 'params': {}}
Fetched stepDetails(step-42107de274dd49edb537cc5bd1b21570)
Fully warmed Job Entity Cache
[session-603e61dc3f464a11ba218467495b65bd]: Session started
[session-603e61dc3f464a11ba218467495b65bd] [sessionaction-603e61dc3f464a11ba218467495b65bd-0] (step[step-42107de274dd49edb537cc5bd1b21570].run()): Starting action
[session-603e61dc3f464a11ba218467495b65bd] [sessionaction-603e61dc3f464a11ba218467495b65bd-0] (step[step-42107de274dd49edb537cc5bd1b21570].run()): Action completed as SUCCEEDED
Synchronizing with service (sending UpdateWorkerSchedule)
Updating actions: {'sessionaction-603e61dc3f464a11ba218467495b65bd-0': {'startedAt': datetime.datetime(2023, 10, 12, 18, 7, 20, 699589, tzinfo=datetime.timezone.utc), 'completedStatus': 'SUCCEEDED', 'processExitCode': 0, 'endedAt': datetime.datetime(2023, 10, 12, 18, 7, 20, 905813, tzinfo=datetime.timezone.utc)}}
[session-603e61dc3f464a11ba218467495b65bd]: Session complete
Cleaning up remaining session user processes for 'job-run-as-user'
No processes stopped because none were found running as 'job-run-as-user'
Done synchronizing with service
```