### PR TITLE
feat: Cancel Job Attachments session action when transfer rates drop below threshold

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -820,3 +820,18 @@ def record_sync_outputs_telemetry_event(queue_id: str, summary: SummaryStatistic
         event_type="com.amazon.rum.deadline.worker_agent.sync_outputs_summary",
         event_details=details,
     )
+
+
+def record_sync_inputs_fail_telemetry_event(
+    queue_id: str,
+    failure_reason: str,
+) -> None:
+    """Calls the telemetry client to record an event capturing the sync-inputs failure."""
+    details = {
+        "queue_id": queue_id,
+        "failure_reason": failure_reason,
+    }
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.sync_inputs_failure",
+        event_details=details,
+    )

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -64,7 +64,11 @@ from deadline.job_attachments.os_file_permission import (
 )
 from deadline.job_attachments.progress_tracker import ProgressReportMetadata, SummaryStatistics
 
-from ..aws.deadline import record_sync_inputs_telemetry_event, record_sync_outputs_telemetry_event
+from ..aws.deadline import (
+    record_sync_inputs_fail_telemetry_event,
+    record_sync_inputs_telemetry_event,
+    record_sync_outputs_telemetry_event,
+)
 from ..scheduler.session_action_status import SessionActionStatus
 from ..sessions.errors import SessionActionError
 
@@ -83,6 +87,14 @@ OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS: dict[
 }
 TIME_DELTA_ZERO = timedelta()
 
+# During a SYNC_INPUT_JOB_ATTACHMENTS session action, the transfer rate is periodically reported through
+# a callback function. If a transfer rate lower than LOW_TRANSFER_RATE_THRESHOLD is observed in a series
+# for LOW_TRANSFER_COUNT_THRESHOLD times, it is considered concerning or potentially stalled, and the
+# session action is canceled.
+LOW_TRANSFER_RATE_THRESHOLD = 10 * 10**3  # 10 KB/s
+LOW_TRANSFER_COUNT_THRESHOLD = (
+    60  # Each progress report takes 1 sec at the longest, so 60 reports amount to 1 min in total.
+)
 
 logger = getLogger(__name__)
 
@@ -776,12 +788,45 @@ class Session:
         if self._asset_sync is None:
             return
 
-        def progress_handler(job_upload_status: ProgressReportMetadata) -> bool:
+        low_transfer_count = 0
+
+        def progress_handler(job_attachments_download_status: ProgressReportMetadata) -> bool:
+            """
+            Callback for Job Attachments' sync_inputs() to track the download progress.
+            Returns True if the operation should continue as normal or False to cancel.
+            """
+            # Check the transfer rate from the progress report. It monitors for a series of
+            # alarmingly low transfer rates, and if the count exceeds the specified threshold,
+            # cancels the download and fails the current (SYNC_INPUT_JOB_ATTACHMENTS) action.
+            nonlocal low_transfer_count
+            transfer_rate = job_attachments_download_status.transferRate
+
+            if transfer_rate < LOW_TRANSFER_RATE_THRESHOLD:
+                low_transfer_count += 1
+            else:
+                low_transfer_count = 0
+            if low_transfer_count >= LOW_TRANSFER_COUNT_THRESHOLD:
+                cancel.set()
+                action_status = ActionStatus(
+                    state=ActionState.FAILED,
+                    fail_message=(
+                        f"Input syncing failed due to successive low transfer rates (< {LOW_TRANSFER_RATE_THRESHOLD / 1000} KB/s). "
+                        f"The transfer rate was below the threshold for the last {self._seconds_to_minutes_str(LOW_TRANSFER_COUNT_THRESHOLD)}."
+                    ),
+                )
+                self.update_action(action_status)
+                # Send the telemetry data of input syncing failure due to insufficient download speed.
+                record_sync_inputs_fail_telemetry_event(
+                    queue_id=self._queue_id,
+                    failure_reason=(f"Insufficient download speed: {action_status.fail_message}"),
+                )
+                return False
+
             self.update_action(
                 action_status=ActionStatus(
                     state=ActionState.RUNNING,
-                    status_message=job_upload_status.progressMessage,
-                    progress=job_upload_status.progress,
+                    status_message=job_attachments_download_status.progressMessage,
+                    progress=job_attachments_download_status.progress,
                 ),
             )
             return not cancel.is_set()
@@ -887,6 +932,18 @@ class Session:
         # rules that are subsets of each other behave in a predictable manner. We must
         # sort here since we're modifying that internal list appending to the list.
         self._session._path_mapping_rules.sort(key=lambda rule: -len(rule.source_path.parts))
