### PR TITLE
ci:add python-semantic-release dependency to release env

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -49,8 +49,8 @@ integ-test = "pytest --no-cov test/integ {args:}"
 
 [envs.release]
 detached = true
-pre-install-commands = [
-  "pip install -r requirements-release.txt"
+dependencies = [
+  "python-semantic-release == 8.7.*"
 ]
 
 [envs.release.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ fail_under = 78
 [tool.semantic_release]
 # Can be removed or set to true once we are v1
 major_on_zero = false
-tag_format = "v{version}"
+tag_format = "{version}"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
semantic release is failing to install in the hatch env

### What was the solution? (How)
Updating to specify the dependency and fixed tag format

### What is the impact of this change?
fix ci

### How was this change tested?
no

### Was this change documented?
no

### Is this a breaking change?
no