### PR TITLE
test: Enable github actions on windows_feature branch

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -2,7 +2,7 @@ name: Code Quality
 
 on:
   pull_request:
-    branches: [ mainline ]
+    branches: [ mainline, feature_windows ]
 
 jobs:
   Test:

--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     env:
       PYTHON: ${{ matrix.python-version }}
       CODEARTIFACT_REGION: "us-west-2"
@@ -45,12 +45,21 @@ jobs:
         aws-region: us-west-2
         mask-aws-account-id: true
 
-    - name: Install Hatch
+    - name: Install Hatch Posix
+      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'}}
       shell: bash
       run: |
         CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
         echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
         echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Install Hatch Windows
+      if: ${{ matrix.os == 'windows-latest'}}
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
         pip install --upgrade hatch
 
     - name: Run Linting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "requests ~= 2.29",
     "boto3 ~= 1.26",
     "deadline == 0.32.*",
-    "openjd-sessions == 0.2.*",
+    "openjd-sessions >= 0.2.3, < 0.3.0",
     # tomli became tomllib in standard library in Python 3.11
     "tomli >= 1.1.0 ; python_version<'3.11'",
     "typing_extensions ~= 4.5",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want the code quality approval workflows to run for PRs into the `feature_windows` branch so that we can ensure code quality.

### What was the solution? (How)
- Modify `reuse_python_build.yml` to test on Windows
- Modify `SesisonUser` fixtures in `test_session_cleanup.py` to ensure they have an implementation of the abstract `get_process_user`. This is required because the method is abstract in the base class.
- Uprade `openjd-sessions` to `>= 0.2.3` so we get [this change](https://github.com/xxyggoqtpcmcofkc/openjd-sessions-for-python/pull/22) exporting `WindowsSessionUser`.

### What is the impact of this change?
Code quality approval workflows run for PRs into the `feature_windows` branch.

### How was this change tested?
Unit tests pass

### Was this change documented?
N/A

### Is this a breaking change?
No