### PR TITLE
feat(install): Adding vfs install path to install parameters

### DIFF
--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -13,8 +13,6 @@ INSTALLER_PATH = {
     "linux": Path(__file__).parent / "install.sh",
 }
 
-VFS_DEFAULT_INSTALL_PATH = "/opt/deadline_vfs"
-
 
 def install() -> None:
     """Installer entrypoint for the Amazon Deadline Cloud Worker Agent"""
@@ -40,9 +38,9 @@ def install() -> None:
         args.user,
         "--scripts-path",
         str(scripts_path),
-        "--vfs-install-path",
-        args.vfs_install_path,
     ]
+    if args.vfs_install_path:
+        cmd += ["--vfs-install-path", args.vfs_install_path]
     if args.group:
         cmd += ["--group", args.group]
     if args.confirmed:
@@ -145,7 +143,6 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
     parser.add_argument(
         "--vfs-install-path",
         help="Absolute path for the install location of the deadline vfs.",
-        default=VFS_DEFAULT_INSTALL_PATH,
     )
 
     return parser

--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -13,6 +13,8 @@ INSTALLER_PATH = {
     "linux": Path(__file__).parent / "install.sh",
 }
 
+VFS_DEFAULT_INSTALL_PATH = "/opt/fus3"
+
 
 def install() -> None:
     """Installer entrypoint for the Amazon Deadline Cloud Worker Agent"""
@@ -38,6 +40,8 @@ def install() -> None:
         args.user,
         "--scripts-path",
         str(scripts_path),
+        "--vfs-install-path",
+        args.vfs_install_path,
     ]
     if args.group:
         cmd += ["--group", args.group]
@@ -75,6 +79,7 @@ class ParsedCommandLineArguments(Namespace):
     allow_shutdown: bool
     install_service: bool
     telemetry_opt_out: bool
+    vfs_install_path: str
 
 
 def get_argument_parser() -> ArgumentParser:  # pragma: no cover
@@ -136,6 +141,11 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
         help="Confirms the installation and skips the interactive confirmation prompt.",
         action="store_true",
         dest="confirmed",
+    )
+    parser.add_argument(
+        "--vfs-install-path",
+        help="Absolute path for the install location of the deadline vfs.",
+        default=VFS_DEFAULT_INSTALL_PATH,
     )
 
     return parser

--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -13,7 +13,7 @@ INSTALLER_PATH = {
     "linux": Path(__file__).parent / "install.sh",
 }
 
-VFS_DEFAULT_INSTALL_PATH = "/opt/fus3"
+VFS_DEFAULT_INSTALL_PATH = "/opt/deadline_vfs"
 
 
 def install() -> None:

--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -53,7 +53,7 @@ usage()
     echo "                  [--region REGION] [--user USER]"
     echo "                  [--scripts-path SCRIPTS_PATH]"
     echo "                  [-y]"
-    echo "                  [--vfs_install_path VFS_INSTALL_PATH]"
+    echo "                  [--vfs-install-path VFS_INSTALL_PATH]"
     echo ""
     echo "Arguments"
     echo "---------"

--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -89,7 +89,7 @@ usage()
     echo "        Skips a confirmation prompt before performing the installation."
     echo "    --vfs-install-path VFS_INSTALL_PATH"
     echo "        An optional, absolute path to the directory that the Deadline Virtual File System (VFS) is"
-    echo "        installed. If it is not specified, the default path /opt/fus3 is used"
+    echo "        installed. If it is not specified, the default path /opt/deadline_vfs is used"
 
     exit 2
 }
