### PR TITLE
fix: Adding os_user to FileSystemPermissionSettings for use in the deadline vfs

### DIFF
--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -851,6 +851,7 @@ class Session:
             storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules_dict,
             step_dependencies=step_dependencies,
             on_downloading_files=progress_handler,
+            os_env_vars=self._env,
         )
 
         ASSET_SYNC_LOGGER.info(

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -554,6 +554,7 @@ class TestSessionSyncAssetInputs:
             storage_profiles_path_mapping_rules={},
             step_dependencies=None,
             on_downloading_files=ANY,
+            os_env_vars=ANY,
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The deadline VFS is unable to locate the credentials for the job-user when syncing inputs.

### What was the solution? (How)
Pass the os_user as part of the FileSystemPermissionSettings object for use rebuilding the path to the AWS config file for the user running the render job. This along with the queueId will be used to reconstruct the Config path and profile name before mounting the VFS.

### What is the impact of this change?
This will fix the deadline VFS so jobs marked with `VIRTUAL` file system will succeed.

### How was this change tested?
* hatch run test
* hatch run lint
* ran this on a worker and successfully completed both VIRTUAL and COPIED jobs

### Was this change documented?
No

### Is this a breaking change?
No, as long as my [deadline-cloud PR](https://github.com/casillas2/deadline-cloud/pull/104) is merged in first