### PR TITLE
fix(windows-installer): adjust help text to be compatible with Windows installation

### DIFF
--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -105,6 +105,7 @@ class ParsedCommandLineArguments(Namespace):
 
 def get_argument_parser() -> ArgumentParser:  # pragma: no cover
     """Returns a command-line argument parser for the Amazon Deadline Cloud Worker Agent"""
+
     parser = ArgumentParser(
         prog="install-deadline-worker",
         description="Installer for the Amazon Deadline Cloud Worker Agent",
@@ -124,31 +125,39 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
         help='The AWS region of the Amazon Deadline Cloud farm. Defaults to "us-west-2".',
         default="us-west-2",
     )
+
+    # Windows local usernames are restricted to 20 characters in length.
+    default_username = "deadline-worker-agent" if sys.platform != "win32" else "deadline-worker"
     parser.add_argument(
         "--user",
-        help='The username of the Amazon Deadline Cloud Worker Agent user. Defaults to "deadline-worker-agent".',
-        # Windows local usernames are restricted to 20 characters in length.
-        default="deadline-worker-agent" if sys.platform != "win32" else "deadline-worker",
+        help=f'The username of the Amazon Deadline Cloud Worker Agent user. Defaults to "{default_username}".',
+        default=default_username,
     )
+
     parser.add_argument(
         "--group",
-        help='The POSIX group that is shared between the Agent user and the user(s) that jobs run as. Defaults to "deadline-job-users".',
+        help='The group that is shared between the Agent user and the user(s) that jobs run as. Defaults to "deadline-job-users".',
     )
     parser.add_argument(
         "--start",
-        help="Starts the systemd service immediately. Defaults to start on system boot. This option is ignored if --no-install-service is used.",
+        help="Starts the service immediately. Defaults to start on system boot. This option is ignored if --no-install-service is used.",
         action="store_true",
         dest="service_start",
     )
+
+    if sys.platform == "win32":
+        help = "Controls whether to grant the worker agent OS user the privilege to shutdown the system"
+    else:
+        help = "Controls whether to create/delete a sudoers rule allowing the worker agent OS user to shutdown the system"
     parser.add_argument(
         "--allow-shutdown",
-        help="Controls whether to create/delete a sudoers rule allowing the worker agent OS user to"
-        "shutdown the system",
+        help=help,
         action="store_true",
     )
