### PR TITLE
fix: increasing default password length for windows users

### DIFF
--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -36,7 +36,7 @@ from ..windows.win_service import WorkerAgentWindowsService
 # Defaults
 DEFAULT_WA_USER = "deadline-worker"
 DEFAULT_JOB_GROUP = "deadline-job-users"
-DEFAULT_PASSWORD_LENGTH = 12
+DEFAULT_PASSWORD_LENGTH = 32
 
 # Environment variable that overrides the config path used by the Deadline client
 DEADLINE_CLIENT_CONFIG_PATH_OVERRIDE_ENV_VAR = "DEADLINE_CONFIG_FILE_PATH"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The default password length used by the Windows installer may have been shorter than enterprise organisation requirements. 

### What was the solution? (How)
Increase the default length used by the installer to 32 characters. 

### What is the impact of this change?
The password generated by the Windows installer will be more likely to conform to customer requirements. 

### How was this change tested?
Manual install. 

### Was this change documented?
NA

### Is this a breaking change?
No