### PR TITLE
feat: include Queue ID in sync_inputs, sync_outputs telemetry

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -802,18 +802,20 @@ def record_worker_start_telemetry_event(capabilities: Capabilities) -> None:
     )
 
 
-def record_sync_inputs_telemetry_event(summary: SummaryStatistics) -> None:
+def record_sync_inputs_telemetry_event(queue_id: str, summary: SummaryStatistics) -> None:
     """Calls the telemetry client to record an event capturing the sync-inputs summary."""
     details: Dict[str, Any] = asdict(summary)
+    details["queue_id"] = queue_id
     _get_deadline_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.worker_agent.sync_inputs_summary",
         event_details=details,
     )
 
 
-def record_sync_outputs_telemetry_event(summary: SummaryStatistics) -> None:
+def record_sync_outputs_telemetry_event(queue_id: str, summary: SummaryStatistics) -> None:
     """Calls the telemetry client to record an event capturing the sync-outputs summary."""
     details: Dict[str, Any] = asdict(summary)
+    details["queue_id"] = queue_id
     _get_deadline_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.worker_agent.sync_outputs_summary",
         event_details=details,

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -862,7 +862,7 @@ class Session:
         )
 
         # Send the summary stats of input syncing through the telemetry client.
-        record_sync_inputs_telemetry_event(download_summary_statistics)
+        record_sync_inputs_telemetry_event(self._queue_id, download_summary_statistics)
 
         job_attachment_path_mappings = [
             PathMappingRule.from_dict(rule) for rule in path_mapping_rules
@@ -1131,7 +1131,7 @@ class Session:
         ASSET_SYNC_LOGGER.info(f"Summary Statistics for file uploads:\n{upload_summary_statistics}")
 
         # Send the summary stats of output syncing through the telemetry client.
-        record_sync_outputs_telemetry_event(upload_summary_statistics)
+        record_sync_outputs_telemetry_event(self._queue_id, upload_summary_statistics)
 
         ASSET_SYNC_LOGGER.info("Finished syncing outputs using Job Attachments")
 

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -62,7 +62,10 @@ def test_record_sync_inputs_telemetry_event():
             transfer_rate=100,
         )
         # WHEN
-        record_sync_inputs_telemetry_event(summary_stats)
+        record_sync_inputs_telemetry_event(
+            queue_id="queue-test",
+            summary=summary_stats,
+        )
 
     # THEN
     mock_telemetry_client.record_event.assert_called_with(
@@ -76,6 +79,7 @@ def test_record_sync_inputs_telemetry_event():
             "skipped_files": 2,
             "skipped_bytes": 200,
             "transfer_rate": 100.0,
+            "queue_id": "queue-test",
         },
     )
 
@@ -101,7 +105,10 @@ def test_record_sync_outputs_telemetry_event():
             transfer_rate=100,
         )
         # WHEN
-        record_sync_outputs_telemetry_event(summary_stats)
+        record_sync_outputs_telemetry_event(
+            queue_id="queue-test",
+            summary=summary_stats,
+        )
 
     # THEN
     mock_telemetry_client.record_event.assert_called_with(
@@ -115,5 +122,6 @@ def test_record_sync_outputs_telemetry_event():
             "skipped_files": 2,
             "skipped_bytes": 200,
             "transfer_rate": 100.0,
+            "queue_id": "queue-test",
         },
     )

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -574,7 +574,10 @@ class TestSessionSyncAssetInputs:
             os_env_vars=ANY,
         )
 
-        mock_telemetry_event_for_sync_inputs.assert_called_once_with(SummaryStatistics())
+        mock_telemetry_event_for_sync_inputs.assert_called_once_with(
+            "queue-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            SummaryStatistics(),
+        )
 
     @pytest.mark.parametrize(
         "sync_asset_inputs_args_sequence, expected_error",
@@ -646,7 +649,10 @@ class TestSessionSyncAssetInputs:
                 session.sync_asset_inputs(cancel=cancel, **args)  # type: ignore[arg-type]
             # THEN
             for call in mock_telemetry_event_for_sync_inputs.call_args_list:
-                assert call[0] == (SummaryStatistics(),)
+                assert call[0] == (
+                    "queue-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    SummaryStatistics(),
+                )
             assert mock_telemetry_event_for_sync_inputs.call_count == len(
                 sync_asset_inputs_args_sequence
             )
@@ -721,7 +727,10 @@ class TestSessionSyncAssetOutputs:
             storage_profiles_path_mapping_rules={},
             on_uploading_files=ANY,
         )
-        mock_telemetry_event_for_sync_outputs.assert_called_once_with(SummaryStatistics())
+        mock_telemetry_event_for_sync_outputs.assert_called_once_with(
+            "queue-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            SummaryStatistics(),
+        )
 
 
 class TestSessionInnerRun:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When sending a Telemetry request, if required, it would be beneficial to include resource ID in the data to be sent.

### What was the solution? (How)
Included Queue ID in the telemetry data being sent when input syncing / output syncing is done.
- `record_sync_inputs_telemetry_event()`
- `record_sync_outputs_telemetry_event()`

### What is the impact of this change?
This change allows the worker agent to include the Queue ID as an additional information when making the telemetry requests.

### How was this change tested?
Manually ran the worker with the change. The shape of the telemetry data received looked as below. It has `"queue_id"` in the `"event_details"`.
```
{
    "event_timestamp": 1705354811000,
    "event_type": "com.amazon.rum.deadline.worker_agent.sync_outputs_summary",
    "event_id": "5dd2a52d-4a4d-4894-a313-c7c1751c4a62",
    "event_version": "1.0.0",
    "log_stream": "2024-01-15T14",
    "application_id": "00cf4815-a611-42f0-85ac-1e05b995e6e6",
    "metadata": {
        "version": "0.18.0",
        "osName": "Linux",
        "osVersion": "5.10.205-172.804.amzn2int.x86_64",
        "domain": "*.madstudio.aws.dev",
        "service": "deadline-cloud-worker-agent",
        "python_version": "3.10.8",
        "countryCode": "US",
        "subdivisionCode": "OR"
    },
    "user_details": {
        "sessionId": "4f761750-f12c-40e1-880c-8dc6e41eeef0",
        "userId": "e726a3a4-d7c4-4e32-9610-dc333200a625"
    },
    "event_details": {
        "total_time": 0.44686946901492774,
        "total_files": 2,
        "total_bytes": 20971520,
        "processed_files": 2,
        "processed_bytes": 20971520,
        "skipped_files": 0,
        "skipped_bytes": 0,
        "transfer_rate": 46929856.376693845,
        "queue_id": "queue-a0c93fade6de47009999b273cc5b6249"
    }
}
```

### Was this change documented?
No.

### Is this a breaking change?
No.
