### PR TITLE
fix: NEVER_ATTEMPTED session actions should not report timestamps

### DIFF
--- a/docs/worker_api_contract.md
+++ b/docs/worker_api_contract.md
@@ -348,7 +348,8 @@ attempt to run.
 
 If the Worker Agent reports these Session Action as `FAILED`, `INTERRUPTED`, or `CANCELED` then the Worker Agent
 must report all queued Session Actions after it in the Session as `NEVER_ATTEMPTED`; except for
-`envExit` actions that correspond to already completed `envEnter` Session Actions. The service
+`envExit` actions that correspond to already completed `envEnter` Session Actions. Session Actions that are 
+reported as `NEVER_ATTEMPTED` must not report `startedAt` or `endedAt` times. The service
 must not queue additional Session Actions to the Session except for `envExit` Session Actions that
 correspond to already completed `envEnter` Session Actions for the same Session.
 

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -618,8 +618,8 @@ class WorkerScheduler:
                 action["sessionActionId"]: SessionActionStatus(
                     id=action["sessionActionId"],
                     completed_status="FAILED" if action is actions[0] else "NEVER_ATTEMPTED",
-                    start_time=now,
-                    end_time=now,
+                    start_time=now if action is actions[0] else None,
+                    end_time=now if action is actions[0] else None,
                     status=ActionStatus(
                         state=ActionState.FAILED,
                         fail_message=str(error_message),

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -704,17 +704,21 @@ class TestCreateNewSessions:
                 action_update := scheduler._action_updates_map.get(action_id, None)
             ), f"no action update for {action_id}"
             assert action_update.id == action_id
-            assert action_update.completed_status == (
-                "FAILED" if action_num == 1 else "NEVER_ATTEMPTED"
-            )
             assert action_update.status is not None
             assert action_update.status.state == ActionState.FAILED
             assert (
                 action_update.status.fail_message
                 == f"Log provisioning error: {log_provision_error_msg}"
             )
-            assert action_update.start_time == datetime_now_mock.return_value
-            assert action_update.end_time == datetime_now_mock.return_value
+            if action_num == 1:
+                assert action_update.completed_status == "FAILED"
+
+                assert action_update.start_time == datetime_now_mock.return_value
+                assert action_update.end_time == datetime_now_mock.return_value
+            else:
+                assert action_update.completed_status == "NEVER_ATTEMPTED"
+                assert action_update.start_time is None
+                assert action_update.end_time is None
 
     @pytest.mark.parametrize(
         argnames="job_details_error",
@@ -783,14 +787,18 @@ class TestCreateNewSessions:
                 action_update := scheduler._action_updates_map.get(action_id, None)
             ), f"no action update for {action_id}"
             assert action_update.id == action_id
-            assert action_update.completed_status == (
-                "FAILED" if action_num == 1 else "NEVER_ATTEMPTED"
-            )
             assert action_update.status is not None
             assert action_update.status.state == ActionState.FAILED
             assert action_update.status.fail_message == str(job_details_error)
-            assert action_update.start_time == datetime_now_mock.return_value
-            assert action_update.end_time == datetime_now_mock.return_value
+            if action_num == 1:
+                assert action_update.completed_status == "FAILED"
+
+                assert action_update.start_time == datetime_now_mock.return_value
+                assert action_update.end_time == datetime_now_mock.return_value
+            else:
+                assert action_update.completed_status == "NEVER_ATTEMPTED"
+                assert action_update.start_time is None
+                assert action_update.end_time is None
 
     @pytest.mark.skipif(os.name != "nt", reason="Windows-only test.")
     def test_job_details_run_as_worker_agent_user_windows(
@@ -856,14 +864,17 @@ class TestCreateNewSessions:
                 action_update := scheduler._action_updates_map.get(action_id, None)
             ), f"no action update for {action_id}"
             assert action_update.id == action_id
-            assert action_update.completed_status == (
-                "FAILED" if action_num == 1 else "NEVER_ATTEMPTED"
-            )
             assert action_update.status is not None
             assert action_update.status.state == ActionState.FAILED
             assert action_update.status.fail_message == expected_err_msg
-            assert action_update.start_time == datetime_now_mock.return_value
-            assert action_update.end_time == datetime_now_mock.return_value
+            if action_num == 1:
+                assert action_update.completed_status == "FAILED"
+                assert action_update.start_time == datetime_now_mock.return_value
+                assert action_update.end_time == datetime_now_mock.return_value
+            else:
+                assert action_update.completed_status == "NEVER_ATTEMPTED"
+                assert action_update.start_time is None
+                assert action_update.end_time is None
 
 
 class TestQueueAwsCredentialsManagement:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Worker Agent was reporting `NEVER_ATTEMPTED` session actions with a `startedAt` timestamp. This was incorrect. 

### What was the solution? (How)
Don't set timestamps on `NEVER_ATTEMPTED` Session Actions. 

### What is the impact of this change?
Worker Agent conforms to intended contract. 

### How was this change tested?
Unit tests

### Was this change documented?
Yes.

### Is this a breaking change?
No