### PR TITLE
fix: change windows logon type from NETWORK to INTERACTIVE

### DIFF
--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -200,7 +200,7 @@ def ensure_user_profile_exists(username: str, password: str):
         # https://timgolden.me.uk/pywin32-docs/win32security__LogonUser_meth.html
         logon_token = win32security.LogonUser(
             Username=username,
-            LogonType=win32security.LOGON32_LOGON_NETWORK_CLEARTEXT,
+            LogonType=win32security.LOGON32_LOGON_INTERACTIVE,
             LogonProvider=win32security.LOGON32_PROVIDER_DEFAULT,
             Password=password,
             Domain=None,

--- a/src/deadline_worker_agent/windows/win_credentials_resolver.py
+++ b/src/deadline_worker_agent/windows/win_credentials_resolver.py
@@ -21,7 +21,7 @@ from openjd.sessions import WindowsSessionUser, BadCredentialsException
 from pywintypes import HANDLE as PyHANDLE
 from win32security import (
     LogonUser,
-    LOGON32_LOGON_NETWORK_CLEARTEXT,
+    LOGON32_LOGON_INTERACTIVE,
     LOGON32_PROVIDER_DEFAULT,
 )
 from win32profile import LoadUserProfile, PI_NOUI, UnloadUserProfile
@@ -214,7 +214,7 @@ class WindowsCredentialsResolver:
                             # https://timgolden.me.uk/pywin32-docs/win32profile__LoadUserProfile_meth.html
                             logon_token = LogonUser(
                                 Username=user,
-                                LogonType=LOGON32_LOGON_NETWORK_CLEARTEXT,
+                                LogonType=LOGON32_LOGON_INTERACTIVE,
                                 LogonProvider=LOGON32_PROVIDER_DEFAULT,
                                 Password=password,
                                 Domain=None,

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -238,7 +238,7 @@ class TestEnsureUserProfileExists:
         # THEN
         mock_LogonUser.assert_called_once_with(
             Username=username,
-            LogonType=win32security.LOGON32_LOGON_NETWORK_CLEARTEXT,
+            LogonType=win32security.LOGON32_LOGON_INTERACTIVE,
             LogonProvider=win32security.LOGON32_PROVIDER_DEFAULT,
             Password=password,
             Domain=None,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Some applications have security controls that restrict what a network logon user can do, but do not have such restrictions for interactive logons.

### What was the solution? (How)

Change the win32 logon kind from NETWORK to INTERACTIVE. NETWORK was oridinally chosen as it was believed that it was required for the logon to have access to network shares, but INTERACTIVE grants the same access so this should be a safe change.

### What is the impact of this change?

Applications that restrict network logons should now function.

### How was this change tested?

A colleague manually applied the change and tested it with the application in question.

### Was this change documented?

N/A

### Is this a breaking change?

No, it should not be.
