### PR TITLE
fix: permissions on /var/log/amazon directory

### DIFF
--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -327,6 +327,7 @@ fi
 # Provision log directory
 echo "Provisioning log directory (/var/log/amazon/deadline)"
 mkdir -p /var/log/amazon/deadline
+chmod 755 /var/log/amazon
 chown -R "${wa_user}:${wa_user}" /var/log/amazon/deadline
 chmod -R 750 /var/log/amazon/deadline
 echo "Done provisioning log directory (/var/log/amazon/deadline)"


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

It's been reported that when the worker-agent installer, running as root, creates `/var/log/amazon/deadline` that the agent was unable to write its own logs to that directory when running as a non-root user.

### What was the solution? (How)

Add go+rx to `/var/log/amazon` -- this is the solution reported to work by the reporting customer.

### What is the impact of this change?

The installer should be closer to working as-is without hacks.

### How was this change tested?

It's a straightforward application of the solution found by the customer. We don't currently have direct tests for the installer, unfortunately.

### Was this change documented?

N/A

### Is this a breaking change?

No