### PR TITLE
ci: Add canary environment

### DIFF
--- a/.github/workflows/release_integration_canary.yml
+++ b/.github/workflows/release_integration_canary.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   ReleaseIntegrationCanary:
     runs-on: ubuntu-latest
-    environment: release
+    environment: canary
     permissions:
       id-token: write
       contents: read
@@ -19,11 +19,11 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_INTEG_ROLE }}
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_CANARY_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: deadline-cloud-worker-agent-IntegTest
+          project-name: deadline-cloud-worker-agent-Canary
           hide-cloudwatch-logs: true


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We are adding approvals on the release environment. Since the Canary uses this environment it will require approval every run, we do not want this.

### What was the solution? (How)

We added infrastructure specifically for the Canary. Updated the workflow to now use the canary environment and infrastructure.

### What is the impact of this change?
Canaries will run in a separate environment from release and will not have to adhere to the same protection rules.

### How was this change tested?
This was tested in a development github account

### Was this change documented?
No

### Is this a breaking change?
No