### PR TITLE
feat(windows): use agent user for file ACLs instead of jobRunAsUser group

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -244,7 +244,7 @@ class WindowsUser(TypedDict):
     user: str
     """The windows user name to run session actions as, as well as session file ownership"""
 
-    group: str
+    group: NotRequired[str]
     """The windows group name associated with session file ownership"""
 
     passwordArn: str

--- a/src/deadline_worker_agent/aws_credentials/aws_configs.py
+++ b/src/deadline_worker_agent/aws_credentials/aws_configs.py
@@ -52,7 +52,7 @@ def _setup_parent_dir(*, dir_path: Path, owner: SessionUser | None = None) -> No
                 dir_path=dir_path,
                 permitted_user=owner,
                 user_permission=FileSystemPermissionEnum.READ_WRITE,
-                group_permission=FileSystemPermissionEnum.READ_WRITE,
+                agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 parents=True,
                 exist_ok=True,
             )
@@ -81,7 +81,7 @@ def _setup_file(*, file_path: Path, owner: SessionUser | None = None) -> None:
                 file_path=file_path,
                 permitted_user=owner,
                 user_permission=FileSystemPermissionEnum.READ_WRITE,
-                group_permission=FileSystemPermissionEnum.READ_WRITE,
+                agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
             )
 
 

--- a/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
+++ b/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
@@ -253,7 +253,7 @@ class QueueBoto3Session(BaseBoto3Session):
                         ),
                         permitted_user=self._os_user,
                         agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
-                        group_permission=FileSystemPermissionEnum.READ,
+                        user_permission=FileSystemPermissionEnum.READ,
                     )
             credentials_object = cast(SettableCredentials, self.get_credentials())
             credentials_object.set_credentials(temporary_creds.to_deadline())
@@ -298,8 +298,8 @@ class QueueBoto3Session(BaseBoto3Session):
                     exist_ok=True,
                     parents=True,
                     permitted_user=self._os_user,
-                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    group_permission=FileSystemPermissionEnum.READ,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
+                    user_permission=FileSystemPermissionEnum.READ,
                 )
 
     def _delete_credentials_directory(self) -> None:
@@ -347,7 +347,7 @@ class QueueBoto3Session(BaseBoto3Session):
                         file_path=self._credentials_process_script_path,
                         permitted_user=self._os_user,
                         agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
-                        group_permission=FileSystemPermissionEnum.EXECUTE,
+                        user_permission=FileSystemPermissionEnum.EXECUTE,
                     )
 
         # install credential process to ~<job-user>/.aws/config and

--- a/src/deadline_worker_agent/file_system_operations.py
+++ b/src/deadline_worker_agent/file_system_operations.py
@@ -23,7 +23,6 @@ def set_permissions(
     file_path: Path,
     user_permission: Optional[FileSystemPermissionEnum] = None,
     permitted_user: Optional[SessionUser] = None,
-    group_permission: Optional[FileSystemPermissionEnum] = None,
     agent_user_permission: Optional[FileSystemPermissionEnum] = None,
 ):
     if os.name == "nt":
@@ -33,8 +32,6 @@ def set_permissions(
             path=file_path,
             user=permitted_user.user if permitted_user else None,
             user_permission=user_permission,
-            group=permitted_user.group if permitted_user else None,
-            group_permission=group_permission,
             agent_user_permission=agent_user_permission,
         )
 
@@ -43,7 +40,6 @@ def touch_file(
     file_path: Path,
     user_permission: Optional[FileSystemPermissionEnum] = None,
     permitted_user: Optional[SessionUser] = None,
-    group_permission: Optional[FileSystemPermissionEnum] = None,
     agent_user_permission: Optional[FileSystemPermissionEnum] = None,
 ):
     if os.name == "nt":
@@ -56,8 +52,6 @@ def touch_file(
             path=file_path,
             user=permitted_user.user if permitted_user else None,
             user_permission=user_permission,
-            group=permitted_user.group if permitted_user else None,
-            group_permission=group_permission,
             agent_user_permission=agent_user_permission,
         )
 
