### PR TITLE
ci: Add windows integration test workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -64,7 +64,6 @@ jobs:
           git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
           git config --local user.name "client-software-ci"
 
-      
       - name: MergePushRelease
         run: |
           git merge --ff-only origin/mainline -v

--- a/.github/workflows/windows_integration.yml
+++ b/.github/workflows/windows_integration.yml
@@ -1,0 +1,39 @@
+name: Windows Integration Tests
+
+on:
+  workflow_call:
+    
+jobs:
+  WindowsIntegrationTests:
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    env:
+        PYTHON: ${{ matrix.python-version }}
+        CODEARTIFACT_REGION: "us-west-2"
+        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+    
+    - name: Install Hatch
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Run Windows Integration Tests
+      run: hatch run integ-windows

--- a/hatch.toml
+++ b/hatch.toml
@@ -10,6 +10,7 @@ test = "pytest {args:test/unit --numprocesses=auto}"
 # pytest-xdist does not allow live output of stdout, meaning integ tests only show output after the test is done
 # See: https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers
 integ-test = "pytest test/integ {args}"
+integ-windows = "pytest --no-cov test/integ/installer {args:}"
 typing = "mypy {args:src test}"
 style = [
   "ruff {args:.}",
@@ -37,6 +38,7 @@ python = ["3.9", "3.10", "3.11"]
 
 [envs.default.env-vars]
 PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
+RUN_AS_ADMIN="true"
 
 [envs.codebuild.env-vars]
 PIP_INDEX_URL=""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The windows installer integration tests are not being run in the CI

### What was the solution? (How)
Add a dispatch workflow that will run the windows integration tests to see if they will run on github windows runners.

### What is the impact of this change?
Add windows integration tests

### How was this change tested?
hatch run integ-windows

### Was this change documented?
No

### Is this a breaking change?
No