### PR TITLE
fix: no longer sigterm agent when running jobs as same user

### DIFF
--- a/src/deadline_worker_agent/scheduler/session_cleanup.py
+++ b/src/deadline_worker_agent/scheduler/session_cleanup.py
@@ -99,7 +99,7 @@ class SessionUserCleanupManager:
             raise NotImplementedError("Windows not supported")
 
         # Check that the session user isn't the current user (agent user)
-        current_user = subprocess.check_output(["/usr/bin/whoami"], text=True)
+        current_user = subprocess.check_output(["/usr/bin/whoami"], text=True).strip()
         if current_user == user.user:
             logger.info(
                 f"Skipping cleaning up processes because the session user matches the agent user '{current_user}'"

--- a/test/unit/scheduler/test_session_cleanup.py
+++ b/test/unit/scheduler/test_session_cleanup.py
@@ -212,7 +212,7 @@ class TestSessionUserCleanupManager:
             with patch.object(
                 session_cleanup_mod.subprocess,
                 "check_output",
-                return_value=agent_user.user,
+                return_value=f"{agent_user.user}\n",
             ) as mock:
                 yield mock
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running jobs as the same user as the agent (i.e. the Queue's jobsRunAs user is the same os user) the agent is SIGTERMing itself when there is no work left for it to work on. It shouldn't be doing that.

### What was the solution? (How)

We were doing a /usr/bin/whoami to find out who the agent is running as, but that output had a trailing newline that was interfering with the check for whether the job user and agent user are the same. This fixes that.

### What is the impact of this change?

The agent can no longer be convinced to take a long walk off of a short pier.

### How was this change tested?

I updated the unit tests, but also:

```
>>> import subprocess
>>> subprocess.check_output(["/usr/bin/whoami"], text=True)
'username\n'
>>> subprocess.check_output(["/usr/bin/whoami"], text=True).strip()
'username'
```

### Was this change documented?

N/A

### Is this a breaking change?

No