### PR TITLE
test: add unit tests for file system operations

### DIFF
--- a/test/unit/test_file_system_operations.py
+++ b/test/unit/test_file_system_operations.py
@@ -70,7 +70,7 @@ class TestFileSystemOperations:
         )
 
         # THEN
-        dacl_mocked_obj.AddAccessAllowedAceEx.assert_called_once()
+        dacl_mocked_obj.AddAccessAllowedAceEx.assert_called_once_with(2, 3, 1179926, mock.Mock)
         sd_mocked_obj.SetSecurityDescriptorDacl.assert_called_once_with(1, dacl_mocked_obj, 0)
 
     @patch("win32security.SetFileSecurity", return_value=mock.Mock)
@@ -103,7 +103,12 @@ class TestFileSystemOperations:
         )
 
         # THEN
-        assert dacl_mocked_obj.AddAccessAllowedAceEx.call_count == 2
+        dacl_mocked_obj.AddAccessAllowedAceEx.assert_has_calls(
+            [
+                mock.call(2, 3, 1179926, mock.Mock),
+                mock.call(2, 3, 1179926, mock.Mock),
+            ]
+        )
         sd_mocked_obj.SetSecurityDescriptorDacl.assert_called_once_with(1, dacl_mocked_obj, 0)
 
     @patch("win32security.SetFileSecurity", return_value=mock.Mock)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
FileSystemOperations do not have unit tests currently

### What was the solution? (How)
Added Unit tests for all methods used in FileSystemOperations.

### What is the impact of this change?
Better coverage.

### How was this change tested?
Ran all existing Unit tests and new Unit tests to determine if all works well!

```
============================= slowest 5 durations =============================
1.10s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_no_imds[jobs_run_as_overrides0]
1.03s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_asg_termination[jobs_run_as_overrides0]
1.03s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[jobs_run_as_overrides0-spot-shutdown-1-min]
1.02s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[jobs_run_as_overrides0-spot-shutdown-15-sec]
0.20s call     test/unit/sessions/test_log_config.py::TestLogConfiguration::test_from_boto_local_log_setup
=============== 2533 passed, 19 skipped, 13 warnings in 24.80s ================

```

```
============================= test session starts =============================
platform win32 -- Python 3.12.2, pytest-7.4.4, pluggy-1.4.0
rootdir: c:\Users\sakshie\codebase\deadline-cloud-worker-agent
configfile: pyproject.toml
plugins: deadline-cloud-test-fixtures-0.5.4, cov-4.1.0, xdist-3.3.1
collected 7 items

test/unit/test_file_system_operations.py::TestFileSystemOperations::test_set_permissions_invalid_session_user_with_user_permissions PASSED [ 14%]
test/unit/test_file_system_operations.py::TestFileSystemOperations::test_set_permissions_invalid_session_user_with_group_permissions PASSED [ 28%]
test/unit/test_file_system_operations.py::TestFileSystemOperations::test_set_permissions_valid_session_user_with_permissions[None-FileSystemPermissionEnum.WRITE] PASSED [ 42%]
test/unit/test_file_system_operations.py::TestFileSystemOperations::test_set_permissions_valid_session_user_with_permissions[FileSystemPermissionEnum.WRITE-None] PASSED [ 57%]
test/unit/test_file_system_operations.py::TestFileSystemOperations::test_set_permissions_valid_session_user_multiple_permissions PASSED [ 71%]
test/unit/test_file_system_operations.py::TestFileSystemOperations::test_touch_file_not_exists PASSED [ 85%]
test/unit/test_file_system_operations.py::TestFileSystemOperations::test_make_directory PASSED [100%]

============================== warnings summary ===============================
.venv\Lib\site-packages\xdist\plugin.py:245
  c:\Users\sakshie\codebase\deadline-cloud-worker-agent\.venv\Lib\site-packages\xdist\plugin.py:245: DeprecationWarning: The --looponfail command line argument and looponfailroots config variable are deprecated.
  The loop-on-fail feature will be removed in pytest-xdist 4.0.
    config.issue_config_time_warning(warning, 2)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= slowest 5 durations =============================
0.01s call     test/unit/test_file_system_operations.py::TestFileSystemOperations::test_make_directory

(4 durations < 0.005s hidden.  Use -vv to show these durations.)
======================== 7 passed, 1 warning in 0.07s =========================
```

### Was this change documented?
N/A

### Is this a breaking change?
No