### PR TITLE
feat: Add job and session metadata to the environment of a job

### DIFF
--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -766,6 +766,12 @@ class WorkerScheduler:
                 queue_id=queue_id,
                 env={
                     "AWS_PROFILE": queue_credentials.session.credential_process_profile_name,
+                    "DEADLINE_SESSION_ID": new_session_id,
+                    "DEADLINE_FARM_ID": self._farm_id,
+                    "DEADLINE_QUEUE_ID": queue_id,
+                    "DEADLINE_JOB_ID": job_id,
+                    "DEADLINE_FLEET_ID": self._fleet_id,
+                    "DEADLINE_WORKER_ID": self._worker_id,
                 }
                 if queue_credentials
                 else None,

--- a/src/deadline_worker_agent/sessions/actions/enter_env.py
+++ b/src/deadline_worker_agent/sessions/actions/enter_env.py
@@ -110,4 +110,5 @@ class EnterEnvironmentAction(OpenjdAction):
         session.enter_environment(
             job_env_id=self._job_env_id,
             environment=self._details.environment,
+            os_env_vars={"DEADLINE_SESSIONACTION_ID": self._id},
         )

--- a/src/deadline_worker_agent/sessions/actions/exit_env.py
+++ b/src/deadline_worker_agent/sessions/actions/exit_env.py
@@ -59,4 +59,6 @@ class ExitEnvironmentAction(OpenjdAction):
         executor : Executor
             An executor for running futures
         """
-        session.exit_environment(job_env_id=self._environment_id)
+        session.exit_environment(
+            job_env_id=self._environment_id, os_env_vars={"DEADLINE_SESSIONACTION_ID": self._id}
+        )

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -75,6 +75,7 @@ class RunStepTaskAction(OpenjdAction):
         session.run_task(
             step_script=self._details.step_template.script,
             task_parameter_values=self._task_parameter_values,
+            os_env_vars={"DEADLINE_SESSIONACTION_ID": self._id, "DEADLINE_TASK_ID": self.task_id},
         )
 
     def human_readable(self) -> str:

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -723,9 +723,10 @@ class Session:
         *,
         job_env_id: str,
         environment: EnvironmentModel,
+        os_env_vars: Optional[dict[str, str]] = None,
     ) -> None:
         session_env_id = self._session.enter_environment(
-            environment=environment, identifier=job_env_id
+            environment=environment, identifier=job_env_id, os_env_vars=os_env_vars
         )
         self._active_envs.append(
             ActiveEnvironment(
@@ -738,6 +739,7 @@ class Session:
         self,
         *,
         job_env_id: str,
+        os_env_vars: Optional[dict[str, str]] = None,
     ) -> None:
         if not self._active_envs or self._active_envs[-1].job_env_id != job_env_id:
             env_stack_str = ", ".join(env.job_env_id for env in self._active_envs)
@@ -746,7 +748,9 @@ class Session:
                 f"Active environments from outer-most to inner-most are: {env_stack_str}"
             )
         active_env = self._active_envs[-1]
-        self._session.exit_environment(identifier=active_env.session_env_id)
+        self._session.exit_environment(
+            identifier=active_env.session_env_id, os_env_vars=os_env_vars
+        )
         self._active_envs.pop()
 
     def _notifier_callback(
@@ -1222,10 +1226,12 @@ class Session:
         *,
         step_script: StepScriptModel,
         task_parameter_values: TaskParameterSet,
+        os_env_vars: Optional[dict[str, str]] = None,
     ) -> None:
         self._session.run_task(
             step_script=step_script,
             task_parameter_values=task_parameter_values,
+            os_env_vars=os_env_vars,
         )
 
     def stop(

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -142,6 +142,11 @@ def action_id() -> str:
     return "action-111"
 
 
+@pytest.fixture
+def job_env_id() -> str:
+    return "job_env-111"
+
+
 @pytest.fixture(
     params=(
         Attachments(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A customer may like to be able to reference information about the execution of a job so that they can pass that information to other systems like a lambda function.

Possibly interesting information:

Job ID, queue ID, farm ID
session ID, task IDs in the session
status of tasks in the session

### What was the solution? (How)
Added the following env variables:

For every action:

```
DEADLINE_SESSION_ID
DEADLINE_FARM_ID
DEADLINE_QUEUE_ID
DEADLINE_JOB_ID
DEADLINE_FLEET_ID
DEADLINE_WORKER_ID
```
Then on each individual action:
```
DEADLINE_SESSIONACTION_ID
```

Futhermore, on "task run" actions:

```
DEADLINE_TASK_ID
```

### What is the impact of this change?
Feature support for obtaining env variables for customers.

### How was this change tested?
Created unit tests. Tested e2e on Linux by getting worker agent up using docker on local.After that ran a sample job on the worker as follows:

```
{
    "specificationVersion": "jobtemplate-2023-09",
    "name": "TestEnv",
    "steps": [
        {
            "name": "EnvStep",
            "script": {
                "actions": {
                    "onRun": {
                        "command": "bash",
                        "args": ["-c", "env"]
                    }
                }
            },
            "stepEnvironments": [
                {
                    "name": "myenv",
                    "script": {
                        "actions": {
                            "onEnter": {
                                "command": "bash",
                                "args": ["-c", "env"]
                            },
                            "onExit": {
                                "command": "bash",
                                "args": ["-c", "env"]
                            }
                        }
                    }
                }
            ]
        }
    ]
}
```

Verified that the env variables were printed in the customer account logs
![Screenshot 2024-02-29 at 6 33 03 PM](https://github.com/casillas2/deadline-cloud-worker-agent/assets/151677550/76ed4bab-0e40-4b55-bb5e-e5f3654bed47)

### Was this change documented?
N/A
### Is this a breaking change?
No, feature request!