@@ -213,7 +213,7 @@ if [[ ! -z "${job_group}" ]] && [[ ! "${job_group}" =~ ^[a-z_]([a-z0-9_-]{0,31}|
 fi
 
 if [[ "${vfs_install_path}" == "unset" ]]; then
-    vfs_install_path="/opt/fus3"
+    vfs_install_path="/opt/deadline_vfs"
 elif [[ ! -d "${vfs_install_path}" ]]; then
     echo "ERROR: The specified vfs install path is not found: \"${vfs_install_path}\""
     usage
@@ -221,12 +221,8 @@ else
     set +e
     deadline_vfs_executable="${vfs_install_path}"/bin/deadline_vfs
     if [[ ! -f "${deadline_vfs_executable}" ]]; then
-        echo "Deadline vfs not found at \"${deadline_vfs_executable}\", using fus3 fallback."
-        fus3_executable="${vfs_install_path}"/bin/fus3
-        if [[ ! -f "${fus3_executable}" ]]; then
-            echo "ERROR: Could not find deadline vfs at install path \"${deadline_vfs_executable}\""
-            exit 1
-        fi
+        echo "ERROR: Deadline vfs not found at \"${deadline_vfs_executable}\"."
+        exit 1
     fi
     set -e
 fi
@@ -382,7 +378,7 @@ Description=Amazon Deadline Cloud Worker Agent
 [Service]
 User=${wa_user}
 WorkingDirectory=${worker_agent_homedir}
-Environment=AWS_REGION=$region AWS_DEFAULT_REGION=$region FUS3_PATH=$vfs_install_path
+Environment=AWS_REGION=$region AWS_DEFAULT_REGION=$region FUS3_PATH=$vfs_install_path DEADLINE_VFS_PATH=$vfs_install_path
 ExecStart=$worker_agent_program
 Restart=on-failure
 

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -10,7 +10,11 @@ import sysconfig
 
 import pytest
 
-from deadline_worker_agent.installer import ParsedCommandLineArguments, install
+from deadline_worker_agent.installer import (
+    ParsedCommandLineArguments,
+    install,
+    VFS_DEFAULT_INSTALL_PATH,
+)
 from deadline_worker_agent import installer as installer_mod
 
 
@@ -83,6 +87,11 @@ def install_service() -> bool:
 
 
 @pytest.fixture
+def vfs_install_path() -> str:
+    return VFS_DEFAULT_INSTALL_PATH
+
+
+@pytest.fixture
 def parsed_args(
     farm_id: str,
     fleet_id: str,
@@ -94,6 +103,7 @@ def parsed_args(
     allow_shutdown: bool,
     install_service: bool,
     telemetry_opt_out: bool,
+    vfs_install_path: str,
 ) -> ParsedCommandLineArguments:
     parsed_args = ParsedCommandLineArguments()
     parsed_args.farm_id = farm_id
@@ -106,6 +116,7 @@ def parsed_args(
     parsed_args.allow_shutdown = allow_shutdown
     parsed_args.install_service = install_service
     parsed_args.telemetry_opt_out = telemetry_opt_out
+    parsed_args.vfs_install_path = vfs_install_path
     return parsed_args
 
 
@@ -140,6 +151,8 @@ def expected_cmd(
         parsed_args.user,
         "--scripts-path",
         sysconfig.get_path("scripts"),
+        "--vfs-install-path",
+        parsed_args.vfs_install_path,
     ]
     if parsed_args.group is not None:
         expected_cmd.extend(("--group", parsed_args.group))

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -13,9 +13,11 @@ import pytest
 from deadline_worker_agent.installer import (
     ParsedCommandLineArguments,
     install,
-    VFS_DEFAULT_INSTALL_PATH,
 )
 from deadline_worker_agent import installer as installer_mod
+
+
+VFS_DEFAULT_INSTALL_PATH = "/opt/deadline_vfs"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When launching the worker agent moved to systemd being spun up in the user data of the EC2 launch template, the FUS3_PATH environment variable in the profile.d file was no longer being exported. This resulted in deadline-cloud being unable to locate the VFS executable causing it to use the fallback loading method.

### What was the solution? (How)
Add a `--vfs-install-path` argument to the install method which is then added to the env section of the systemd process definition. This will be set by the AMI builder so it can match the install location of the Fus3 package.

### What is the impact of this change?
Deadline VFS install location will now be properly exported when the worker agent is started. Logging will be added to the deadline worker to make it more obvious next time the install location isn't available via the expected environment variable.
https://github.com/casillas2/deadline-cloud/pull/75

### How was this change tested?
* hatch run test
* Created a CMF using the deadline worker AMI, used the install script to install the deadline-worker service on said ami, launch the systemd service through the user data in Ec2 launch template user data section, and then confirmed through the cloudwatch logs that the VFS install location was found using the environment variable set in the service environment variables.

### Was this change documented?
No

### Is this a breaking change?
No