### PR TITLE
ci: use release environment in release workflow integ tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
     needs: UnitTests
     name: Integration Tests
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The new `release` workflow failed because the integration test stage to configure AWS credentials failed (see https://github.com/casillas2/deadline-cloud-worker-agent/actions/runs/7188624961/job/19578694519#step:3:10). Root cause of this seems to be that we're referencing a `release` secret environment variable in that stage but we're missing the statement in the workflow file to use the `release` environment.

### What was the solution? (How)
Use the `release` environment in the integration tests of the release workflow

### What is the impact of this change?
release workflow works

### How was this change tested?
N/A / TODO

### Was this change documented?
No

### Is this a breaking change?
No