### PR TITLE
chore(deps): update deadline-cloud-test-fixtures requirement from ~= 0.3.0 to == 0.4.*

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,5 +1,5 @@
 coverage[toml] ~= 7.3
-deadline-cloud-test-fixtures ~= 0.3.0
+deadline-cloud-test-fixtures == 0.4.*
 pytest ~= 7.4
 pytest-cov ~= 4.1.0
 pytest-xdist ~= 3.3.1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `deadline-cloud-test-fixtures` version `0.4.0` was just released with a fix to adopt a breaking `CreateFleet` API change.

### What was the solution? (How)

Bumps our pinned version to adopt `deadline-cloud-test-fixtures == 0.4.*`.

### What is the impact of this change?

The Worker Agent integration tests are unblocked from `CreateFleet` API errors.

### How was this change tested?

In casillas2/deadline-cloud-test-fixtures#35, the changes were tested by running the test fixtures locally using the docker container. This relies on that same testing.

### Was this change documented?

No

### Is this a breaking change?

No