### PR TITLE
test(integ): worker credential file permissions secured

### DIFF
--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -1,2 +1,87 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import dataclasses
+from typing import Generator
+
+from deadline_test_fixtures import (
+    DeadlineClient,
+    DeadlineResources,
+    DeadlineWorkerConfiguration,
+    Farm,
+    Fleet,
+    JobRunAsUser,
+    PosixSessionUser,
+    Queue,
+    QueueFleetAssociation,
+)
+import pytest
+
+
 pytest_plugins = ["deadline_test_fixtures.pytest_hooks"]
+
+
+@pytest.fixture(scope="session")
+def farm(deadline_resources: DeadlineResources) -> Farm:
+    return deadline_resources.farm
+
+
+@pytest.fixture(scope="session")
+def queue(deadline_resources: DeadlineResources) -> Queue:
+    return deadline_resources.queue
+
+
+@pytest.fixture(scope="session")
+def fleet(deadline_resources: DeadlineResources) -> Fleet:
+    return deadline_resources.fleet
+
+
+@pytest.fixture(scope="session")
+def job_run_as_user() -> PosixSessionUser:
+    return PosixSessionUser(
+        user="job-run-as-user",
+        group="job-run-as-user-group",
+    )
+
+
+@pytest.fixture(scope="session")
+def worker_config(
+    worker_config: DeadlineWorkerConfiguration,
+    job_run_as_user: PosixSessionUser,
+) -> DeadlineWorkerConfiguration:
+    return dataclasses.replace(
+        worker_config,
+        job_users=[
+            *worker_config.job_users,
+            job_run_as_user,
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def queue_with_job_run_as_user(
+    farm: Farm,
+    fleet: Fleet,
+    deadline_client: DeadlineClient,
+    job_run_as_user: PosixSessionUser,
+) -> Generator[Queue, None, None]:
+    queue = Queue.create(
+        client=deadline_client,
+        display_name=f"Queue with jobsRunAsUser {job_run_as_user.user}",
+        farm=farm,
+        job_run_as_user=JobRunAsUser(posix=job_run_as_user),
+    )
+
+    qfa = QueueFleetAssociation.create(
+        client=deadline_client,
+        farm=farm,
+        queue=queue,
+        fleet=fleet,
+    )
+
+    yield queue
+
+    qfa.delete(
+        client=deadline_client,
+        stop_mode="STOP_SCHEDULING_AND_CANCEL_TASKS",
+    )
+    queue.delete(client=deadline_client)

--- a/test/integ/test_credential_handling.py
+++ b/test/integ/test_credential_handling.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+This test module contains tests that verify the Worker agent's credential handling behavior.
+
+Once the worker is online, the tests run SSM commands that attempt to access credentials from an
+attacker position in a supposed different security boundary.
+"""
+
+import logging
+
+from deadline_test_fixtures import CommandResult, DeadlineWorker, DeadlineWorkerConfiguration
+
+
+def test_access_worker_credential_file_from_job(
+    worker: DeadlineWorker,
+    worker_config: DeadlineWorkerConfiguration,
+) -> None:
+    """Tests that the worker agent credentials file cannot be read by a job user"""
+
+    # GIVEN
+    job_users = worker_config.job_users
+    assert len(job_users) >= 1
+    job_user = job_users[0]
+
+    ########################################################################################
+    # We first ensure that the worker agent user can read the agent's IAM credential files
+    # to ensure that the file exists and our test is valid
+    ########################################################################################
+    # WHEN
+    result = worker.send_command(
+        f'sudo -u "{worker_config.user}" cat /var/lib/deadline/credentials/{worker.worker_id}.json > /dev/null'
+    )
+
+    # THEN
+    expect_ssm_success(
+        result,
+        failure_msg="Worker credentials file existence check SSM command failed",
+    )
+
+    ########################################################################################
+    # Next we try to access the same credential file(s) as the job user and assert that the
+    # command fails.
+    ########################################################################################
+    # WHEN
+    result = worker.send_command(
+        f'sudo -u "{job_user.user}" cat /var/lib/deadline/credentials/{worker.worker_id}.json > /dev/null'
+    )
+
+    # THEN
+    assert result.exit_code != 0
+
+
+def expect_ssm_success(
+    result: CommandResult,
+    *,
+    failure_msg: str,
+) -> None:
+    """Expects an SSM command to succeed or raises an AssertionError"""
+    if result.exit_code != 0:
+        logging.info(failure_msg)
+        logging.info("")
+        logging.info("    [STDOUT]")
+        logging.info("")
+        logging.info(result.stdout)
+        logging.info("")
+        logging.info("    [STDERR]")
+        logging.info("")
+        logging.info(result.stderr)
+        assert False, failure_msg

--- a/test/integ/test_job_submissions.py
+++ b/test/integ/test_job_submissions.py
@@ -8,96 +8,20 @@ import boto3
 import botocore.client
 import botocore.config
 import botocore.exceptions
-import dataclasses
-
-import pytest  # noqa: F401
+import pytest
 
 import logging
 
-from typing import Generator
-
 from deadline_test_fixtures import (
     DeadlineClient,
-    DeadlineResources,
-    DeadlineWorkerConfiguration,
     Farm,
-    Fleet,
     Job,
-    JobRunAsUser,
     PosixSessionUser,
     Queue,
-    QueueFleetAssociation,
     TaskStatus,
 )
 
 LOG = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="session")
-def farm(deadline_resources: DeadlineResources) -> Farm:
-    return deadline_resources.farm
-
-
-@pytest.fixture(scope="session")
-def queue(deadline_resources: DeadlineResources) -> Queue:
-    return deadline_resources.queue
-
-
-@pytest.fixture(scope="session")
-def fleet(deadline_resources: DeadlineResources) -> Fleet:
-    return deadline_resources.fleet
-
-
-@pytest.fixture(scope="session")
-def job_run_as_user() -> PosixSessionUser:
-    return PosixSessionUser(
-        user="job-run-as-user",
-        group="job-run-as-user-group",
-    )
-
-
-@pytest.fixture(scope="session")
-def worker_config(
-    worker_config: DeadlineWorkerConfiguration,
-    job_run_as_user: PosixSessionUser,
-) -> DeadlineWorkerConfiguration:
-    return dataclasses.replace(
-        worker_config,
-        job_users=[
-            *worker_config.job_users,
-            job_run_as_user,
-        ],
-    )
-
-
-@pytest.fixture(scope="session")
-def queue_with_job_run_as_user(
-    farm: Farm,
-    fleet: Fleet,
-    deadline_client: DeadlineClient,
-    job_run_as_user: PosixSessionUser,
-) -> Generator[Queue, None, None]:
-    queue = Queue.create(
-        client=deadline_client,
-        display_name=f"Queue with jobsRunAsUser {job_run_as_user.user}",
-        farm=farm,
-        job_run_as_user=JobRunAsUser(posix=job_run_as_user),
-    )
-
-    qfa = QueueFleetAssociation.create(
-        client=deadline_client,
-        farm=farm,
-        queue=queue,
-        fleet=fleet,
-    )
-
-    yield queue
-
-    qfa.delete(
-        client=deadline_client,
-        stop_mode="STOP_SCHEDULING_AND_CANCEL_TASKS",
-    )
-    queue.delete(client=deadline_client)
 
 
 @pytest.mark.usefixtures("worker")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We require an end-to-end test to ensure that job users cannot access the IAM credentials file persisted and used by the worker agent. 

### What was the solution? (How)

Wrote an end-to-end test that runs an SSM command to attempt to access the worker credentials file as a job user. The test expects that the command fails.

In order to get the tests to work, I had to hoist some of the test fixtures which resided in `test/integ/test_job_submissions.py` up to `test/integ/conftest.py` so that they are common to all "integ" tests.

### What is the impact of this change?

The worker agent codebase has automated tests which protect this security behavior from regressing.

### How was this change tested?

Ran the integration tests with:

```
hatch run integ-test
```

and confirmed the tests pass

### Was this change documented?

No

### Is this a breaking change?

No