+
+    def _seconds_to_minutes_str(self, seconds: int) -> str:
+        minutes = seconds // 60
+        remaining_seconds = seconds % 60
+        if minutes > 0 and remaining_seconds > 0:
+            return f"{minutes} minute{'s' if minutes != 1 else ''} {remaining_seconds} second{'s' if remaining_seconds != 1 else ''}"
+        elif minutes > 0:
+            return f"{minutes} minute{'s' if minutes != 1 else ''}"
+        elif remaining_seconds == 0:
+            return "0 seconds"
+        else:
+            return f"{remaining_seconds} second{'s' if remaining_seconds != 1 else ''}"
 
     def update_action(self, action_status: ActionStatus) -> None:
         """Callback called on every Open Job Description status/progress update and the completion/exit of the


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
During the SYNC_INPUT_JOB_ATTACHMENTS session actions, there might be a potential for the download operation to get stuck or stall due to unexpected issues. Currently, there is no mechanism to monitor or detect such scenarios. This poses a risk, especially when downloading many/large files or using slow/unstable network.

### What was the solution? (How)
- Leverages the `on_downloading_files` callback function, which is passed to the AssetSync's `sync_inputs` function to track the the file transfer progress. This callback is intended to be called at regular intervals - 1 second at the longest.
- Monitors the transfer rate from the progress report delivered via the callback function. If it detects a series of alarmingly low transfer rates (`< LOW_TRANSFER_RATE_THRESHOLD`), and if the count exceeds the specified threshold (`>= LOW_TRANSFER_COUNT_THRESHOLD`), cancels the download and fails the current (SYNC_INPUT_JOB_ATTACHMENTS) action.

### What is the impact of this change?
Worker agent can now detect and halt potentially stuck SYNC_INPUT_JOB_ATTACHMENTS session actions. This ensures that resources are not wasted on prolonged stalled operations, and that users are timely notified about the issues.

### How was this change tested?
- `hatch run lint && hatch run test`
- Run an end-to-end test (submitting a non-rendering job bundle --> running a CMF)
  - Happy-path: ensured that there were no issues/errors until output files were generated as expected.
  - When Job Attachment's AssetSync (intentionally) reported the download speed lower than the speed threshold for the time longer than the time threshold:
  ```
  Canceled sessionaction-674e8fc017e24d7b94f8dd98eefbbf4f-1 as NEVER_ATTEMPTED
  INFO     [session-674e8fc017e24d7b94f8dd98eefbbf4f] [sessionaction-674e8fc017e24d7b94f8dd98eefbbf4f-0] (job.sync_input_job_attachments()): Action completed as FAILED
  INFO     Synchronizing with service (sending UpdateWorkerSchedule)
  INFO     Updating actions: {'sessionaction-674e8fc017e24d7b94f8dd98eefbbf4f-0': {'startedAt': datetime.datetime(2024, 1, 30, 17, 43, 49, 135243, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'progressMessage': 'Input syncing failed due to successive low transfer rates (< 10 Kb/s). The transfer rate was below the threshold for the last 1 minute.', 'endedAt': datetime.datetime(2024, 1, 30, 17, 44, 16, 518941, tzinfo=datetime.timezone.utc)}, 'sessionaction-674e8fc017e24d7b94f8dd98eefbbf4f-1': {'completedStatus': 'NEVER_ATTEMPTED', 'progressMessage': 'Input syncing failed due to successive low transfer rates (< 10 Kb/s). The transfer rate was below the threshold for the last 1 minute.'}}
  ```

  Also, confirmed that a telemetry data capturing this sync-inputs failure was sent correctly. 
  ```
  {
    "event_timestamp":1706636627000,
    "event_type":"com.amazon.rum.deadline.worker_agent.sync_inputs_failure",
    "event_id":"16c2f820-6d7d-40b5-b777-df2f565a93d1",
    "event_version":"1.0.0",
    "log_stream":"2024-01-30T10",
    "application_id":"00cf4815-a611-42f0-85ac-1e05b995e6e6",
    "metadata": {
      "version":"0.20.0",
      "osName":"Linux",
      "osVersion":"5.10.205-172.807.amzn2int.x86_64",
      "domain":"*.madstudio.aws.dev",
      "service":"deadline-cloud-worker-agent",
      "python_version":"3.10.8",
      "countryCode":"US",
      "subdivisionCode":"OR"
    },
    "user_details":{
      "sessionId":"779308b4-9b63-4c94-8e60-0da0a0155169",
      "userId":"e726a3a4-d7c4-4e32-9610-dc333200a625"
    },
    "event_details":{
      "queue_id":"queue-a0c93fade6de47009999b273cc5b6249",
      "failure_reason":"Insufficient download speed: Input syncing failed due to successive low transfer rates (< 10 Kb/s). The transfer rate was below the threshold for the last 1 minute."
    }
  }
  ```

### Was this change documented?
No.

### Is this a breaking change?
No.
