### PR TITLE
feat!: retool scale-in behaviour

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -3,6 +3,7 @@ coverage-conditional-plugin == 0.9.*
 deadline-cloud-test-fixtures == 0.5.*
 pytest ~= 8.1
 pytest-cov == 4.1.*
+pytest-timeout == 2.2.*
 pytest-xdist == 3.5.*
 black[jupyter] ~= 23.12
 rich == 13.7.*


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

We're modifying the worker contract as it pertains to scale-in/service-initiated-drain operations. Currently, the behavior is to DeleteWorker and then try to shut down the host. 

### What was the solution? (How)

The new proposed behaviour is to go to STOPPING and then repeatedly heartbeat with the service while attempting to shutdown the host; with the expectation that a nominally behaving host will properly shut down. The service will then Delete the worker once the heartbeats stop.

Worker behaviour with locally initiated shutdowns (spot interruptions, SIGTERM, SIGINT, etc) remains unchanged; we transition to STOPPING while trying to end the work we have and then transition to STOPPED and exit when done.

### What is the impact of this change?

In combination with the service-side changes, this should make the system able to detect:
1.  A Worker that was asked to shutdown, but is having trouble doing so -- it will be in STOPPING status for an extended period of time while still heartbeating.
2. A STOPPED Worker that should be Deleted -- in the old system, a Worker in an autoscaling CMF that shutsdown due to spot interruption will remain as a Worker in the service in STOPPED status indefinitely. This happens because the Agent was responsible for Deleting the Worker, and it doesn't know that it's in an autoscaling situation, so it doesn't Delete the Worker when locally interrupted. With the new system, the service is responsible for Deleting the Worker in an autoscaling situation, so these Workers should no longer remain.

### How was this change tested?

Enhancements to the unit tests, and against the live service.

### Was this change documented?

Yes, the worker api contract document has been updated.

### Is this a breaking change?

Yes! The agent is no longer deleting the Worker, and the scale-in behavior is different.