### PR TITLE
ci: set windows integ test workflow to dispatch

### DIFF
--- a/.github/workflows/windows_integration.yml
+++ b/.github/workflows/windows_integration.yml
@@ -1,8 +1,8 @@
 name: Windows Integration Tests
 
 on:
-  workflow_call:
-    
+  workflow_dispatch:
+
 jobs:
   WindowsIntegrationTests:
     runs-on: windows-latest


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Need to change `workflow_call:` to `workflow_dispatch:`

### What was the solution? (How)
change `workflow_call:` to `workflow_dispatch:`

### What is the impact of this change?
Allows us to run the workflow manually

### How was this change tested?
N/A

### Was this change documented?
no

### Is this a breaking change?
no