### PR TITLE
ci: add windows integration testing to mainline and release workflows

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -7,6 +7,41 @@ on:
       - 'mainline'
 
 jobs:
+  WindowsIntegrationTests:
+    name: Windows Integration Tests
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    env:
+        PYTHON: ${{ matrix.python-version }}
+        CODEARTIFACT_REGION: "us-west-2"
+        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+    
+    - name: Install Hatch
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Run Windows Integration Tests
+      run: hatch run integ-windows
+      
   MainlineIntegrationTest:
     name: Integration Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -21,6 +21,42 @@ jobs:
       commit: ${{ github.sha }}
     secrets: inherit
 
+  WindowsIntegrationTests:
+    needs: UnitTests
+    name: Windows Integration Tests
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    env:
+        PYTHON: ${{ matrix.python-version }}
+        CODEARTIFACT_REGION: "us-west-2"
+        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+    
+    - name: Install Hatch
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Run Windows Integration Tests
+      run: hatch run integ-windows
+
   IntegrationTests:
     needs: UnitTests
     name: Integration Tests

--- a/.github/workflows/release_integration_canary.yml
+++ b/.github/workflows/release_integration_canary.yml
@@ -6,6 +6,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  WindowsIntegrationTests:
+    name: Windows Integration Tests
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    env:
+        PYTHON: ${{ matrix.python-version }}
+        CODEARTIFACT_REGION: "us-west-2"
+        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+    
+    - name: Install Hatch
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Run Windows Integration Tests
+      run: hatch run integ-windows
+      
   ReleaseIntegrationCanary:
     runs-on: ubuntu-latest
     environment: canary


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have confirmed that the Windows integration tests run successfully on github runners so we need to add them to the mainline push, release, and canary workflows.

### What was the solution? (How)
Add the a new jobs to the workflows to run the Windows Integration tests

### What is the impact of this change?
Windows Integration tests will run in CI

### How was this change tested?
The workflow job was testing here: https://github.com/casillas2/deadline-cloud-worker-agent/actions/runs/8351372188

### Was this change documented?
No

### Is this a breaking change?
No