### PR TITLE
fix: don't invert shutdown_on_stop config file setting's meaning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,14 +95,16 @@ module = [
 ]
 
 [tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
 ignore = [
   "E501",
   "E722",
   "F811",
 ]
-line-length = 100
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = [
   "deadline_worker_agent",
   "deadline",

--- a/src/deadline_worker_agent/startup/config_file.py
+++ b/src/deadline_worker_agent/startup/config_file.py
@@ -116,6 +116,8 @@ class ConfigFile(BaseModel):
             output_settings["worker_persistence_dir"] = self.worker.worker_persistence_dir
         if self.aws.profile is not None:
             output_settings["profile"] = self.aws.profile
+        if self.aws.allow_ec2_instance_profile is not None:
+            output_settings["allow_instance_profile"] = self.aws.allow_ec2_instance_profile
         if self.logging.verbose is not None:
             output_settings["verbose"] = self.logging.verbose
         if self.logging.worker_logs_dir is not None:
@@ -129,13 +131,11 @@ class ConfigFile(BaseModel):
                 "host_metrics_logging_interval_seconds"
             ] = self.logging.host_metrics_logging_interval_seconds
         if self.os.shutdown_on_stop is not None:
-            output_settings["no_shutdown"] = self.os.shutdown_on_stop
+            output_settings["no_shutdown"] = not self.os.shutdown_on_stop
         if self.os.run_jobs_as_agent_user is not None:
             output_settings["run_jobs_as_agent_user"] = self.os.run_jobs_as_agent_user
         if self.os.posix_job_user is not None:
             output_settings["posix_job_user"] = self.os.posix_job_user
-        if self.aws.allow_ec2_instance_profile is not None:
-            output_settings["allow_instance_profile"] = self.aws.allow_ec2_instance_profile
         if self.capabilities is not None:
             output_settings["capabilities"] = self.capabilities
 

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -456,7 +456,7 @@ def test_system_shutdown(
         entrypoint_mod._system_shutdown(config=configuration)
 
     # THEN
-    logger_info_mock.assert_any_call("Shutting down the instance")
+    logger_info_mock.assert_any_call("Shutting down the host")
     subprocess_popen_mock.assert_called_once_with(
         expected_command,
         stdout=subprocess.PIPE,
@@ -501,7 +501,7 @@ def test_system_shutdown_failure(
         entrypoint_mod._system_shutdown(config=configuration)
 
     # THEN
-    logger_mock.info.assert_any_call("Shutting down the instance")
+    logger_mock.info.assert_any_call("Shutting down the host")
     subprocess_popen_mock.assert_called_once_with(
         expected_command,
         stdout=subprocess.PIPE,
@@ -542,9 +542,8 @@ def test_no_shutdown_only_log(
         entrypoint_mod._system_shutdown(config=configuration)
 
     # THEN
-    logger_info_mock.assert_called_with("Shutting down the instance")
-    logger_debug_mock.assert_called_with(
-        f"Skipping system shutdown. The following command would have been run: '{expected_command}'"
+    logger_info_mock.assert_called_with(
+        "NOT shutting down the host. Local configuration settings say not to."
     )
     system_mock.assert_not_called()
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1. The configuration file setting "shutdown_on_stop" inadvertently had its meaning inverted. If set to 'true' then it would *not* shutdown the host when requested; it's supposed to shutdown the host.
2. The log for choosing to not shutdown the host when the service suggests it was a debug level log.

### What was the solution? (How)

1. Invert the use of 'shutdown_on_stop' internally so that the meaning of the option is as the plain language meaning says.
2. Rework the logging around host shutdown to be clearer regarding what's happening.

### What is the impact of this change?

Customers should be less confused. We had someone that set 'shutdown_on_stop = true' in their configuration file, as per our service documentation, and was puzzled by the host not terminating as expected.

### How was this change tested?

I added to the unit tests. The problematic code for the configuration file was completely untested. It is now tested.

### Was this change documented?

N/A

### Is this a breaking change?

Potentially; only if someone was relying on the inverted behavior in their configuration file.
