### PR TITLE
fix: long output job attachment uploads block UpdateWorkerSchedule requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
-    "deadline == 0.34.*",
+    "deadline == 0.35.*",
     "openjd-sessions == 0.2.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -220,11 +220,11 @@ class WorkerScheduler:
         The Worker begins by hydrating its assigned work using the UpdateWorkerSchedule API.
 
         The scheduler then enters a loop of processing assigned actions - creating and deleting
-        Worker sessions as required. If no actions are assigned, the Worke idles for 5 seconds.
+        Worker sessions as required. If no actions are assigned, the Worker idles for 5 seconds.
         If any action completes, finishes cancelation, or if the Worker is done idling, an
         UpdateWorkerSchedule API request is made with any relevant changes specified in the request.
 
-        The scheduler is responsible for heartbeating which also includes reporting progress and
+        The scheduler is responsible for heart-beating which also includes reporting progress and
         status of ongoing active session actions, receiving session action cancelations, and
         also receiving commands from the service to shutdown.
 
@@ -361,12 +361,12 @@ class WorkerScheduler:
         Returns
         -------
         int
-            The interval (in seconds) to sync with the service returned in the UpdateWorkerSchedule repsonse
+            The interval (in seconds) to sync with the service returned in the UpdateWorkerSchedule response
         """
 
         logger.info("Synchronizing with service (sending UpdateWorkerSchedule)")
 
-        # 1. collect info to be send in the UpdateWorkerSchedule API request
+        # 1. collect info to be sent in the UpdateWorkerSchedule API request
         #    1.1. finished/in-progress action results
         updated_actions, commit_completed_actions = self._updated_session_actions()
         if updated_actions:
@@ -398,7 +398,6 @@ class WorkerScheduler:
         #    3.3. cancel actions in existing sessions
         #    3.4. update the queues for existing sessions
         #    3.5. persist the idle and healthy timeouts
-        # self._apply_response(response=response)
         self._update_sessions(response=response)
 
         if response.get("desiredWorkerStatus", None) == "STOPPED":

--- a/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
+++ b/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
@@ -76,7 +76,7 @@ class SyncInputJobAttachmentsAction(SessionActionDefinition):
         session: Session,
         executor: Executor,
     ) -> None:
-        """Initiates the synchonization of the input job attachments
+        """Initiates the synchronization of the input job attachments
 
         Parameters
         ----------
@@ -115,7 +115,7 @@ class SyncInputJobAttachmentsAction(SessionActionDefinition):
         future : Future[None]
             The future tracking the asset synchronization.
         session : Session
-            The session that the aciton is running in
+            The session that the action is running in
         """
         action_status: ActionStatus = ActionStatus(state=ActionState.SUCCESS)
         try:

--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -169,7 +169,7 @@ class Worker:
 
     @property
     def sessions(self) -> WorkerSessionCollection:
-        raise NotImplementedError("Worker.sessions property not implemeneted")
+        raise NotImplementedError("Worker.sessions property not implemented")
 
     def run(self) -> None:
         """Runs the main Worker loop for processing sessions."""
@@ -317,7 +317,7 @@ class Worker:
                 )
                 return WorkerShutdown(
                     grace_time=Worker._ASG_LIFECYCLE_SHUTDOWN_GRACE,
-                    fail_message="The Worker receieved an auto-scaling life-cycle change event",
+                    fail_message="The Worker received an auto-scaling life-cycle change event",
                 )
 
         logger.debug("EC2 shutdown monitoring thread exited")

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -307,7 +307,7 @@ class TestMonitorEc2Shutdown:
         # THEN
         assert result == worker_mod.WorkerShutdown(
             grace_time=timedelta(minutes=2),
-            fail_message="The Worker receieved an auto-scaling life-cycle change event",
+            fail_message="The Worker received an auto-scaling life-cycle change event",
         )
         logger_info.assert_called_once_with(
             "Auto-scaling life-cycle change event detected. Termination in %s", timedelta(minutes=2)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The worker was not sending UpdateWorkerSchedule API (as periodic heartbeat checks) to the backend service during the Job Attachments output syncing (output upload), leading to `ConflictException`. 

### What was the solution? (How)
Modified the output syncing to be asynchronous.
- Added a ThreadPoolExecutor object (`self._executor`) as a member variable in Session class
- Updated the `_start_action()` to use this executor.
- In `_action_updated_impl()`, the `self._sync_asset_outputs()` is now executed asynchronously. It prevents the blocking of the main thread that calls UpdateWorkerSchedule API and so the heartbeat checks continues.
- Fixed unit tests to align with the changes, ensuring all tests pass.

### What is the impact of this change?
The UpdateWorkerSchedule calls are not blocked, even during a long upload process that takes > 10 mins. This change addresses the issue where the worker status update was failing with `ConflictException`.

### How was this change tested?
- Made sure all unit tests pass successfully.
- Manual end-to-end tests: confirmed that the UpdateWorkerSchedule API calls continue at 15-seconds intervals (by default) during output syncing, and the error did not occur.

### Was this change documented?
No.

### Is this a breaking change?
No.
