### PR TITLE
feat: change OpenJD's session directory path, and add  command option

### DIFF
--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -351,6 +351,11 @@ if [ -f /var/lib/deadline/worker.json ]; then
 fi
 echo "Done provisioning persistence directory (/var/lib/deadline)"
 
+echo "Provisioning session directory (/var/tmp/openjd)"
+mkdir -p /var/tmp/openjd
+chown "${wa_user}" /var/tmp/openjd
+chmod 400 /var/tmp/openjd
+
 echo "Provisioning configuration directory (/etc/amazon/deadline)"
 mkdir -p /etc/amazon/deadline
 chmod 750 /etc/amazon/deadline

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -200,6 +200,18 @@
 #
 # shutdown_on_stop = false
 
+# Whether the worker agent should retain the OpenJD Session's working directory on the Session completion.
+# This value is overridden when the DEADLINE_WORKER_RETAIN_SESSION_DIR environment variable is set using
+# one of the following case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# or if the --retain-session-dir command-line flag is specified.
+#
+# By default retaining the Session directory is turned off, meaning the directory will be deleted.
+# To retain this Session directory after the Session ends, uncomment the line below:
+#
+# retain_session_dir = true
 
 [capabilities]
 

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -157,6 +157,7 @@ class WorkerScheduler:
     _boto_session: BotoSession
     _worker_persistence_dir: Path
     _worker_logs_dir: Path | None
+    _retain_session_dir: bool
 
     # Map from queueId -> QueueAwsCredentials.
     _queue_aws_credentials: dict[str, QueueAwsCredentials]
@@ -176,6 +177,7 @@ class WorkerScheduler:
         cleanup_session_user_processes: bool,
         worker_persistence_dir: Path,
         worker_logs_dir: Path | None,
+        retain_session_dir: bool = False,
     ) -> None:
         """Queue of Worker Sessions and their actions
 
@@ -209,6 +211,7 @@ class WorkerScheduler:
         self._queue_aws_credentials_lock = Lock()
         self._worker_persistence_dir = worker_persistence_dir
         self._worker_logs_dir = worker_logs_dir
+        self._retain_session_dir = retain_session_dir
 
     def _assign_sessions(self) -> None:
         """Handles an AssignSessions API cycle"""
@@ -778,6 +781,7 @@ class WorkerScheduler:
                 asset_sync=asset_sync,
                 job_details=job_details,
                 os_user=os_user,
+                retain_session_dir=self._retain_session_dir,
                 action_update_callback=self._handle_session_action_update,
                 action_update_lock=self._action_update_lock,
             )

--- a/src/deadline_worker_agent/startup/cli_args.py
+++ b/src/deadline_worker_agent/startup/cli_args.py
@@ -22,6 +22,7 @@ class ParsedCommandLineArguments(Namespace):
     logs_dir: Path | None = None
     local_session_logs: bool | None = None
     persistence_dir: Path | None = None
+    retain_session_dir: bool | None = None
     # TODO: Remove when deprecating --no-allow-instance-profile
     no_allow_instance_profile: bool | None = None
     host_metrics_logging: bool | None = None
@@ -140,6 +141,14 @@ def get_argument_parser() -> ArgumentParser:
         "--verbose",
         "-v",
         help="Use verbose console logging",
+        action="store_const",
+        const=True,
+        default=None,
+    )
+    parser.add_argument(
+        "--retain-session-dir",
+        help="Retain the session directory on completion",
+        dest="retain_session_dir",
         action="store_const",
         const=True,
         default=None,

--- a/src/deadline_worker_agent/startup/config.py
+++ b/src/deadline_worker_agent/startup/config.py
@@ -69,6 +69,8 @@ class Configuration:
     """Whether host metrics logging is enabled"""
     host_metrics_logging_interval_seconds: float
     """The interval in seconds between host metrics logs"""
+    retain_session_dir: bool
+    """Whether to retain the OpenJD's session directory on completion"""
 
     # Used to optimize the memory allocation and attribute lookup speed. Tells python to not create a dict
     # for the attributes.
@@ -89,6 +91,7 @@ class Configuration:
         "local_session_logs",
         "host_metrics_logging",
         "host_metrics_logging_interval_seconds",
+        "retain_session_dir",
     )
 
     def __init__(
@@ -134,6 +137,8 @@ class Configuration:
             settings_kwargs[
                 "host_metrics_logging_interval_seconds"
             ] = parsed_cli_args.host_metrics_logging_interval_seconds
+        if parsed_cli_args.retain_session_dir is not None:
+            settings_kwargs["retain_session_dir"] = parsed_cli_args.retain_session_dir
 
         settings = WorkerSettings(**settings_kwargs)
 
@@ -165,6 +170,7 @@ class Configuration:
         self.local_session_logs = settings.local_session_logs
         self.host_metrics_logging = settings.host_metrics_logging
         self.host_metrics_logging_interval_seconds = settings.host_metrics_logging_interval_seconds
+        self.retain_session_dir = settings.retain_session_dir
 
         self._validate()
 

--- a/src/deadline_worker_agent/startup/config_file.py
+++ b/src/deadline_worker_agent/startup/config_file.py
@@ -49,6 +49,7 @@ class OsConfigSection(BaseModel):
         regex=r"^[a-zA-Z0-9_.][^:]{0,31}:[a-zA-Z0-9_.][^:]{0,31}$"
     )
     shutdown_on_stop: Optional[bool] = None
