### PR TITLE
ci: Add mainline integration test workflow

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -1,13 +1,16 @@
-name: Integration Test
+name: Mainline Integration Test
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - 'mainline'
 
 jobs:
-  IntegrationTest:
+  MainlineIntegrationTest:
     name: Integration Test
     runs-on: ubuntu-latest
-    environment: release
+    environment: mainline
     permissions:
       id-token: write
       contents: read
@@ -18,13 +21,13 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_INTEG_ROLE }}
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INTEG_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: deadline-cloud-worker-agent-IntegTest
+          project-name: deadline-cloud-worker-agent-dev-IntegTest
           hide-cloudwatch-logs: true
           env-vars-for-codebuild: |
             TEST_TYPE

--- a/pipeline/canary.sh
+++ b/pipeline/canary.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Set the -e option
+set -e
+
+pip install --upgrade pip
+pip install --upgrade hatch
+
+hatch run codebuild:integ-test


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. Need a way to run integration tests on the mainline branch.
2. Require a canary script to run integration tests on release branch

### What was the solution? (How)
1. Added a Workflow that will run the Integration tests on the mainline branch whenever there is a push to it. This can also be dispatched manually if needed.
2. Add canary script that runs the integ tests

### What is the impact of this change?
Whenever new changes are merged to mainline we will now run integration tests on those changes.

### How was this change tested?
Dispatched the workflow manually to confirm it worked.

### Was this change documented?
No

### Is this a breaking change?
No