### PR TITLE
chore: update deadline-cloud dep to 0.31.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
-    "deadline == 0.30.*",
+    "deadline == 0.31.*",
     "openjd-sessions == 0.2.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The deadline-cloud dep is out of date.

### What was the solution? (How)

Update it to 0.31.*

### What is the impact of this change?

The worker agent uses the latest dependency.

### How was this change tested?

Running the tests.

### Was this change documented?

No

### Is this a breaking change?

No