@@ -66,7 +60,6 @@ def make_directory(
     dir_path: Path,
     user_permission: Optional[FileSystemPermissionEnum] = None,
     permitted_user: Optional[SessionUser] = None,
-    group_permission: Optional[FileSystemPermissionEnum] = None,
     agent_user_permission: Optional[FileSystemPermissionEnum] = None,
     exist_ok: bool = True,
     parents: bool = False,
@@ -80,8 +73,6 @@ def make_directory(
             path=dir_path,
             user=permitted_user.user if permitted_user else None,
             user_permission=user_permission,
-            group=permitted_user.group if permitted_user else None,
-            group_permission=group_permission,
             agent_user_permission=agent_user_permission,
         )
 

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -643,7 +643,7 @@ class WorkerScheduler:
                         make_directory(
                             dir_path=queue_log_dir,
                             exist_ok=True,
-                            agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                            agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                         )
                 except OSError:
                     error_msg = (

--- a/src/deadline_worker_agent/sessions/job_entities/job_entities.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_entities.py
@@ -329,7 +329,7 @@ class JobEntities:
             if windows_settings is not None and self._windows_credentials_resolver is not None:
                 job_details.job_run_as_user.windows = (
                     self._windows_credentials_resolver.get_windows_session_user(
-                        windows_settings.user, windows_settings.group, windows_settings.passwordArn
+                        windows_settings.user, windows_settings.passwordArn
                     )
                 )
 

--- a/src/deadline_worker_agent/windows_credentials_resolver.py
+++ b/src/deadline_worker_agent/windows_credentials_resolver.py
@@ -100,9 +100,7 @@ class WindowsCredentialsResolver:
             if now - value.last_accessed < self.CACHE_EXPIRATION
         }
 
-    def get_windows_session_user(
-        self, user: str, group: Optional[str], passwordArn: str
-    ) -> WindowsSessionUser:
+    def get_windows_session_user(self, user: str, passwordArn: str) -> WindowsSessionUser:
         # Raises ValueError on problems so that the scheduler can cleanly fail the associated jobs
         # Any failure here should be cached so that we wait self.RETRY_AFTER minutes before fetching
         # again
@@ -149,9 +147,7 @@ class WindowsCredentialsResolver:
                 else:
                     try:
                         # OpenJD will test the ultimate validity of the credentials when creating a WindowsSessionUser
-                        windows_session_user = WindowsSessionUser(
-                            user=user, group=group, password=password
-                        )
+                        windows_session_user = WindowsSessionUser(user=user, password=password)
                     except BadCredentialsException:
                         logger.error(
                             f"Username and/or password within {passwordArn} were not correct"

--- a/test/unit/aws_credentials/test_aws_configs.py
+++ b/test/unit/aws_credentials/test_aws_configs.py
@@ -86,7 +86,7 @@ class TestSetupParentDir:
                     dir_path=dir_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    group_permission=FileSystemPermissionEnum.READ,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                     parents=True,
                     exist_ok=True,
                 )
@@ -128,7 +128,7 @@ class TestSetupParentDir:
                     dir_path=dir_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    group_permission=FileSystemPermissionEnum.READ,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                     parents=True,
                     exist_ok=True,
                 )
@@ -191,7 +191,7 @@ class TestSetupFile:
                     file_path=file_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    group_permission=FileSystemPermissionEnum.READ_WRITE,
+                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
                 )
         else:
             file_path.exists.assert_called_once_with()
@@ -230,7 +230,7 @@ class TestSetupFile:
                     file_path=file_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    group_permission=FileSystemPermissionEnum.READ_WRITE,
+                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
                 )
         else:
             chmod.assert_called_once_with(mode=0o640 if os_user is not None else 0o600)
@@ -267,7 +267,7 @@ class TestSetupFile:
                     file_path=file_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    group_permission=FileSystemPermissionEnum.READ_WRITE,
+                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
                 )
         else:
             mock_run_cmd_as.assert_not_called()

--- a/test/unit/aws_credentials/test_queue_boto3_session.py
+++ b/test/unit/aws_credentials/test_queue_boto3_session.py
@@ -487,7 +487,7 @@ class TestCreateCredentialsDirectory:
                 parents=True,
                 permitted_user=os_user,
                 agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
