### PR TITLE
feat: Cleanup deadline_vfs as job-user

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -7,6 +7,41 @@ on:
       - 'mainline'
 
 jobs:
+  WindowsIntegrationTests:
+    name: Windows Integration Tests
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    env:
+        PYTHON: ${{ matrix.python-version }}
+        CODEARTIFACT_REGION: "us-west-2"
+        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+    
+    - name: Install Hatch
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Run Windows Integration Tests
+      run: hatch run integ-windows
+      
   MainlineIntegrationTest:
     name: Integration Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -21,6 +21,42 @@ jobs:
       commit: ${{ github.sha }}
     secrets: inherit
 
+  WindowsIntegrationTests:
+    needs: UnitTests
+    name: Windows Integration Tests
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    env:
+        PYTHON: ${{ matrix.python-version }}
+        CODEARTIFACT_REGION: "us-west-2"
+        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+    
+    - name: Install Hatch
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Run Windows Integration Tests
+      run: hatch run integ-windows
+
   IntegrationTests:
     needs: UnitTests
     name: Integration Tests

--- a/.github/workflows/release_integration_canary.yml
+++ b/.github/workflows/release_integration_canary.yml
@@ -6,6 +6,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  WindowsIntegrationTests:
+    name: Windows Integration Tests
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    env:
+        PYTHON: ${{ matrix.python-version }}
+        CODEARTIFACT_REGION: "us-west-2"
+        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+    
+    - name: Install Hatch
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Run Windows Integration Tests
+      run: hatch run integ-windows
+      
   ReleaseIntegrationCanary:
     runs-on: ubuntu-latest
     environment: canary

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -100,31 +100,30 @@ jobs:
         run: |
           export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
           pip install --upgrade hatch
-          hatch build
+          hatch -v build
 
-      # TODO: Uncomment below once the Deadline Cloud PGP key is available
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
-      #     aws-region: us-west-2
-      #     mask-aws-account-id: true
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
 
-      # - name: Import PGP Key
-      #   run: |
-      #     export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
-      #     printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
+      - name: Import PGP Key
+        run: |
+          export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
+          printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
 
-      #     PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
-      #     echo "::add-mask::$PGP_KEY_PASSPHRASE"
-      #     echo "PGP_KEY_PASSPHRASE=$PGP_KEY_PASSPHRASE" >> $GITHUB_ENV
+          PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
+          echo "::add-mask::$PGP_KEY_PASSPHRASE"
+          echo "PGP_KEY_PASSPHRASE=$PGP_KEY_PASSPHRASE" >> $GITHUB_ENV
 
