### PR TITLE
chore(deps): upgrade deadline-cloud version to 0.31.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
-    "deadline == 0.30.*",
+    "deadline == 0.31.*",
     "openjd-sessions == 0.2.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The dependency version for `deadline-cloud` is outdated.

### What was the solution? (How)
Updated `deadline-cloud` version to `0.31.*`

### What is the impact of this change?
N/A

### How was this change tested?
- `hatch run lint && hatch run test`
- End-to-end test have been conducted in this PR#82 https://github.com/casillas2/deadline-cloud/pull/82 with worker agent upgraded to deadline-cloud 0.31.*.

### Was this change documented?
No

### Is this a breaking change?
No