### PR TITLE
feat: Cleanup session as os_user.

### DIFF
--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -91,6 +91,7 @@ OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS: dict[
 }
 DEFAULT_POSIX_OPENJD_SESSION_DIR = Path("/var/tmp/openjd")
 TIME_DELTA_ZERO = timedelta()
+DEFAULT_SHUTDOWN_USER = "job-user"
 
 # During a SYNC_INPUT_JOB_ATTACHMENTS session action, the transfer rate is periodically reported through
 # a callback function. If a transfer rate lower than LOW_TRANSFER_RATE_THRESHOLD is observed in a series
@@ -401,9 +402,11 @@ class Session:
         finally:
             if self._asset_sync is not None and self._job_attachment_details is not None:
                 # terminate any running virtual file systems
+                shutdown_user = self._os_user.user if self._os_user else DEFAULT_SHUTDOWN_USER
                 self._asset_sync.cleanup_session(
                     session_dir=self._session.working_directory,
                     file_system=self._job_attachment_details.job_attachments_file_system,
+                    os_user=shutdown_user,
                 )
             # Clean-up the Open Job Description session
             self._session.cleanup()

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1930,6 +1930,7 @@ class TestSessionCleanup:
         mock_asset_sync_cleanup.assert_called_once_with(
             session_dir=mock_openjd_session.working_directory,
             file_system=job_attachment_details.job_attachments_file_system,
+            os_user="some-user",
         )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
deadline_vfs was previously run (And shut down) as deadline-worker rather than os_user (job-user)

This change converts worker agent to expect the larger deadline-cloud change here https://github.com/casillas2/deadline-cloud/pull/223

### What was the solution? (How)
worker-agent needs to pass in the os_user to cleanup_session so the appropriate user attempts to shut down the vfs.

### What is the impact of this change?
VFS cleanup should be called by os_user rather than deadline-worker

### How was this change tested?
Unit test updated to validate os_user is passed in.

Manual testing on a CMF worker 

### Was this change documented?
Internal documentation - should not affect customer workflows

### Is this a breaking change?
No