-                group_permission=FileSystemPermissionEnum.READ,
+                user_permission=FileSystemPermissionEnum.READ,
             )
 
     def test_reraises_oserror(
@@ -668,7 +668,7 @@ class TestInstallCredentialProcess:
                     file_path=credentials_process_script_path,
                     permitted_user=os_user,
                     agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    group_permission=FileSystemPermissionEnum.EXECUTE,
+                    user_permission=FileSystemPermissionEnum.EXECUTE,
                 )
 
         aws_config_mock.install_credential_process.assert_called_once_with(

--- a/test/unit/sessions/job_entities/test_job_details.py
+++ b/test/unit/sessions/job_entities/test_job_details.py
@@ -19,7 +19,7 @@ def os_user() -> SessionUser:
     if os.name == "posix":
         return PosixSessionUser(user="user1", group="group1")
     else:
-        return WindowsSessionUser(user="user1", group="group1", password="fakepassword")
+        return WindowsSessionUser(user="user1", password="fakepassword")
 
 
 @pytest.fixture
@@ -36,9 +36,7 @@ def job_details_with_user(os_user) -> JobDetails:
             log_group_name="/aws/deadline/queue-0000",
             schema_version=SpecificationRevision.v2023_09,
             job_run_as_user=JobRunAsUser(
-                windows_settings=JobRunAsWindowsUser(
-                    user="user1", group="group1", passwordArn="anarn"
-                )
+                windows_settings=JobRunAsWindowsUser(user="user1", passwordArn="anarn")
             ),
         )
 
@@ -76,7 +74,6 @@ def job_details_no_user() -> JobDetails:
                 "jobRunAsUser": {
                     "windows": {
                         "user": "user1",
-                        "group": "group1",
                         "passwordArn": "anarn",
                     },
                 },
@@ -191,7 +188,6 @@ def job_details_no_user() -> JobDetails:
                     },
                     "windows": {
                         "user": "user1",
-                        "group": "group1",
                         "passwordArn": "anarn",
                     },
                     "runAs": "QUEUE_CONFIGURED_USER",
@@ -274,7 +270,6 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
                     },
                     "windows": {
                         "user": "user1",
-                        "group": "group1",
                         "passwordArn": "anarn",
                     },
                 },
@@ -294,7 +289,6 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
                     },
                     "windows": {
                         "user": "user1",
-                        "group": "group1",
                         "passwordArn": "anarn",
                     },
                     "runAs": "QUEUE_CONFIGURED_USER",
@@ -361,13 +355,12 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
                 "jobRunAsUser": {
                     "windows": {
                         "user": "",
-                        "group": "",
                         "passwordArn": "",
                     },
                 },
             },
             "job_details_no_user",
