### PR TITLE
fix: handle CONCURRENT_MODIFICATION conflict from UpdateWorkerSchedule

### DIFF
--- a/docs/worker_api_contract.md
+++ b/docs/worker_api_contract.md
@@ -142,6 +142,8 @@ Workflow before proceeding.
         [Worker Agent Startup](#worker-agent-startup-workflow) Workflow. The Worker is no longer
         in the STARTED status; this is likely due to failing to successfully call this API for an
         extended period of time.
+        * `reason` is `CONURRENT_MODIFICATION` -> Perform exponential backoff, and then retry.
+        * Any other -> Unrecoverable error. Abort. Exit the application.
     * Response: AccessDeniedException(403) -> Abort. Exit the application. The IAM Role on the
     Fleet lacks the required permissions.
     * Response: ResourceNotFoundException(404) -> Abort; the Worker has been deleted from the service.

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -762,6 +762,9 @@ def update_worker_schedule(
                         raise DeadlineRequestWorkerOfflineError(e)
                     # If anything else is in STATUS_CONFLICT, then we can't recover.
                     raise DeadlineRequestUnrecoverableError(e)
+                elif exception_reason == "CONCURRENT_MODIFICATION":
+                    # Something else modified the Worker at the same time. Just retry.
+                    _logger.info(f"UpdateWorkerSchedule conflict. Retrying in {delay} seconds...")
                 else:
                     # Unknown exception_reason. Treat as unrecoverable
                     raise DeadlineRequestUnrecoverableError(e) from None

--- a/test/unit/aws/deadline/test_update_worker_schedule.py
+++ b/test/unit/aws/deadline/test_update_worker_schedule.py
@@ -115,6 +115,17 @@ def test_can_interrupt(
     [
         pytest.param(
             ClientError(
+                {
+                    "Error": {"Code": "ConflictException", "Message": "A message"},
+                    "reason": "CONCURRENT_MODIFICATION",
+                },
+                "UpdateWorkerSchedule",
+            ),
+            None,
+            id="ConcurrentMod",
+        ),
+        pytest.param(
+            ClientError(
                 {"Error": {"Code": "ThrottlingException", "Message": "A message"}},
                 "UpdateWorkerSchedule",
             ),
@@ -128,6 +139,18 @@ def test_can_interrupt(
             ),
             None,
             id="InternalServer",
+        ),
+        pytest.param(
+            ClientError(
+                {
+                    "Error": {"Code": "ConflictException", "Message": "A message"},
+                    "reason": "CONCURRENT_MODIFICATION",
+                    "retryAfterSeconds": 30,
+                },
+                "UpdateWorkerSchedule",
+            ),
+            30,
+            id="ConcurrentMod-minretry",
         ),
         pytest.param(
             ClientError(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

 When calling UpdateWorkerSchedule returns a ConflictException with the
"CONCURRENT_MODIFICATION" reason code we should be doing a backoff & retry, since this is an indication of a race between clients. We're currently just bailing on the application if we get the error.

### What was the solution? (How)

 Add "CONCURRENT_MODIFICATION" as a backoff-retry case to the API
contract, and handle it in code.

### What is the impact of this change?

Better edge-case handling, and a lower probability of an agent shutting down when it shouldn't.

### How was this change tested?

Just through the unit tests.

### Was this change documented?

Yes, in the document for the worker api contract as part of this PR.

### Is this a breaking change?

Nope; just better error handling.