### PR TITLE
chore(deps): upgrade to openjd-sessions 0.7.* and deadline 0.40.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
-    "deadline == 0.39.*",
-    "openjd-sessions == 0.6.*",
+    "deadline == 0.40.*",
+    "openjd-sessions == 0.7.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "typing_extensions ~= 4.8",

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -901,10 +901,9 @@ class Session:
             else:
                 if not isinstance(self._os_user, WindowsSessionUser):
                     raise ValueError(f"The user must be a windows-user. Got {type(self._os_user)}")
-                if self._os_user.group is not None:
+                if self._os_user.user is not None:
                     fs_permission_settings = WindowsFileSystemPermissionSettings(
                         os_user=self._os_user.user,
-                        os_group=self._os_user.group,
                         dir_mode=WindowsPermissionEnum.WRITE,
                         file_mode=WindowsPermissionEnum.WRITE,
                     )

--- a/test/unit/aws_credentials/test_aws_configs.py
+++ b/test/unit/aws_credentials/test_aws_configs.py
@@ -46,7 +46,7 @@ def os_user() -> Optional[SessionUser]:
     if os.name == "posix":
         return PosixSessionUser(user="user", group="group")
     else:
-        return WindowsSessionUser(user="user", group="group", password="fakepassword")
+        return WindowsSessionUser(user="user", password="fakepassword")
 
 
 class TestSetupParentDir:

--- a/test/unit/aws_credentials/test_queue_boto3_session.py
+++ b/test/unit/aws_credentials/test_queue_boto3_session.py
@@ -57,7 +57,7 @@ def os_user() -> Optional[SessionUser]:
     if os.name == "posix":
         return PosixSessionUser(user="user", group="group")
     else:
-        return WindowsSessionUser(user="user", group="group", password="fakepassword")
+        return WindowsSessionUser(user="user", password="fakepassword")
 
 
 class TestInit:

--- a/test/unit/scheduler/test_session_cleanup.py
+++ b/test/unit/scheduler/test_session_cleanup.py
@@ -43,7 +43,7 @@ class TestSessionUserCleanupManager:
         if os.name == "posix":
             return PosixSessionUser(user="user", group="group")
         else:
-            return WindowsSessionUser(user="user", group="group", password="fakepassword")
+            return WindowsSessionUser(user="user", password="fakepassword")
 
     @pytest.fixture
     def session(self, os_user: PosixSessionUser) -> MagicMock:
@@ -175,7 +175,7 @@ class TestSessionUserCleanupManager:
             if os.name == "posix":
                 return PosixSessionUser(user="agent_user", group="agent_group")
             else:
-                return WindowsSessionUser(user="user", group="group", password="fakepassword")
+                return WindowsSessionUser(user="user", password="fakepassword")
 
         @pytest.mark.skipif(os.name != "posix", reason="Posix-only test.")
         @pytest.fixture(autouse=True)

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -78,7 +78,7 @@ def os_user() -> SessionUser:
     if os.name == "posix":
         return PosixSessionUser(user="user", group="group")
     else:
-        return WindowsSessionUser(user="user", group="group", password="fakepassword")
+        return WindowsSessionUser(user="user", password="fakepassword")
 
 
 @pytest.fixture
@@ -366,10 +366,6 @@ class TestDetails:
             assert (
                 details.job_run_as_user.windows.user
                 == expected_details.job_run_as_user.windows.user
-            )
-            assert (
-                details.job_run_as_user.windows.group
-                == expected_details.job_run_as_user.windows.group
             )
         assert details.job_attachment_settings == expected_details.job_attachment_settings
         assert details.parameters == expected_details.parameters

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -75,7 +75,7 @@ def os_user() -> Optional[SessionUser]:
     if os.name == "posix":
         return PosixSessionUser(user="some-user", group="some-group")
     elif os.name == "nt":
-        return WindowsSessionUser(user="SomeUser", group="SomeGroup", password="qwe123!@#")
+        return WindowsSessionUser(user="SomeUser", password="qwe123!@#")
     else:
         return None
 
@@ -702,7 +702,6 @@ class TestSessionSyncAssetInputs:
         elif os.name == "nt":
             expected_fs_permission_settings = WindowsFileSystemPermissionSettings(
                 os_user="SomeUser",
-                os_group="SomeGroup",
                 dir_mode=WindowsPermissionEnum.WRITE,
                 file_mode=WindowsPermissionEnum.WRITE,
             )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Deadline worker agent needs to be modified to upgrade to openjd version 0.7* since the changes were breaking.

### What was the solution? (How)
Removed user group from windows as that is deprecated as of openjd-sessions-0.7.* and deadline-0.40.*

### What is the impact of this change?
Upgrading versions to latest and removing windows group support from deadline worker agent.

### How was this change tested?
Unit tests

### Was this change documented?
N/A

### Is this a breaking change?
N/A