### PR TITLE
feat: fail jobs configured to run as worker agent user on Windows

### DIFF
--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -93,7 +93,8 @@ def job_run_as_user_api_model_to_worker_agent(
     expected by the Worker Agent.
     """
     if "runAs" in job_run_as_user_data and job_run_as_user_data["runAs"] == "WORKER_AGENT_USER":
-        return None
+        job_run_as_user = JobRunAsUser(is_worker_agent_user=True)
+        return job_run_as_user
 
     if os.name == "posix":
         user = ""
@@ -154,6 +155,7 @@ class JobRunAsUser:
     posix: PosixSessionUser | None = None
     windows: WindowsSessionUser | None = None
     windows_settings: JobRunAsWindowsUser | None = None
+    is_worker_agent_user: bool = False
 
     def __eq__(self, other: Any) -> bool:
         if other is None:

--- a/test/unit/sessions/job_entities/test_job_details.py
+++ b/test/unit/sessions/job_entities/test_job_details.py
@@ -49,6 +49,15 @@ def job_details_no_user() -> JobDetails:
     )
 
 
+@pytest.fixture
+def job_details_only_run_as_worker_agent_user() -> JobDetails:
+    return JobDetails(
+        log_group_name="/aws/deadline/queue-0000",
+        schema_version=SpecificationRevision.v2023_09,
+        job_run_as_user=JobRunAsUser(is_worker_agent_user=True),
+    )
+
+
 @pytest.mark.parametrize(
     "data",
     [
@@ -413,7 +422,7 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
                     "runAs": "WORKER_AGENT_USER",
                 },
             },
-            "job_details_no_user",
+            "job_details_only_run_as_worker_agent_user",
             id="required with runAs WORKER_AGENT_USER",
         ),
     ],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have determined that the Worker Agent needs Administrator privileges in Windows.
This poses risk that any queues configured to run jobs as the agent user would then have administrator privileges.
### What was the solution? (How)
If the agent is running as an administrator and receives a job and the ``BatchGetJobEntity`` API request for the jobDetails returns a ``jobRunAsUser`` → ``runAs`` is ``WORKER_AGENT_USER``, then we should fail the job with a message explaining that the queue and fleet are setup in an insecure configuration and the job would run with administrator privileges.
### What is the impact of this change?
Better security
### How was this change tested?
Added unit tests
### Was this change documented?
N/A
### Is this a breaking change?
N/A