### PR TITLE
ci: Add environment to release integ tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
     needs: UnitTests
     name: Integration Tests
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Integration Tests job requires the release environment

### What was the solution? (How)
Add the release environment

### What is the impact of this change?
Fix release workflow

### How was this change tested?
n/a

### Was this change documented?
No

### Is this a breaking change?
No