### PR TITLE
feat: add Windows file permission support for job attachments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
-    "deadline == 0.32.*",
+    "deadline == 0.33.*",
     "openjd-sessions >= 0.2.3, < 0.3.0",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",

--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -173,7 +173,7 @@ class JobDetailsError(TypedDict):
 
 class JobAttachmentQueueSettings(TypedDict):
     """
-    Containts the configuration of job attachments for a Amazon Deadline Cloud queue. This includes the name of
+    Contains the configuration of job attachments for a Amazon Deadline Cloud queue. This includes the name of
     the S3 bucket as well as the object key structure. The structure of the objects with respect to
     this structure's fields is illustrated below:
 


### PR DESCRIPTION
This commit integrates WindowsFileSystemPermissionSettings, WindowsPermissionEnum classes from Job Attachments module.

### What was the problem/requirement? (What/Why)
With the upcoming implementation of Windows file permission handling in Job Attachment module (from [PR#88](https://github.com/casillas2/deadline-cloud/pull/88),) changes are required in Worker agent-side to accommodate these new features.

### What was the solution? (How)
- Made changes to use `WindowsFileSystemPermissionSettings`, `WindowsPermissionEnum` classes imported from Job Attachment module for managing file permissions on Windows.
- Upgraded the `deadline-cloud` dependency version to `0.33.*`
- Additional changes: corrected minor typos.

### What is the impact of this change?
This update will provide Windows compatibility for file permissions and ownership handling for job attachment files.

### How was this change tested?
`hatch run lint && hatch run test`

### Was this change documented?
No.

### Is this a breaking change?
No.