### PR TITLE
fix: crash if queue has no user defined

### DIFF
--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -86,7 +86,7 @@ def path_mapping_api_model_to_openjd(
 
 def job_run_as_user_api_model_to_worker_agent(
     job_run_as_user_data: JobRunAsUserModel,
-) -> JobRunAsUser:
+) -> JobRunAsUser | None:
     """Converts the 'JobRunAsUser' api model to the 'JobRunAsUser' dataclass
     expected by the Worker Agent.
     """
@@ -94,6 +94,8 @@ def job_run_as_user_api_model_to_worker_agent(
         job_run_as_user_posix = job_run_as_user_data.get("posix", {})
         user = job_run_as_user_posix.get("user", "")
         group = job_run_as_user_posix.get("group", "")
+        if not (user and group):
+            return None
 
         job_run_as_user = JobRunAsUser(
             posix=PosixSessionUser(user=user, group=group),
@@ -128,6 +130,9 @@ class JobRunAsUser:
     posix: PosixSessionUser
     # TODO: windows support
 
+    def __eq__(self, other: Any) -> bool:
+        return self.posix.user == other.posix.user and self.posix.group == other.posix.group
+
 
 @dataclass(frozen=True)
 class JobDetails:
@@ -142,14 +147,14 @@ class JobDetails:
     schema_version: SchemaVersion
     """The Open Job Description schema version"""
 
-    job_run_as_user: JobRunAsUser
-    """The user associated with the job's Amazon Deadline Cloud queue"""
-
     job_attachment_settings: JobAttachmentSettings | None = None
     """The job attachment settings of the job's queue"""
 
     parameters: list[Parameter] = field(default_factory=list)
     """The job's parameters"""
+
+    job_run_as_user: JobRunAsUser | None = None
+    """The user associated with the job's Amazon Deadline Cloud queue"""
 
     path_mapping_rules: list[OPENJDPathMappingRule] = field(default_factory=list)
     """The path mapping rules for the job"""
@@ -184,7 +189,7 @@ class JobDetails:
             job_attachment_settings = JobAttachmentSettings.from_boto(job_attachment_settings_boto)
 
         job_run_as_user_data = job_details_data["jobRunAsUser"]
-        job_run_as_user: JobRunAsUser = job_run_as_user_api_model_to_worker_agent(
+        job_run_as_user: JobRunAsUser | None = job_run_as_user_api_model_to_worker_agent(
             job_run_as_user_data
         )
 

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -237,6 +237,7 @@ class TestDetails:
                 posix=PosixSessionUser(user="job-user", group="job-group")
             ),
         )
+        assert expected_details.job_run_as_user is not None  # For type checker
         deadline_client.batch_get_job_entity.return_value = response
         job_entities = JobEntities(
             farm_id="farm-id",
@@ -252,6 +253,7 @@ class TestDetails:
         # THEN
         assert details.log_group_name == expected_details.log_group_name
         assert details.schema_version == expected_details.schema_version
+        assert details.job_run_as_user is not None
         assert details.job_run_as_user.posix.user == expected_details.job_run_as_user.posix.user
         assert details.job_run_as_user.posix.group == expected_details.job_run_as_user.posix.group
         assert details.job_attachment_settings == expected_details.job_attachment_settings


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The fix in https://github.com/casillas2/deadline-cloud-worker-agent/commit/fab7d538d598285d8385779e1b82114565ea0e8f caused a regression whereby the agent would crash if it dequeues a job from a Queue that has an empty posix user/group defined. The crash was due to the QueueBoto3Session being passed a PosixSessionUser with empty user/group -- it expects to be passed None in this case.

### What was the solution? (How)

When converting the boto3 payload in to a JobDetails object I added back the case that checks for an empty string user/group, and handle those properly again.

### What is the impact of this change?

The agent no longer crashes if a queue has no user or group.

### How was this change tested?

I tested this locally using our docker containers; I had to modify the container scripting to not override the job user/group to do the test. I was able to reproduce the crash in this setup before applying the fix, and then see that the fix stopped the crash.

### Was this change documented?

No

### Is this a breaking change?

No