-      # - name: Sign
-      #   run: |
-      #     for file in dist/*; do
-      #       printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "Open Job Description" --passphrase-fd 0 --output $file.sig --detach-sign $file
-      #       echo "Created signature file for $file"
-      #     done
+      - name: Sign
+        run: |
+          for file in dist/*; do
+            printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "AWS Deadline Cloud" --passphrase-fd 0 --output $file.sig --detach-sign $file
+            echo "Created signature file for $file"
+          done
 
       - name: PushRelease
         env:
@@ -132,6 +131,26 @@ jobs:
         run: |
           git push origin $TAG
           gh release create $TAG dist/* --notes "$RELEASE_NOTES"
+
+  PublishToInternal:
+    needs: Release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ github.event.repository.name }}-Publish
+          hide-cloudwatch-logs: true
 
   PublishToRepository:
     needs: Release
@@ -175,7 +194,7 @@ jobs:
           pip install --upgrade twine
 
       - name: Build
-        run: hatch build
+        run: hatch -v build
 
       - name: Publish to Repository
         run: |
@@ -195,24 +214,4 @@ jobs:
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       # - name: Publish to PyPI
       #   uses: pypa/gh-action-pypi-publish@release/v1
-
-  PublishToInternal:
-    needs: Release
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
-          aws-region: us-west-2
-          mask-aws-account-id: true
-
-      - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
-        with:
-          project-name: ${{ github.event.repository.name }}-Publish
-          hide-cloudwatch-logs: true
         

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -64,7 +64,6 @@ jobs:
           git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
           git config --local user.name "client-software-ci"
 
-      
       - name: MergePushRelease
         run: |
           git merge --ff-only origin/mainline -v

--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -71,10 +71,10 @@ jobs:
         pip install --upgrade hatch
 
     - name: Run Linting
-      run: hatch run lint
+      run: hatch -v run lint
 
     - name: Run Build
-      run: hatch build
+      run: hatch -v build
 
     - name: Run Tests
       run: hatch run test

--- a/.github/workflows/windows_integration.yml
+++ b/.github/workflows/windows_integration.yml
@@ -1,0 +1,39 @@
+name: Windows Integration Tests
+
+on:
+  workflow_call:
+    
+jobs:
+  WindowsIntegrationTests:
+    runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    env:
+        PYTHON: ${{ matrix.python-version }}
+        CODEARTIFACT_REGION: "us-west-2"
+        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+        aws-region: us-west-2
+        mask-aws-account-id: true
+    
+    - name: Install Hatch
+      run: |
+        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
+        pip install --upgrade hatch
+
+    - name: Run Windows Integration Tests
+      run: hatch run integ-windows

--- a/.github/workflows/windows_integration.yml
+++ b/.github/workflows/windows_integration.yml
@@ -1,8 +1,8 @@
 name: Windows Integration Tests
 
 on:
-  workflow_call:
-    
+  workflow_dispatch:
+
 jobs:
   WindowsIntegrationTests:
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
+## 0.23.0 (2024-03-21)
+
+### BREAKING CHANGES
+* Fail jobs configured to run as worker agent on Windows (#230) ([`7ce01a8`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/7ce01a8731005178a6da964c24870b3fc9d57f03))
+
+### Features
+* agent logs contain more verbose API request/response information (#215) ([`6e8e566`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/6e8e566dadfd39c77737ac5243276256f87d492c))
+* session cleanup on windows (#212) ([`93f4305`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/93f43053ccd498fd913b31b8aa96c4d43fae7157))
+* **windows-installer**: grant and validate agent user permissions (#206) ([`0d8e3de`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/0d8e3de5ee4ccdadffbbc365c2e822ff62efc0fd))
+* Add telemetry event for uncaught exceptions (#203) ([`9a17a07`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/9a17a0786fe47b1e0ad0d69ee55c0746823a95a5))
+
+### Bug Fixes
+* NEVER_ATTEMPTED session actions should not report startedAt or endedAt (#237) ([`99fd7d3`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/99fd7d385dedc25c22aeaecee7247bef3e682fa0))
+* improve logging when getting secret (#184) ([`d3e2e0c`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/d3e2e0c863efd2af8b1eeb0a6f3173b7c6b6a23d))
+* increasing default password length for windows users (#236) ([`c411c85`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/c411c851395fa6a46a174d9709b3b907dd9796f1))
+* change windows logon type from NETWORK to INTERACTIVE (#234) ([`82a5c11`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/82a5c11195102e3334961b4420915feccfc849b0))
+
 ## 0.22.1 (2024-03-19)
-
-
 
 ### Bug Fixes
 * change OpenJD&#39;s session root directory to /sessions (#222) ([`3b68342`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/3b68342bc12307e63f84214b310ed616437c1c8e))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.22.1 (2024-03-19)
+
+
+
+### Bug Fixes
+* change OpenJD&#39;s session root directory to /sessions (#222) ([`3b68342`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/3b68342bc12307e63f84214b310ed616437c1c8e))
+
 ## 0.22.0 (2024-03-18)
 
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.22.0 (2024-03-18)
+
+### BREAKING CHANGES
+* retool scale-in behaviour (#193) ([`40390e9`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/40390e92d3e799f5299233b6d030a9e66582e18c))
+
+### Features
+* windows service (#207) ([`1d97970`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/1d979709941e2c2b116cb7932d664a64584a95d4))
+* **windows-installer**: add client telemetry opt out option (#210) ([`7551869`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/7551869124f8a7ef219888b52e472f632ec68b0d))
+* windows support (#205) ([`80e8ec4`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/80e8ec423ced2130792d95af7690bb9b64b77565))
+* change OpenJD&#39;s session directory path, and add `--retain-session-dir` command option (#196) ([`091608c`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/091608c65b50e6fecac94dfff4e2f088c1f49926))
+
+### Bug Fixes
+* improve error messaging for Windows logon (#219) ([`de23226`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/de232262d503da01f5f1aa974d985555fe51008a))
+* **install.sh**: update ownership and permissions for session root directory (#201) ([`230b73c`](https://github.com/casillas2/deadline-cloud-worker-agent/commit/230b73c5c6c472256db68ab43ddd83203889d245))
+
 ## 0.21.2 (2024-03-07)
 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ to interact with AWS Deadline Cloud and perform tasks.
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
+## Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Providing the installer flag: `--telemetry-opt-out`
+3. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/docs/worker_api_contract.md
+++ b/docs/worker_api_contract.md
@@ -348,7 +348,8 @@ attempt to run.
 
 If the Worker Agent reports these Session Action as `FAILED`, `INTERRUPTED`, or `CANCELED` then the Worker Agent
 must report all queued Session Actions after it in the Session as `NEVER_ATTEMPTED`; except for
-`envExit` actions that correspond to already completed `envEnter` Session Actions. The service
+`envExit` actions that correspond to already completed `envEnter` Session Actions. Session Actions that are 
+reported as `NEVER_ATTEMPTED` must not report `startedAt` or `endedAt` times. The service
 must not queue additional Session Actions to the Session except for `envExit` Session Actions that
 correspond to already completed `envEnter` Session Actions for the same Session.
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -10,6 +10,7 @@ test = "pytest {args:test/unit --numprocesses=auto}"
 # pytest-xdist does not allow live output of stdout, meaning integ tests only show output after the test is done
 # See: https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers
 integ-test = "pytest test/integ {args}"
+integ-windows = "pytest --no-cov test/integ/installer {args:}"
 typing = "mypy {args:src test}"
 style = [
   "ruff {args:.}",
@@ -37,6 +38,7 @@ python = ["3.9", "3.10", "3.11"]
 
 [envs.default.env-vars]
 PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
+RUN_AS_ADMIN="true"
 
 [envs.codebuild.env-vars]
 PIP_INDEX_URL=""

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -5,6 +5,6 @@ set -e
 pip install --upgrade pip
 pip install --upgrade hatch
 pip install --upgrade twine
-hatch run codebuild:lint
+hatch -v run codebuild:lint
 hatch run codebuild:test
-hatch run codebuild:build
+hatch -v run codebuild:build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
-    "deadline == 0.40.*",
+    "deadline == 0.43.*",
     "openjd-sessions == 0.7.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/requirements-research.txt
+++ b/requirements-research.txt
@@ -1,3 +1,3 @@
-ipykernel==6.26.*
+ipykernel==6.29.*
 matplotlib==3.8.*
 pandas==2.1.*

--- a/requirements-research.txt
+++ b/requirements-research.txt
@@ -1,3 +1,3 @@
 ipykernel==6.29.*
 matplotlib==3.8.*
-pandas==2.1.*
+pandas==2.2.*

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -11,5 +11,5 @@ types-python-dateutil ~= 2.9
 mypy ~= 1.8
 types-requests ~= 2.31
 ruff ~= 0.3.3
-twine ~= 4.0
+twine ~= 5.0
 types-psutil ~= 5.9

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -7,7 +7,7 @@ pytest-timeout == 2.2.*
 pytest-xdist == 3.5.*
 black[jupyter] ~= 23.12
 rich == 13.7.*
-types-python-dateutil ~= 2.8
+types-python-dateutil ~= 2.9
 mypy ~= 1.8
 types-requests ~= 2.31
 ruff ~= 0.2.1

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -3,7 +3,7 @@ coverage-conditional-plugin == 0.9.*
 deadline-cloud-test-fixtures == 0.5.*
 pytest ~= 8.1
 pytest-cov == 4.1.*
-pytest-timeout == 2.2.*
+pytest-timeout == 2.3.*
 pytest-xdist == 3.5.*
 black[jupyter] ~= 23.12
 rich == 13.7.*

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -8,7 +8,7 @@ pytest-xdist == 3.5.*
 black[jupyter] ~= 23.12
 rich == 13.7.*
 types-python-dateutil ~= 2.9
-mypy ~= 1.8
+mypy ~= 1.9
 types-requests ~= 2.31
 ruff ~= 0.3.3
 twine ~= 5.0

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -3,6 +3,7 @@ coverage-conditional-plugin == 0.9.*
 deadline-cloud-test-fixtures == 0.5.*
 pytest ~= 8.1
 pytest-cov == 4.1.*
+pytest-timeout == 2.2.*
 pytest-xdist == 3.5.*
 black[jupyter] ~= 23.12
 rich == 13.7.*

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -10,6 +10,6 @@ rich == 13.7.*
 types-python-dateutil ~= 2.9
 mypy ~= 1.8
 types-requests ~= 2.31
-ruff ~= 0.2.1
+ruff ~= 0.3.3
 twine ~= 4.0
 types-psutil ~= 5.9

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -10,6 +10,6 @@ rich == 13.7.*
 types-python-dateutil ~= 2.9
 mypy ~= 1.9
 types-requests ~= 2.31
-ruff ~= 0.3.3
+ruff ~= 0.3.4
 twine ~= 5.0
 types-psutil ~= 5.9

--- a/src/deadline_worker_agent/aws_credentials/aws_configs.py
+++ b/src/deadline_worker_agent/aws_credentials/aws_configs.py
@@ -81,7 +81,7 @@ def _setup_file(*, file_path: Path, owner: SessionUser | None = None) -> None:
                 file_path=file_path,
                 permitted_user=owner,
                 user_permission=FileSystemPermissionEnum.READ_WRITE,
-                agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
             )
 
 

--- a/src/deadline_worker_agent/file_system_operations.py
+++ b/src/deadline_worker_agent/file_system_operations.py
@@ -5,12 +5,10 @@ from openjd.sessions import WindowsSessionUser, SessionUser
 import getpass
 from pathlib import Path
 import os
-from dataclasses import dataclass
 from typing import cast
 from enum import Enum
 
 
-@dataclass
 class FileSystemPermissionEnum(Enum):
     READ = "READ"
     WRITE = "WRITE"

--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -33,12 +33,12 @@ def install() -> None:
             farm_id=args.farm_id,
             fleet_id=args.fleet_id,
             region=args.region,
-            worker_agent_program=scripts_path,
             install_service=args.install_service,
             start_service=args.service_start,
             confirm=args.confirmed,
             allow_shutdown=args.allow_shutdown,
             parser=arg_parser,
+            grant_required_access=args.grant_required_access,
         )
         if args.user:
             installer_args.update(user_name=args.user)
@@ -104,6 +104,7 @@ class ParsedCommandLineArguments(Namespace):
     install_service: bool
     telemetry_opt_out: bool
     vfs_install_path: str
+    grant_required_access: bool
 
 
 def get_argument_parser() -> ArgumentParser:  # pragma: no cover
@@ -190,6 +191,17 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
             ),
             required=False,
             default=None,
+        )
+        parser.add_argument(
+            "--grant-required-access",
+            help=(
+                "Allows the installer to modify an existing user so that it can successfully run the worker agent. This will allow "
+                "the installer to add the user to the Administrators group and grant any missing user rights which are required to "
+                "run the worker agent. This option has no effect if a new user is created by the installer."
+            ),
+            action="store_true",
+            required=False,
+            default=False,
         )
 
     return parser

--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -351,10 +351,10 @@ if [ -f /var/lib/deadline/worker.json ]; then
 fi
 echo "Done provisioning persistence directory (/var/lib/deadline)"
 
-echo "Provisioning root directory for OpenJD Sessions (/var/tmp/openjd)"
-mkdir -p /var/tmp/openjd
-chown "${wa_user}:${job_group}" /var/tmp/openjd
-chmod 755 /var/tmp/openjd
+echo "Provisioning root directory for OpenJD Sessions (/sessions)"
+mkdir -p /sessions
+chown "${wa_user}:${job_group}" /sessions
+chmod 755 /sessions
 
 echo "Provisioning configuration directory (/etc/amazon/deadline)"
 mkdir -p /etc/amazon/deadline

--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -200,7 +200,7 @@ def ensure_user_profile_exists(username: str, password: str):
         # https://timgolden.me.uk/pywin32-docs/win32security__LogonUser_meth.html
         logon_token = win32security.LogonUser(
             Username=username,
-            LogonType=win32security.LOGON32_LOGON_NETWORK_CLEARTEXT,
+            LogonType=win32security.LOGON32_LOGON_INTERACTIVE,
             LogonProvider=win32security.LOGON32_PROVIDER_DEFAULT,
             Password=password,
             Domain=None,

--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -36,7 +36,7 @@ from ..windows.win_service import WorkerAgentWindowsService
 # Defaults
 DEFAULT_WA_USER = "deadline-worker"
 DEFAULT_JOB_GROUP = "deadline-job-users"
-DEFAULT_PASSWORD_LENGTH = 12
+DEFAULT_PASSWORD_LENGTH = 32
 
 # Environment variable that overrides the config path used by the Deadline client
 DEADLINE_CLIENT_CONFIG_PATH_OVERRIDE_ENV_VAR = "DEADLINE_CONFIG_FILE_PATH"

--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -56,7 +56,7 @@ class WorkerAgentDirectories:
     deadline_config_subdir: Path
 
 
-def generate_password(length: int = DEFAULT_PASSWORD_LENGTH) -> str:
+def generate_password() -> str:
     """
     Generate password of given length.
 
@@ -66,7 +66,7 @@ def generate_password(length: int = DEFAULT_PASSWORD_LENGTH) -> str:
     alphabet = string.ascii_letters + string.digits + string.punctuation
     # Use secrets.choice to ensure a secure random selection of characters
     # https://docs.python.org/3/library/secrets.html#recipes-and-best-practices
-    password = "".join(secrets.choice(alphabet) for _ in range(length))
+    password = "".join(secrets.choice(alphabet) for _ in range(DEFAULT_PASSWORD_LENGTH))
     return password
 
 

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -618,8 +618,8 @@ class WorkerScheduler:
                 action["sessionActionId"]: SessionActionStatus(
                     id=action["sessionActionId"],
                     completed_status="FAILED" if action is actions[0] else "NEVER_ATTEMPTED",
-                    start_time=now,
-                    end_time=now,
+                    start_time=now if action is actions[0] else None,
+                    end_time=now if action is actions[0] else None,
                     status=ActionStatus(
                         state=ActionState.FAILED,
                         fail_message=str(error_message),

--- a/src/deadline_worker_agent/scheduler/session_cleanup.py
+++ b/src/deadline_worker_agent/scheduler/session_cleanup.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import subprocess
 import os
+import getpass
 from threading import Lock
 
 from openjd.sessions import SessionUser, PosixSessionUser, WindowsSessionUser
-from typing import cast
 from .log import LOGGER
 from ..sessions import Session
 
@@ -38,25 +38,16 @@ class SessionUserCleanupManager:
         self._user_session_map = {}
         self._cleanup_session_user_processes = cleanup_session_user_processes
 
-    def _get_user(self, session: Session):
-        if os.name == "posix":
-            posix_user: PosixSessionUser = cast(PosixSessionUser, session.os_user)
-            return posix_user.user
-        else:
-            windows_user: WindowsSessionUser = cast(WindowsSessionUser, session._os_user)
-            return windows_user.user
-
     def register(self, session: Session):
         if session.os_user is None:
             return
 
         with self._user_session_map_lock:
-            user_name = self._get_user(session)
+            user_name = session.os_user.user
             session_dict = self._user_session_map.get(user_name, None)
             if session_dict is None:
                 session_dict = {}
                 self._user_session_map[user_name] = session_dict
-
             session_dict[session.id] = session
 
     def deregister(self, session: Session):
@@ -64,7 +55,7 @@ class SessionUserCleanupManager:
             return
 
         with self._user_session_map_lock:
-            user_name = self._get_user(session)
+            user_name = session.os_user.user
             session_dict = self._user_session_map.get(user_name, None)
             if session_dict is None:
                 return
@@ -90,23 +81,20 @@ class SessionUserCleanupManager:
                 logger.warn(f"Failed to stop session user processes: {e}")
 
     @staticmethod
-    def cleanup_session_user_processes(user: SessionUser):
-        if not isinstance(user, PosixSessionUser):
-            # TODO: Windows support
-            logger.warning(
-                "Stopping session user processes will be skipped because this feature is only supported on POSIX systems"
-            )
-            raise NotImplementedError("Windows not supported")
+    def _extract_username(user: str):
+        parts = user.split("\\")
+        return parts[-1].lower()
 
-        # Check that the session user isn't the current user (agent user)
-        current_user = subprocess.check_output(["/usr/bin/whoami"], text=True).strip()
-        if current_user == user.user:
-            logger.info(
-                f"Skipping cleaning up processes because the session user matches the agent user '{current_user}'"
-            )
-            return
+    @staticmethod
+    def _is_current_user(user: SessionUser):
+        current_user = getpass.getuser()
+        return SessionUserCleanupManager._extract_username(
+            user.user
+        ) == SessionUserCleanupManager._extract_username(current_user)
 
-        logger.info(f"Cleaning up remaining session user processes for '{user.user}'")
+    @staticmethod
+    def _posix_cleanup_user_processes(user: SessionUser):
+        assert isinstance(user, PosixSessionUser)
         try:
             pkill_result = subprocess.run(
                 args=["sudo", "-u", user.user, "/usr/bin/pkill", "-eU", user.user],
@@ -130,3 +118,62 @@ class SessionUserCleanupManager:
             #  etc.
             pkill_output = "\n".join([pkill_result.stdout, pkill_result.stderr]).rstrip()
             logger.info(f"Stopped processes:\n{pkill_output}")
+
+    @staticmethod
+    def _windows_cleanup_user_processes(user: SessionUser):
+        import psutil
+        import win32api
+        import win32con
+
+        assert isinstance(user, WindowsSessionUser)
+        username = SessionUserCleanupManager._extract_username(user.user)
+        processes = []
+
+        for proc in psutil.process_iter(["pid", "username"]):
+            proc_info = proc.info  # type: ignore
+            try:
+                if process_owner_with_domain := proc_info.get("username"):
+                    # username is always 'host\user' or 'domain\user' so split it
+                    process_owner = SessionUserCleanupManager._extract_username(
+                        process_owner_with_domain
+                    )
+                    if username == process_owner:
+                        processes.append(proc_info)
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                # Finding a process we can't get info for is not concerning
+                pass
+
+        if processes:
+            for proc_info in processes:
+                try:
+                    # Administrators can stop any process. Non-administrators can stop
+                    # any process they spawn regardless of the user it is spawned as
+                    pid = proc_info["pid"]
+                    process_handle = win32api.OpenProcess(win32con.PROCESS_TERMINATE, 0, pid)
+                    win32api.TerminateProcess(process_handle, 0)
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to stop process PID: {pid} running as {username}: {str(e)}"
+                    )
+                else:
+                    logger.info(f"Stopped process PID: {pid} running as {username}")
+                finally:
+                    win32api.CloseHandle(process_handle)
+        else:
+            logger.info(f"No processes stopped because none were found running as '{user.user}'")
+
+    @staticmethod
+    def cleanup_session_user_processes(user: SessionUser):
+        # Check that the session user isn't the current user (agent user)
+        if SessionUserCleanupManager._is_current_user(user):
+            logger.info(
+                f"Skipping cleaning up processes because the session user matches the agent user '{user.user}'"
+            )
+            return
+
+        logger.info(f"Cleaning up remaining session user processes for '{user.user}'")
+
+        if os.name == "posix":
+            SessionUserCleanupManager._posix_cleanup_user_processes(user)
+        else:
+            SessionUserCleanupManager._windows_cleanup_user_processes(user)

--- a/src/deadline_worker_agent/session_events.py
+++ b/src/deadline_worker_agent/session_events.py
@@ -1,10 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import logging
-from typing import Any, Dict, List, TypedDict, Union
+from typing import Any, TypedDict, Union
 from typing_extensions import NotRequired
 import json
-from typing import Any, Dict, List, TypedDict, Union
+import datetime
+import re
 
 log = logging.getLogger(__name__)
 
@@ -19,10 +20,11 @@ class BotoLogStatement(TypedDict):
     operation: str
     # Only in requests
     request_url: NotRequired[str]
-    params: Union[List[Dict[str, Any]], Dict[str, Any]]
+    params: Union[dict[str, Any], str]
     # Only in responses
     error: NotRequired[str]
     status_code: NotRequired[str]
+    request_id: NotRequired[str]
 
 
 class Boto3ClientEvent:
@@ -30,80 +32,364 @@ class Boto3ClientEvent:
     AFTER_CALL_PREFIX = "after-call"
 
 
+# The actual type here is recursive:
+#  T = dict[str, T] | dict[str, bool]
+# 1) If a key does not appear in this recursive dictionary, then it is
+#    never logged.
+# 2) Only those keys that have a value that is True or a dictionary are logged.
+AllowableBodyKeysT = dict[str, Any]
+
+
 class LoggingAllowList(TypedDict, total=False):
     # RESTful services have IDs in the url
     # set this to true to include the request URL in the logs
     log_request_url: bool
-    # keys to log for this operation from the request's body
-    req_body_keys: List[str]
-    # keys to log for this operation from the response's body
-    res_body_keys: List[str]
+    # Parts of the request to log.
+    req_log_body: AllowableBodyKeysT
+    # Parts of the response to log.
+    res_log_body: AllowableBodyKeysT
 
 
-LOGGING_ALLOW_LIST: Dict[str, LoggingAllowList] = {
-    "deadline.CreateWorker": {"log_request_url": True, "res_body_keys": ["workerId"]},
-    "deadline.AssumeFleetRoleForWorker": {"log_request_url": True},
-    "deadline.AssumeQueueRoleForWorker": {"log_request_url": True},
+# The AWS API calls that we log, and the specific request/response properties that we log.
+# Note: The log must NEVER contain customer personal information, or information that a customer
+# might consider secret/sensitive.
+LOGGING_ALLOW_LIST: dict[str, LoggingAllowList] = {
+    "deadline.CreateWorker": {
+        "log_request_url": True,
+        "req_log_body": {"hostProperties": True},
+        "res_log_body": {"workerId": True},
+    },
+    "deadline.AssumeFleetRoleForWorker": {
+        "log_request_url": True,
+        # req_log_body -- no body to log
+        "res_log_body": {
+            "credentials": {
+                "accessKeyId": True,  # Not a secret
+                "expiration": True
+                # exclude: secretAccessKey & sessionToken
+            }
+        },
+    },
+    "deadline.AssumeQueueRoleForWorker": {
+        "log_request_url": True,
+        # req_log_body -- no body to log
+        "res_log_body": {
+            "credentials": {
+                "accessKeyId": True,  # Not a secret
+                "expiration": True
+                # exclude: secretAccessKey & sessionToken
+            }
+        },
+    },
     "deadline.UpdateWorker": {
         "log_request_url": True,
-        "req_body_keys": ["status"],
-        "res_body_keys": ["log"],
+        "req_log_body": {
+            "status": True,
+            # capabilities are not sensitive. They're treated like AWS Tags for privacy.
+            "capabilities": True,
+            "hostProperties": True,
+        },
+        "res_log_body": {"log": True},
     },
-    "deadline.BatchGetJobEntity": {"log_request_url": True},
-    "deadline.DeleteWorker": {"log_request_url": True},
+    "deadline.UpdateWorkerSchedule": {
+        "log_request_url": True,
+        "req_log_body": {
+            "updatedSessionActions": {
+                # Key is a Session Action Id
+                "*": {
+                    "completedStatus": True,
+                    "processExitCode": True,
+                    "startedAt": True,
+                    "endedAt": True,
+                    "updatedAt": True,
+                    "progressPercent": True,
+                    # progressMessage excluded
+                },
+            }
+        },
+        "res_log_body": {
+            # assignedSessions only contains non-sensitive data by design.
+            "assignedSessions": {
+                "*": {
+                    "queueId": True,
+                    "jobId": True,
+                    "sessionActions": {  # is an array of objects
+                        "sessionActionId": True,
+                        "definition": {
+                            "envEnter": {"environmentId": True},
+                            "envExit": {"environmentId": True},
+                            "taskRun": {
+                                "taskId": True,
+                                "stepId": True,
+                                # parameters excluded. It's sensitive for the Agent log since the parameter
+                                # names may have meaning to the customer. It should only appear in the session log.
+                            },
+                            "syncInputJobAttachments": {"stepId": True},
+                        },
+                    },
+                    "logConfiguration": True,  # log the entire dictionary
+                },
+            },
+            "cancelSessionActions": True,  # array of IDs. Log the whole thing
+            "desiredWorkerStatus": True,
+            "updateIntervalSeconds": True,
+        },
+    },
+    "deadline.BatchGetJobEntity": {
+        "log_request_url": True,
+        "req_log_body": {
+            "identifiers": True,  # only contains identifiers
+        },
+        "res_log_body": {
+            "entities": {
+                "jobDetails": {
+                    "jobId": True,
+                    "jobAttachmentSettings": {"s3BucketName": True, "rootPrefix": True},
+                    "jobRunAsUser": True,
+                    "logGroupName": True,
+                    "queueRoleArn": True,
+                    # parameters excluded.  It's sensitive for the Agent log since the parameter
+                    # names may have meaning to the customer. It should only appear in the session log.
+                    "schemaVersion": True,
+                    "pathMappingRules": False,  # will contain filesystem paths; err on the side of caution
+                },
+                "jobAttachmentDetails": {
+                    "jobId": True,
+                    "attachments": {
+                        "manifests": {  # array of objects
+                            "fileSystemLocationName": True,
+                            "rootPath": False,  # will contain filesystem paths; err on the side of caution
+                            "rootPathFormat": True,
+                            "outputRelativeDirectories": False,  # will contain filesystem paths; err on the side of caution
+                            "inputManifestPath": True,
+                            "inputManifestHash": True,
+                        },
+                        "fileSystem": True,
+                    },
+                },
+                "environmentDetails": {
+                    "jobId": True,
+                    "environmentId": True,
+                    "schemaVersion": True,
+                    # template excluded. It's sensitive; it contains the commands to run
+                },
+                "stepDetails": {
+                    "jobId": True,
+                    "stepId": True,
+                    "schemaVersion": True,
+                    "dependencies": True,  # list of step IDs
+                    # template excluded. It's sensitive; it contains the commands to run
+                },
+            },
+            "errors": True,  # log all errors
+        },
+    },
+    "deadline.DeleteWorker": {
+        "log_request_url": True,
+        # request is empty
+        # response is empty
+    },
+    # =========================
+    #  Non-Deadline Services
+    "secretsmanager.GetSecretValue": {
+        "log_request_url": True,
+        "req_log_body": {"SecretId": True, "VersionId": True, "VersionStage": True},
+        "res_log_body": {
+            "ARN": True,
+            "CreatedDate": True,
+            "Name": True,
+            "VersionId": True
+            # excluding: SecretString/SecretBinary, for obvious reasons
+            # excluding VersionStages; seems unnecessary
+        },
+    },
 }
+
+# Not logging:
+#  cloudwatch.PutLogEvents -- logging that you're logging just clutters the log
+#  s3.* -- For now. Very verbose to be logging these dataplane APIs; maybe when we have a verbose log mode.
+_IGNORE_LIST = ["cloudwatch-logs\..*", "s3\..*"]
+LOGGING_IGNORE_MATCHER = re.compile("^(" + "|".join(_IGNORE_LIST) + ")$")
+
+
+def _get_loggable_parameters(
+    body: dict[str, Any], allowable_keys: AllowableBodyKeysT
+) -> dict[str, Any]:
+    to_be_logged = dict[str, Any]()
+    if body is None:  # Handle the None case
+        return to_be_logged
+    for k, v in body.items():
+        if k not in allowable_keys:
+            if "*" not in allowable_keys:
+                to_be_logged[k] = "*REDACTED*"
+                continue
+            allow_key = "*"
+        else:
+            allow_key = k
+        allowable = allowable_keys[allow_key]
+        if isinstance(v, datetime.datetime):
+            v = str(v)
+        if isinstance(allowable, bool):
+            if allowable:
+                to_be_logged[k] = v
+            else:
+                to_be_logged[k] = "*REDACTED*"
+        elif isinstance(v, dict):
+            to_be_logged[k] = _get_loggable_parameters(v, allowable)
+        elif isinstance(v, list):
+            to_be_logged[k] = [_get_loggable_parameters(vv, allowable) for vv in v]
+    return to_be_logged
 
 
 def log_before_call(event_name, params, **kwargs) -> None:
     # event name is of the form `before_call.{operation}`
+    # params looks like:
+    # {
+    #   "url_path": "/...",
+    #   "query_string": {},
+    #   "method": "POST",
+    #   "headers": {
+    #       "X-Amz-Client-Token": "f3a3e84d-f024-4caa-87a7-4a83e1361fef",
+    #       "Content-Type": "application/json",
+    #       "User-Agent": <string>
+    #   },
+    #   "body": b"...",
+    #   "url": "https://....amazonaws.com/...",
+    #   "context": {
+    #       "client_region": "us-west-2",
+    #       "client_config": <botocore.config.Config object at 0x7f552d8312e0>,
+    #       "has_streaming_input": False,
+    #       "auth_type": None
+    #   }
+    # }
     try:
         operation_name = event_name.split(".", 1)[1]
+        if LOGGING_IGNORE_MATCHER.match(operation_name):
+            return
+        body = params["body"]
+        if isinstance(body, bytes):
+            if body == b"":
+                body = None
+            # Body can be string or bytes
+            else:
+                body = body.decode()
+        if isinstance(body, str):
+            body = json.loads(body)
+        loggable_params: Union[dict[str, Any], str] = {}
         if operation_name in LOGGING_ALLOW_LIST:
             allow_list = LOGGING_ALLOW_LIST[operation_name]
-            body = params["body"]
-            if isinstance(body, bytes):
-                if body == b"":
-                    body = None
-                # Body can be string or bytes
-                else:
-                    body = body.decode()
-            if isinstance(body, str):
-                body = json.loads(body)
             if allow_list.get("log_request_url", True):
                 url = params.get("url")
-            loggable_params = {key: body.get(key) for key in allow_list.get("req_body_keys", [])}
-            log_statement: BotoLogStatement = {
-                "log_type": "boto_request",
-                "operation": operation_name,
-                "params": loggable_params,
-            }  # noqa
-            if url is not None:
-                log_statement["request_url"] = url
-            log.info(log_statement)
+            allowable_response_fields = allow_list.get("req_log_body", dict())
+            loggable_params = _get_loggable_parameters(body, allowable_response_fields)
+        else:
+            loggable_params = "*REDACTED*"
+            url = "*REDACTED*"
+        log_statement: BotoLogStatement = {
+            "log_type": "boto_request",
+            "operation": operation_name,
+            "params": loggable_params,
+        }  # noqa
+        if url is not None:
+            log_statement["request_url"] = url
+        log.info(json.dumps(log_statement))
     except Exception:
         log.exception(f"Error Logging Boto Request with name {event_name}!")
 
 
 def log_after_call(event_name, parsed, **kwargs) -> None:
     # event name is of the form `after_call.{operation}`
+    # parsed looks like:
+    # {
+    #   "ResponseMetadata": {
+    #       "RequestId": "9885082b-3d0a-40f3-854a-223aa86f549b",
+    #       "HTTPStatusCode": 200,
+    #       "HTTPHeaders": {
+    #           "date": "Sun,17 Mar 2024 19: 08: 19 GMT",
+    #           "content-type": "application/json",
+    #           "content-length": "81",
+    #           "connection": "keep-alive",
+    #           "x-amzn-requestid": "9885082b-3d0a-40f3-854a-223aa86f549b",
+    #           "access-control-allow-origin": "*",
+    #           "access-control-expose-headers-age": "86400",
+    #           "x-amz-apigw-id": <string>,
+    #           "cache-control": "no-cache; no-store, must-revalidate, private",
+    #           "expires": "0",
+    #           "access-control-allow-methods": "GET,PATCH,POST,PUT,DELETE",
+    #           "access-control-expose-headers": "x-amzn-ErrorType,x-amzn-requestid,x-amzn-trace-id,x-amz-apigw-id",
+    #           "x-amzn-trace-id": "Root=1-65f73fa2-3b164cfd5721593c539e68b4",
+    #           "pragma": "no-cache",
+    #           "access-control-max-age": "86400"
+    #       },
+    #       "RetryAttempts": 0
+    #   },
+    #   ... fields of the response.
+    # }
+    #
+    # OR
+    #
+    # {
+    #     "ResponseMetadata": {
+    #       "RequestId": "9885082b-3d0a-40f3-854a-223aa86f549b",
+    #       "HTTPStatusCode": 200,
+    #       "HTTPHeaders": {
+    #           "date": "Sun,17 Mar 2024 19: 08: 19 GMT",
+    #           "content-type": "application/json",
+    #           "content-length": "81",
+    #           "connection": "keep-alive",
+    #           "x-amzn-requestid": "9885082b-3d0a-40f3-854a-223aa86f549b",
+    #           "access-control-allow-origin": "*",
+    #           "access-control-expose-headers-age": "86400",
+    #           "x-amz-apigw-id": <string>,
+    #           "cache-control": "no-cache; no-store, must-revalidate, private",
+    #           "expires": "0",
+    #           "access-control-allow-methods": "GET,PATCH,POST,PUT,DELETE",
+    #           "access-control-expose-headers": "x-amzn-ErrorType,x-amzn-requestid,x-amzn-trace-id,x-amz-apigw-id",
+    #           "x-amzn-trace-id": "Root=1-65f73fa2-3b164cfd5721593c539e68b4",
+    #           "pragma": "no-cache",
+    #           "access-control-max-age": "86400"
+    #     },
+    #     "Error": {
+    #         "Message": "<string>",
+    #         "Code": "ConflictException"
+    #     },
+    #     # The following are properties of the exception raised by the service
+    #     # They don't need to be redacted in logs
+    #     "message": "<string",
+    #     "reason": "CONFLICT_EXCEPTION",
+    #     "resourceId": "fleet-75103c183347473db3300904feceb78c",
+    #     "resourceType": "worker"
+    # }
     try:
         operation_name = event_name.split(".", 1)[1]
-        loggable_params: Dict[str, Any] = {}
+        if LOGGING_IGNORE_MATCHER.match(operation_name):
+            return
+        loggable_params: Union[dict[str, Any], str] = {}
+        if "Error" in parsed:
+            loggable_params = dict(parsed)
+            del loggable_params["Error"]
+        else:
+            if operation_name in LOGGING_ALLOW_LIST:
+                allow_list = LOGGING_ALLOW_LIST[operation_name]
+                allowable_response_fields = allow_list.get("res_log_body", dict())
+                loggable_params = _get_loggable_parameters(parsed, allowable_response_fields)
+            else:
+                loggable_params = "*REDACTED*"
+        # We don't want metadata to show up at all as params, so delete it from the result
+        if isinstance(loggable_params, dict):
+            del loggable_params["ResponseMetadata"]
+
+        log_statement: BotoLogStatement = {
+            "log_type": "boto_response",
+            "operation": operation_name,
+            "status_code": parsed.get("ResponseMetadata", {}).get("HTTPStatusCode"),
+            "params": loggable_params,
+        }
         error = parsed.get("Error")
-        if operation_name in LOGGING_ALLOW_LIST:
-            allow_list = LOGGING_ALLOW_LIST[operation_name]
-            loggable_params = {key: parsed.get(key) for key in allow_list.get("res_body_keys", [])}
-            log_statement: BotoLogStatement = {
-                "log_type": "boto_response",
-                "operation": operation_name,
-                "status_code": parsed.get("ResponseMetadata", {}).get("HTTPStatusCode"),
-                "params": loggable_params,
-            }
-            error_code = None
-            if error is not None:
-                log_statement["error"] = error
-                error_code = error.get("Code")  # noqa: F841
-            log.info(log_statement)
+        if error is not None:
+            log_statement["error"] = error
+        log_statement["request_id"] = parsed.get("ResponseMetadata", {}).get("RequestId")
+        log.info(json.dumps(log_statement))
     except Exception:
         log.exception(f"Error Logging Boto Response with name {event_name}!")
 

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -93,7 +93,8 @@ def job_run_as_user_api_model_to_worker_agent(
     expected by the Worker Agent.
     """
     if "runAs" in job_run_as_user_data and job_run_as_user_data["runAs"] == "WORKER_AGENT_USER":
-        return None
+        job_run_as_user = JobRunAsUser(is_worker_agent_user=True)
+        return job_run_as_user
 
     if os.name == "posix":
         user = ""
@@ -154,6 +155,7 @@ class JobRunAsUser:
     posix: PosixSessionUser | None = None
     windows: WindowsSessionUser | None = None
     windows_settings: JobRunAsWindowsUser | None = None
+    is_worker_agent_user: bool = False
 
     def __eq__(self, other: Any) -> bool:
         if other is None:

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -89,7 +89,7 @@ OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS: dict[
     ActionState.SUCCESS: "SUCCEEDED",
     ActionState.TIMEOUT: "FAILED",
 }
-DEFAULT_POSIX_OPENJD_SESSION_DIR = Path("/var/tmp/openjd")
+DEFAULT_POSIX_OPENJD_SESSION_DIR = Path("/sessions")
 TIME_DELTA_ZERO = timedelta()
 
 # During a SYNC_INPUT_JOB_ATTACHMENTS session action, the transfer rate is periodically reported through

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -91,6 +91,7 @@ OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS: dict[
 }
 DEFAULT_POSIX_OPENJD_SESSION_DIR = Path("/var/tmp/openjd")
 TIME_DELTA_ZERO = timedelta()
+DEFAULT_SHUTDOWN_USER = "job-user"
 
 # During a SYNC_INPUT_JOB_ATTACHMENTS session action, the transfer rate is periodically reported through
 # a callback function. If a transfer rate lower than LOW_TRANSFER_RATE_THRESHOLD is observed in a series
@@ -401,9 +402,11 @@ class Session:
         finally:
             if self._asset_sync is not None and self._job_attachment_details is not None:
                 # terminate any running virtual file systems
+                shutdown_user = self._os_user.user if self._os_user else DEFAULT_SHUTDOWN_USER
                 self._asset_sync.cleanup_session(
                     session_dir=self._session.working_directory,
                     file_system=self._job_attachment_details.job_attachments_file_system,
+                    os_user=shutdown_user,
                 )
             # Clean-up the Open Job Description session
             self._session.cleanup()

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -91,7 +91,6 @@ OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS: dict[
 }
 DEFAULT_POSIX_OPENJD_SESSION_DIR = Path("/var/tmp/openjd")
 TIME_DELTA_ZERO = timedelta()
-DEFAULT_SHUTDOWN_USER = "job-user"
 
 # During a SYNC_INPUT_JOB_ATTACHMENTS session action, the transfer rate is periodically reported through
 # a callback function. If a transfer rate lower than LOW_TRANSFER_RATE_THRESHOLD is observed in a series
@@ -402,11 +401,12 @@ class Session:
         finally:
             if self._asset_sync is not None and self._job_attachment_details is not None:
                 # terminate any running virtual file systems
-                shutdown_user = self._os_user.user if self._os_user else DEFAULT_SHUTDOWN_USER
+                if not self._os_user:
+                    raise ValueError("No os user set, can't perform session cleanup")
                 self._asset_sync.cleanup_session(
                     session_dir=self._session.working_directory,
                     file_system=self._job_attachment_details.job_attachments_file_system,
-                    os_user=shutdown_user,
+                    os_user=self._os_user.user,
                 )
             # Clean-up the Open Job Description session
             self._session.cleanup()

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -400,13 +400,11 @@ class Session:
                 cur_time = monotonic()
         finally:
             if self._asset_sync is not None and self._job_attachment_details is not None:
-                # terminate any running virtual file systems
-                if not self._os_user:
-                    raise ValueError("No os user set, can't perform session cleanup")
+                # Perform any cleanup the job attachments system needs to do
                 self._asset_sync.cleanup_session(
                     session_dir=self._session.working_directory,
                     file_system=self._job_attachment_details.job_attachments_file_system,
-                    os_user=self._os_user.user,
+                    os_user=self._os_user.user if self._os_user else None,
                 )
             # Clean-up the Open Job Description session
             self._session.cleanup()

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -34,6 +34,7 @@ from ..aws.deadline import (
     update_worker,
     update_worker_schedule,
     record_worker_start_telemetry_event,
+    record_uncaught_exception_telemetry_event,
 )
 
 __all__ = ["entrypoint"]
@@ -161,6 +162,7 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
             raise
         else:
             _logger.critical(e, exc_info=True)
+            record_uncaught_exception_telemetry_event(exception_type=str(type(e)))
             sys.exit(1)
     finally:
         _logger.info("Worker Agent exiting")

--- a/src/deadline_worker_agent/windows/win_credentials_resolver.py
+++ b/src/deadline_worker_agent/windows/win_credentials_resolver.py
@@ -21,7 +21,7 @@ from openjd.sessions import WindowsSessionUser, BadCredentialsException
 from pywintypes import HANDLE as PyHANDLE
 from win32security import (
     LogonUser,
-    LOGON32_LOGON_NETWORK_CLEARTEXT,
+    LOGON32_LOGON_INTERACTIVE,
     LOGON32_PROVIDER_DEFAULT,
 )
 from win32profile import LoadUserProfile, PI_NOUI, UnloadUserProfile
@@ -214,7 +214,7 @@ class WindowsCredentialsResolver:
                             # https://timgolden.me.uk/pywin32-docs/win32profile__LoadUserProfile_meth.html
                             logon_token = LogonUser(
                                 Username=user,
-                                LogonType=LOGON32_LOGON_NETWORK_CLEARTEXT,
+                                LogonType=LOGON32_LOGON_INTERACTIVE,
                                 LogonProvider=LOGON32_PROVIDER_DEFAULT,
                                 Password=password,
                                 Domain=None,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -79,6 +79,11 @@ def vfs_install_path() -> str:
 
 
 @pytest.fixture
+def grant_required_access() -> bool:
+    return True
+
+
+@pytest.fixture
 def parsed_args(
     farm_id: str,
     fleet_id: str,
@@ -92,6 +97,7 @@ def parsed_args(
     install_service: bool,
     telemetry_opt_out: bool,
     vfs_install_path: str,
+    grant_required_access: bool,
 ) -> ParsedCommandLineArguments:
     parsed_args = ParsedCommandLineArguments()
     parsed_args.farm_id = farm_id
@@ -106,6 +112,7 @@ def parsed_args(
     parsed_args.install_service = install_service
     parsed_args.telemetry_opt_out = telemetry_opt_out
     parsed_args.vfs_install_path = vfs_install_path
+    parsed_args.grant_required_access = grant_required_access
     return parsed_args
 
 

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -8,6 +8,7 @@ from deadline_worker_agent.aws.deadline import (
     record_worker_start_telemetry_event,
     record_sync_inputs_telemetry_event,
     record_sync_outputs_telemetry_event,
+    record_uncaught_exception_telemetry_event,
 )
 from deadline_worker_agent.startup.capabilities import Capabilities
 from deadline.job_attachments.progress_tracker import SummaryStatistics
@@ -124,4 +125,26 @@ def test_record_sync_outputs_telemetry_event():
             "transfer_rate": 100.0,
             "queue_id": "queue-test",
         },
+    )
+
+
+def test_record_uncaught_exception_telemetry_event():
+    """
+    Tests that when record_uncaught_exception_telemetry_event() is called, the correct
+    event type and details are passed to the telemetry client's record_event() method.
+    """
+    # GIVEN
+    mock_telemetry_client = MagicMock()
+
+    with patch.object(deadline_mod, "_get_deadline_telemetry_client") as mock_get_telemetry_client:
+        mock_get_telemetry_client.return_value = mock_telemetry_client
+
+        # WHEN
+        error = ValueError()
+        record_uncaught_exception_telemetry_event(str(type(error)))
+
+    # THEN
+    mock_telemetry_client.record_error.assert_called_with(
+        exception_type="<class 'ValueError'>",
+        event_details={"exception_scope": "uncaught"},
     )

--- a/test/unit/aws_credentials/test_aws_configs.py
+++ b/test/unit/aws_credentials/test_aws_configs.py
@@ -191,7 +191,7 @@ class TestSetupFile:
                     file_path=file_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 )
         else:
             file_path.exists.assert_called_once_with()
@@ -230,7 +230,7 @@ class TestSetupFile:
                     file_path=file_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 )
         else:
             chmod.assert_called_once_with(mode=0o640 if os_user is not None else 0o600)
@@ -267,7 +267,7 @@ class TestSetupFile:
                     file_path=file_path,
                     permitted_user=os_user,
                     user_permission=FileSystemPermissionEnum.READ_WRITE,
-                    agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 )
         else:
             mock_run_cmd_as.assert_not_called()

--- a/test/unit/aws_credentials/test_queue_boto3_session.py
+++ b/test/unit/aws_credentials/test_queue_boto3_session.py
@@ -486,7 +486,7 @@ class TestCreateCredentialsDirectory:
                 exist_ok=True,
                 parents=True,
                 permitted_user=os_user,
-                agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 user_permission=FileSystemPermissionEnum.READ,
             )
 

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -238,7 +238,7 @@ class TestEnsureUserProfileExists:
         # THEN
         mock_LogonUser.assert_called_once_with(
             Username=username,
-            LogonType=win32security.LOGON32_LOGON_NETWORK_CLEARTEXT,
+            LogonType=win32security.LOGON32_LOGON_INTERACTIVE,
             LogonProvider=win32security.LOGON32_PROVIDER_DEFAULT,
             Password=password,
             Domain=None,

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -305,16 +305,18 @@ class TestEnsureUserProfileExists:
 @patch("deadline_worker_agent.installer.win_installer.secrets.choice")
 def test_generate_password(mock_choice):
     # Given
-    password_length = 27
+    password_length = 32
     characters = string.ascii_letters[:password_length]
     mock_choice.side_effect = characters
 
     # When
-    password = win_installer.generate_password(password_length)
+    password = win_installer.generate_password()
 
     # Then
+    assert win_installer.DEFAULT_PASSWORD_LENGTH == password_length
     expected_password = "".join(characters)
     assert password == expected_password
+    assert len(password) == password_length
 
 
 def test_validate_deadline_id():

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -704,17 +704,21 @@ class TestCreateNewSessions:
                 action_update := scheduler._action_updates_map.get(action_id, None)
             ), f"no action update for {action_id}"
             assert action_update.id == action_id
-            assert action_update.completed_status == (
-                "FAILED" if action_num == 1 else "NEVER_ATTEMPTED"
-            )
             assert action_update.status is not None
             assert action_update.status.state == ActionState.FAILED
             assert (
                 action_update.status.fail_message
                 == f"Log provisioning error: {log_provision_error_msg}"
             )
-            assert action_update.start_time == datetime_now_mock.return_value
-            assert action_update.end_time == datetime_now_mock.return_value
+            if action_num == 1:
+                assert action_update.completed_status == "FAILED"
+
+                assert action_update.start_time == datetime_now_mock.return_value
+                assert action_update.end_time == datetime_now_mock.return_value
+            else:
+                assert action_update.completed_status == "NEVER_ATTEMPTED"
+                assert action_update.start_time is None
+                assert action_update.end_time is None
 
     @pytest.mark.parametrize(
         argnames="job_details_error",
@@ -783,14 +787,18 @@ class TestCreateNewSessions:
                 action_update := scheduler._action_updates_map.get(action_id, None)
             ), f"no action update for {action_id}"
             assert action_update.id == action_id
-            assert action_update.completed_status == (
-                "FAILED" if action_num == 1 else "NEVER_ATTEMPTED"
-            )
             assert action_update.status is not None
             assert action_update.status.state == ActionState.FAILED
             assert action_update.status.fail_message == str(job_details_error)
-            assert action_update.start_time == datetime_now_mock.return_value
-            assert action_update.end_time == datetime_now_mock.return_value
+            if action_num == 1:
+                assert action_update.completed_status == "FAILED"
+
+                assert action_update.start_time == datetime_now_mock.return_value
+                assert action_update.end_time == datetime_now_mock.return_value
+            else:
+                assert action_update.completed_status == "NEVER_ATTEMPTED"
+                assert action_update.start_time is None
+                assert action_update.end_time is None
 
     @pytest.mark.skipif(os.name != "nt", reason="Windows-only test.")
     def test_job_details_run_as_worker_agent_user_windows(
@@ -856,14 +864,17 @@ class TestCreateNewSessions:
                 action_update := scheduler._action_updates_map.get(action_id, None)
             ), f"no action update for {action_id}"
             assert action_update.id == action_id
-            assert action_update.completed_status == (
-                "FAILED" if action_num == 1 else "NEVER_ATTEMPTED"
-            )
             assert action_update.status is not None
             assert action_update.status.state == ActionState.FAILED
             assert action_update.status.fail_message == expected_err_msg
-            assert action_update.start_time == datetime_now_mock.return_value
-            assert action_update.end_time == datetime_now_mock.return_value
+            if action_num == 1:
+                assert action_update.completed_status == "FAILED"
+                assert action_update.start_time == datetime_now_mock.return_value
+                assert action_update.end_time == datetime_now_mock.return_value
+            else:
+                assert action_update.completed_status == "NEVER_ATTEMPTED"
+                assert action_update.start_time is None
+                assert action_update.end_time is None
 
 
 class TestQueueAwsCredentialsManagement:

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -531,7 +531,7 @@ class TestCreateNewSessions:
         else:
             mock_make_directory.assert_called_once_with(
                 dir_path=queue_log_dir_path,
-                agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 exist_ok=True,
             )
         mock_queue_session_log_file_path.assert_called_once_with(

--- a/test/unit/sessions/job_entities/test_job_details.py
+++ b/test/unit/sessions/job_entities/test_job_details.py
@@ -49,6 +49,15 @@ def job_details_no_user() -> JobDetails:
     )
 
 
+@pytest.fixture
+def job_details_only_run_as_worker_agent_user() -> JobDetails:
+    return JobDetails(
+        log_group_name="/aws/deadline/queue-0000",
+        schema_version=SpecificationRevision.v2023_09,
+        job_run_as_user=JobRunAsUser(is_worker_agent_user=True),
+    )
+
+
 @pytest.mark.parametrize(
     "data",
     [
@@ -413,7 +422,7 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
                     "runAs": "WORKER_AGENT_USER",
                 },
             },
-            "job_details_no_user",
+            "job_details_only_run_as_worker_agent_user",
             id="required with runAs WORKER_AGENT_USER",
         ),
     ],

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1933,6 +1933,25 @@ class TestSessionCleanup:
             os_user="some-user",
         )
 
+    def test_asset_sync_cleanup_raises_with_no_os_user(
+        self,
+        session: Session,
+        job_attachment_details: JobAttachmentDetails,
+        mock_asset_sync: MagicMock,
+    ) -> None:
+        # GIVEN
+        mock_asset_sync_cleanup: MagicMock = mock_asset_sync.cleanup_session
+        session._job_attachment_details = job_attachment_details
+        session._os_user = None
+
+        # THEN
+        with pytest.raises(ValueError):
+            # WHEN
+            session._cleanup()
+
+        # THEN
+        mock_asset_sync_cleanup.assert_not_called()
+
 
 class TestSessionStartAction:
     """Tests for Session._start_action()"""

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1938,19 +1938,22 @@ class TestSessionCleanup:
         session: Session,
         job_attachment_details: JobAttachmentDetails,
         mock_asset_sync: MagicMock,
+        mock_openjd_session: MagicMock,
     ) -> None:
         # GIVEN
         mock_asset_sync_cleanup: MagicMock = mock_asset_sync.cleanup_session
         session._job_attachment_details = job_attachment_details
         session._os_user = None
 
-        # THEN
-        with pytest.raises(ValueError):
-            # WHEN
-            session._cleanup()
+        # WHEN
+        session._cleanup()
 
         # THEN
-        mock_asset_sync_cleanup.assert_not_called()
+        mock_asset_sync_cleanup.assert_called_once_with(
+            session_dir=mock_openjd_session.working_directory,
+            file_system=job_attachment_details.job_attachments_file_system,
+            os_user=None,
+        )
 
 
 class TestSessionStartAction:

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1930,6 +1930,7 @@ class TestSessionCleanup:
         mock_asset_sync_cleanup.assert_called_once_with(
             session_dir=mock_openjd_session.working_directory,
             file_system=job_attachment_details.job_attachments_file_system,
+            os_user="some-user",
         )
 
 

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -186,9 +186,11 @@ def test_calls_worker_run(
     mock_worker_run.assert_called_once_with()
 
 
+@patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")
 @patch.object(entrypoint_mod.sys, "exit")
 def test_worker_run_exception(
     sys_exit_mock: MagicMock,
+    telemetry_mock: MagicMock,
     mock_worker_run: MagicMock,
 ) -> None:
     """Tests that exceptions raised by Worker.run() are logged and the program exits with a non-zero exit code"""
@@ -205,6 +207,7 @@ def test_worker_run_exception(
     logger_exception: MagicMock = logger.exception
     logger_exception.assert_called_once_with("Failed running worker: %s", exception)
     sys_exit_mock.assert_called_once_with(1)
+    telemetry_mock.assert_called_once_with(exception_type=str(type(exception)))
 
 
 def test_configuration_load(

--- a/test/unit/test_session_events.py
+++ b/test/unit/test_session_events.py
@@ -9,20 +9,127 @@ from deadline_worker_agent.session_events import (
 )
 from typing import Dict
 from typing import Any
+import datetime
 
 
 def test_logging_allow_list():
+    # This test exists to ensure that no ACCIDENTAL changes are made to the logging allow-list
+
     test_allow_list: Dict[str, LoggingAllowList] = {
-        "deadline.CreateWorker": {"log_request_url": True, "res_body_keys": ["workerId"]},
-        "deadline.AssumeFleetRoleForWorker": {"log_request_url": True},
-        "deadline.AssumeQueueRoleForWorker": {"log_request_url": True},
+        "deadline.CreateWorker": {
+            "log_request_url": True,
+            "req_log_body": {"hostProperties": True},
+            "res_log_body": {"workerId": True},
+        },
+        "deadline.AssumeFleetRoleForWorker": {
+            "log_request_url": True,
+            "res_log_body": {"credentials": {"accessKeyId": True, "expiration": True}},
+        },
+        "deadline.AssumeQueueRoleForWorker": {
+            "log_request_url": True,
+            "res_log_body": {"credentials": {"accessKeyId": True, "expiration": True}},
+        },
         "deadline.UpdateWorker": {
             "log_request_url": True,
-            "req_body_keys": ["status"],
-            "res_body_keys": ["log"],
+            "req_log_body": {
+                "status": True,
+                "capabilities": True,
+                "hostProperties": True,
+            },
+            "res_log_body": {"log": True},
         },
-        "deadline.BatchGetJobEntity": {"log_request_url": True},
-        "deadline.DeleteWorker": {"log_request_url": True},
+        "deadline.UpdateWorkerSchedule": {
+            "log_request_url": True,
+            "req_log_body": {
+                "updatedSessionActions": {
+                    "*": {
+                        "completedStatus": True,
+                        "processExitCode": True,
+                        "startedAt": True,
+                        "endedAt": True,
+                        "updatedAt": True,
+                        "progressPercent": True,
+                    },
+                }
+            },
+            "res_log_body": {
+                "assignedSessions": {
+                    "*": {
+                        "queueId": True,
+                        "jobId": True,
+                        "sessionActions": {
+                            "sessionActionId": True,
+                            "definition": {
+                                "envEnter": {"environmentId": True},
+                                "envExit": {"environmentId": True},
+                                "taskRun": {
+                                    "taskId": True,
+                                    "stepId": True,
+                                },
+                                "syncInputJobAttachments": {"stepId": True},
+                            },
+                        },
+                        "logConfiguration": True,
+                    },
+                },
+                "cancelSessionActions": True,
+                "desiredWorkerStatus": True,
+                "updateIntervalSeconds": True,
+            },
+        },
+        "deadline.BatchGetJobEntity": {
+            "log_request_url": True,
+            "req_log_body": {
+                "identifiers": True,
+            },
+            "res_log_body": {
+                "entities": {
+                    "jobDetails": {
+                        "jobId": True,
+                        "jobAttachmentSettings": {"s3BucketName": True, "rootPrefix": True},
+                        "jobRunAsUser": True,
+                        "logGroupName": True,
+                        "queueRoleArn": True,
+                        "schemaVersion": True,
+                        "pathMappingRules": False,
+                    },
+                    "jobAttachmentDetails": {
+                        "jobId": True,
+                        "attachments": {
+                            "manifests": {
+                                "fileSystemLocationName": True,
+                                "rootPath": False,
+                                "rootPathFormat": True,
+                                "outputRelativeDirectories": False,
+                                "inputManifestPath": True,
+                                "inputManifestHash": True,
+                            },
+                            "fileSystem": True,
+                        },
+                    },
+                    "environmentDetails": {
+                        "jobId": True,
+                        "environmentId": True,
+                        "schemaVersion": True,
+                    },
+                    "stepDetails": {
+                        "jobId": True,
+                        "stepId": True,
+                        "schemaVersion": True,
+                        "dependencies": True,
+                    },
+                },
+                "errors": True,
+            },
+        },
+        "deadline.DeleteWorker": {
+            "log_request_url": True,
+        },
+        "secretsmanager.GetSecretValue": {
+            "log_request_url": True,
+            "req_log_body": {"SecretId": True, "VersionId": True, "VersionStage": True},
+            "res_log_body": {"ARN": True, "CreatedDate": True, "Name": True, "VersionId": True},
+        },
     }
 
     assert test_allow_list == LOGGING_ALLOW_LIST
@@ -38,7 +145,7 @@ def test_logging_allow_list():
                 "body": '{"hostProperties": {"ipAddresses": {"ipV4Addresses": ["0.0.0.0", "127.0.0.1", "0.0.0.0"], "ipV6Addresses": ["0000:0000:0000:0000:0000:0000:0000:0000", "0000:0000:0000:0000:0000:0000:0000:0000", "0000:0000:0000:0000:0000:0000:0000:0000"]}, "hostName": "host.us-west-2.amazon.com"}}',
                 "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers",
             },
-            "{'log_type': 'boto_request', 'operation': 'deadline.CreateWorker', 'params': {}, 'request_url': 'https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers'}",
+            '{"log_type": "boto_request", "operation": "deadline.CreateWorker", "params": {"hostProperties": {"ipAddresses": {"ipV4Addresses": ["0.0.0.0", "127.0.0.1", "0.0.0.0"], "ipV6Addresses": ["0000:0000:0000:0000:0000:0000:0000:0000", "0000:0000:0000:0000:0000:0000:0000:0000", "0000:0000:0000:0000:0000:0000:0000:0000"]}, "hostName": "host.us-west-2.amazon.com"}}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers"}',
             id="CreateWorkerBeforeCallTest",
         ),
         pytest.param(
@@ -53,8 +160,23 @@ def test_logging_allow_list():
                 "body": b"",
                 "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/fleet-role",
             },
-            "{'log_type': 'boto_request', 'operation': 'deadline.AssumeFleetRoleForWorker', 'params': {}, 'request_url': 'https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/fleet-role'}",
+            '{"log_type": "boto_request", "operation": "deadline.AssumeFleetRoleForWorker", "params": {}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/fleet-role"}',
             id="AssumeFleetRoleForWorkerBeforeCallTest",
+        ),
+        pytest.param(
+            "before-call.deadline.AssumeQueueRoleForWorker",
+            {
+                "url_path": "/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/queue-role",
+                "query_string": {"queueId": "queue-0000000000000000000000000000000"},
+                "method": "GET",
+                "headers": {
+                    "User-Agent": "Boto3/1.28.12 md/Botocore#1.31.12 ua/2.0 os/linux#5.4.247-169.350.amzn2int.x86_64 md/arch#x86_64 lang/python#3.9.17 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.12 deadline_worker_agent/0.9.0.post4+g43d00ae.d20230726"
+                },
+                "body": b"",
+                "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/queue-role?queueId=queue-0000000000000000000000000000000",
+            },
+            '{"log_type": "boto_request", "operation": "deadline.AssumeQueueRoleForWorker", "params": {}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/queue-role?queueId=queue-0000000000000000000000000000000"}',
+            id="AssumeQueueRoleForWorkerBeforeCallTest",
         ),
         pytest.param(
             "before-call.deadline.UpdateWorker",
@@ -69,23 +191,24 @@ def test_logging_allow_list():
                 "body": b'{"status": "STARTED", "capabilities": {"amounts": [{"name": "amount.worker.vcpu", "value": 8.0}, {"name": "amount.worker.memory", "value": 14987.5234375}, {"name": "amount.worker.disk.scratch", "value": 0.0}, {"name": "amount.worker.gpu", "value": 0.0}, {"name": "amount.worker.gpu.memory", "value": 0.0}], "attributes": [{"name": "attr.worker.os.family", "values": ["linux"]}, {"name": "attr.worker.cpu.arch", "values": ["x86_64"]}]}, "hostProperties": {"ipAddresses": {"ipV4Addresses": ["127.0.0.1", "0.0.0.0", "0.0.0.0"], "ipV6Addresses": ["0000:0000:0000:0000:0000:0000:00000:0000", "0000:0000:0000:0000:0000:0000:0000:0001", "0000:0000:0000:0000:0000:0000:0000:0000"]}, "hostName": "host.us-west-2.amazon.com"}}',
                 "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000",
             },
-            "{'log_type': 'boto_request', 'operation': 'deadline.UpdateWorker', 'params': {'status': 'STARTED'}, 'request_url': 'https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000'}",
+            '{"log_type": "boto_request", "operation": "deadline.UpdateWorker", "params": {"status": "STARTED", "capabilities": {"amounts": [{"name": "amount.worker.vcpu", "value": 8.0}, {"name": "amount.worker.memory", "value": 14987.5234375}, {"name": "amount.worker.disk.scratch", "value": 0.0}, {"name": "amount.worker.gpu", "value": 0.0}, {"name": "amount.worker.gpu.memory", "value": 0.0}], "attributes": [{"name": "attr.worker.os.family", "values": ["linux"]}, {"name": "attr.worker.cpu.arch", "values": ["x86_64"]}]}, "hostProperties": {"ipAddresses": {"ipV4Addresses": ["127.0.0.1", "0.0.0.0", "0.0.0.0"], "ipV6Addresses": ["0000:0000:0000:0000:0000:0000:00000:0000", "0000:0000:0000:0000:0000:0000:0000:0001", "0000:0000:0000:0000:0000:0000:0000:0000"]}, "hostName": "host.us-west-2.amazon.com"}}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000"}',
             id="UpdateWorkerBeforeCallTest",
         ),
         pytest.param(
-            "before-call.deadline.DeleteWorker",
+            "before-call.deadline.UpdateWorkerSchedule",
             {
                 "url_path": "/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000",
                 "query_string": {},
-                "method": "DELETE",
+                "method": "PATCH",
                 "headers": {
-                    "User-Agent": "Boto3/1.28.12 md/Botocore#1.31.12 ua/2.0 os/linux#5.4.247-169.350.amzn2int.x86_64 md/arch#x86_64 lang/python#3.9.17 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.12 deadline_worker_agent/0.9.0.post2+g64a93a0.d20230726"
+                    "Content-Type": "application/json",
+                    "User-Agent": "Boto3/1.28.12 md/Botocore#1.31.12 ua/2.0 os/linux#5.4.247-169.350.amzn2int.x86_64 md/arch#x86_64 lang/python#3.9.17 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.12",
                 },
-                "body": b"",
-                "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000",
+                "body": b'{"updatedSessionActions": {"sessionaction-45044d1fbc4f4d6388f5ef694ed0c298-0": {"startedAt": "2024-03-15T22:58:02.574480Z", "completedStatus": "FAILED", "processExitCode": 126, "endedAt": "2024-03-15T22:58:02.589172Z"}, "sessionaction-45044d1fbc4f4d6388f5ef694ed0c298-1": {"completedStatus": "NEVER_ATTEMPTED", "progressMessage": "We dun failed"}, "sessionaction-45044d1fbc4f4d6388f5ef694ed0c298-2": {"completedStatus": "NEVER_ATTEMPTED", "progressMessage": "We dun failed"}}}',
+                "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/schedule",
             },
-            "{'log_type': 'boto_request', 'operation': 'deadline.DeleteWorker', 'params': {}, 'request_url': 'https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000'}",
-            id="DeleteWorkerBeforeCallTest",
+            '{"log_type": "boto_request", "operation": "deadline.UpdateWorkerSchedule", "params": {"updatedSessionActions": {"sessionaction-45044d1fbc4f4d6388f5ef694ed0c298-0": {"startedAt": "2024-03-15T22:58:02.574480Z", "completedStatus": "FAILED", "processExitCode": 126, "endedAt": "2024-03-15T22:58:02.589172Z"}, "sessionaction-45044d1fbc4f4d6388f5ef694ed0c298-1": {"completedStatus": "NEVER_ATTEMPTED", "progressMessage": "*REDACTED*"}, "sessionaction-45044d1fbc4f4d6388f5ef694ed0c298-2": {"completedStatus": "NEVER_ATTEMPTED", "progressMessage": "*REDACTED*"}}}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/schedule"}',
+            id="UpdateWorkerScheduleBeforeCallTest",
         ),
         pytest.param(
             "before-call.deadline.BatchGetJobEntity",
@@ -100,32 +223,139 @@ def test_logging_allow_list():
                 "body": b'{"identifiers": [{"jobDetails": {"jobId": "job-0771968389a54c26adf4afd80bac1b82"}}]}',
                 "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity",
             },
-            "{'log_type': 'boto_request', 'operation': 'deadline.BatchGetJobEntity', 'params': {}, 'request_url': 'https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity'}",
-            id="BatchGetJobEntityBeforeCallTest",
+            '{"log_type": "boto_request", "operation": "deadline.BatchGetJobEntity", "params": {"identifiers": [{"jobDetails": {"jobId": "job-0771968389a54c26adf4afd80bac1b82"}}]}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity"}',
+            id="BatchGetJobEntityBeforeCallTest-JobDetails",
         ),
         pytest.param(
-            "before-call.deadline.AssumeQueueRoleForWorker",
+            "before-call.deadline.BatchGetJobEntity",
             {
-                "url_path": "/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/queue-role",
-                "query_string": {"queueId": "queue-0000000000000000000000000000000"},
-                "method": "GET",
+                "url_path": "/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity",
+                "query_string": {},
+                "method": "POST",
                 "headers": {
-                    "User-Agent": "Boto3/1.28.12 md/Botocore#1.31.12 ua/2.0 os/linux#5.4.247-169.350.amzn2int.x86_64 md/arch#x86_64 lang/python#3.9.17 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.12 deadline_worker_agent/0.9.0.post4+g43d00ae.d20230726"
+                    "Content-Type": "application/json",
+                    "User-Agent": "Boto3/1.28.12 md/Botocore#1.31.12 ua/2.0 os/linux#5.4.247-169.350.amzn2int.x86_64 md/arch#x86_64 lang/python#3.9.17 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.12 deadline_worker_agent/0.9.0.post4+g43d00ae.d20230726",
+                },
+                "body": b'{"identifiers": [{"jobAttachmentDetails": {"jobId": "job-0771968389a54c26adf4afd80bac1b82"}}]}',
+                "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity",
+            },
+            '{"log_type": "boto_request", "operation": "deadline.BatchGetJobEntity", "params": {"identifiers": [{"jobAttachmentDetails": {"jobId": "job-0771968389a54c26adf4afd80bac1b82"}}]}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity"}',
+            id="BatchGetJobEntityBeforeCallTest-JobAttachmentDetails",
+        ),
+        pytest.param(
+            "before-call.deadline.BatchGetJobEntity",
+            {
+                "url_path": "/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity",
+                "query_string": {},
+                "method": "POST",
+                "headers": {
+                    "Content-Type": "application/json",
+                    "User-Agent": "Boto3/1.28.12 md/Botocore#1.31.12 ua/2.0 os/linux#5.4.247-169.350.amzn2int.x86_64 md/arch#x86_64 lang/python#3.9.17 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.12 deadline_worker_agent/0.9.0.post4+g43d00ae.d20230726",
+                },
+                "body": b'{"identifiers": [{"stepDetails": {"jobId": "job-0771968389a54c26adf4afd80bac1b82", "stepId": "step-0771968389a54c26adf4afd80bac1b82"}}]}',
+                "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity",
+            },
+            '{"log_type": "boto_request", "operation": "deadline.BatchGetJobEntity", "params": {"identifiers": [{"stepDetails": {"jobId": "job-0771968389a54c26adf4afd80bac1b82", "stepId": "step-0771968389a54c26adf4afd80bac1b82"}}]}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity"}',
+            id="BatchGetJobEntityBeforeCallTest-StepDetails",
+        ),
+        pytest.param(
+            "before-call.deadline.BatchGetJobEntity",
+            {
+                "url_path": "/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity",
+                "query_string": {},
+                "method": "POST",
+                "headers": {
+                    "Content-Type": "application/json",
+                    "User-Agent": "Boto3/1.28.12 md/Botocore#1.31.12 ua/2.0 os/linux#5.4.247-169.350.amzn2int.x86_64 md/arch#x86_64 lang/python#3.9.17 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.12 deadline_worker_agent/0.9.0.post4+g43d00ae.d20230726",
+                },
+                "body": b'{"identifiers": [{"environmentDetails": {"jobId": "job-0771968389a54c26adf4afd80bac1b82", "environmentId": "STEP:step-0771968389a54c26adf4afd80bac1b82:Identifier"}}]}',
+                "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity",
+            },
+            '{"log_type": "boto_request", "operation": "deadline.BatchGetJobEntity", "params": {"identifiers": [{"environmentDetails": {"jobId": "job-0771968389a54c26adf4afd80bac1b82", "environmentId": "STEP:step-0771968389a54c26adf4afd80bac1b82:Identifier"}}]}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/batchGetJobEntity"}',
+            id="BatchGetJobEntityBeforeCallTest-EnvironmentDetails",
+        ),
+        pytest.param(
+            "before-call.deadline.DeleteWorker",
+            {
+                "url_path": "/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000",
+                "query_string": {},
+                "method": "DELETE",
+                "headers": {
+                    "User-Agent": "Boto3/1.28.12 md/Botocore#1.31.12 ua/2.0 os/linux#5.4.247-169.350.amzn2int.x86_64 md/arch#x86_64 lang/python#3.9.17 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.12 deadline_worker_agent/0.9.0.post2+g64a93a0.d20230726"
                 },
                 "body": b"",
-                "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/queue-role?queueId=queue-0000000000000000000000000000000",
+                "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000",
             },
-            "{'log_type': 'boto_request', 'operation': 'deadline.AssumeQueueRoleForWorker', 'params': {}, 'request_url': 'https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000/queue-role?queueId=queue-0000000000000000000000000000000'}",
-            id="AssumeQueueRoleForWorkerBeforeCallTest",
+            '{"log_type": "boto_request", "operation": "deadline.DeleteWorker", "params": {}, "request_url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/workers/worker-0000000000000000000000000000000"}',
+            id="DeleteWorkerBeforeCallTest",
+        ),
+        # ====================
+        pytest.param(
+            "before-call.secretsmanager.GetSecretValue",
+            {
+                "url_path": "/",
+                "query_string": {},
+                "method": "POST",
+                "headers": {
+                    "User-Agent": "Boto3/1.28.12 md/Botocore#1.31.12 ua/2.0 os/linux#5.4.247-169.350.amzn2int.x86_64 md/arch#x86_64 lang/python#3.9.17 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.31.12 deadline_worker_agent/0.9.0.post2+g64a93a0.d20230726"
+                },
+                "body": b'{"SecretId": "secret-id", "VersionId": "6fb9f17a-f9a9-4729-af0f-df67e976484c", "VersionStage": "AWSCURRENT"}',
+                "url": "https://secretsmanager.us-west-2.amazonaws.com/",
+            },
+            '{"log_type": "boto_request", "operation": "secretsmanager.GetSecretValue", "params": {"SecretId": "secret-id", "VersionId": "6fb9f17a-f9a9-4729-af0f-df67e976484c", "VersionStage": "AWSCURRENT"}, "request_url": "https://secretsmanager.us-west-2.amazonaws.com/"}',
+            id="GetSecretValueBeforeCallTest",
+        ),
+        # ====================
+        # Unknown API tests -- make sure that we redact the params, but still report the API
+        pytest.param(
+            "before-call.deadline.NotAnAPI",
+            {
+                "url_path": "/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/newthing",
+                "body": '{"requestParam": "requestValue"}',
+                "url": "https://**********.execute-api.us-west-2.amazonaws.com/2020-08-21/farms/farm-0000000000000000000000000000000/fleets/fleet-0000000000000000000000000000000/newthing",
+            },
+            '{"log_type": "boto_request", "operation": "deadline.NotAnAPI", "params": "*REDACTED*", "request_url": "*REDACTED*"}',
+            id="NotAnAPIBeforeCallTest",
         ),
     ),
 )
 def test_log_before_call(
     event_name: str, params: Dict[str, Any], expected_result: str, caplog: pytest.LogCaptureFixture
-):
+) -> None:
     caplog.set_level(0)
     log_before_call(event_name, params)
     assert caplog.messages == [expected_result]
+
+
+@pytest.mark.parametrize(
+    argnames=("api_name", "params"),
+    argvalues=(
+        pytest.param(
+            "cloudwatch-logs.PutLogEvent",
+            {
+                "url_path": "/",
+                "body": '{"requestParam": "requestValue"}',
+                "url": "https://cloudwatch-logs.us-west-2.amazonaws.com/",
+            },
+            id="IgnoreCloudWatchBeforeCall",
+        ),
+        pytest.param(
+            "s3.GetObject",
+            {
+                "url_path": "/",
+                "body": '{"requestParam": "requestValue"}',
+                "url": "https://s3.us-west-2.amazonaws.com/",
+            },
+            id="IgnoreS3BeforeCall",
+        ),
+    ),
+)
+def test_log_before_ignore_list(
+    api_name: str, params: Dict[str, Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(0)
+    log_before_call("before-call." + api_name, params)
+    assert all(api_name not in msg for msg in caplog.messages)
 
 
 @pytest.mark.parametrize(
@@ -140,7 +370,7 @@ def test_log_before_call(
                 },
                 "workerId": "worker-38aab2f87d2b45298b39875639580970",
             },
-            "{'log_type': 'boto_response', 'operation': 'deadline.CreateWorker', 'status_code': 200, 'params': {'workerId': 'worker-38aab2f87d2b45298b39875639580970'}}",
+            '{"log_type": "boto_response", "operation": "deadline.CreateWorker", "status_code": 200, "params": {"workerId": "worker-38aab2f87d2b45298b39875639580970"}, "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
             id="CreateWorkerAfterCallTest",
         ),
         pytest.param(
@@ -149,10 +379,16 @@ def test_log_before_call(
                 "ResponseMetadata": {
                     "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
                     "HTTPStatusCode": 200,
-                }
+                },
+                "credentials": {
+                    "accessKeyId": "accesskey",
+                    "secretAccessKey": "secretkey",
+                    "sessionToken": "token",
+                    "expiration": "some date",
+                },
             },
-            "{'log_type': 'boto_response', 'operation': 'deadline.AssumeFleetRoleForWorker', 'status_code': 200, 'params': {}}",
-            id="AssumeFleetRoleAfterCallTest",
+            '{"log_type": "boto_response", "operation": "deadline.AssumeFleetRoleForWorker", "status_code": 200, "params": {"credentials": {"accessKeyId": "accesskey", "secretAccessKey": "*REDACTED*", "sessionToken": "*REDACTED*", "expiration": "some date"}}, "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
+            id="AssumeFleetRoleForWorkerAfterCallTest",
         ),
         pytest.param(
             "after-call.deadline.AssumeQueueRoleForWorker",
@@ -160,9 +396,15 @@ def test_log_before_call(
                 "ResponseMetadata": {
                     "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
                     "HTTPStatusCode": 200,
-                }
+                },
+                "credentials": {
+                    "accessKeyId": "accesskey",
+                    "secretAccessKey": "secretkey",
+                    "sessionToken": "token",
+                    "expiration": "some date",
+                },
             },
-            "{'log_type': 'boto_response', 'operation': 'deadline.AssumeQueueRoleForWorker', 'status_code': 200, 'params': {}}",
+            '{"log_type": "boto_response", "operation": "deadline.AssumeQueueRoleForWorker", "status_code": 200, "params": {"credentials": {"accessKeyId": "accesskey", "secretAccessKey": "*REDACTED*", "sessionToken": "*REDACTED*", "expiration": "some date"}}, "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
             id="AssumeQueueRoleForWorkerAfterCallTest",
         ),
         pytest.param(
@@ -172,10 +414,74 @@ def test_log_before_call(
                     "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
                     "HTTPStatusCode": 200,
                 },
-                "status": "STOPPED",
+                "log": {
+                    "logDriver": "AWS",
+                    "options": {"option1": "foo"},
+                    "parameters": {"param1": "bar"},
+                    "error": "AccessDeniedException",
+                },
             },
-            "{'log_type': 'boto_response', 'operation': 'deadline.UpdateWorker', 'status_code': 200, 'params': {'log': None}}",
+            '{"log_type": "boto_response", "operation": "deadline.UpdateWorker", "status_code": 200, "params": {"log": {"logDriver": "AWS", "options": {"option1": "foo"}, "parameters": {"param1": "bar"}, "error": "AccessDeniedException"}}, "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
             id="UpdateWorkerAfterCallTest",
+        ),
+        pytest.param(
+            "after-call.deadline.UpdateWorkerSchedule",
+            {
+                "ResponseMetadata": {
+                    "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
+                    "HTTPStatusCode": 200,
+                },
+                "assignedSessions": {
+                    "session-e4ffe548f48d456ca11b5337bdc7a175": {
+                        "queueId": "queue-f9848b67822d49299296e3e47d8cc523",
+                        "jobId": "job-ac95524e7128498b9082375f8e3d7665",
+                        "sessionActions": [
+                            {
+                                "sessionActionId": "sessionaction-e4ffe548f48d456ca11b5337bdc7a175-0",
+                                "definition": {
+                                    "envEnter": {
+                                        "environmentId": "JOB:job-ac95524e7128498b9082375f8e3d7665:TestEnvironment"
+                                    }
+                                },
+                            },
+                            {
+                                "sessionActionId": "sessionaction-e4ffe548f48d456ca11b5337bdc7a175-1",
+                                "definition": {
+                                    "envEnter": {
+                                        "environmentId": "STEP:step-ff15e0f18561495399cb07b64342b538:myenv"
+                                    }
+                                },
+                            },
+                            {
+                                "sessionActionId": "sessionaction-e4ffe548f48d456ca11b5337bdc7a175-2",
+                                "definition": {
+                                    "taskRun": {
+                                        "taskId": "task-ff15e0f18561495399cb07b64342b538-0",
+                                        "stepId": "step-ff15e0f18561495399cb07b64342b538",
+                                        "parameters": {"Foo": "FooValue"},
+                                    }
+                                },
+                            },
+                            {
+                                "sessionActionId": "sessionaction-e4ffe548f48d456ca11b5337bdc7a175-3",
+                                "definition": {
+                                    "syncInputJobAttachments": {
+                                        "stepId": "step-ff15e0f18561495399cb07b64342b500",
+                                    }
+                                },
+                            },
+                        ],
+                        "logConfiguration": {
+                            "logDriver": "AWS",
+                            "options": {"option1": "foo"},
+                            "parameters": {"param1": "bar"},
+                            "error": "AccessDeniedException",
+                        },
+                    },
+                },
+            },
+            '{"log_type": "boto_response", "operation": "deadline.UpdateWorkerSchedule", "status_code": 200, "params": {"assignedSessions": {"session-e4ffe548f48d456ca11b5337bdc7a175": {"queueId": "queue-f9848b67822d49299296e3e47d8cc523", "jobId": "job-ac95524e7128498b9082375f8e3d7665", "sessionActions": [{"sessionActionId": "sessionaction-e4ffe548f48d456ca11b5337bdc7a175-0", "definition": {"envEnter": {"environmentId": "JOB:job-ac95524e7128498b9082375f8e3d7665:TestEnvironment"}}}, {"sessionActionId": "sessionaction-e4ffe548f48d456ca11b5337bdc7a175-1", "definition": {"envEnter": {"environmentId": "STEP:step-ff15e0f18561495399cb07b64342b538:myenv"}}}, {"sessionActionId": "sessionaction-e4ffe548f48d456ca11b5337bdc7a175-2", "definition": {"taskRun": {"taskId": "task-ff15e0f18561495399cb07b64342b538-0", "stepId": "step-ff15e0f18561495399cb07b64342b538", "parameters": "*REDACTED*"}}}, {"sessionActionId": "sessionaction-e4ffe548f48d456ca11b5337bdc7a175-3", "definition": {"syncInputJobAttachments": {"stepId": "step-ff15e0f18561495399cb07b64342b500"}}}], "logConfiguration": {"logDriver": "AWS", "options": {"option1": "foo"}, "parameters": {"param1": "bar"}, "error": "AccessDeniedException"}}}}, "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
+            id="UpdateWorkerScheduleAfterCallTest",
         ),
         pytest.param(
             "after-call.deadline.BatchGetJobEntity",
@@ -183,9 +489,71 @@ def test_log_before_call(
                 "ResponseMetadata": {
                     "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
                     "HTTPStatusCode": 200,
-                }
+                },
+                "entities": [
+                    {
+                        "jobDetails": {
+                            "jobId": "job-ac95524e7128498b9082375f8e3d7665",
+                            "jobAttachmentSettings": {
+                                "s3BucketName": "bucketname",
+                                "rootPrefix": "assets/",
+                            },
+                            "jobRunAsUser": {
+                                "posix": {"user": "jobuser", "group": "jobuser"},
+                                "windows": {
+                                    "user": "jobuser",
+                                    "passwordArn": "arn:aws:secretsmanager:us-west-2:000000000000:secret:PasswordSecret-qsrF9d",
+                                },
+                                "runAs": "QUEUE_CONFIGURED_USER",
+                            },
+                            "logGroupName": "/aws/deadline/farm-1b84ca8d938d47d99a00675ff4eedd41/queue-f9848b67822d49299296e3e47d8cc523",
+                            "queueRoleArn": "arn:aws:iam::000000000000:role/QueueRole",
+                            "parameters": {"Foo": "FooValue"},
+                            "schemaVersion": "jobtemplate-2023-09",
+                        },
+                        "stepDetails": {
+                            "jobId": "job-ac95524e7128498b9082375f8e3d7665",
+                            "stepId": "step-ff15e0f18561495399cb07b64342b538",
+                            "schemaVersion": "jobtemplate-2023-09",
+                            "template": {
+                                "name": "StepName",
+                                "script": {
+                                    "actions": {"onRun": {"command": "echo", "args": ["Hi"]}}
+                                },
+                            },
+                            "dependencies": ["step-ff15e0f18561495399cb07b64342b500"],
+                        },
+                        "environmentDetails": {
+                            "jobId": "job-ac95524e7128498b9082375f8e3d7665",
+                            "environmentId": "JOB:job-ac95524e7128498b9082375f8e3d7665:TestEnvironment",
+                            "schemaVersion": "jobtemplate-2023-09",
+                            "template": {
+                                "name": "TestEnvironment",
+                                "script": {
+                                    "actions": {"onEnter": {"command": "echo", "args": ["hi"]}}
+                                },
+                            },
+                        },
+                        "jobAttachmentDetails": {
+                            "jobId": "job-ac95524e7128498b9082375f8e3d7665",
+                            "attachments": {
+                                "manifests": [
+                                    {
+                                        "fileSystemLocationName": "Filesystem",
+                                        "rootPath": "/mnt/shared",
+                                        "rootPathFormat": "posix",
+                                        "outputRelativeDirectories": ["../output"],
+                                        "inputManifestPath": "manifest_file",
+                                        "inputManifestHash": "1234",
+                                    }
+                                ],
+                                "fileSystem": "COPIED",
+                            },
+                        },
+                    }
+                ],
             },
-            "{'log_type': 'boto_response', 'operation': 'deadline.BatchGetJobEntity', 'status_code': 200, 'params': {}}",
+            '{"log_type": "boto_response", "operation": "deadline.BatchGetJobEntity", "status_code": 200, "params": {"entities": [{"jobDetails": {"jobId": "job-ac95524e7128498b9082375f8e3d7665", "jobAttachmentSettings": {"s3BucketName": "bucketname", "rootPrefix": "assets/"}, "jobRunAsUser": {"posix": {"user": "jobuser", "group": "jobuser"}, "windows": {"user": "jobuser", "passwordArn": "arn:aws:secretsmanager:us-west-2:000000000000:secret:PasswordSecret-qsrF9d"}, "runAs": "QUEUE_CONFIGURED_USER"}, "logGroupName": "/aws/deadline/farm-1b84ca8d938d47d99a00675ff4eedd41/queue-f9848b67822d49299296e3e47d8cc523", "queueRoleArn": "arn:aws:iam::000000000000:role/QueueRole", "parameters": "*REDACTED*", "schemaVersion": "jobtemplate-2023-09"}, "stepDetails": {"jobId": "job-ac95524e7128498b9082375f8e3d7665", "stepId": "step-ff15e0f18561495399cb07b64342b538", "schemaVersion": "jobtemplate-2023-09", "template": "*REDACTED*", "dependencies": ["step-ff15e0f18561495399cb07b64342b500"]}, "environmentDetails": {"jobId": "job-ac95524e7128498b9082375f8e3d7665", "environmentId": "JOB:job-ac95524e7128498b9082375f8e3d7665:TestEnvironment", "schemaVersion": "jobtemplate-2023-09", "template": "*REDACTED*"}, "jobAttachmentDetails": {"jobId": "job-ac95524e7128498b9082375f8e3d7665", "attachments": {"manifests": [{"fileSystemLocationName": "Filesystem", "rootPath": "*REDACTED*", "rootPathFormat": "posix", "outputRelativeDirectories": "*REDACTED*", "inputManifestPath": "manifest_file", "inputManifestHash": "1234"}], "fileSystem": "COPIED"}}}]}, "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
             id="BatchGetJobEntityAfterCallTest",
         ),
         pytest.param(
@@ -194,10 +562,60 @@ def test_log_before_call(
                 "ResponseMetadata": {
                     "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
                     "HTTPStatusCode": 200,
-                }
+                },
             },
-            "{'log_type': 'boto_response', 'operation': 'deadline.DeleteWorker', 'status_code': 200, 'params': {}}",
+            '{"log_type": "boto_response", "operation": "deadline.DeleteWorker", "status_code": 200, "params": {}, "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
             id="DeleteWorkerAfterCallTest",
+        ),
+        # ====================
+        # Unknown API tests -- make sure that we redact the params, but still report the API
+        pytest.param(
+            "before-call.deadline.NotAnAPI",
+            {
+                "ResponseMetadata": {
+                    "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
+                    "HTTPStatusCode": 200,
+                },
+                "ResponseParam": "ResponseValue",
+            },
+            '{"log_type": "boto_response", "operation": "deadline.NotAnAPI", "status_code": 200, "params": "*REDACTED*", "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
+            id="NotAnAPIBeforeCallTest",
+        ),
+        # ====================
+        pytest.param(
+            "after-call.secretsmanager.GetSecretValue",
+            {
+                "ResponseMetadata": {
+                    "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
+                    "HTTPStatusCode": 200,
+                },
+                "ARN": "arn:aws:secretsmanager:us-west-2:000000000000:secret:Secret-qsrF9d",
+                "Name": "Secret",
+                "VersionId": "6fb9f17a-f9a9-4729-af0f-df67e976484c",
+                "SecretString": '{"username": "fakeuser", "password": "fakepassword"}',
+                "SecretBinary": b"abdc",
+                "VersionStages": ["AWSCURRENT"],
+                "CreatedDate": datetime.datetime(
+                    2021, 4, 27, 14, 8, 44, 337000, tzinfo=datetime.timezone.utc
+                ),
+            },
+            '{"log_type": "boto_response", "operation": "secretsmanager.GetSecretValue", "status_code": 200, "params": {"ARN": "arn:aws:secretsmanager:us-west-2:000000000000:secret:Secret-qsrF9d", "Name": "Secret", "VersionId": "6fb9f17a-f9a9-4729-af0f-df67e976484c", "SecretString": "*REDACTED*", "SecretBinary": "*REDACTED*", "VersionStages": "*REDACTED*", "CreatedDate": "2021-04-27 14:08:44.337000+00:00"}, "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
+            id="GetSecretValueAfterCallTest",
+        ),
+        # ====================
+        # Test that the error is logged
+        pytest.param(
+            "after-call.deadline.CreateWorker",
+            {
+                "ResponseMetadata": {
+                    "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
+                    "HTTPStatusCode": 500,
+                },
+                "Error": {"Message": "This is a test", "Code": "InternalServerException"},
+                "reason": "CONFLICT_EXCEPTION",
+            },
+            '{"log_type": "boto_response", "operation": "deadline.CreateWorker", "status_code": 500, "params": {"reason": "CONFLICT_EXCEPTION"}, "error": {"Message": "This is a test", "Code": "InternalServerException"}, "request_id": "abc878ee-32b5-44d4-885f-29071648328c"}',
+            id="ErrorCase",
         ),
     ),
 )
@@ -207,3 +625,39 @@ def test_log_after_call(
     caplog.set_level(0)
     log_after_call(event_name, params)
     assert caplog.messages == [expected_result]
+
+
+@pytest.mark.parametrize(
+    argnames=("api_name", "params"),
+    argvalues=(
+        pytest.param(
+            "cloudwatch-logs.PutLogEvent",
+            {
+                "ResponseMetadata": {
+                    "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
+                    "HTTPStatusCode": 200,
+                },
+                "SomeResponseParam": "ResponseValue",
+            },
+            id="IgnoreCloudWatchAfterCall",
+        ),
+        pytest.param(
+            "s3.GetObject",
+            {
+                "ResponseMetadata": {
+                    "RequestId": "abc878ee-32b5-44d4-885f-29071648328c",
+                    "HTTPStatusCode": 200,
+                },
+                "SomeResponseParam": "ResponseValue",
+            },
+            id="IgnoreS3AfterCall",
+        ),
+    ),
+)
+def test_log_after_ignore_list(
+    api_name: str, params: Dict[str, Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(0)
+    log_before_call("after-call." + api_name, params)
+
+    assert all(api_name not in msg for msg in caplog.messages)

--- a/test/unit/windows/test_win_credentials_resolver.py
+++ b/test/unit/windows/test_win_credentials_resolver.py
@@ -175,6 +175,7 @@ if sys.platform == "win32":
                 "ResourceNotFoundException",
                 "InvalidRequestException",
                 "DecryptionFailure",
+                "AccessDeniedException",
             ],
         )
         @patch(

--- a/testing_containers/posix_local_multiuser/Dockerfile
+++ b/testing_containers/posix_local_multiuser/Dockerfile
@@ -29,6 +29,9 @@ RUN chmod 777 /code /aws && \
     chown ${AGENT_USER}:${AGENT_USER} /var/log/amazon/deadline && \
     chmod 700 /var/log/amazon/deadline && \
     mkdir -p /var/lib/deadline && \
+    mkdir -p /var/tmp/openjd && \
+    chown ${AGENT_USER}:${SHARED_GROUP} /var/tmp/openjd && \
+    chmod 755 /var/tmp/openjd && \
     # Shared directory for sharing credentials process with the job user.
     mkdir -p /var/lib/deadline/queues && \
     chown ${AGENT_USER}:${SHARED_GROUP} /var/lib/deadline /var/lib/deadline/queues && \

--- a/testing_containers/posix_local_multiuser_jobRunAsUser/Dockerfile
+++ b/testing_containers/posix_local_multiuser_jobRunAsUser/Dockerfile
@@ -29,6 +29,9 @@ RUN chmod 777 /code /aws && \
     chown ${AGENT_USER}:${AGENT_USER} /var/log/amazon/deadline && \
     chmod 700 /var/log/amazon/deadline && \
     mkdir -p /var/lib/deadline && \
+    mkdir -p /var/tmp/openjd && \
+    chown ${AGENT_USER}:${SHARED_GROUP} /var/tmp/openjd && \
+    chmod 755 /var/tmp/openjd && \
     # Shared directory for sharing credentials process with the job user.
     mkdir -p /var/lib/deadline/queues && \
     chown ${AGENT_USER}:${SHARED_GROUP} /var/lib/deadline /var/lib/deadline/queues && \


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
(This change requires the upcoming deadline-cloud release 0.43)
 
We're currently running deadline_vfs as the privileged "deadline-worker" user rather than "job-user"

This fix depends on the larger fix in deadline-cloud - https://github.com/casillas2/deadline-cloud/pull/223

This fix handles cleanup as the os_user.

### What was the solution? (How)

Pass os_user into cleanup_session

### What is the impact of this change?

Combined with the other linked change to deadline-cloud, deadline_vfs should launch and be shut down as job-user

### How was this change tested?

Tests updated which now pass.  Manual testing on CMF worker.

### Was this change documented?

No

### Is this a breaking change?

Requires the dependent library update.