### PR TITLE
fix(install.sh): update ownership and permissions for session root directory

### DIFF
--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -351,10 +351,10 @@ if [ -f /var/lib/deadline/worker.json ]; then
 fi
 echo "Done provisioning persistence directory (/var/lib/deadline)"
 
-echo "Provisioning session directory (/var/tmp/openjd)"
+echo "Provisioning root directory for OpenJD Sessions (/var/tmp/openjd)"
 mkdir -p /var/tmp/openjd
-chown "${wa_user}" /var/tmp/openjd
-chmod 400 /var/tmp/openjd
+chown "${wa_user}:${job_group}" /var/tmp/openjd
+chmod 755 /var/tmp/openjd
 
 echo "Provisioning configuration directory (/etc/amazon/deadline)"
 mkdir -p /etc/amazon/deadline


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The provisioning of the root directory for OpenJD sessions (`/var/tmp/openjd`) had incorrect ownership and permissions settings.
1. Since this directory serves as the root directory where OpenJD step session directories are kept, `wa_user` needs write and execute permisisons.
2. Also, by default, OpenJD creates a `/tmp/openjd` folder with `755` permission if no session root directory is specified. ([reference](https://github.com/OpenJobDescription/openjd-sessions-for-python/blob/9db0d4f1a395a97561bb2136bc9a3b23b582652d/src/openjd/sessions/_session.py#L816-L835)). This does not align with the current permission settings in install.sh.

### What was the solution? (How)
This provisioning of the session root directory was updated to correctly set the ownership and permissions as follows:
```
chown "${wa_user}:${job_group}" /var/tmp/openjd
chmod 755 /var/tmp/openjd
```
This change aligns the session root directory's permissions with OpenJD's default bahaviour and ensures granting correct access for both `wa_user` and `job_group`.

### What is the impact of this change?
N/A

### How was this change tested?
Ran unit tests

### Was this change documented?
No.

### Is this a breaking change?
No.
