### PR TITLE
feat: emit job attachment transfer statistics as telemetry events

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -2,15 +2,16 @@
 
 import logging
 from time import sleep, monotonic
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 from threading import Event
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 import random
 
 from botocore.retries.standard import RetryContext
 from botocore.exceptions import ClientError
 
 from deadline.client.api import get_telemetry_client, TelemetryClient
+from deadline.job_attachments.progress_tracker import SummaryStatistics
 
 from ..._version import __version__ as version  # noqa
 from ...startup.config import Configuration
@@ -80,7 +81,7 @@ class DeadlineRequestConditionallyRecoverableError(DeadlineRequestError):
 
 class DeadlineRequestWorkerOfflineError(DeadlineRequestConditionallyRecoverableError):
     """Raised by some APIs when invoking the API discovers that the requesting
-    Worker is no longer condidered to be online in the service (e.g. its
+    Worker is no longer considered to be online in the service (e.g. its
     status has been set to NOT_RESPONDING))
     """
 
@@ -794,8 +795,26 @@ def _get_deadline_telemetry_client() -> TelemetryClient:
     return get_telemetry_client("deadline-cloud-worker-agent", version)
 
 
-def record_worker_start_event(capabilities: Capabilities) -> None:
+def record_worker_start_telemetry_event(capabilities: Capabilities) -> None:
     """Calls the telemetry client to record an event capturing generic machine information."""
     _get_deadline_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.worker_agent.start", event_details=capabilities.dict()
+    )
+
+
+def record_sync_inputs_telemetry_event(summary: SummaryStatistics) -> None:
+    """Calls the telemetry client to record an event capturing the sync-inputs summary."""
+    details: Dict[str, Any] = asdict(summary)
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.sync_inputs_summary",
+        event_details=details,
+    )
+
+
+def record_sync_outputs_telemetry_event(summary: SummaryStatistics) -> None:
+    """Calls the telemetry client to record an event capturing the sync-outputs summary."""
+    details: Dict[str, Any] = asdict(summary)
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.sync_outputs_summary",
+        event_details=details,
     )

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -23,7 +23,6 @@ from pydantic import PositiveFloat
 
 from .._version import __version__
 from ..api_models import WorkerStatus
-from ..aws.deadline import DeadlineRequestError, delete_worker, update_worker
 from ..boto import DEADLINE_BOTOCORE_CONFIG, OTHER_BOTOCORE_CONFIG
 from ..errors import ServiceShutdown
 from ..log_sync.cloudwatch import stream_cloudwatch_logs
@@ -36,7 +35,7 @@ from ..aws.deadline import (
     DeadlineRequestError,
     delete_worker,
     update_worker,
-    record_worker_start_event,
+    record_worker_start_telemetry_event,
 )
 
 __all__ = ["entrypoint"]
@@ -95,7 +94,7 @@ def entrypoint(cli_args: Optional[list[str]] = None) -> None:
         # if customer manually provided the capabilities (to be added in this function)
         # then we default to the customer provided ones
         system_capabilities = detect_system_capabilities()
