### PR TITLE
chore: increase aws credentials timeout in CI

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -24,6 +24,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INTEG_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
+          role-duration-seconds: 7200 # 2 hours, default is 3600
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_INTEG_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
+          role-duration-seconds: 7200 # 2 hours, default is 3600
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:

--- a/.github/workflows/release_integration_canary.yml
+++ b/.github/workflows/release_integration_canary.yml
@@ -22,6 +22,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_CANARY_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
+          role-duration-seconds: 7200 # 2 hours, default is 3600
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The integration tests that run in codebuild have started to take longer than an hour to complete. When that happens, the credentials that we had to interact with that codebuild are expiring and causing the CI to fail.

e.g. https://github.com/casillas2/deadline-cloud-worker-agent/actions/runs/7416021910

### What was the solution? (How)

I've increased the timeout to 2 hours.

Note, from: https://github.com/aws-actions/configure-aws-credentials
"By default, the assumed role credentials will only be valid for one hour in all use cases. This is changed from 6 hours in v2. You can adjust this value with the role-duration-seconds input."

### What is the impact of this change?

Hopefully, the integration canaries stop failing due to credentials expiring.

### How was this change tested?

It was not. This has to be changed in github.

### Was this change documented?

N/A

### Is this a breaking change?

No