### PR TITLE
feat(windows-installer): add option to allow granting user rights to existing user

### DIFF
--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -46,6 +46,8 @@ def install() -> None:
             installer_args.update(group_name=args.group)
         if args.password:
             installer_args.update(password=args.password)
+        if args.grant_existing_user_rights:
+            installer_args.update(grant_existing_user_rights=args.grant_existing_user_rights)
 
         start_windows_installer(**installer_args)
     else:
@@ -102,6 +104,7 @@ class ParsedCommandLineArguments(Namespace):
     install_service: bool
     telemetry_opt_out: bool
     vfs_install_path: str
+    grant_existing_user_rights: bool
 
 
 def get_argument_parser() -> ArgumentParser:  # pragma: no cover
@@ -185,6 +188,13 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
             help="The password for the Amazon Deadline Cloud Worker Agent user. Defaults to generating a password.",
             required=False,
             default=None,
+        )
+        parser.add_argument(
+            "--grant-existing-user-rights",
+            help="Allows the installer to grant an existing user any missing user rights required to run the worker agent",
+            action="store_true",
+            required=False,
+            default=False,
         )
 
     return parser

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -79,6 +79,11 @@ def vfs_install_path() -> str:
 
 
 @pytest.fixture
+def grant_existing_user_rights() -> bool:
+    return True
+
+
+@pytest.fixture
 def parsed_args(
     farm_id: str,
     fleet_id: str,
@@ -92,6 +97,7 @@ def parsed_args(
     install_service: bool,
     telemetry_opt_out: bool,
     vfs_install_path: str,
+    grant_existing_user_rights: bool,
 ) -> ParsedCommandLineArguments:
     parsed_args = ParsedCommandLineArguments()
     parsed_args.farm_id = farm_id
@@ -106,6 +112,7 @@ def parsed_args(
     parsed_args.install_service = install_service
     parsed_args.telemetry_opt_out = telemetry_opt_out
     parsed_args.vfs_install_path = vfs_install_path
+    parsed_args.grant_existing_user_rights = grant_existing_user_rights
     return parsed_args
 
 

--- a/test/integ/installer/test_windows_installer.py
+++ b/test/integ/installer/test_windows_installer.py
@@ -10,15 +10,18 @@ import pytest
 
 import win32api
 import win32net
+import win32security
 
 import deadline_worker_agent.installer.win_installer as installer_mod
 from deadline_worker_agent.installer.win_installer import (
     add_user_to_group,
-    check_user_existence,
+    check_account_existence,
     update_config_file,
-    ensure_local_agent_user,
-    ensure_local_queue_user_group_exists,
+    create_local_agent_user,
+    create_local_queue_user_group,
     generate_password,
+    get_user_effective_rights,
+    grant_account_rights,
     provision_directories,
     WorkerAgentDirectories,
 )
@@ -29,12 +32,12 @@ if sys.platform != "win32":
 
 def test_user_existence():
     current_user = win32api.GetUserNameEx(win32api.NameSamCompatible)
-    result = check_user_existence(current_user)
+    result = check_account_existence(current_user)
     assert result
 
 
 def test_user_existence_with_without_existing_user():
-    result = check_user_existence("ImpossibleUser")
+    result = check_account_existence("ImpossibleUser")
     assert not result
 
 
@@ -62,40 +65,29 @@ def check_admin_privilege_and_skip_test():
 
 
 @pytest.fixture
-def user_setup_and_teardown():
+def windows_user():
     """
     Pytest fixture to create a user before the test and ensure it is deleted after the test.
     """
     check_admin_privilege_and_skip_test()
     username = "InstallerTestUser"
-    ensure_local_agent_user(username, generate_password())
+    create_local_agent_user(username, generate_password())
     yield username
     delete_local_user(username)
 
 
-def test_ensure_local_agent_user(user_setup_and_teardown):
+def test_create_local_agent_user(windows_user):
     """
     Tests the creation of a local user and validates it exists.
     """
-    assert check_user_existence(user_setup_and_teardown)
-
-
-def group_exists(group_name: str) -> bool:
-    """
-    Check if a local group exists.
-    """
-    try:
-        win32net.NetLocalGroupGetInfo(None, group_name, 1)
-        return True
-    except win32net.error:
-        return False
+    assert check_account_existence(windows_user)
 
 
 def delete_group(group_name: str) -> None:
     """
     Delete a local group if it exists.
     """
-    if group_exists(group_name):
+    if check_account_existence(group_name):
         win32net.NetLocalGroupDel(None, group_name)
 
 
@@ -106,28 +98,34 @@ def is_user_in_group(group_name, username):
 
 
 @pytest.fixture
-def setup_and_teardown_group():
+def windows_group():
     check_admin_privilege_and_skip_test()
     group_name = "user_group_for_agent_testing_only"
-    # Ensure the group does not exist before the test
-    delete_group(group_name)
+    win32net.NetLocalGroupAdd(None, 1, {"name": group_name})
     yield group_name  # This value will be used in the test function
     # Cleanup after test execution
     delete_group(group_name)
 
 
-def test_ensure_local_group_exists(setup_and_teardown_group):
-    group_name = setup_and_teardown_group
+def test_create_local_queue_user_group():
+    group_name = "test_create_local_queue_user_group"
     # Ensure the group does not exist initially
-    assert not group_exists(group_name), "Group already exists before test."
-    ensure_local_queue_user_group_exists(group_name)
-    assert group_exists(group_name), "Group was not created as expected."
+    assert not check_account_existence(
+        group_name
+    ), f"Group '{group_name}' already exists before test."
+
+    try:
+        create_local_queue_user_group(group_name)
+        assert check_account_existence(
+            group_name
+        ), f"Group '{group_name}' was not created as expected."
+    finally:
+        delete_group(group_name)
 
 
-def test_add_user_to_group(setup_and_teardown_group, user_setup_and_teardown):
-    group_name = setup_and_teardown_group
-    ensure_local_queue_user_group_exists(group_name)
-    user_name = user_setup_and_teardown
+def test_add_user_to_group(windows_group, windows_user):
+    group_name = windows_group
+    user_name = windows_user
     add_user_to_group(group_name, user_name)
     assert is_user_in_group(group_name, user_name), "User was not added to group as expected."
 
@@ -191,7 +189,7 @@ def test_update_config_file_creates_backup(setup_example_config):
 
 
 def test_provision_directories(
-    user_setup_and_teardown: str,
+    windows_user: str,
     tmp_path: pathlib.Path,
 ):
     # GIVEN
@@ -218,7 +216,7 @@ def test_provision_directories(
 
     # WHEN
     with patch.dict(installer_mod.os.environ, {"PROGRAMDATA": str(root_dir)}):
-        actual_dirs = provision_directories(user_setup_and_teardown)
+        actual_dirs = provision_directories(windows_user)
 
     # THEN
     assert actual_dirs == expected_dirs
@@ -226,3 +224,58 @@ def test_provision_directories(
     assert actual_dirs.deadline_log_subdir.exists()
     assert actual_dirs.deadline_persistence_subdir.exists()
     assert actual_dirs.deadline_config_subdir.exists()
+
+
+def test_get_user_effective_rights(
+    windows_user: str,
+    windows_group: str,
+) -> None:
+    try:
+        # GIVEN
+        add_user_to_group(
+            group_name=windows_group,
+            user_name=windows_user,
+        )
+        grant_account_rights(
+            account_name=windows_user,
+            rights=[win32security.SE_BACKUP_NAME],
+        )
+        grant_account_rights(
+            account_name=windows_group,
+            rights=[win32security.SE_RESTORE_NAME],
+        )
+
+        # WHEN
+        effective_rights = get_user_effective_rights(windows_user)
+
+        # THEN
+        assert effective_rights == set(
+            [
+                win32security.SE_BACKUP_NAME,
+                win32security.SE_RESTORE_NAME,
+            ]
+        )
+    finally:
+        # Clean up the added rights since they stick around in Local Security Policy
+        # even after the user and group have been deleted
+        policy_handle = win32security.LsaOpenPolicy(None, win32security.POLICY_ALL_ACCESS)
+        try:
+            # Remove backup right from user
+            user_sid, _, _ = win32security.LookupAccountName(None, windows_user)
+            win32security.LsaRemoveAccountRights(
+                policy_handle,
+                user_sid,
+                AllRights=False,
+                UserRights=[win32security.SE_BACKUP_NAME],
+            )
+
+            # Remove restore right from group
+            group_sid, _, _ = win32security.LookupAccountName(None, windows_group)
+            win32security.LsaRemoveAccountRights(
+                policy_handle,
+                group_sid,
+                AllRights=False,
+                UserRights=[win32security.SE_RESTORE_NAME],
+            )
+        finally:
+            win32api.CloseHandle(policy_handle)

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -7,11 +7,10 @@ import pytest
 if sys.platform != "win32":
     pytest.skip("Windows-specific tests", allow_module_level=True)
 
-import pywintypes
 from pywintypes import error as PyWinTypesError
 from deadline_worker_agent.installer.win_installer import (
-    ensure_local_queue_user_group_exists,
-    ensure_local_agent_user,
+    create_local_queue_user_group,
+    create_local_agent_user,
     generate_password,
     start_windows_installer,
     validate_deadline_id,
@@ -52,6 +51,7 @@ def test_start_windows_installer(
                 group_name=parsed_args.group,
                 password=parsed_args.password,
                 allow_shutdown=parsed_args.allow_shutdown,
+                grant_existing_user_rights=parsed_args.grant_existing_user_rights,
             )
 
 
@@ -99,59 +99,38 @@ def test_group_creation_failure(group_name):
         "win32net.NetLocalGroupAdd", side_effect=Exception("Test Failure")
     ), patch("logging.error") as mock_log_error:
         with pytest.raises(Exception):
-            ensure_local_queue_user_group_exists(group_name)
+            create_local_queue_user_group(group_name)
         mock_log_error.assert_called_with(
             f"Failed to create group {group_name}. Error: Test Failure"
         )
 
 
-def test_unexpected_error_code_handling(group_name):
-    with patch("win32net.NetLocalGroupGetInfo", side_effect=MockPyWinTypesError(9999)), patch(
-        "win32net.NetLocalGroupAdd"
-    ) as mock_group_add, patch("logging.error"):
-        with pytest.raises(pywintypes.error):
-            ensure_local_queue_user_group_exists(group_name)
-        mock_group_add.assert_not_called()
-
-
-def test_ensure_local_agent_user_raises_exception_on_creation_failure():
+def test_create_local_agent_user_raises_exception_on_creation_failure():
     username = "testuser"
     password = "password123"
     error_message = "System error"
     with patch(
-        "deadline_worker_agent.installer.win_installer.check_user_existence", return_value=False
+        "deadline_worker_agent.installer.win_installer.check_account_existence", return_value=False
     ), patch("win32net.NetUserAdd") as mocked_net_user_add, patch(
         "deadline_worker_agent.installer.win_installer.logging.error"
     ) as mocked_logging_error:
         mocked_net_user_add.side_effect = Exception(error_message)
 
         with pytest.raises(Exception):
-            ensure_local_agent_user(username, password)
+            create_local_agent_user(username, password)
 
         mocked_logging_error.assert_called_once_with(
             f"Failed to create user '{username}'. Error: {error_message}"
         )
 
 
-@patch("win32net.NetUserAdd")
-def test_ensure_local_agent_user_logs_info_if_user_exists(mock_net_user_add: MagicMock):
-    username = "existinguser"
-    password = "password123"
-    with patch(
-        "deadline_worker_agent.installer.win_installer.check_user_existence", return_value=True
-    ), patch("deadline_worker_agent.installer.win_installer.logging.info") as mocked_logging_info:
-        ensure_local_agent_user(username, password)
-        mock_net_user_add.assert_not_called()
-        mocked_logging_info.assert_called_once_with(f"Agent User {username} already exists")
-
-
-def test_ensure_local_agent_user_correct_parameters_passed_to_netuseradd():
+def test_create_local_agent_user_correct_parameters_passed_to_netuseradd():
     username = "newuser"
     password = "password123"
     with patch(
-        "deadline_worker_agent.installer.win_installer.check_user_existence", return_value=False
+        "deadline_worker_agent.installer.win_installer.check_account_existence", return_value=False
     ), patch("win32net.NetUserAdd") as mocked_net_user_add:
-        ensure_local_agent_user(username, password)
+        create_local_agent_user(username, password)
 
         expected_user_info = {
             "name": username,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
On Windows, the Worker agent user requires some user rights depending on the installation configuration. We know of the following rights requirements so far: (see https://learn.microsoft.com/en-us/windows/win32/secauthz/privilege-constants)

**When being installed as a Windows service**
- SeServiceLogonRight
- SeBackupPrivilege
- SeRestorePrivilege
- SeIncreaseQuotaPrivilege

**When allowed to shutdown the host**
- SeShutdownPrivilege

### What was the solution? (How)
- Update the Windows installer to grant the Worker agent user these permissions.
    - If a new user is created, the permissions are always granted.
    - If an existing user was provided, the user must opt-in to granting the missing rights (if any) via a new `--grant-existing-user-rights` option, otherwise the installer prints an error and quits.

### What is the impact of this change?
Installer now ensures that the Worker agent user has the necessary user rights to function on Windows

### How was this change tested?
- Unit/integration tests
- Manual testing on a Windows machine (results below)

### Was this change documented?
No

### Is this a breaking change?
No

### Manual testing results
1. Verified a new user created by the installer has all user rights added to it
```
INFO: Creating Agent user new-worker
INFO: User 'new-worker' created successfully.
INFO: Successfully granted the following rights to new-worker: ['SeIncreaseQuotaPrivilege', 'SeBackupPrivilege', 'SeServiceLogonRight', 'SeShutdownPrivilege', 'SeRestorePrivilege']
```
2. Verified providing existing user correctly setup without `--grant-existing-user-rights` succeeds
3. Removed `SeBackupPrivilege` from the existing user, then reran the installer and got expected error:
```
ERROR: Existing Worker agent user was provided (new-worker) but is missing the following rights: {'SeBackupPrivilege'}
Provide the --grant-existing-user-rights option to allow the installer to grant the missing rights to the user.
```
4. Granted a group the existing user was in the `SeBackupPrivilege` right and verified the installer succeeded (verifies rights inherited via group ownership are checked as well)
5. Created a fresh user and provided the --grant-existing-user-rights and verified the installer granted the missing rights:
```
INFO: Using existing user (other-new-user) as worker agent user
INFO: Successfully granted the following rights to other-new-user: ['SeIncreaseQuotaPrivilege', 'SeBackupPrivilege', 'SeServiceLogonRight', 'SeShutdownPrivilege', 'SeRestorePrivilege']
```