### PR TITLE
feat!: adds compatibility with upcoming BatchGetJobEntity API change

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -73,7 +73,7 @@ class RunStepTaskAction(OpenjdAction):
             An executor for running futures
         """
         session.run_task(
-            step_script=self._details.script,
+            step_script=self._details.step_template.script,
             task_parameter_values=self._task_parameter_values,
         )
 

--- a/src/deadline_worker_agent/sessions/job_entities/step_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/step_details.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from openjd.model import parse_model, SchemaVersion, UnsupportedSchema
-from openjd.model.v2023_09 import StepScript as StepScript_2023_09
-from openjd.sessions import StepScriptModel
+from openjd.model.v2023_09 import StepTemplate as StepTemplate_2023_09
 
 from ...api_models import StepDetailsData
 from .job_entity_type import JobEntityType
 from .validation import Field, validate_object
+
+if TYPE_CHECKING:
+    # Replace with `StepTemplate` from openjd-model once that lib adds one.
+    StepTemplate = StepTemplate_2023_09
+else:
+    StepTemplate = Any
 
 
 @dataclass
@@ -20,8 +25,9 @@ class StepDetails:
     ENTITY_TYPE = JobEntityType.STEP_DETAILS.value
     """The JobEntityType handled by this class"""
 
-    script: StepScriptModel
-    """The step's Open Job Description script"""
+    step_template: StepTemplate
+    """The step's Open Job Description step template.
+    """
 
     dependencies: list[str] = field(default_factory=list)
     """The dependencies (a list of IDs) that the step depends on"""
@@ -50,12 +56,23 @@ class StepDetails:
         schema_version = SchemaVersion(step_details_data["schemaVersion"])
 
         if schema_version == SchemaVersion.v2023_09:
-            step_script = parse_model(model=StepScript_2023_09, obj=step_details_data["template"])
+            # Jan 23, 2024: Forwards compatibility. The 'template' field is changing from a StepScript to
+            # a StepTemplate. Remove the StepScript case after the transition is complete.
+            details_data = step_details_data["template"]
+            if "name" in details_data:
+                # New API shape -- 'template' contains a StepTemplate
+                step_template = parse_model(model=StepTemplate_2023_09, obj=details_data)
+            else:
+                # Old API shape -- 'template' contains a StepScript.
+                # If we're GA and you're reading this, then delete this code path.
+                step_template = parse_model(
+                    model=StepTemplate_2023_09, obj={"name": "Placeholder", "script": details_data}
+                )
         else:
             raise UnsupportedSchema(schema_version.value)
 
         return StepDetails(
-            script=step_script,
+            step_template=step_template,
             dependencies=step_details_data["dependencies"],
         )
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -277,6 +277,11 @@ def step_script() -> MagicMock:
 
 
 @pytest.fixture
+def step_template() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
 def hostname() -> str:
     return "workerhostname"
 

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -14,6 +14,7 @@ from openjd.model.v2023_09 import (
     Action,
     StepScript,
     StepActions,
+    StepTemplate,
 )
 from openjd.sessions import Parameter, ParameterType
 import pytest
@@ -66,7 +67,9 @@ _TEST_ENVIRONMENT = Environment(
     name="TestEnv",
     script=_TEST_ENVIRONMENT_SCRIPT,
 )
-_TEST_STEP_SCRIPT = StepScript(actions=StepActions(onRun=Action(command="test.exe")))
+_TEST_STEP_TEMPLATE = StepTemplate(
+    name="TestStep", script=StepScript(actions=StepActions(onRun=Action(command="test.exe")))
+)
 
 
 @pytest.fixture
@@ -148,7 +151,7 @@ class TestSessionActionQueueDequeue:
                     id="id",
                     step_id="stepId",
                     task_id="taskId",
-                    details=StepDetails(script=_TEST_STEP_SCRIPT),
+                    details=StepDetails(step_template=_TEST_STEP_TEMPLATE),
                     task_parameter_values=[
                         Parameter(ParameterType.STRING, "oldstrP", "stringValue"),
                         Parameter(ParameterType.STRING, "strP", "stringValue"),
@@ -187,7 +190,9 @@ class TestSessionActionQueueDequeue:
                 ),
                 SyncInputJobAttachmentsAction(
                     id="id",
-                    step_details=StepDetails(script=_TEST_STEP_SCRIPT, dependencies=["step-1"]),
+                    step_details=StepDetails(
+                        step_template=_TEST_STEP_TEMPLATE, dependencies=["step-1"]
+                    ),
                 ),
                 id="sync input job attachments with step Id",
             ),

--- a/test/unit/sessions/actions/test_sync_input_job_attachments.py
+++ b/test/unit/sessions/actions/test_sync_input_job_attachments.py
@@ -89,7 +89,7 @@ class TestStart:
         self,
         executor: Mock,
         session: Mock,
