### PR TITLE
chore(deps): update deadline verison to 0.42

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
-    "deadline == 0.41.*",
+    "deadline == 0.42.*",
     "openjd-sessions == 0.7.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Update deadline library to 0.42 to get us the job attachments changes to storageprofile and pathformat enums

### What was the solution? (How)

update!

### What is the impact of this change?

we have it!

### How was this change tested?

@jusiskin tested this change from submission to download output. Everything still worked.

### Was this change documented?

N/A

### Is this a breaking change?

Nope