### PR TITLE
fix(session): fix instantiation of of `WindowsFileSystemPermissionSettings` to not use `os_group`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
-    "deadline == 0.39.*",
+    "deadline == 0.40.*",
     "openjd-sessions == 0.6.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -901,10 +901,9 @@ class Session:
             else:
                 if not isinstance(self._os_user, WindowsSessionUser):
                     raise ValueError(f"The user must be a windows-user. Got {type(self._os_user)}")
-                if self._os_user.group is not None:
+                if self._os_user.user is not None:
                     fs_permission_settings = WindowsFileSystemPermissionSettings(
                         os_user=self._os_user.user,
-                        os_group=self._os_user.group,
                         dir_mode=WindowsPermissionEnum.WRITE,
                         file_mode=WindowsPermissionEnum.WRITE,
                     )

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -702,7 +702,6 @@ class TestSessionSyncAssetInputs:
         elif os.name == "nt":
             expected_fs_permission_settings = WindowsFileSystemPermissionSettings(
                 os_user="SomeUser",
-                os_group="SomeGroup",
                 dir_mode=WindowsPermissionEnum.WRITE,
                 file_mode=WindowsPermissionEnum.WRITE,
             )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Job Attachment has been updated so that it does not use group names in permissions settings for Windows file system. For details, please see: https://github.com/casillas2/deadline-cloud/pull/196. Specifically, the `os_group` field in the `WindowsFileSystemPermissionSettings` class can now be effectively ignored. 

### What was the solution? (How)
Do not pass `os_group` when instantiate `WindowsFileSystemPermissionSettings` class

### What is the impact of this change?
N/A

### How was this change tested?
Ran unit tests

### Was this change documented?
Yes.

### Is this a breaking change?
No.
