### PR TITLE
revert: "chore: increase aws credentials timeout in CI (#125)"

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -24,7 +24,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INTEG_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
-          role-duration-seconds: 7200 # 2 hours, default is 3600
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_INTEG_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
-          role-duration-seconds: 7200 # 2 hours, default is 3600
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:

--- a/.github/workflows/release_integration_canary.yml
+++ b/.github/workflows/release_integration_canary.yml
@@ -22,7 +22,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_CANARY_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
-          role-duration-seconds: 7200 # 2 hours, default is 3600
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The CI role isn't configured to allow more than one hour assume-roles. I'll have to update the role first, and then reapply this change. 

### What was the solution? (How)

This reverts commit bb1cf46cbb70238a435f3686ce29c046eab27260.

In the meantime, back out the change.

### What is the impact of this change?

Different error when running integration tests.

### How was this change tested?

Can only test in github

### Was this change documented?

N/A

### Is this a breaking change?

No