+
     parser.add_argument(
         "--no-install-service",
-        help="Skips the worker agent systemd service installation",
+        help="Skips the worker agent service installation",
         action="store_false",
         dest="install_service",
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Running the Windows installer help text and some of the descriptions are still mentioning usage in POSIX systems. We need to update these to Windows if running on Windows.

Affected fields:
- `--group` (POSIX)
- `--start` (systemd)
- `--no-install-service` (systemd)
- `--allow-shutdown` (sudoers)
- `--user` (default is `deadline-worker-agent` which is too long for a Windows username)

```
> install-deadline-worker --help
usage: install-deadline-worker [-h] --farm-id FARM_ID --fleet-id FLEET_ID [--region REGION] [--user USER] [--group GROUP] [--start] [--allow-shutdown]
                               [--no-install-service] [--telemetry-opt-out] [--yes] [--vfs-install-path VFS_INSTALL_PATH] [--password PASSWORD]

Installer for the Amazon Deadline Cloud Worker Agent

options:
  -h, --help            show this help message and exit
  --farm-id FARM_ID     The Amazon Deadline Cloud Farm ID that the Worker belongs to.
  --fleet-id FLEET_ID   The Amazon Deadline Cloud Fleet ID that the Worker belongs to.
  --region REGION       The AWS region of the Amazon Deadline Cloud farm. Defaults to "us-west-2".
  --user USER           The username of the Amazon Deadline Cloud Worker Agent user. Defaults to "deadline-worker-agent".
  --group GROUP         The POSIX group that is shared between the Agent user and the user(s) that jobs run as. Defaults to "deadline-job-users".
  --start               Starts the systemd service immediately. Defaults to start on system boot. This option is ignored if --no-install-service is used.
  --allow-shutdown      Controls whether to create/delete a sudoers rule allowing the worker agent OS user toshutdown the system
  --no-install-service  Skips the worker agent systemd service installation
  --telemetry-opt-out   Opts out of telemetry data collection
  --yes, -y             Confirms the installation and skips the interactive confirmation prompt.
  --vfs-install-path VFS_INSTALL_PATH
                        Absolute path for the install location of the deadline vfs.
  --password PASSWORD   The password for the Amazon Deadline Cloud Worker Agent user. Defaults to generating a password if the user does not exist or
                        prompting for the password if the user pre-exists.
```

### What was the solution? (How)
Adjust the help text to either be generic or have Windows/Linux specific versions

### What is the impact of this change?
Help text makes sense on Windows

### How was this change tested?
Ran the installer help text

### Was this change documented?
No

### Is this a breaking change?
No

### Installer help - Windows

```
> install-deadline-worker --help
usage: install-deadline-worker [-h] --farm-id FARM_ID --fleet-id FLEET_ID [--region REGION] [--user USER]
                               [--group GROUP] [--start] [--allow-shutdown] [--no-install-service]
                               [--telemetry-opt-out] [--yes] [--vfs-install-path VFS_INSTALL_PATH]
                               [--password PASSWORD]

Installer for the Amazon Deadline Cloud Worker Agent

options:
  -h, --help            show this help message and exit
  --farm-id FARM_ID     The Amazon Deadline Cloud Farm ID that the Worker belongs to.
  --fleet-id FLEET_ID   The Amazon Deadline Cloud Fleet ID that the Worker belongs to.
  --region REGION       The AWS region of the Amazon Deadline Cloud farm. Defaults to "us-west-2".
  --user USER           The username of the Amazon Deadline Cloud Worker Agent user. Defaults to "deadline-worker".
  --group GROUP         The group that is shared between the Agent user and the user(s) that jobs run as. Defaults to
                        "deadline-job-users".
  --start               Starts the service immediately. Defaults to start on system boot. This option is ignored if
                        --no-install-service is used.
  --allow-shutdown      Controls whether to grant the worker agent OS user the privilege to shutdown the system
  --no-install-service  Skips the worker agent service installation
  --telemetry-opt-out   Opts out of telemetry data collection
  --yes, -y             Confirms the installation and skips the interactive confirmation prompt.
  --vfs-install-path VFS_INSTALL_PATH
                        Absolute path for the install location of the deadline vfs.
  --password PASSWORD   The password for the Amazon Deadline Cloud Worker Agent user. Defaults to generating a
                        password.
```

### Installer help - Linux

```
$ hatch run install-deadline-worker --help
usage: install-deadline-worker [-h] --farm-id FARM_ID --fleet-id FLEET_ID [--region REGION] [--user USER]
                               [--group GROUP] [--start] [--allow-shutdown] [--no-install-service]
                               [--telemetry-opt-out] [--yes] [--vfs-install-path VFS_INSTALL_PATH]

Installer for the Amazon Deadline Cloud Worker Agent

optional arguments:
  -h, --help            show this help message and exit
  --farm-id FARM_ID     The Amazon Deadline Cloud Farm ID that the Worker belongs to.
  --fleet-id FLEET_ID   The Amazon Deadline Cloud Fleet ID that the Worker belongs to.
  --region REGION       The AWS region of the Amazon Deadline Cloud farm. Defaults to "us-west-2".
  --user USER           The username of the Amazon Deadline Cloud Worker Agent user. Defaults to "deadline-worker-
                        agent".
  --group GROUP         The group that is shared between the Agent user and the user(s) that jobs run as. Defaults to
                        "deadline-job-users".
  --start               Starts the service immediately. Defaults to start on system boot. This option is ignored if
                        --no-install-service is used.
  --allow-shutdown      Controls whether to create/delete a sudoers rule allowing the worker agent OS user to shutdown
                        the system
  --no-install-service  Skips the worker agent service installation
  --telemetry-opt-out   Opts out of telemetry data collection
  --yes, -y             Confirms the installation and skips the interactive confirmation prompt.
  --vfs-install-path VFS_INSTALL_PATH
                        Absolute path for the install location of the deadline vfs.
```