+    retain_session_dir: Optional[bool] = None
 
     @root_validator(pre=True)
     def _disallow_impersonation(cls, values: dict[str, Any]) -> dict[str, Any]:
@@ -136,6 +137,8 @@ class ConfigFile(BaseModel):
             output_settings["run_jobs_as_agent_user"] = self.os.run_jobs_as_agent_user
         if self.os.posix_job_user is not None:
             output_settings["posix_job_user"] = self.os.posix_job_user
+        if self.os.retain_session_dir is not None:
+            output_settings["retain_session_dir"] = self.os.retain_session_dir
         if self.capabilities is not None:
             output_settings["capabilities"] = self.capabilities
 

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -96,7 +96,7 @@ def entrypoint(cli_args: Optional[list[str]] = None) -> None:
 
         # Let's treat this log line as a contract. It's the last thing that we'll
         # emit to the bootstrapping log, and external systems can use it as a
-        # sentinel to know that the worker has progressed sucessfully to processing
+        # sentinel to know that the worker has progressed successfully to processing
         # jobs.
         _logger.info("Worker successfully bootstrapped and is now running.")
 
@@ -134,6 +134,7 @@ def entrypoint(cli_args: Optional[list[str]] = None) -> None:
                 worker_logs_dir=config.worker_logs_dir if config.local_session_logs else None,
                 host_metrics_logging=config.host_metrics_logging,
                 host_metrics_logging_interval_seconds=config.host_metrics_logging_interval_seconds,
+                retain_session_dir=config.retain_session_dir,
             )
             try:
                 worker_sessions.run()

--- a/src/deadline_worker_agent/startup/settings.py
+++ b/src/deadline_worker_agent/startup/settings.py
@@ -68,6 +68,8 @@ class WorkerSettings(BaseSettings):
         Whether to log host metrics
     host_metrics_logging_interval_seconds : float
         The interval between host metrics log messages
