### PR TITLE
fix: handle non-existent queue jobRunAsUser on worker host

### DIFF
--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -14,10 +14,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Event, RLock, Lock, Timer
 from typing import Callable, Tuple, Union, cast, Optional, Any
-import grp
 import logging
 import os
-import pwd
 import stat
 
 from openjd.sessions import ActionState, ActionStatus, SessionUser
@@ -705,28 +703,6 @@ class WorkerScheduler:
                         raise NotImplementedError(f"{os.name} is not supported")
                     os_user = job_details.job_run_as_user.posix
 
-                if os_user and os.name == "posix":
-                    os_user_error_messages = []
-                    try:
-                        pwd.getpwnam(os_user.user)
-                    except KeyError:
-                        os_user_error_messages.append(f"User not found: {os_user.user}.")
-                    if hasattr(os_user, "group"):
-                        try:
-                            grp.getgrnam(os_user.group)
-                        except KeyError:
-                            os_user_error_messages.append(f"User group not found: {os_user.group}.")
-                    else:
-                        os_user_error_messages.append("User group not defined.")
-
-                    if os_user_error_messages:
-                        for message in os_user_error_messages:
-                            logger.warning(message)
-                        message = "  ".join(os_user_error_messages)
-                        self._fail_all_actions(session_spec, message)
-                        self._wakeup.set()
-                        continue
-
             queue_credentials: QueueAwsCredentials | None = None
             asset_sync: AssetSync | None = None
             if job_details.queue_role_arn:
@@ -745,7 +721,7 @@ class WorkerScheduler:
                     # Terminal error. We need to fail the Session.
                     message = f"Unrecoverable error trying to obtain AWS Credentials for the Queue Role: {e}"
                     if str(e).startswith("Can't determine home directory"):
-                        message += ". Possible invalid username."
+                        message += ". Possible non-valid username."
                     self._fail_all_actions(session_spec, message)
                     logger.warning("[%s] %s", new_session_id, message)
                     # Force an immediate UpdateWorkerSchedule request


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Worker crashed if trying to run as an invalid user (or group)

### What was the solution? (How)
Catch RuntimeError from _get_queue_aws_credentials call.  If the error is about the homedir, add a hint to the message that the user may not be valid.

### What is the impact of this change?
Workers will stay alive, logging the error.

### How was this change tested?
passed invalid user/group names.  
Session was failed, worker remains up.
viewed in logs.
```
WARNING  [session-5ae7c71530224d02afc42329863ddbc7] Unrecoverable error trying to obtain AWS Credentials for the Queue Role: Can't determine home directory for 'nouser'. Possible non-valid username.                                                                                                                                                                                     
...
INFO     Updating actions: {....
   'completedStatus': 'FAILED', 'progressMessage': "Unrecoverable error trying to obtain AWS Credentials for the Queue Role: Can't determine home directory for 'nouser'. Possible non-valid username." 
} 
```


### Was this change documented?
No
### Is this a breaking change?
No