### PR TITLE
test: add unit test for password length in windows installer

### DIFF
--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -56,7 +56,7 @@ class WorkerAgentDirectories:
     deadline_config_subdir: Path
 
 
-def generate_password(length: int = DEFAULT_PASSWORD_LENGTH) -> str:
+def generate_password() -> str:
     """
     Generate password of given length.
 
@@ -66,7 +66,7 @@ def generate_password(length: int = DEFAULT_PASSWORD_LENGTH) -> str:
     alphabet = string.ascii_letters + string.digits + string.punctuation
     # Use secrets.choice to ensure a secure random selection of characters
     # https://docs.python.org/3/library/secrets.html#recipes-and-best-practices
-    password = "".join(secrets.choice(alphabet) for _ in range(length))
+    password = "".join(secrets.choice(alphabet) for _ in range(DEFAULT_PASSWORD_LENGTH))
     return password
 
 

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -305,16 +305,18 @@ class TestEnsureUserProfileExists:
 @patch("deadline_worker_agent.installer.win_installer.secrets.choice")
 def test_generate_password(mock_choice):
     # Given
-    password_length = 27
+    password_length = 32
     characters = string.ascii_letters[:password_length]
     mock_choice.side_effect = characters
 
     # When
-    password = win_installer.generate_password(password_length)
+    password = win_installer.generate_password()
 
     # Then
+    assert win_installer.DEFAULT_PASSWORD_LENGTH == password_length
     expected_password = "".join(characters)
     assert password == expected_password
+    assert len(password) == password_length
 
 
 def test_validate_deadline_id():


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There was no unit test on password length in the Worker Agent Windows installer.

### What was the solution? (How)
Added one. 

### What is the impact of this change?
No customer impact. 

### How was this change tested?
Unit tests pass. 

### Was this change documented?
NA

### Is this a breaking change?
No