### PR TITLE
fix: change OpenJD's session root directory to /sessions

### DIFF
--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -351,10 +351,10 @@ if [ -f /var/lib/deadline/worker.json ]; then
 fi
 echo "Done provisioning persistence directory (/var/lib/deadline)"
 
-echo "Provisioning root directory for OpenJD Sessions (/var/tmp/openjd)"
-mkdir -p /var/tmp/openjd
-chown "${wa_user}:${job_group}" /var/tmp/openjd
-chmod 755 /var/tmp/openjd
+echo "Provisioning root directory for OpenJD Sessions (/sessions)"
+mkdir -p /sessions
+chown "${wa_user}:${job_group}" /sessions
+chmod 755 /sessions
 
 echo "Provisioning configuration directory (/etc/amazon/deadline)"
 mkdir -p /etc/amazon/deadline

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -89,7 +89,7 @@ OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS: dict[
     ActionState.SUCCESS: "SUCCEEDED",
     ActionState.TIMEOUT: "FAILED",
 }
-DEFAULT_POSIX_OPENJD_SESSION_DIR = Path("/var/tmp/openjd")
+DEFAULT_POSIX_OPENJD_SESSION_DIR = Path("/sessions")
 TIME_DELTA_ZERO = timedelta()
 
 # During a SYNC_INPUT_JOB_ATTACHMENTS session action, the transfer rate is periodically reported through


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The session root directory for OpenJD was previously set to `/var/tmp` by this PR: https://github.com/casillas2/deadline-cloud-worker-agent/pull/196. While this was intended to avoid potential issues with `/tmp` being mounted as tmpfs, it was still susceptible to data loss risks due to the volatile nature of `/var/tmp`.

### What was the solution? (How)
The session root directory has been changed to `/sessions` directly under the root directory (`/`). This location is mounted on physical storage and not tmpfs, providing a more reliable and durable solution.

### What is the impact of this change?
This change should have no direct impact on customers.

### How was this change tested?
- Unit tests were run and passed.
- End-to-end (E2E) testing was performed locally by creating the `/sessions` directory, provisioning it, submitting jobs, and verifying that session directories were created as expected under `/sessions`.

### Was this change documented?
No.

### Is this a breaking change?
No.