### PR TITLE
fix: HostMetricsLogger causing test failures

### DIFF
--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -87,7 +87,7 @@ class Worker:
         worker_persistence_dir: Path,
         worker_logs_dir: Path | None,
         host_metrics_logging: bool,
-        host_metrics_logging_interval_seconds: float | None,
+        host_metrics_logging_interval_seconds: float | None = None,
     ) -> None:
         self._deadline_client = deadline_client
         self._s3_client = s3_client

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -56,9 +56,9 @@ def worker(
     # This is unused, but declaring it as a dependency fixture ensures we mock the scheduler class
     # before we instantiate the Worker instance within this fixture body
     mock_scheduler_cls: MagicMock,
-) -> Worker:
+) -> Generator[Worker, None, None]:
     with patch.object(worker_mod, "HostMetricsLogger"):
-        return Worker(
+        yield Worker(
             farm_id=farm_id,
             deadline_client=client,
             boto_session=boto_session,
@@ -70,8 +70,7 @@ def worker(
             cleanup_session_user_processes=True,
             worker_persistence_dir=Path("/var/lib/deadline"),
             worker_logs_dir=worker_logs_dir,
-            host_metrics_logging=True,
-            host_metrics_logging_interval_seconds=60,
+            host_metrics_logging=False,
         )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The unit tests in deadline-cloud-worker-agent repository can sometimes fail due to a race condition introduced in my PR that added host metrics logging: https://github.com/casillas2/deadline-cloud-worker-agent/pull/45

Sometimes, psutil.virtual_memory() will raise a KeyError complaining about missing "MemTotal" key

I attempted to fix this in [this PR](https://github.com/casillas2/deadline-cloud-worker-agent/pull/64), however that was insufficient.

### What was the solution? (How)
- Fix mock in `test_metrics.py::TestHostMetricsLogger.test_enter`  so that it mocks `HostMetricsLogger.log_metrics` (which uses `psutil`) instead of just the `HostMetricsLogger._set_timer` method
- Mocked psutil in all tests in `test_metrics.py` to prevent psutil from actually being called
- Improve/fix mock in `test_worker.py` so that the mock stays in effect for the duration of the test

### What is the impact of this change?
Unit test should not fail due to above error anymore

### How was this change tested?
Ran the tests and it didn't fail. I will keep them running until ~100 successful runs before considering this bug as fixed (this PR can still be merged though, currently at 30 successful runs as of 4:27PM central time)

### Was this change documented?
No

### Is this a breaking change?
No