### PR TITLE
feat: rename "updateTime" to "updatedAt" in UpdateWorkerSchedule API request

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -377,7 +377,7 @@ class UpdatedSessionActionInfo(TypedDict):
     progressMessage: NotRequired[str]
     startedAt: NotRequired[datetime]
     endedAt: NotRequired[datetime]
-    updateTime: NotRequired[datetime]
+    updatedAt: NotRequired[datetime]
     progressPercent: NotRequired[float]
 
 

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -507,7 +507,7 @@ class WorkerScheduler:
         if action_updated.completed_status:
             updated_action["completedStatus"] = action_updated.completed_status
         elif action_updated.update_time:
-            updated_action["updateTime"] = action_updated.update_time
+            updated_action["updatedAt"] = action_updated.update_time
         if action_updated.status:
             if action_updated.status.exit_code is not None:
                 updated_action["processExitCode"] = action_updated.status.exit_code


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `UpdateWorkerSchedule` API request's `updatedSessionActions` &rarr; `<SESSION_ACTION_ID>` &rarr; `updateTime` field was deprecated in favor of `updatedAt`.

### What was the solution? (How)

Renamed the field

### What is the impact of this change?

The Worker Agent now uses the proper API field name and is no longer using a deprecated API field name.

### How was this change tested?

Ran the Worker Agent and submitted a job. Observed the new API request field being used in the log:

```txt
2024-01-10 22:49:38,055 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-c3d5848048c44389bacb0f46e4813654-0': {'startedAt': datetime.datetime(2024, 1, 10, 22, 49, 23, 567183, tzinfo=datetime.timezone.utc), 'completedStatus': 'SUCCEEDED', 'processExitCode': 0, 'endedAt': datetime.datetime(2024, 1, 10, 22, 49, 23, 575897, tzinfo=datetime.timezone.utc)}, 'sessionaction-c3d5848048c44389bacb0f46e4813654-1': {'startedAt': datetime.datetime(2024, 1, 10, 22, 49, 23, 675861, tzinfo=datetime.timezone.utc), 'updatedAt': datetime.datetime(2024, 1, 10, 22, 49, 37, 717986, tzinfo=datetime.timezone.utc), 'progressPercent': 31.111111111111104}}
```

### Was this change documented?

No

### Is this a breaking change?

No