### PR TITLE
ci: update changelog script tag version format

### DIFF
--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -4,17 +4,17 @@ This script gets the changelog notes for the latest version of this package. It 
 1. A file called CHANGELOG.md is in the current directory that has the changelog
 2. The changelog file is formatted in a way such that level 2 headers are:
     a. The only indication of the beginning of a version's changelog notes.
-    b. Always begin with `## v` (i.e. v1.2.3)
+    b. Always begin with `## `
 3. The changelog file contains the newest version's changelog notes at the top of the file.
 
 Example CHANGELOG.md:
 ```
-## v1.0.0 (2024-02-06)
+## 1.0.0 (2024-02-06)
 
 ### BREAKING CHANGES
 * **api**: rename all APIs
 
-## v0.1.0 (2024-02-06)
+## 0.1.0 (2024-02-06)
 
 ### Features
 * **api**: add new api
@@ -22,7 +22,7 @@ Example CHANGELOG.md:
 
 Running this script on the above CHANGELOG.md should return the following contents:
 ```
-## v1.0.0 (2024-02-06)
+## 1.0.0 (2024-02-06)
 
 ### BREAKING CHANGES
 * **api**: rename all APIs
@@ -31,7 +31,7 @@ Running this script on the above CHANGELOG.md should return the following conten
 """
 import re
 
-h2 = r"^##\sv.*$"
+h2 = r"^##\s.*$"
 with open("CHANGELOG.md") as f:
     contents = f.read()
 matches = re.findall(h2, contents, re.MULTILINE)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
incorrect version format in get_latest_changelog.py

### What was the solution? (How)
update tag formats

### What is the impact of this change?
Fix CI

### How was this change tested?
n/a

### Was this change documented?
no

### Is this a breaking change?
no