### PR TITLE
chore(deps): bump openjd-sessions and deadline-cloud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
-    "deadline == 0.38.*",
-    "openjd-sessions == 0.5.*",
+    "deadline == 0.39.*",
+    "openjd-sessions == 0.6.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "typing_extensions ~= 4.8",

--- a/test/unit/scheduler/test_session_cleanup.py
+++ b/test/unit/scheduler/test_session_cleanup.py
@@ -20,7 +20,7 @@ class FakeSessionUser(SessionUser):
         self.user = user
 
     @staticmethod
-    def get_process_user() -> str:
+    def _get_process_user() -> str:
         return ""
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
New versions of `deadline-cloud` and `openjd-sessions` were released. We need to update to those versions to get the latest code.

### What was the solution? (How)
- Update the dependencies
- Also updated a test file due to a method rename in `openjd-sessions`

### What is the impact of this change?
We have the updated deps

### How was this change tested?
hatch build && hatch run test

### Was this change documented?
No

### Is this a breaking change?
No