### PR TITLE
fix: Improve logging on failures to fetch secret

### DIFF
--- a/test/unit/windows/test_win_credentials_resolver.py
+++ b/test/unit/windows/test_win_credentials_resolver.py
@@ -175,6 +175,7 @@ if sys.platform == "win32":
                 "ResourceNotFoundException",
                 "InvalidRequestException",
                 "DecryptionFailure",
+                "AccessDeniedException",
             ],
         )
         @patch(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The logging around `get_secret_value` previously gave the customer no indication as to what might be wrong. 

### What was the solution? (How)
Making sure `AccessDeniedException` is not swallowed and customers are given some information on how to resolve failures. 

### What is the impact of this change?
See above. 

### How was this change tested?
Unit tests. 

### Was this change documented?
NA. 

### Is this a breaking change?
No. 