### PR TITLE
fix: Check Admin permission before installing worker agent

### DIFF
--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -23,6 +23,7 @@ import win32net
 import win32netcon
 import win32security
 import winerror
+from win32comext.shell import shell
 
 
 # Defaults
@@ -426,6 +427,11 @@ def start_windows_installer(
         print_helping_info_and_exit()
     if not password:
         password = generate_password()
+
+    # Check that user has Administrator privileges
+    if not shell.IsUserAnAdmin():
+        logging.error(f"User does not have Administrator privileges: {os.environ['USERNAME']}")
+        print_helping_info_and_exit()
 
     # Print configuration
     print_banner()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Because installer requires Admin permission to create user and group.
So we need to do a pre-flight check to ensure we have the correct privileges to successfully install

### What was the solution? (How)
Added Admin permission pre-flight check to ensure correct privileges to successfully install 

### What is the impact of this change?
Pre-flight check, better customer experience.

### How was this change tested?
Created unit test for functionality. Also tested e2e with running the installer with and without Admin privileges

WIthout Admin privileges on current user:
```
(venv) PS C:\Users\workeruser> install-deadline-worker --farm-id farm-9cc701bd6e1f43e18363e04990527463 --fleet-id fleet-87d0bc8521654f7fa7410135e8f3b8c7 --user automatedworker --group test-queue-jobusers --start
ERROR: User does not have Administrator priviledges: workeruser
```

With Admin privileges on current user, installation runs successfully:
```
(venv) PS C:\Users\workeruser\deadline-cloud-worker-agent> install-deadline-worker --farm-id farm-9cc701bd6e1f43e18363e04990527463 --fleet-id fleet-87d0bc8521654f7fa7410135e8f3b8c7 --user automatedworker --group test-queue-jobusers
===========================================================
|      Amazon Deadline Cloud Worker Agent Installer       |
===========================================================

Farm ID: farm-9cc701bd6e1f43e18363e04990527463
Fleet ID: fleet-87d0bc8521654f7fa7410135e8f3b8c7
Region: us-west-2
Worker agent user: automatedworker
Worker job group: test-queue-jobusers
Worker agent program path: C:\Users\workeruser\venv\Scripts
Allow worker agent shutdown: False
Start service: False
Confirm install (y/n):y
INFO: Creating Agent user automatedworker
INFO: User 'automatedworker2' created successfully.
INFO: Group test-queue-jobusers already exists
INFO: User automatedworker2 is added to group test-queue-jobusers.
INFO: Provisioning root directory (C:\ProgramData\Amazon\Deadline)
INFO: Done provisioning root directory (C:\ProgramData\Amazon\Deadline)
INFO: Provisioning log directory (C:\ProgramData\Amazon\Deadline\Logs)
INFO: Done provisioning log directory (C:\ProgramData\Amazon\Deadline\Logs)
INFO: Provisioning persistence directory (C:\ProgramData\Amazon\Deadline\Cache)
INFO: Done provisioning persistence directory (C:\ProgramData\Amazon\Deadline\Cache)
INFO: Provisioning config directory (C:\ProgramData\Amazon\Deadline\Config)
INFO: Done provisioning config directory (C:\ProgramData\Amazon\Deadline\Config)
INFO: Updating configuration file
INFO: Done configuring ['farm_id', 'fleet_id', 'shutdown_on_stop'] in C:\ProgramData\Amazon\Deadline\Config\worker.toml
```

Unit tests all run successfully:
```
================================================= slowest 5 durations =================================================
1.16s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_no_imds[job_run_as_user_overrides0]
1.02s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[job_run_as_user_overrides0-spot-shutdown-1-min]
shutdown-15-sec]
1.02s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_asg_termination[job_run_as_user_overrides0]
0.20s call     test/unit/sessions/test_log_config.py::TestLogConfiguration::test_from_boto_local_log_setup
==================================== 2315 passed, 20 skipped, 17 warnings in 9.66s ====================================
```
### Was this change documented?
N/A

### Is this a breaking change?
N/A