### PR TITLE
fix: use NEVER_ATTEMPTED after session action failures

### DIFF
--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -926,8 +926,8 @@ class TestSessionActionUpdatedImpl:
         mock_report_action_update: MagicMock,
     ) -> None:
         """Tests that if a environment enter action fails (the Open Job Description action), that the action
-        failure is returned, and that any pending actions other than ENV_EXITS are marked as FAILED
-        with a message that explains that the env enter action failed."""
+        failure is returned, and that any pending actions other than ENV_EXITS are marked as
+        NEVER_ATTEMPTED with a message that explains that the env enter action failed."""
         # GIVEN
         job_env_id = "job_env_id"
         current_action = CurrentAction(
@@ -972,7 +972,7 @@ class TestSessionActionUpdatedImpl:
         # THEN
         mock_report_action_update.assert_called_once_with(expected_action_update)
         queue_cancel_all.assert_called_once_with(
-            cancel_outcome="FAILED",
+            cancel_outcome="NEVER_ATTEMPTED",
             message=expected_next_action_message,
             ignore_env_exits=True,
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Worker Agent makes API requests to `UpdateWorkerSchedule` with session actions marked as `FAILED` if they followed a non-successful action. This is violating the Worker protocol, notably:

1.  [Service-Initiated Session Action Cancelation](https://github.com/casillas2/deadline-cloud-worker-agent/blob/95c7748c9c43638a6ea8b461e3b7886c72b6464c/docs/worker_api_contract.md#service-initiated-session-action-cancelation)
2. [Handling Unsuccessful syncInputJobAttachments or taskRun Session Actions](https://github.com/casillas2/deadline-cloud-worker-agent/blob/95c7748c9c43638a6ea8b461e3b7886c72b6464c/docs/worker_api_contract.md#handling-unsuccessful-syncinputjobattachments-or-taskrun-session-actions)
3. [Handling Unsuccessful envEnter Session Actions](https://github.com/casillas2/deadline-cloud-worker-agent/blob/95c7748c9c43638a6ea8b461e3b7886c72b6464c/docs/worker_api_contract.md#handling-unsuccessful-enventer-session-actions)

Instead, the worker should be completing the actions as `NEVER_ATTEMPTED`.

### What was the solution? (How)

Modify the code and tests to follow the correct behavior described in the Worker protocol linked above.

### What is the impact of this change?

The Worker Agent follows the worker protocol and session actions are marked with the semantically correct `completedStatus` in the `UpdateWorkerSchedule` API.

### How was this change tested?

1.  The unit tests were updated and pass
2. Ran end-to-end job submissions and processing on the worker for cancelation via the service APIs and failure in the session start. The following logs show the correct behavior:

#### Session Cancelation

```
2023-10-27 19:03:31,163 INFO [deadline_worker_agent.scheduler] Synchronizing with service (sending UpdateWorkerSchedule)
2023-10-27 19:03:31,165 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-2cb1e5bbfe354bdc93f488e609340006-6': {'startedAt': datetime.datetime(2023, 10, 27, 19, 3, 15, 640969, tzinfo=datetime.timezone.utc), 'completedStatus': 'SUCCEEDED', 'processExitCode': 0, 'endedAt': datetime.datetime(2023, 10, 27, 19, 3, 25, 681700, tzinfo=datetime.timezone.utc)}, 'sessionaction-2cb1e5bbfe354bdc93f488e609340006-7': {'startedAt': datetime.datetime(2023, 10, 27, 19, 3, 25, 759866, tzinfo=datetime.timezone.utc), 'updateTime': datetime.datetime(2023, 10, 27, 19, 3, 25, 766762, tzinfo=datetime.timezone.utc)}}
2023-10-27 19:03:31,609 INFO [deadline_worker_agent.sessions.session] [session-2cb1e5bbfe354bdc93f488e609340006] [sessionaction-2cb1e5bbfe354bdc93f488e609340006-7] (step[step-444c72b7c7d241e9b691c456abb73f84].run(iteration='7')): Canceling action
2023-10-27 19:03:31,616 INFO [deadline_worker_agent.scheduler.session_queue] Enqueued new action: {'sessionActionId': 'sessionaction-2cb1e5bbfe354bdc93f488e609340006-11', 'actionType': 'ENV_EXIT', 'environmentId': 'STEP:step-444c72b7c7d241e9b691c456abb73f84:myenv'}
2023-10-27 19:03:31,618 INFO [deadline_worker_agent.scheduler] Done synchronizing with service
2023-10-27 19:03:35,800 INFO [deadline_worker_agent.scheduler.session_queue] Canceled sessionaction-2cb1e5bbfe354bdc93f488e609340006-8 as NEVER_ATTEMPTED
2023-10-27 19:03:35,802 INFO [deadline_worker_agent.scheduler.session_queue] Canceled sessionaction-2cb1e5bbfe354bdc93f488e609340006-9 as NEVER_ATTEMPTED
2023-10-27 19:03:35,803 INFO [deadline_worker_agent.scheduler.session_queue] Canceled sessionaction-2cb1e5bbfe354bdc93f488e609340006-10 as NEVER_ATTEMPTED
2023-10-27 19:03:35,804 INFO [deadline_worker_agent.sessions.session] [session-2cb1e5bbfe354bdc93f488e609340006] [sessionaction-2cb1e5bbfe354bdc93f488e609340006-7] (step[step-444c72b7c7d241e9b691c456abb73f84].run(iteration='7')): Action completed as CANCELED
2023-10-27 19:03:35,877 INFO [deadline_worker_agent.sessions.session] [session-2cb1e5bbfe354bdc93f488e609340006] [sessionaction-2cb1e5bbfe354bdc93f488e609340006-11] (environment[STEP:step-444c72b7c7d241e9b691c456abb73f84:myenv].exit()): Starting action
2023-10-27 19:03:35,885 INFO [deadline_worker_agent.sessions.session] [session-2cb1e5bbfe354bdc93f488e609340006] [sessionaction-2cb1e5bbfe354bdc93f488e609340006-11] (environment[STEP:step-444c72b7c7d241e9b691c456abb73f84:myenv].exit()): Action completed as SUCCEEDED
2023-10-27 19:03:35,886 INFO [deadline_worker_agent.scheduler] Synchronizing with service (sending UpdateWorkerSchedule)
2023-10-27 19:03:35,889 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-2cb1e5bbfe354bdc93f488e609340006-8': {'completedStatus': 'NEVER_ATTEMPTED', 'progressMessage': "Action step[step-444c72b7c7d241e9b691c456abb73f84].run(iteration='7') failed"}, 'sessionaction-2cb1e5bbfe354bdc93f488e609340006-9': {'completedStatus': 'NEVER_ATTEMPTED', 'progressMessage': "Action step[step-444c72b7c7d241e9b691c456abb73f84].run(iteration='7') failed"}, 'sessionaction-2cb1e5bbfe354bdc93f488e609340006-10': {'completedStatus': 'NEVER_ATTEMPTED', 'progressMessage': "Action step[step-444c72b7c7d241e9b691c456abb73f84].run(iteration='7') failed"}, 'sessionaction-2cb1e5bbfe354bdc93f488e609340006-7': {'startedAt': datetime.datetime(2023, 10, 27, 19, 3, 25, 759866, tzinfo=datetime.timezone.utc), 'completedStatus': 'CANCELED', 'processExitCode': 0, 'endedAt': datetime.datetime(2023, 10, 27, 19, 3, 35, 800294, tzinfo=datetime.timezone.utc)}, 'sessionaction-2cb1e5bbfe354bdc93f488e609340006-11': {'startedAt': datetime.datetime(2023, 10, 27, 19, 3, 35, 877449, tzinfo=datetime.timezone.utc), 'completedStatus': 'SUCCEEDED', 'processExitCode': 0, 'endedAt': datetime.datetime(2023, 10, 27, 19, 3, 35, 885222, tzinfo=datetime.timezone.utc)}}
2023-10-27 19:03:36,171 INFO [deadline_worker_agent.sessions.session] [session-2cb1e5bbfe354bdc93f488e609340006]: Session complete
```

#### Session Startup Failure

```
2023-10-27 18:53:27,565 INFO [deadline_worker_agent.scheduler] Synchronizing with service (sending UpdateWorkerSchedule)
2023-10-27 18:53:28,132 INFO [deadline_worker_agent.session_events] {'log_type': 'boto_request', 'operation': 'deadline.BatchGetJobEntity', 'params': {}, 'request_url': 'https://dfyn8if2i8.execute-api.us-west-2.amazonaws.com/2023-10-12/farms/farm-ae7057c74a7f489d9d0debeec6b715a5/fleets/fleet-36974f60a2f34cfea7a92702c4e8b0cf/workers/worker-6edb01e7271c451ba82eed3f2e5e4f48/batchGetJobEntity'}
2023-10-27 18:53:35,542 INFO [deadline_worker_agent.session_events] {'log_type': 'boto_response', 'operation': 'deadline.BatchGetJobEntity', 'status_code': 200, 'params': {}}
2023-10-27 18:53:35,544 INFO [deadline_worker_agent.sessions.job_entities.job_entities] Fetched jobDetails(job-38303a430b1e429dae84a2bc010c8721)
2023-10-27 18:53:35,546 INFO [deadline_worker_agent.scheduler.session_queue] Enqueued new action: {'sessionActionId': 'sessionaction-6164ee64a4ae435aaeffee94182d1224-0', 'actionType': 'ENV_ENTER', 'environmentId': 'STEP:step-4607b0e250724641a0f8c7b68fed5cd2:myenv'}
2023-10-27 18:53:35,548 INFO [deadline_worker_agent.scheduler.session_queue] Enqueued new action: {'sessionActionId': 'sessionaction-6164ee64a4ae435aaeffee94182d1224-1', 'actionType': 'TASK_RUN', 'taskId': 'task-4607b0e250724641a0f8c7b68fed5cd2-0', 'stepId': 'step-4607b0e250724641a0f8c7b68fed5cd2'}
2023-10-27 18:53:35,549 INFO [deadline_worker_agent.scheduler] Job has no Queue Role. Not obtaining AWS Credentials for the Session.
2023-10-27 18:53:35,554 INFO [deadline_worker_agent.scheduler] Done synchronizing with service
2023-10-27 18:53:35,556 INFO [deadline_worker_agent.sessions.log_config] [session-6164ee64a4ae435aaeffee94182d1224] logs streamed to CloudWatch target: /aws/deadline/farm-ae7057c74a7f489d9d0debeec6b715a5/queue-413f8055590141d780aea16df66f0be9/session-6164ee64a4ae435aaeffee94182d1224
2023-10-27 18:53:35,558 INFO [deadline_worker_agent.sessions.log_config] [session-6164ee64a4ae435aaeffee94182d1224] local logs target: /var/log/amazon/deadline/queue-413f8055590141d780aea16df66f0be9/session-6164ee64a4ae435aaeffee94182d1224.log
2023-10-27 18:53:35,560 INFO [deadline_worker_agent.sessions.session] Warming Job Entity Cache
2023-10-27 18:53:35,561 INFO [deadline_worker_agent.session_events] {'log_type': 'boto_request', 'operation': 'deadline.BatchGetJobEntity', 'params': {}, 'request_url': 'https://dfyn8if2i8.execute-api.us-west-2.amazonaws.com/2023-10-12/farms/farm-ae7057c74a7f489d9d0debeec6b715a5/fleets/fleet-36974f60a2f34cfea7a92702c4e8b0cf/workers/worker-6edb01e7271c451ba82eed3f2e5e4f48/batchGetJobEntity'}
2023-10-27 18:53:35,983 INFO [deadline_worker_agent.session_events] {'log_type': 'boto_response', 'operation': 'deadline.BatchGetJobEntity', 'status_code': 200, 'params': {}}
2023-10-27 18:53:35,985 INFO [deadline_worker_agent.sessions.job_entities.job_entities] Fetched environmentDetails(STEP:step-4607b0e250724641a0f8c7b68fed5cd2:myenv)
2023-10-27 18:53:35,986 INFO [deadline_worker_agent.sessions.job_entities.job_entities] Fetched stepDetails(step-4607b0e250724641a0f8c7b68fed5cd2)
2023-10-27 18:53:35,988 INFO [deadline_worker_agent.sessions.session] Fully warmed Job Entity Cache
2023-10-27 18:53:35,989 INFO [deadline_worker_agent.sessions.session] [session-6164ee64a4ae435aaeffee94182d1224]: Session started
2023-10-27 18:53:36,091 INFO [deadline_worker_agent.sessions.session] [session-6164ee64a4ae435aaeffee94182d1224] [sessionaction-6164ee64a4ae435aaeffee94182d1224-0] (environment[STEP:step-4607b0e250724641a0f8c7b68fed5cd2:myenv].enter()): Starting action
2023-10-27 18:53:36,098 INFO [deadline_worker_agent.scheduler.session_queue] Canceled sessionaction-6164ee64a4ae435aaeffee94182d1224-1 as NEVER_ATTEMPTED
2023-10-27 18:53:36,100 INFO [deadline_worker_agent.sessions.session] [session-6164ee64a4ae435aaeffee94182d1224] [sessionaction-6164ee64a4ae435aaeffee94182d1224-0] (environment[STEP:step-4607b0e250724641a0f8c7b68fed5cd2:myenv].enter()): Action completed as FAILED
2023-10-27 18:53:36,102 INFO [deadline_worker_agent.scheduler] Synchronizing with service (sending UpdateWorkerSchedule)
2023-10-27 18:53:36,104 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-6164ee64a4ae435aaeffee94182d1224-0': {'startedAt': datetime.datetime(2023, 10, 27, 18, 53, 36, 91182, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'processExitCode': 1, 'endedAt': datetime.datetime(2023, 10, 27, 18, 53, 36, 98524, tzinfo=datetime.timezone.utc)}, 'sessionaction-6164ee64a4ae435aaeffee94182d1224-1': {'completedStatus': 'NEVER_ATTEMPTED', 'progressMessage': 'Action environment[STEP:step-4607b0e250724641a0f8c7b68fed5cd2:myenv].enter() failed'}}
2023-10-27 18:53:36,549 INFO [deadline_worker_agent.scheduler.session_queue] Enqueued new action: {'sessionActionId': 'sessionaction-6164ee64a4ae435aaeffee94182d1224-2', 'actionType': 'ENV_EXIT', 'environmentId': 'STEP:step-4607b0e250724641a0f8c7b68fed5cd2:myenv'}
2023-10-27 18:53:36,551 INFO [deadline_worker_agent.scheduler] Done synchronizing with service
2023-10-27 18:53:36,598 INFO [deadline_worker_agent.sessions.session] [session-6164ee64a4ae435aaeffee94182d1224] [sessionaction-6164ee64a4ae435aaeffee94182d1224-2] (environment[STEP:step-4607b0e250724641a0f8c7b68fed5cd2:myenv].exit()): Starting action
2023-10-27 18:53:36,606 INFO [deadline_worker_agent.sessions.session] [session-6164ee64a4ae435aaeffee94182d1224] [sessionaction-6164ee64a4ae435aaeffee94182d1224-2] (environment[STEP:step-4607b0e250724641a0f8c7b68fed5cd2:myenv].exit()): Action completed as SUCCEEDED
2023-10-27 18:53:36,607 INFO [deadline_worker_agent.scheduler] Synchronizing with service (sending UpdateWorkerSchedule)
2023-10-27 18:53:36,610 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-6164ee64a4ae435aaeffee94182d1224-2': {'startedAt': datetime.datetime(2023, 10, 27, 18, 53, 36, 598740, tzinfo=datetime.timezone.utc), 'completedStatus': 'SUCCEEDED', 'processExitCode': 0, 'endedAt': datetime.datetime(2023, 10, 27, 18, 53, 36, 606150, tzinfo=datetime.timezone.utc)}}
2023-10-27 18:53:36,873 INFO [deadline_worker_agent.sessions.session] [session-6164ee64a4ae435aaeffee94182d1224]: Session complete
```

### Was this change documented?

No, the correct protocol behavior is already documented, but the implementation was not following it.

### Is this a breaking change?

No