### PR TITLE
fix: insufficient Windows ACLs for job user AWS config files

### DIFF
--- a/src/deadline_worker_agent/aws_credentials/aws_configs.py
+++ b/src/deadline_worker_agent/aws_credentials/aws_configs.py
@@ -81,7 +81,7 @@ def _setup_file(*, file_path: Path, owner: SessionUser | None = None) -> None:
                 file_path=file_path,
                 permitted_user=owner,
                 user_permission=FileSystemPermissionEnum.READ_WRITE,
-                agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
             )
 
 

--- a/src/deadline_worker_agent/file_system_operations.py
+++ b/src/deadline_worker_agent/file_system_operations.py
@@ -5,12 +5,10 @@ from openjd.sessions import WindowsSessionUser, SessionUser
 import getpass
 from pathlib import Path
 import os
-from dataclasses import dataclass
 from typing import cast
 from enum import Enum
 
 
-@dataclass
 class FileSystemPermissionEnum(Enum):
     READ = "READ"
     WRITE = "WRITE"

--- a/test/unit/aws_credentials/test_aws_configs.py
+++ b/test/unit/aws_credentials/test_aws_configs.py
@@ -191,7 +191,7 @@ class TestSetupFile:
                     file_path=file_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 )
         else:
             file_path.exists.assert_called_once_with()
@@ -230,7 +230,7 @@ class TestSetupFile:
                     file_path=file_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 )
         else:
             chmod.assert_called_once_with(mode=0o640 if os_user is not None else 0o600)
@@ -267,7 +267,7 @@ class TestSetupFile:
                     file_path=file_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 )
         else:
             mock_run_cmd_as.assert_not_called()

--- a/test/unit/aws_credentials/test_queue_boto3_session.py
+++ b/test/unit/aws_credentials/test_queue_boto3_session.py
@@ -486,7 +486,7 @@ class TestCreateCredentialsDirectory:
                 exist_ok=True,
                 parents=True,
                 permitted_user=os_user,
-                agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 user_permission=FileSystemPermissionEnum.READ,
             )
 

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -531,7 +531,7 @@ class TestCreateNewSessions:
         else:
             mock_make_directory.assert_called_once_with(
                 dir_path=queue_log_dir_path,
-                agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 exist_ok=True,
             )
         mock_queue_session_log_file_path.assert_called_once_with(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1.  The worker agent had a bug on Windows where it was not setting sufficient ACL permissions on the job user's `%USERPROFILE%\.aws\[config|credentials]`.

    It was granting read/write permissions every time it needed to setup session credentials for a queue. Because this was being done at run-time repeatedly, read/write is insufficient. In order to set ACLs, the caller must have full control.

    When the agent would try to set ACLs a second time it encountered the error:

    ```
    2024-03-22T15:33:47.753000+00:00 worker-83c0e3d66d994530a78e7efd81957252 Exception in WorkerScheduler
    Traceback (most recent call last):
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 271, in run
        interval = self._sync(interruptable=True)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 422, in _sync
        self._update_sessions(response=response)
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 567, in _update_sessions
        created_session_ids = self._create_new_sessions(assigned_sessions=assigned_sessions)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 746, in _create_new_sessions
        queue_credentials = self._get_queue_aws_credentials(
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 936, in _get_queue_aws_credentials
        session = QueueBoto3Session(
                  ^^^^^^^^^^^^^^^^^^
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\aws_credentials\queue_boto3_session.py", line 122, in __init__
        self._aws_config = AWSConfig(self._os_user)
                          ^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\aws_credentials\aws_configs.py", line 126, in __init__
        _setup_file(
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\aws_credentials\aws_configs.py", line 80, in _setup_file
        touch_file(
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\file_system_operations.py", line 51, in touch_file
        _set_windows_permissions(
      File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\file_system_operations.py", line 147, in _set_windows_permissions
        win32security.SetFileSecurity(full_path, win32security.DACL_SECURITY_INFORMATION, sd)
    pywintypes.error: (5, 'SetFileSecurity', 'Access is denied.')
    ```

2.  Discovered while working on this that the unit tests were not failing when they should have when asserting the values of `FileSystemPermissionEnum` variable types. This turned out to be because the class inherited from `enum.Enum` AND was decorated with `dataclasses.dataclass`. After removing this, tests were failing.

### What was the solution? (How)

1.  Grant the agent user full control of the job user's `%USERPROFILE%\.aws\[config|credentials]` files.
2.  Remove the `dataclasses.dataclass` decorator from `FileSystemPermissionEnum` and fix the bad tests.

### What is the impact of this change?

1.  The agent can set ACLs on the job user's AWS config/credential files when vend queue credentials without an error for the same job user after previously setting ACLs.
2.  The agent code tests no longer masks logic errors in our tests - potentially causing security regressions.

### How was this change tested?

1.  Ran the agent with the modified code and confirmed the agent can run sessions for the same queue after going idle without encountering the error.
2.  The unit tests were fixed and are passing

### Was this change documented?

No

### Is this a breaking change?

No