-        record_worker_start_event(system_capabilities)
+        record_worker_start_telemetry_event(system_capabilities)
         config.capabilities = system_capabilities.merge(config.capabilities)
 
         # Log the configuration

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -1,0 +1,119 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+from unittest.mock import patch, MagicMock
+
+import deadline_worker_agent.aws.deadline as deadline_mod
+from deadline_worker_agent.aws.deadline import (
+    record_worker_start_telemetry_event,
+    record_sync_inputs_telemetry_event,
+    record_sync_outputs_telemetry_event,
+)
+from deadline_worker_agent.startup.capabilities import Capabilities
+from deadline.job_attachments.progress_tracker import SummaryStatistics
+
+
+def test_record_worker_start_telemetry_event():
+    """
+    Tests that when record_worker_start_telemetry_event() is called, the correct
+    event type and details are passed to the telemetry client's record_event() method.
+    """
+    mock_telemetry_client = MagicMock()
+
+    with patch.object(deadline_mod, "_get_deadline_telemetry_client") as mock_get_telemetry_client:
+        mock_get_telemetry_client.return_value = mock_telemetry_client
+
+        # GIVEN
+        caps = Capabilities(
+            amounts={"amount.a": 2, "amount.b": 99},
+            attributes={"attr.a": ["z"], "attr.b": ["c"]},
+        )
+        # WHEN
+        record_worker_start_telemetry_event(caps)
+
+    # THEN
+    mock_telemetry_client.record_event.assert_called_with(
+        event_type="com.amazon.rum.deadline.worker_agent.start",
+        event_details={
+            "amounts": {"amount.a": 2, "amount.b": 99},
+            "attributes": {"attr.a": ["z"], "attr.b": ["c"]},
+        },
+    )
+
+
+def test_record_sync_inputs_telemetry_event():
+    """
+    Tests that when record_sync_inputs_telemetry_event() is called, the correct
+    event type and details are passed to the telemetry client's record_event() method.
+    """
+    mock_telemetry_client = MagicMock()
+
+    with patch.object(deadline_mod, "_get_deadline_telemetry_client") as mock_get_telemetry_client:
+        mock_get_telemetry_client.return_value = mock_telemetry_client
+        # GIVEN
+        summary_stats = SummaryStatistics(
+            total_time=8,
+            total_files=10,
+            total_bytes=1000,
+            processed_files=8,
+            processed_bytes=800,
+            skipped_files=2,
+            skipped_bytes=200,
+            transfer_rate=100,
+        )
+        # WHEN
+        record_sync_inputs_telemetry_event(summary_stats)
+
+    # THEN
+    mock_telemetry_client.record_event.assert_called_with(
+        event_type="com.amazon.rum.deadline.worker_agent.sync_inputs_summary",
+        event_details={
+            "total_time": 8,
+            "total_files": 10,
+            "total_bytes": 1000,
+            "processed_files": 8,
+            "processed_bytes": 800,
+            "skipped_files": 2,
+            "skipped_bytes": 200,
+            "transfer_rate": 100.0,
+        },
+    )
+
+
+def test_record_sync_outputs_telemetry_event():
+    """
+    Tests that when record_sync_outputs_telemetry_event() is called, the correct
+    event type and details are passed to the telemetry client's record_event() method.
+    """
+    mock_telemetry_client = MagicMock()
+
+    with patch.object(deadline_mod, "_get_deadline_telemetry_client") as mock_get_telemetry_client:
+        mock_get_telemetry_client.return_value = mock_telemetry_client
+        # GIVEN
+        summary_stats = SummaryStatistics(
+            total_time=8,
+            total_files=10,
+            total_bytes=1000,
+            processed_files=8,
+            processed_bytes=800,
+            skipped_files=2,
+            skipped_bytes=200,
+            transfer_rate=100,
+        )
+        # WHEN
+        record_sync_outputs_telemetry_event(summary_stats)
+
+    # THEN
+    mock_telemetry_client.record_event.assert_called_with(
+        event_type="com.amazon.rum.deadline.worker_agent.sync_outputs_summary",
+        event_details={
+            "total_time": 8,
+            "total_files": 10,
+            "total_bytes": 1000,
+            "processed_files": 8,
+            "processed_bytes": 800,
+            "skipped_files": 2,
+            "skipped_bytes": 200,
+            "transfer_rate": 100.0,
+        },
+    )

--- a/test/unit/startup/test_capabilities.py
+++ b/test/unit/startup/test_capabilities.py
@@ -77,7 +77,7 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
     ],
 )
 def test_input_validation_failure(data: dict[str, Any]) -> None:
-    """Tests that an invalid iniput dictionary fails Capabilities model validation"""
+    """Tests that an invalid input dictionary fails Capabilities model validation"""
     # WHEN
     with pytest.raises(ValidationError) as excinfo:
         Capabilities.parse_obj(data)

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -152,7 +152,7 @@ def block_rich_import() -> Generator[None, None, None]:
 
 @pytest.fixture(autouse=True)
 def block_telemetry_client() -> Generator[MagicMock, None, None]:
-    with patch.object(entrypoint_mod, "record_worker_start_event") as telem_mock:
+    with patch.object(entrypoint_mod, "record_worker_start_telemetry_event") as telem_mock:
         yield telem_mock
 
 
@@ -443,7 +443,7 @@ def test_system_shutdown(
     configuration: MagicMock,
 ) -> None:
     """
-    Tests that entrypoint._system_shudown() has the correct platform-specific behavior
+    Tests that entrypoint._system_shutdown() has the correct platform-specific behavior
     """
     # GIVEN
     process: MagicMock = subprocess_popen_mock.return_value
@@ -533,7 +533,7 @@ def test_no_shutdown_only_log(
     configuration: MagicMock,
 ) -> None:
     """
-    Tests if the system shudown call is suppressed in a certain case, instead just logs it.
+    Tests if the system shutdown call is suppressed in a certain case, instead just logs it.
     """
     # GIVEN
     configuration.no_shutdown = True


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently, Worker Agent is not sending telemetry data related to Job Attachment (i.e., summary statistics) upon the completion of input and output syncing. This limited our ability to monitor and analyze the performance of these process. 

### What was the solution? (How)
Send the summary stats through our telemetry client once the input sync or output sync is done. 

### What is the impact of this change?
This allows us to collect Job Attachment-related performance metrics, and enhance our monitoring capabilities.

### How was this change tested?
- Ran unit tests and made sure that all tests passed.
- Tested in the Beta environment. Submitted a job, and then run my local CMF on the job. Upon completion, verified that the transmission of the summary stats info to the telemetry account was successful, ensuring the functionality works as intended. 

### Was this change documented?
No.

### Is this a breaking change?
No.