+    retain_session_dir : bool
+        If true, then the OpenJD's session directory will not be removed after the job is finished.
     """
 
     farm_id: str = Field(regex=r"^farm-[a-z0-9]{32}$")
@@ -89,6 +91,7 @@ class WorkerSettings(BaseSettings):
     local_session_logs: bool = True
     host_metrics_logging: bool = True
     host_metrics_logging_interval_seconds: float = 60
+    retain_session_dir: bool = False
 
     class Config:
         fields = {
@@ -111,6 +114,7 @@ class WorkerSettings(BaseSettings):
             "host_metrics_logging_interval_seconds": {
                 "env": "DEADLINE_WORKER_HOST_METRICS_LOGGING_INTERVAL_SECONDS"
             },
+            "retain_session_dir": {"env": "DEADLINE_WORKER_RETAIN_SESSION_DIR"},
         }
 
         @classmethod
@@ -134,7 +138,7 @@ class WorkerSettings(BaseSettings):
             init_settings : pydantic.env_settings.SettingsSourceCallable
                 The pydantic built-in init arguments settings source
             env_settings : pydantic.env_settings.SettingsSourceCallable
-                The pydantic built-in environment variable setting ssource
+                The pydantic built-in environment variable settings source
             file_secret_settings : pydantic.env_settings.SettingsSourceCallable
                 The pydantic built-in (Docker) secret file settings source
 

--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -71,6 +71,7 @@ class Worker:
     _boto_session: WorkerBoto3Session
     _worker_persistence_dir: Path
     _host_metrics_logger: HostMetricsLogger | None = None
+    _retain_session_dir: bool
 
     def __init__(
         self,
@@ -88,6 +89,7 @@ class Worker:
         worker_logs_dir: Path | None,
         host_metrics_logging: bool,
         host_metrics_logging_interval_seconds: float | None = None,
+        retain_session_dir: bool = False,
     ) -> None:
         self._deadline_client = deadline_client
         self._s3_client = s3_client
@@ -106,10 +108,12 @@ class Worker:
             cleanup_session_user_processes=cleanup_session_user_processes,
             worker_persistence_dir=worker_persistence_dir,
             worker_logs_dir=worker_logs_dir,
+            retain_session_dir=retain_session_dir,
         )
         self._stop = Event()
         self._boto_session = boto_session
         self._worker_persistence_dir = worker_persistence_dir
+        self._retain_session_dir = retain_session_dir
 
         if host_metrics_logging:
             assert (

--- a/test/unit/startup/test_config.py
+++ b/test/unit/startup/test_config.py
@@ -37,6 +37,7 @@ def mock_worker_settings_cls() -> Generator[MagicMock, None, None]:
         "local_session_logs": None,
         "host_metrics_logging": True,
         "host_metrics_logging_interval_seconds": 10,
+        "retain_session_dir": False,
     }
 
     class FakeWorkerSettings:
@@ -331,6 +332,29 @@ class TestLoad:
 
         # THEN
         assert config.local_session_logs == local_session_logs
+
+    @pytest.mark.parametrize(
+        argnames="retain_session_dir",
+        argvalues=(
+            True,
+            False,
+        ),
+    )
+    def test_uses_retain_session_dir(
+        self,
+        parsed_args: config_mod.ParsedCommandLineArguments,
+        retain_session_dir: bool,
+    ) -> None:
+        # GIVEN
+        parsed_args.retain_session_dir = retain_session_dir
+        parsed_args.farm_id = "farm_id"
+        parsed_args.fleet_id = "fleet_id"
+
+        # WHEN
+        config = config_mod.Configuration.load()
+
+        # THEN
+        assert config.retain_session_dir == retain_session_dir
 
     def test_impersonation_mutual_exclusion(
         self, parsed_args: config_mod.ParsedCommandLineArguments
@@ -781,6 +805,35 @@ class TestInit:
             assert call.kwargs.get("local_session_logs") == local_session_logs
         else:
             assert "local_session_logs" not in call.kwargs
+
+    @pytest.mark.parametrize(
+        argnames="retain_session_dir",
+        argvalues=(
+            True,
+            False,
+            None,
+        ),
+    )
+    def test_retain_session_dir_passed_to_settings_initializer(
+        self,
+        retain_session_dir: bool | None,
+        parsed_args: ParsedCommandLineArguments,
+        mock_worker_settings_cls: MagicMock,
+    ) -> None:
+        # GIVEN
+        parsed_args.retain_session_dir = retain_session_dir
+
+        # WHEN
+        config_mod.Configuration(parsed_cli_args=parsed_args)
+
+        # THEN
+        mock_worker_settings_cls.assert_called_once()
+        call = mock_worker_settings_cls.call_args_list[0]
+
+        if retain_session_dir is not None:
+            assert call.kwargs.get("retain_session_dir") == retain_session_dir
+        else:
+            assert "retain_session_dir" not in call.kwargs
 
     @pytest.mark.parametrize(
         argnames=("posix_job_user_setting", "expected_config_posix_job_user"),

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -595,6 +595,7 @@ def test_passes_worker_logs_dir(
         worker_logs_dir=tmp_path,
         host_metrics_logging=ANY,
         host_metrics_logging_interval_seconds=ANY,
+        retain_session_dir=ANY,
     )
 
 

--- a/test/unit/startup/test_settings.py
+++ b/test/unit/startup/test_settings.py
@@ -136,6 +136,13 @@ FIELD_TEST_CASES: list[FieldTestCaseParams] = [
         expected_default=60,
         expected_default_factory_return_value=None,
     ),
+    FieldTestCaseParams(
+        field_name="retain_session_dir",
+        expected_type=bool,
+        expected_required=False,
+        expected_default=False,
+        expected_default_factory_return_value=None,
+    ),
 ]
 
 

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -154,6 +154,7 @@ class TestInit:
             cleanup_session_user_processes=ANY,
             worker_persistence_dir=ANY,
             worker_logs_dir=worker_logs_dir,
+            retain_session_dir=ANY,
         )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
By default, the OpenJD's Session creates the Session's Working Directory under /tmp, but sometimes a system may be configured so that /tmp is mounted on tmpfs and thus doesn't have a lot of space available. It may lead to this error: `[Errno 28] No space left on device`.
Furthermore, the automatic deletion of the session directory upon completion of the session (either succeeded or failed) made debugging difficult, especially in cases of errors or failures.

### What was the solution? (How)
Two key changes:
1. Modified to create the OpenJD's session directory under `/var/tmp/openjd` instead of the default `/tmp`. This aims to prevent the 'No space left' errors by using a directory not mounted on tmpfs.
    - Why `/var/tmp`?
     1.  it shares the root location `/var` with other directories like the worker's persistence directory (var/lib/deadline) and the log directory (/var/log/amazon/deadline), so we can position them closely together.
     2. Also, `/var/tmp` is traditional location for temporary storage in Unix and Linux, typically being backed by physical storage ([reference](https://systemd.io/TEMPORARY_DIRECTORIES/)), providing persistence and more space compared to tmpfs.

2. Introduced `--retain-session-dir` option for the `deadline-worker-agent` command. When this flag is given, it prevents the session directory from being deleted after the sessions, allowing it to retain (for debugging purposes.)

### What is the impact of this change?
- Avoiding potential 'No space left' errors that could disrupt running a worker.
- Facilitating debugging efforts by retaining session directories when needed. 

### How was this change tested?
The changes were tested by running the command with and without the `--retain-session-dir` flag.
- Without the flag, the session directory was created under `/var/tmp/openjd` and then automatically removed after the session ends, as expected.
- With the flag, the session directory was successfully retained as intended, in both cases where the session was successful and where it (intentionally) failed in the middle.

### Was this change documented?
No.

### Is this a breaking change?
No.
