### PR TITLE
ci: set source override to release branch for the release canary

### DIFF
--- a/.github/workflows/release_integration_canary.yml
+++ b/.github/workflows/release_integration_canary.yml
@@ -26,4 +26,5 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: deadline-cloud-worker-agent-Canary
+          source-version-override: release
           hide-cloudwatch-logs: true


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The release canary is using the workflow branch which i mainline when running in codebuild. We need it to test the release branch.

### What was the solution? (How)
add the source-version-override option specifying the release branch to be used.

### What is the impact of this change?
Tests will run using a checkout of the release branch

### How was this change tested?
Tested in a development environment. Confirmed that codebuild specified the latest commit of the release branch as its source.

### Was this change documented?
No

### Is this a breaking change?
No