### PR TITLE
chore: mock host metrics logger in worker tests

### DIFF
--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -57,21 +57,22 @@ def worker(
     # before we instantiate the Worker instance within this fixture body
     mock_scheduler_cls: MagicMock,
 ) -> Worker:
-    return Worker(
-        farm_id=farm_id,
-        deadline_client=client,
-        boto_session=boto_session,
-        fleet_id=fleet_id,
-        impersonation=impersonation,
-        logs_client=logs_client,
-        s3_client=s3_client,
-        worker_id=worker_id,
-        cleanup_session_user_processes=True,
-        worker_persistence_dir=Path("/var/lib/deadline"),
-        worker_logs_dir=worker_logs_dir,
-        host_metrics_logging=True,
-        host_metrics_logging_interval_seconds=60,
-    )
+    with patch.object(worker_mod, "HostMetricsLogger"):
+        return Worker(
+            farm_id=farm_id,
+            deadline_client=client,
+            boto_session=boto_session,
+            fleet_id=fleet_id,
+            impersonation=impersonation,
+            logs_client=logs_client,
+            s3_client=s3_client,
+            worker_id=worker_id,
+            cleanup_session_user_processes=True,
+            worker_persistence_dir=Path("/var/lib/deadline"),
+            worker_logs_dir=worker_logs_dir,
+            host_metrics_logging=True,
+            host_metrics_logging_interval_seconds=60,
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Unit tests are sometimes failing due to what we think is a race condition when the HostMetricsLogger is trying to use `psutil` to read host metrics. e.g. https://github.com/casillas2/deadline-cloud-worker-agent/actions/runs/6578725719/job/17874191532

### What was the solution? (How)
Mock the HostMetricsLogger in the worker tests

### What is the impact of this change?
Removes potential for race condition above

### How was this change tested?
N/A

### Was this change documented?
No

### Is this a breaking change?
No