### PR TITLE
feat: provision ownership on /var/lib/deadline/credentials directory

### DIFF
--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -334,12 +334,16 @@ echo "Done provisioning log directory (/var/log/amazon/deadline)"
 # Provision ownership/persistence on persistence directory
 echo "Provisioning persistence directory (/var/lib/deadline)"
 mkdir -p /var/lib/deadline/queues
+mkdir -p /var/lib/deadline/credentials
 chown "${wa_user}:${job_group}" \
     /var/lib/deadline \
     /var/lib/deadline/queues
+chown "${wa_user}" /var/lib/deadline/credentials
 chmod 750 \
     /var/lib/deadline \
     /var/lib/deadline/queues
+chmod 700 \
+    /var/lib/deadline/credentials
 if [ -f /var/lib/deadline/worker.json ]; then
     chown "${wa_user}:${wa_user}" /var/lib/deadline/worker.json
     chmod 600 /var/lib/deadline/worker.json

--- a/test/unit/startup/test_config.py
+++ b/test/unit/startup/test_config.py
@@ -345,7 +345,7 @@ class TestLoad:
 
 
 class TestInit:
-    """Tests for Configutation.__init__"""
+    """Tests for Configuration.__init__"""
 
     @pytest.mark.parametrize(
         argnames=("farm_id", "fleet_id", "profile", "verbose"),
@@ -865,7 +865,7 @@ class TestInit:
 
 
 class TestLog:
-    """Tests for Configutation.log()"""
+    """Tests for Configuration.log()"""
 
     @pytest.mark.parametrize(
         ("farm_id", "fleet_id", "profile", "verbose"),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The worker credentials directory `/var/lib/deadline/credentials` is world read/executable in a worker agent in a SMF. While the credentials for the worker agent are not accessible, we should make this directory inaccessible as a best practice.

### What was the solution? (How)
Updated the `install.sh` to pre-create the directory and set the correct ownership and permissions. This ensures that the directory is secure from the moment it's created, aligning with best practices for handling sensitive directory.

### What is the impact of this change?
This change proactively secures the credentials directory.

### How was this change tested?
- `hatch run fmt && hatch run lint && hatch run test`
- E2E test by cleaning all the persistence directories and re-installing worker agent by running this command:
  ```
  hatch shell
  install-deadline-worker --farm-id $FARM_ID --fleet-id $FLEET_ID
  ```
  After the installation, I confirmed the ownership and permissions of the directories:
  ```
  (24-02-02 21:28:41) <0> [/var/lib]  
  dev-dsk-gahyusuh-2a-387e0b51 % sudo ls -ld deadline/
  drwxr-x--- 4 deadline-worker-agent deadline-job-users 4096 Feb  2 21:16 deadline/

  (24-02-02 21:29:25) <0> [/var/lib]  
  dev-dsk-gahyusuh-2a-387e0b51 % sudo ls -ld deadline/credentials
  drwx------ 2 deadline-worker-agent root 4096 Feb  2 21:16 deadline/credentials
  ```
  - `/var/lib/deadline`: The owner `deadline-worker-agent` has full access. The owning group `deadline-job-users` has read and execute permissions. No permissions have been granted to other users.
  - `/var/lib/deadline/credentials`: Only the owner `deadline-worker-agent` has full access. Neither the owning group members nor any other users have been granted any permissions.

### Was this change documented?
No.

### Is this a breaking change?
No.
