### PR TITLE
chore(deps): update to openjd-sessions 0.5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
     "deadline == 0.37.*",
-    "openjd-sessions == 0.2.*",
+    "openjd-sessions == 0.5.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "typing_extensions ~= 4.8",

--- a/scripts/create_service_resources.sh
+++ b/scripts/create_service_resources.sh
@@ -34,6 +34,7 @@ then
         
     echo "Creating Amazon Deadline Cloud Farm $farm_name"
     FARM_ID=$(aws deadline create-farm --display-name $farm_name | jq -r ".farmId")
+    echo "Created Farm: ${FARM_ID}"
 fi
 
 if [ "${QUEUE_ID_1:-}" == "" ]
@@ -47,7 +48,6 @@ then
 {
     "farmId": "$FARM_ID",
     "displayName": "$queue_name",
-    "status": "IDLE",
     "jobRunAsUser": {
         "posix": {
             "user": "jobuser",
@@ -66,7 +66,6 @@ EOF
 {
     "farmId": "$FARM_ID",
     "displayName": "$queue_name",
-    "status": "IDLE",
     "roleArn": "$queue_1_iam_role",
     "jobRunAsUser": {
         "posix": {
@@ -112,7 +111,6 @@ then
 {
     "farmId": "$FARM_ID",
     "displayName": "$queue_name",
-    "status": "IDLE",
     "jobRunAsUser": {
         "posix": {
             "user": "jobuser",
@@ -131,7 +129,6 @@ EOF
 {
     "farmId": "$FARM_ID",
     "displayName": "$queue_name",
-    "status": "IDLE",
     "roleArn": "$queue_2_iam_role",
     "jobRunAsUser": {
         "posix": {

--- a/scripts/submit_jobs/sleep/sleep_job.json
+++ b/scripts/submit_jobs/sleep/sleep_job.json
@@ -5,7 +5,7 @@
         {
             "name": "duration",
             "type": "INT",
-            "default": 45,
+            "default": 60,
             "minValue": 10,
             "maxValue": 600
         }
@@ -17,7 +17,8 @@
                 "actions": {
                     "onRun": {
                         "command": "{{ Task.File.runScript }}",
-                        "args": ["{{ Param.duration }}"]
+                        "args": ["{{ Param.duration }}"],
+                        "timeout": 45
                     }
                 },
                 "embeddedFiles": [

--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -37,7 +37,7 @@ from ..sessions.errors import (
     JobEntityUnsupportedSchemaError,
     StepDetailsError,
 )
-from ..sessions.job_entities.job_details import parameters_data_to_list
+from ..sessions.job_entities.job_details import parameters_from_api_response
 
 if TYPE_CHECKING:
     from ..sessions.job_entities import JobEntities
@@ -374,7 +374,7 @@ class SessionActionQueue:
                 except (ValueError, RuntimeError) as e:
                     raise StepDetailsError(action_id, str(e)) from e
                 task_parameters_data: dict = action_definition.get("parameters", {})
-                task_parameters = parameters_data_to_list(task_parameters_data)
+                task_parameters = parameters_from_api_response(task_parameters_data)
 
                 next_action = RunStepTaskAction(
                     id=action_id,

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from concurrent.futures import Executor
 from typing import Any, TYPE_CHECKING
 
-from openjd.sessions import Parameter
+from openjd.model import TaskParameterSet
 
 from .openjd_action import OpenjdAction
 
@@ -26,14 +26,14 @@ class RunStepTaskAction(OpenjdAction):
         The environment details
     task_id : str
         The unique task identifier
-    task_parameter_values : list[Parameter]
+    task_parameter_values : TaskParameterSet
         The task parameter values
     """
 
     step_id: str
     task_id: str
     _details: StepDetails
-    _task_parameter_values: list[Parameter]
+    _task_parameter_values: TaskParameterSet
 
     def __init__(
         self,
@@ -42,7 +42,7 @@ class RunStepTaskAction(OpenjdAction):
         step_id: str,
         details: StepDetails,
         task_id: str,
-        task_parameter_values: list[Parameter],
+        task_parameter_values: TaskParameterSet,
     ) -> None:
         super(RunStepTaskAction, self).__init__(
             id=id,
@@ -79,6 +79,6 @@ class RunStepTaskAction(OpenjdAction):
 
     def human_readable(self) -> str:
         param_str = ", ".join(
-            f"{param.name}={repr(param.value)}" for param in self._task_parameter_values
+            f"{name}={repr(param.value)}" for name, param in self._task_parameter_values.items()
         )
         return f"step[{self.step_id}].run({param_str})"

--- a/src/deadline_worker_agent/sessions/job_entities/environment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/environment_details.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, cast
 
-from openjd.model import parse_model, SchemaVersion, UnsupportedSchema
+from openjd.model import parse_model, TemplateSpecificationVersion, UnsupportedSchema
 from openjd.model.v2023_09 import Environment as Environment_2023_09
 from openjd.sessions import EnvironmentModel
 
@@ -44,9 +44,12 @@ class EnvironmentDetails:
             If the environment's Open Job Description schema version not unsupported
         """
 
-        schema_version = SchemaVersion(environment_details_data["schemaVersion"])
+        schema_version = TemplateSpecificationVersion(environment_details_data["schemaVersion"])
 
-        if schema_version == SchemaVersion.v2023_09:
+        if schema_version in (
+            TemplateSpecificationVersion.JOBTEMPLATE_v2023_09,
+            TemplateSpecificationVersion.ENVIRONMENT_v2023_09,
+        ):
             environment = parse_model(
                 model=Environment_2023_09, obj=environment_details_data["template"]
             )

--- a/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_attachment_details.py
@@ -4,46 +4,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, cast
 
-from openjd.sessions import Parameter, ParameterType
 from deadline.job_attachments.models import JobAttachmentsFileSystem
 
 from ...api_models import (
-    FloatParameter,
-    IntParameter,
     JobAttachmentDetailsData,
-    PathParameter,
-    StringParameter,
 )
 from .job_entity_type import JobEntityType
 from .validation import Field, validate_object
-
-
-def parameters_data_to_list(
-    params: dict[str, StringParameter | PathParameter | IntParameter | FloatParameter | str]
-) -> list[Parameter]:
-    result = list[Parameter]()
-    for name, value in params.items():
-        # TODO: Change to the correct type once typing information is available
-        # in the task_run action details.
-        if isinstance(value, str):
-            # old style for the API - TODO remove this once the assign API is updated
-            result.append(Parameter(ParameterType.STRING, name, value))
-        elif "string" in value:
-            value = cast(StringParameter, value)
-            result.append(Parameter(ParameterType.STRING, name, value["string"]))
-        elif "int" in value:
-            value = cast(IntParameter, value)
-            result.append(Parameter(ParameterType.INT, name, value["int"]))
-        elif "float" in value:
-            value = cast(FloatParameter, value)
-            result.append(Parameter(ParameterType.FLOAT, name, value["float"]))
-        elif "path" in value:
-            value = cast(PathParameter, value)
-            result.append(Parameter(ParameterType.PATH, name, value["path"]))
-        else:
-            # TODO - PATH parameter types
-            raise ValueError(f"Parameter {name} -- unknown form in API response: {str(value)}")
-    return result
 
 
 @dataclass(frozen=True)

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -6,10 +6,15 @@ from pathlib import PurePath, PurePosixPath, PureWindowsPath
 from typing import Any, cast
 import os
 
-from openjd.model import SchemaVersion, UnsupportedSchema
+from openjd.model import (
+    JobParameterValues,
+    ParameterValue,
+    ParameterValueType,
+    SpecificationRevision,
+    TemplateSpecificationVersion,
+    UnsupportedSchema,
+)
 from openjd.sessions import (
-    Parameter,
-    ParameterType,
     PathFormat,
     PosixSessionUser,
 )
@@ -29,31 +34,27 @@ from .job_entity_type import JobEntityType
 from .validation import Field, validate_object
 
 
-def parameters_data_to_list(
+def parameters_from_api_response(
     params: dict[str, StringParameter | PathParameter | IntParameter | FloatParameter | str]
-) -> list[Parameter]:
-    result = list[Parameter]()
+) -> dict[str, ParameterValue]:
+    result = dict[str, ParameterValue]()
     for name, value in params.items():
-        # TODO: Change to the correct type once typing information is available
-        # in the task_run action details.
-        if isinstance(value, str):
-            # old style for the API - TODO remove this once the assign API is updated
-            result.append(Parameter(ParameterType.STRING, name, value))
-        elif "string" in value:
+        print(name, value)
+        if "string" in value:
             value = cast(StringParameter, value)
-            result.append(Parameter(ParameterType.STRING, name, value["string"]))
+            param_value = ParameterValue(type=ParameterValueType.STRING, value=value["string"])
         elif "int" in value:
             value = cast(IntParameter, value)
-            result.append(Parameter(ParameterType.INT, name, value["int"]))
+            param_value = ParameterValue(type=ParameterValueType.INT, value=value["int"])
         elif "float" in value:
             value = cast(FloatParameter, value)
-            result.append(Parameter(ParameterType.FLOAT, name, value["float"]))
+            param_value = ParameterValue(type=ParameterValueType.FLOAT, value=value["float"])
         elif "path" in value:
             value = cast(PathParameter, value)
-            result.append(Parameter(ParameterType.PATH, name, value["path"]))
+            param_value = ParameterValue(type=ParameterValueType.PATH, value=value["path"])
         else:
-            # TODO - PATH parameter types
             raise ValueError(f"Parameter {name} -- unknown form in API response: {str(value)}")
+        result[name] = param_value
     return result
 
 
@@ -153,13 +154,13 @@ class JobDetails:
     log_group_name: str
     """The name of the log group for the session"""
 
-    schema_version: SchemaVersion
+    schema_version: SpecificationRevision
     """The Open Job Description schema version"""
 
     job_attachment_settings: JobAttachmentSettings | None = None
     """The job attachment settings of the job's queue"""
 
-    parameters: list[Parameter] = field(default_factory=list)
+    parameters: JobParameterValues = field(default_factory=dict)
     """The job's parameters"""
 
     job_run_as_user: JobRunAsUser | None = None
@@ -187,7 +188,7 @@ class JobDetails:
         """
 
         job_parameters_data: dict = job_details_data.get("parameters", {})
-        job_parameters = parameters_data_to_list(job_parameters_data)
+        job_parameters = parameters_from_api_response(job_parameters_data)
         path_mapping_rules: list[OPENJDPathMappingRule] = []
         path_mapping_rules_data = job_details_data.get("pathMappingRules", None)
         if path_mapping_rules_data:
@@ -209,10 +210,12 @@ class JobDetails:
             or None
         )
 
-        schema_version = SchemaVersion(job_details_data["schemaVersion"])
+        given_schema_version = TemplateSpecificationVersion(job_details_data["schemaVersion"])
 
-        if schema_version != SchemaVersion.v2023_09:
-            raise UnsupportedSchema(schema_version.value)
+        if given_schema_version == TemplateSpecificationVersion.JOBTEMPLATE_v2023_09:
+            schema_version = SpecificationRevision.v2023_09
+        else:
+            raise UnsupportedSchema(given_schema_version.value)
 
         return JobDetails(
             parameters=job_parameters,

--- a/src/deadline_worker_agent/sessions/job_entities/step_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/step_details.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
-from openjd.model import parse_model, SchemaVersion, UnsupportedSchema
+from openjd.model import parse_model, TemplateSpecificationVersion, UnsupportedSchema
 from openjd.model.v2023_09 import StepTemplate as StepTemplate_2023_09
 
 from ...api_models import StepDetailsData
@@ -53,9 +53,9 @@ class StepDetails:
             If the environment's Open Job Description schema version not unsupported
         """
 
-        schema_version = SchemaVersion(step_details_data["schemaVersion"])
+        schema_version = TemplateSpecificationVersion(step_details_data["schemaVersion"])
 
-        if schema_version == SchemaVersion.v2023_09:
+        if schema_version == TemplateSpecificationVersion.JOBTEMPLATE_v2023_09:
             # Jan 23, 2024: Forwards compatibility. The 'template' field is changing from a StepScript to
             # a StepTemplate. Remove the StepScript case after the transition is complete.
             details_data = step_details_data["template"]

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -36,19 +36,19 @@ if TYPE_CHECKING:
     from .actions import SessionActionDefinition
     from .job_entities import JobAttachmentDetails, JobDetails
 
+from openjd.model import TaskParameterSet
 from openjd.sessions import (
     ActionState,
     ActionStatus,
     EnvironmentIdentifier,
     EnvironmentModel,
-    Parameter,
+    LOG as OPENJD_LOG,
     PathMappingRule,
     PosixSessionUser,
     StepScriptModel,
+    Session as OPENJDSession,
     SessionUser,
 )
-from openjd.sessions import Session as OPENJDSession
-from openjd.sessions import LOG as OPENJD_LOG
 
 from deadline.job_attachments.asset_sync import AssetSync
 from deadline.job_attachments.asset_sync import logger as ASSET_SYNC_LOGGER
@@ -79,6 +79,7 @@ OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS: dict[
     ActionState.CANCELED: "CANCELED",
     ActionState.FAILED: "FAILED",
     ActionState.SUCCESS: "SUCCEEDED",
+    ActionState.TIMEOUT: "FAILED",
 }
 TIME_DELTA_ZERO = timedelta()
 
@@ -960,7 +961,11 @@ class Session:
             assert self._stop.is_set(), "current_action is None or stopping"
             return
 
-        is_unsuccessful = action_status.state in (ActionState.FAILED, ActionState.CANCELED)
+        is_unsuccessful = action_status.state in (
+            ActionState.FAILED,
+            ActionState.CANCELED,
+            ActionState.TIMEOUT,
+        )
 
         if (
             action_status.state == ActionState.SUCCESS
@@ -1139,7 +1144,7 @@ class Session:
         self,
         *,
         step_script: StepScriptModel,
-        task_parameter_values: list[Parameter],
+        task_parameter_values: TaskParameterSet,
     ) -> None:
         self._session.run_task(
             step_script=step_script,

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -15,9 +15,13 @@ from deadline.job_attachments.models import (
     ManifestProperties,
     PathFormat,
 )
-from openjd.model import SchemaVersion
+from openjd.model import (
+    JobParameterValues,
+    ParameterValue,
+    SpecificationRevision,
+    TemplateSpecificationVersion,
+)
 from openjd.sessions import (
-    Parameter,
     PathMappingRule,
     SessionUser,
     PosixSessionUser,
@@ -179,9 +183,14 @@ def log_group_name() -> str:
 
 
 @pytest.fixture
-def schema_version() -> SchemaVersion:
+def job_template_version() -> TemplateSpecificationVersion:
     """The Open Job Description schema version"""
-    return SchemaVersion.v2023_09
+    return TemplateSpecificationVersion.JOBTEMPLATE_v2023_09
+
+
+@pytest.fixture
+def specification_revision() -> SpecificationRevision:
+    return SpecificationRevision.v2023_09
 
 
 @pytest.fixture
@@ -232,9 +241,9 @@ def job_attachment_details(
 
 
 @pytest.fixture
-def job_parameters() -> list[Parameter]:
+def job_parameters() -> JobParameterValues:
     """The job's parameters"""
-    return []
+    return dict[str, ParameterValue]()
 
 
 @pytest.fixture
@@ -255,11 +264,11 @@ def path_mapping_rules() -> list[PathMappingRule] | None:
 @pytest.fixture
 def job_details(
     queue_job_attachment_settings: JobAttachmentSettings,
-    job_parameters: list[Parameter],
+    job_parameters: JobParameterValues,
     log_group_name: str,
     job_run_as_user: JobRunAsUser,
     path_mapping_rules: list[PathMappingRule],
-    schema_version: SchemaVersion,
+    specification_revision: SpecificationRevision,
 ) -> JobDetails:
     return JobDetails(
         job_attachment_settings=queue_job_attachment_settings,
@@ -267,7 +276,7 @@ def job_details(
         job_run_as_user=job_run_as_user,
         path_mapping_rules=path_mapping_rules,
         log_group_name=log_group_name,
-        schema_version=schema_version,
+        schema_version=specification_revision,
     )
 
 

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock, Mock, patch
 from collections import OrderedDict
 
 from deadline.job_attachments.models import JobAttachmentsFileSystem
-from openjd.model import SchemaVersion, UnsupportedSchema
+from openjd.model import (
+    ParameterValue,
+    ParameterValueType,
+    TemplateSpecificationVersion,
+    UnsupportedSchema,
+)
 from openjd.model.v2023_09 import (
     Environment,
     EnvironmentScript,
@@ -16,7 +21,6 @@ from openjd.model.v2023_09 import (
     StepActions,
     StepTemplate,
 )
-from openjd.sessions import Parameter, ParameterType
 import pytest
 
 from deadline_worker_agent.scheduler.session_queue import (
@@ -139,7 +143,6 @@ class TestSessionActionQueueDequeue:
                         stepId="stepId",
                         # ordered so that the list order is predictable on output
                         parameters=OrderedDict(
-                            oldstrP="stringValue",
                             strP={"string": "stringValue"},
                             pathP={"path": "/tmp"},
                             intP={"int": "12"},
@@ -152,13 +155,12 @@ class TestSessionActionQueueDequeue:
                     step_id="stepId",
                     task_id="taskId",
                     details=StepDetails(step_template=_TEST_STEP_TEMPLATE),
-                    task_parameter_values=[
-                        Parameter(ParameterType.STRING, "oldstrP", "stringValue"),
-                        Parameter(ParameterType.STRING, "strP", "stringValue"),
-                        Parameter(ParameterType.PATH, "pathP", "/tmp"),
-                        Parameter(ParameterType.INT, "intP", "12"),
-                        Parameter(ParameterType.FLOAT, "floatP", "1.2"),
-                    ],
+                    task_parameter_values={
+                        "strP": ParameterValue(type=ParameterValueType.STRING, value="stringValue"),
+                        "pathP": ParameterValue(type=ParameterValueType.PATH, value="/tmp"),
+                        "intP": ParameterValue(type=ParameterValueType.INT, value="12"),
+                        "floatP": ParameterValue(type=ParameterValueType.FLOAT, value="1.2"),
+                    },
                 ),
                 id="task run",
             ),
@@ -333,7 +335,7 @@ class TestSessionActionQueueDequeue:
         session_queue._actions = [queue_entry]
         session_queue._actions_by_id[queue_entry.definition["sessionActionId"]] = queue_entry
 
-        inner_error = UnsupportedSchema(SchemaVersion.UNDEFINED.value)
+        inner_error = UnsupportedSchema(TemplateSpecificationVersion.UNDEFINED.value)
         job_entity_mock = MagicMock()
         job_entity_mock.environment_details.side_effect = inner_error
         job_entity_mock.step_details.side_effect = inner_error
@@ -384,7 +386,6 @@ class TestCancelAll:
                     stepId="stepId",
                     # ordered so that the list order is predictable on output
                     parameters=OrderedDict(
-                        oldstrP="stringValue",
                         strP={"string": "stringValue"},
                         pathP={"path": "/tmp"},
                         intP={"int": "12"},

--- a/test/unit/sessions/job_entities/test_job_details.py
+++ b/test/unit/sessions/job_entities/test_job_details.py
@@ -5,7 +5,7 @@ import pytest
 
 from deadline_worker_agent.sessions.job_entities.job_details import JobDetails, JobRunAsUser
 from deadline_worker_agent.api_models import JobDetailsData
-from openjd.model import SchemaVersion
+from openjd.model import SpecificationRevision
 from openjd.sessions import PosixSessionUser
 
 
@@ -214,7 +214,7 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
             },
             JobDetails(
                 log_group_name="/aws/deadline/queue-0000",
-                schema_version=SchemaVersion.v2023_09,
+                schema_version=SpecificationRevision.v2023_09,
                 job_run_as_user=JobRunAsUser(posix=PosixSessionUser(user="user1", group="group1")),
             ),
             id="only required fields",
@@ -234,7 +234,7 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
             },
             JobDetails(
                 log_group_name="/aws/deadline/queue-0000",
-                schema_version=SchemaVersion.v2023_09,
+                schema_version=SpecificationRevision.v2023_09,
                 job_run_as_user=JobRunAsUser(posix=PosixSessionUser(user="user1", group="group1")),
             ),
             id="required fields with runAs QUEUE_CONFIGURED_USER",
@@ -253,7 +253,7 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
             },
             JobDetails(
                 log_group_name="/aws/deadline/queue-0000",
-                schema_version=SchemaVersion.v2023_09,
+                schema_version=SpecificationRevision.v2023_09,
             ),
             id="required with empty user/group",
         ),
@@ -268,7 +268,7 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
             },
             JobDetails(
                 log_group_name="/aws/deadline/queue-0000",
-                schema_version=SchemaVersion.v2023_09,
+                schema_version=SpecificationRevision.v2023_09,
             ),
             id="required with runAs WORKER_AGENT_USER",
         ),

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -5,7 +5,12 @@ from typing import Generator
 from unittest.mock import MagicMock, patch
 
 from deadline.job_attachments.models import JobAttachmentsFileSystem
-from openjd.model import SchemaVersion
+from openjd.model import (
+    ParameterValue,
+    ParameterValueType,
+    SpecificationRevision,
+    TemplateSpecificationVersion,
+)
 from openjd.model.v2023_09 import (
     Action,
     Environment,
@@ -197,7 +202,7 @@ class TestJobEntity:
                 },
             },
             "logGroupName": "TEST",
-            "schemaVersion": SchemaVersion.v2023_09.value,
+            "schemaVersion": TemplateSpecificationVersion.JOBTEMPLATE_v2023_09.value,
         }
 
         # WHEN
@@ -225,6 +230,12 @@ class TestDetails:
                         "group": "job-group",
                     },
                 },
+                "parameters": {
+                    "p_string": {"string": "string_value"},
+                    "p_int": {"int": "1"},
+                    "p_float": {"float": "1.2"},
+                    "p_path": {"path": "/tmp/share"},
+                },
             },
         )
         response: BatchGetJobEntityResponse = {
@@ -232,11 +243,17 @@ class TestDetails:
             "errors": [],
         }
         expected_details = JobDetails(
-            schema_version=SchemaVersion("jobtemplate-2023-09"),
+            schema_version=SpecificationRevision("2023-09"),
             log_group_name="fake-name",
             job_run_as_user=JobRunAsUser(
                 posix=PosixSessionUser(user="job-user", group="job-group")
             ),
+            parameters={
+                "p_string": ParameterValue(type=ParameterValueType.STRING, value="string_value"),
+                "p_int": ParameterValue(type=ParameterValueType.INT, value="1"),
+                "p_float": ParameterValue(type=ParameterValueType.FLOAT, value="1.2"),
+                "p_path": ParameterValue(type=ParameterValueType.PATH, value="/tmp/share"),
+            },
         )
         assert expected_details.job_run_as_user is not None  # For type checker
         deadline_client.batch_get_job_entity.return_value = response

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -9,6 +9,7 @@ from typing import Generator, Iterable, Literal, Optional
 from unittest.mock import patch, MagicMock, ANY
 
 import pytest
+from openjd.model import ParameterValue
 from openjd.model.v2023_09 import (
     Action,
     Environment,
@@ -186,7 +187,7 @@ def run_step_task_action(
         id=action_id,
         step_id=step_id,
         task_id=task_id,
-        task_parameter_values=[],
+        task_parameter_values=dict[str, ParameterValue](),
     )
 
 
@@ -705,7 +706,7 @@ class TestSessionSyncAssetOutputs:
                 id=action_id,
                 step_id=step_id,
                 task_id=task_id,
-                task_parameter_values=[],
+                task_parameter_values=dict[str, ParameterValue](),
             ),
             start_time=action_start_time,
         )
@@ -1135,7 +1136,7 @@ class TestSessionActionUpdatedImpl:
                 id=action_id,
                 step_id=step_id,
                 task_id=task_id,
-                task_parameter_values=[],
+                task_parameter_values=dict[str, ParameterValue](),
             ),
             start_time=action_start_time,
         )
@@ -1202,7 +1203,7 @@ class TestSessionActionUpdatedImpl:
                 id=action_id,
                 step_id=step_id,
                 task_id=task_id,
-                task_parameter_values=[],
+                task_parameter_values=dict[str, ParameterValue](),
             ),
             start_time=action_start_time,
         )
@@ -1277,7 +1278,7 @@ class TestSessionActionUpdatedImpl:
                 id=action_id,
                 step_id=step_id,
                 task_id=task_id,
-                task_parameter_values=[],
+                task_parameter_values=dict[str, ParameterValue](),
             ),
             start_time=action_start_time,
         )


### PR DESCRIPTION
Summary:

### What was the problem/requirement? (What/Why)

The worker agent hasn't had an update of its openjd-sessions dependency in quite some time. It's time to do that.

### What was the solution? (How)

This updates the agent to `openjd-sessions` 0.5.x and makes the required breaking changes.

### What is the impact of this change?

We take on improvements that have been made to the runtime. e.g. improved session logs, and reporting of action timeouts separately from cancelations.

### How was this change tested?

I've updated the unit tests and run the agent locally to run a 'sleep' job.

### Was this change documented?

N/A

### Is this a breaking change?

No
