### PR TITLE
test: skip windows installer test if win32api cannot be imported

### DIFF
--- a/test/integ/installer/test_windows_installer.py
+++ b/test/integ/installer/test_windows_installer.py
@@ -8,7 +8,11 @@ from unittest.mock import patch
 
 import pytest
 
-import win32api
+
+try:
+    import win32api
+except ImportError:
+    pytest.skip("win32api not available", allow_module_level=True)
 import win32net
 
 import deadline.client.config.config_file


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Mainline Integration tests are failing to run the windows installer test because the tests are running on linux.

### What was the solution? (How)
Add a pytest.skip if win32api cannot be imported

### What is the impact of this change?
Fix integration tests

### How was this change tested?
Ran `hatch run integ-test` and confirmed the tests no longer failed on the import error and continued to the other tests.

```
=================================================================================================== test session starts ====================================================================================================
platform linux -- Python 3.9.18, pytest-7.4.4, pluggy-1.4.0
rootdir: /local/home/moorec/CICD/git/deadline-cloud-worker-agent
configfile: pyproject.toml
plugins: deadline-cloud-test-fixtures-0.5.5, cov-4.1.0, xdist-3.5.0
collected 3 items / 1 skipped    
```

### Was this change documented?
no

### Is this a breaking change?
no