### PR TITLE
chore: specify worker agent behaviour when a 400 is returned during the service-initiated shutdown flow

### DIFF
--- a/docs/worker_api_contract.md
+++ b/docs/worker_api_contract.md
@@ -544,7 +544,7 @@ then the Worker Agent must:
         * Response: ConflictException(409)
             * `reason` is `CONCURRENT_MODIFICATION` -> Perform exponential backoff, and then retry.
             * Any other -> Ignore & continue.
-        * Response: AccessDeniedException(403), ResourceNotFoundException(404) -> Ignore & continue.
+        * Response: ValidationException(400), AccessDeniedException(403), ResourceNotFoundException(404) -> Ignore & continue.
     3. Sleep for 30 seconds.
 
 In the case of a Worker-initiated shutdown (e.g. SIGTERM, EC2 Spot Interruption, etc) then follow the


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Previously, it was not specified in the Worker API contract what the behaviour of the worker agent should be when it calls UpdateWorkerSchedule during the service-initiated shutdown flow and a 400 was returned. 

### What was the solution? (How)
Specified the behaviour!

Note that this behaviour is already implemented [here](https://github.com/casillas2/deadline-cloud-worker-agent/blob/adf164ff56b56bc48837012d99bc086b1120193a/src/deadline_worker_agent/startup/entrypoint.py#L201-L214)