### PR TITLE
fix!: change default job-user group to match service defaults

### DIFF
--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -108,7 +108,7 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
     )
     parser.add_argument(
         "--group",
-        help='The POSIX group that is shared between the Agent user and the user(s) that jobs run as. Defaults to "deadline-job-users".',
+        help='The POSIX group that is shared between the Agent user and the user(s) that jobs run as. Defaults to "job-group".',
     )
     parser.add_argument(
         "--start",

--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -31,7 +31,7 @@ SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Defaults
 default_wa_user=deadline-worker
-default_job_group=deadline-job-users
+default_job_group=job-group
 farm_id=unset
 fleet_id=unset
 wa_user=$default_wa_user


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The agent's install script creates the deadline-job-users group, but the AWS Console defaults to job-group for the jobRunAsUser option. This has tripped up some customers.

### What was the solution? (How)

Change the install script's created job-group to match the service default.

### What is the impact of this change?

Hopefully fewer confused customers.

### How was this change tested?

Trivial change. No testing

### Was this change documented?

N/A

### Is this a breaking change?

Technically yes. A customer that used the previous defaults will end up with different users when switching to this updated agent.