### PR TITLE
chore: fix sync script in research hatch environment

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -30,7 +30,7 @@ pre-install-commands = [
 ]
 
 [envs.research.scripts]
-sync = "pip install -r requirements-testing.txt"
+sync = "pip install -r requirements-research.txt"
 
 [[envs.all.matrix]]
 python = ["3.9", "3.10", "3.11"]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `sync` script in the `research` hatch environment had a bug where it would update the wrong installed packages. Instead of installing using `requirements-research.txt`, it used `requirements-testing.txt`.

### What was the solution? (How)

Correct the bug and switch the script to install using `requirements-research.txt`.

### What is the impact of this change?

This will fix the logic when running:

```
hatch run research:sync
```

### How was this change tested?

Ran `hatch run research:sync` and confirmed that it ran successfully.

### Was this change documented?

No

### Is this a breaking change?

No