### PR TITLE
feat: print versions of 1st party dependencies to worker log

### DIFF
--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -15,7 +15,10 @@ import psutil
 import shutil
 from pathlib import Path
 
+from openjd.model import version as openjd_model_version
+from openjd.sessions import version as openjd_sessions_version
 from openjd.sessions import LOG as OPENJD_SESSION_LOG
+from deadline.job_attachments import version as deadline_job_attach_version
 from pydantic import PositiveFloat
 
 from .._version import __version__
@@ -331,11 +334,15 @@ def _remove_logging_handler(handler: logging.Handler) -> None:
 
 
 def _log_agent_info() -> None:
-    _logger.info("Agent Version: %s", __version__)
-    _logger.info("Installed at: %s", str(Path(__file__).resolve().parent.parent))
     _logger.info(f"Python Interpreter: {sys.executable}")
     _logger.info("Python Version: %s", sys.version.replace("\n", " - "))
     _logger.info(f"Platform: {sys.platform}")
+    _logger.info("Agent Version: %s", __version__)
+    _logger.info("Installed at: %s", str(Path(__file__).resolve().parent.parent))
+    _logger.info("Dependency versions installed:")
+    _logger.info("\topenjd.model: %s", openjd_model_version)
+    _logger.info("\topenjd.sessions: %s", openjd_sessions_version)
+    _logger.info("\tdeadline.job_attachments: %s", deadline_job_attach_version)
 
 
 def _get_gpu_count(*, verbose: bool = True) -> int:

--- a/test/unit/scheduler/test_session_cleanup.py
+++ b/test/unit/scheduler/test_session_cleanup.py
@@ -19,6 +19,10 @@ class FakeSessionUser(SessionUser):
     def __init__(self, user: str):
         self.user = user
 
+    @staticmethod
+    def get_process_user() -> str:
+        return ""
+
 
 class TestSessionUserCleanupManager:
     @pytest.fixture


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When diagnosing issues it can be useful to have the versions of the `deadline` and `openjd-sessions` packages available in the log. 

### What was the solution? (How)

Import the version numbers of the job attachments, model, and sessions libraries and add them to the log header that we print out at the start of the worker logs.

### What is the impact of this change?

More information available in logs.

### How was this change tested?

Just running the tests.

### Was this change documented?

No

### Is this a breaking change?

No