### PR TITLE
feat: Add telemetry event for uncaught exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ to interact with AWS Deadline Cloud and perform tasks.
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
+## Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Providing the installer flag: `--telemetry-opt-out`
+3. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
-    "deadline == 0.40.*",
+    "deadline == 0.41.*",
     "openjd-sessions == 0.7.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -34,6 +34,7 @@ from ..aws.deadline import (
     update_worker,
     update_worker_schedule,
     record_worker_start_telemetry_event,
+    record_uncaught_exception_telemetry_event,
 )
 
 __all__ = ["entrypoint"]
@@ -161,6 +162,7 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
             raise
         else:
             _logger.critical(e, exc_info=True)
+            record_uncaught_exception_telemetry_event(exception_type=str(type(e)))
             sys.exit(1)
     finally:
         _logger.info("Worker Agent exiting")

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -8,6 +8,7 @@ from deadline_worker_agent.aws.deadline import (
     record_worker_start_telemetry_event,
     record_sync_inputs_telemetry_event,
     record_sync_outputs_telemetry_event,
+    record_uncaught_exception_telemetry_event,
 )
 from deadline_worker_agent.startup.capabilities import Capabilities
 from deadline.job_attachments.progress_tracker import SummaryStatistics
@@ -124,4 +125,26 @@ def test_record_sync_outputs_telemetry_event():
             "transfer_rate": 100.0,
             "queue_id": "queue-test",
         },
+    )
+
+
+def test_record_uncaught_exception_telemetry_event():
+    """
+    Tests that when record_uncaught_exception_telemetry_event() is called, the correct
+    event type and details are passed to the telemetry client's record_event() method.
+    """
+    # GIVEN
+    mock_telemetry_client = MagicMock()
+
+    with patch.object(deadline_mod, "_get_deadline_telemetry_client") as mock_get_telemetry_client:
+        mock_get_telemetry_client.return_value = mock_telemetry_client
+
+        # WHEN
+        error = ValueError()
+        record_uncaught_exception_telemetry_event(str(type(error)))
+
+    # THEN
+    mock_telemetry_client.record_error.assert_called_with(
+        exception_type="<class 'ValueError'>",
+        event_details={"exception_scope": "uncaught"},
     )

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -186,9 +186,11 @@ def test_calls_worker_run(
     mock_worker_run.assert_called_once_with()
 
 
+@patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")
 @patch.object(entrypoint_mod.sys, "exit")
 def test_worker_run_exception(
     sys_exit_mock: MagicMock,
+    telemetry_mock: MagicMock,
     mock_worker_run: MagicMock,
 ) -> None:
     """Tests that exceptions raised by Worker.run() are logged and the program exits with a non-zero exit code"""
@@ -205,6 +207,7 @@ def test_worker_run_exception(
     logger_exception: MagicMock = logger.exception
     logger_exception.assert_called_once_with("Failed running worker: %s", exception)
     sys_exit_mock.assert_called_once_with(1)
+    telemetry_mock.assert_called_once_with(exception_type=str(type(exception)))
 
 
 def test_configuration_load(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We don't have a mechanism to tell if a version of the worker is more error prone than others.

### What was the solution? (How)
Capture telemetry on uncaught exceptions, so we can get an idea of the types of errors customers may be encountering that we're not handling properly. Uses changes from https://github.com/casillas2/deadline-cloud/pull/205

### What is the impact of this change?
We have a better idea if customers are hitting unintended errors using the worker

### How was this change tested?
- ran locally, confirmed it wrote telemetry to backend
- unit tests pass, using changes from deadline-cloud mainline

### Was this change documented?
Updated the README

### Is this a breaking change?
No