-            id="required with empty windows user/group",
+            id="required with empty windows user",
         ),
         pytest.param(
             {
@@ -517,7 +510,7 @@ def test_convert_job_user_from_boto(data: JobDetailsData, expected: JobDetails, 
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-0000-00",
                 "jobRunAsUser": {
-                    "windows": {"group": "group1", "passwordArn": "anarn"},
+                    "windows": {"passwordArn": "anarn"},
                     "runAs": "QUEUE_CONFIGURED_USER",
                 },
             },
@@ -536,19 +529,6 @@ def test_convert_job_user_from_boto(data: JobDetailsData, expected: JobDetails, 
                 },
             },
             id="nonvalid jobRunAsUser - missing posix group",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-0000-00",
-                "jobRunAsUser": {
-                    "windows": {"user": "user1", "passwordArn": "anarn"},
-                    "runAs": "QUEUE_CONFIGURED_USER",
-                },
-            },
-            marks=pytest.mark.skipif(os.name != "nt", reason="Windows-only test."),
-            id="nonvalid jobRunAsUser - missing windows group",
         ),
         pytest.param(
             {
@@ -587,7 +567,6 @@ def test_convert_job_user_from_boto(data: JobDetailsData, expected: JobDetails, 
                     "windows": {
                         # Empty value
                         "user": "",
-                        "group": "abc",
                         "passwordArn": "anarn",
                     },
                     "runAs": "QUEUE_CONFIGURED_USER",
@@ -619,24 +598,6 @@ def test_convert_job_user_from_boto(data: JobDetailsData, expected: JobDetails, 
                 "jobRunAsUser": {
                     "windows": {
                         "user": "abc",
-                        # Empty value
-                        "group": "",
-                        "passwordArn": "anarn",
-                    },
-                    "runAs": "QUEUE_CONFIGURED_USER",
-                },
-            },
-            id="nonvalid new-style jobRunAsUser - empty windows group",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-0000-00",
-                "jobRunAsUser": {
-                    "windows": {
-                        "user": "abc",
-                        "group": "abc",
                         # Empty value
                         "passwordArn": "",
                     },
@@ -762,7 +723,7 @@ def test_convert_job_user_from_boto(data: JobDetailsData, expected: JobDetails, 
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-0000-00",
                 "jobRunAsUser": {
-                    "windows": {"user": "user1", "group": "group1", "passwordArn": "anarn"},
+                    "windows": {"user": "user1", "passwordArn": "anarn"},
                     "runAs": "QUEUE_CONFIGURED_USER",
                 },
             },

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -289,7 +289,6 @@ class TestJobEntity:
         else:
             assert isinstance(entity_obj.job_run_as_user.windows_settings, JobRunAsWindowsUser)
             assert entity_obj.job_run_as_user.windows_settings.user == expected_user
-            assert entity_obj.job_run_as_user.windows_settings.group == expected_group
             assert entity_obj.job_run_as_user.windows_settings.passwordArn == expected_password_arn
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1.  There is a planned removal of the `jobRunAsUser` &rarr; `windows` &rarr; `group` field from the `BatchGetJobEntity` API. This field was deemed unnecessary as Windows ACLs allow granting permissions to multiple individual users. The agent can grant permissions to its own Windows user and independently grant permissions to the queue's `jobRunAs` &rarr; `windows` &rarr; `user` user.

2.  When creating directories, the agent would add an ACL entry granting read/write permissions to the above-mentioned `group` (which the agent user was supposed to be a member of). These permissions are insufficient in the case where an administrator on the worker host changes ownership of the directory. Each time a new session is created the agent tries to re-apply least-privilege ACLs. But if the directory ownership changes, the agent would crash when creating a later session and trying to set ACLs of this directory with:

    ```
    2024-03-07 16:59:25,082 ERROR [deadline_worker_agent.scheduler] Exception in WorkerScheduler
    Traceback (most recent call last):
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 263, in run
        interval = self._sync(interruptable=True)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 411, in _sync
        self._update_sessions(response=response)
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 556, in _update_sessions
        created_session_ids = self._create_new_sessions(assigned_sessions=assigned_sessions)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 643, in _create_new_sessions
        make_directory(
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\file_system_operations.py", line 79, in make_directory
        _set_windows_permissions(
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\file_system_operations.py", line 156, in _set_windows_permissions
        win32security.SetFileSecurity(full_path, win32security.DACL_SECURITY_INFORMATION, sd)
    pywintypes.error: (5, 'SetFileSecurity', 'Access is denied.')
    ```

    The agent code previously relied on being the owner of these directories which grants implicit full control. When the directory ownership changes, this access is lost.

### What was the solution? (How)

Modify the code that sets ACLs on directories and files to ignore the `jobRunAsUser` &rarr; `windows` &rarr; `group` and instead grant permissions to the agent user. Instead of granting read/write to the group, we now grant full control to the agent user since it regularly sets the ACLs to least-privilege.

### What is the impact of this change?

1.  The worker agent no longer uses the `jobRunAsUser` &rarr; `windows` &rarr; `group` field of the `BatchGetJobEntity` API response. Users can adopt a release containing this change and will not be impacted by the API removal.
2. Admins on the Worker Agent can change ownership of the queue session log dir, the job user's `%USERPROFILE%\.aws` directory, the queue IAM credential process directories and the agent will continue to function.

### How was this change tested?

1.  Ran the updated code and confirmed the above error was no longer encountered after changing directory ownership
2.  Manually inspected the ACLs of the directories and confirmed that the agent user had full control

### Was this change documented?

No

### Is this a breaking change?

No