-        step_script: Mock,
+        step_template: Mock,
         action_id: str,
         step_dependencies: list[str],
     ) -> None:
@@ -102,7 +102,7 @@ class TestStart:
         action = SyncInputJobAttachmentsAction(
             id=action_id,
             step_details=StepDetails(
-                script=step_script,
+                step_template=step_template,
                 dependencies=step_dependencies,
             ),
         )

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -16,6 +16,7 @@ from openjd.model.v2023_09 import (
     EnvironmentScript,
     StepActions,
     StepScript,
+    StepTemplate,
 )
 from openjd.sessions import (
     ActionState,
@@ -169,12 +170,15 @@ def run_step_task_action(
     """A fixture that provides a RunStepTaskAction"""
     return RunStepTaskAction(
         details=StepDetails(
-            script=StepScript(
-                actions=StepActions(
-                    onRun=Action(
-                        command=command,
-                        args=on_run_args,
-                        cancelation=None,
+            step_template=StepTemplate(
+                name="Test",
+                script=StepScript(
+                    actions=StepActions(
+                        onRun=Action(
+                            command=command,
+                            args=on_run_args,
+                            cancelation=None,
+                        ),
                     ),
                 ),
             ),
@@ -686,11 +690,14 @@ class TestSessionSyncAssetOutputs:
         current_action = CurrentAction(
             definition=RunStepTaskAction(
                 details=StepDetails(
-                    script=StepScript(
-                        actions=StepActions(
-                            onRun=Action(
-                                command="echo",
-                                args=["hello"],
+                    step_template=StepTemplate(
+                        name="Test",
+                        script=StepScript(
+                            actions=StepActions(
+                                onRun=Action(
+                                    command="echo",
+                                    args=["hello"],
+                                ),
                             ),
                         ),
                     ),
@@ -1113,11 +1120,14 @@ class TestSessionActionUpdatedImpl:
         current_action = CurrentAction(
             definition=RunStepTaskAction(
                 details=StepDetails(
-                    script=StepScript(
-                        actions=StepActions(
-                            onRun=Action(
-                                command="echo",
-                                args=["hello"],
+                    step_template=StepTemplate(
+                        name="Test",
+                        script=StepScript(
+                            actions=StepActions(
+                                onRun=Action(
+                                    command="echo",
+                                    args=["hello"],
+                                ),
                             ),
                         ),
                     ),
@@ -1177,11 +1187,14 @@ class TestSessionActionUpdatedImpl:
         current_action = CurrentAction(
             definition=RunStepTaskAction(
                 details=StepDetails(
-                    script=StepScript(
-                        actions=StepActions(
-                            onRun=Action(
-                                command="echo",
-                                args=["hello"],
+                    step_template=StepTemplate(
+                        name="Test",
+                        script=StepScript(
+                            actions=StepActions(
+                                onRun=Action(
+                                    command="echo",
+                                    args=["hello"],
+                                ),
                             ),
                         ),
                     ),
@@ -1249,11 +1262,14 @@ class TestSessionActionUpdatedImpl:
         current_action = CurrentAction(
             definition=RunStepTaskAction(
                 details=StepDetails(
-                    script=StepScript(
-                        actions=StepActions(
-                            onRun=Action(
-                                command="echo",
-                                args=["hello"],
+                    step_template=StepTemplate(
+                        name="Test",
+                        script=StepScript(
+                            actions=StepActions(
+                                onRun=Action(
+                                    command="echo",
+                                    args=["hello"],
+                                ),
                             ),
                         ),
                     ),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

 The contents of the `template` field in the `stepDetails` response to BatchGetJobEntity API is being changed. It currently contains an Open Job Description StepScript like so:
```
{
   "embeddedFiles": [ ... ],
   "actions": { "onRun": ... }
}
```

This is being changed to contain an Open Job Description StepTemplate, like so:
```
{
  "name": <step name>, (max 64 characters)
  "script": {
     "embeddedFiles": [ ... ],
     "actions": { "onRun": ... }
  }
}
```

The API response will *NOT* contain the entirety of the StepTemplate submitted with the Job, but rather just the subset that is relevant for the Worker to operate.

### What was the solution? (How)

 This is step 1 in a three phase deployment. It is updating the Worker Agent to understand both API response shapes, and act accordingly. The next step, after the service has been updated, will be to delete the code path related to the old API response shape.

### What is the impact of this change?

Customers using the updated Worker Agent will not break when the API update is deployed.

### How was this change tested?

We have unit test coverage for these code paths, so I updated those. I also ran a live test against the service and verified that it can still dequeue and run simple sleep jobs; note that the test did not include the new API shape since that hasn't been implemented yet.

### Was this change documented?

The service API documentation will be updated.

### Is this a breaking change?

No, actually, but I'm marking it as such so that we update the minor version. That'll make which version to upgrade to clearer to customers.
