### PR TITLE
chore: add build to integration pipeline script

### DIFF
--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -9,7 +9,7 @@ if [ $TEST_TYPE ]
 then
   if [ $TEST_TYPE = "WHEEL" ]
   then
-    hatch run codebuild:build --hooks-only
+    hatch run codebuild:build
     export WORKER_AGENT_WHL_PATH=dist/`hatch run codebuild\:metadata name | sed 's/-/_/g'`-`hatch run codebuild\:version`-py3-none-any.whl
     echo "Set WORKER_AGENT_WHL_PATH to $WORKER_AGENT_WHL_PATH"
   fi


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to build the wheel in the pipeline integration script in order to pass it to the worker agent

### What was the solution? (How)
remove `--hooks-only`

### What is the impact of this change?
Working Integration tests

### How was this change tested?
Confirmed Integration tests ran successfully 

https://github.com/casillas2/deadline-cloud-worker-agent/actions/runs/6818175330/job/18543192856

### Was this change documented?
No

### Is this a breaking change?
No