### PR TITLE
fix: handle IMDS disruptions gracefully

### DIFF
--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -239,9 +239,7 @@ class Worker:
                         logger.debug("monitor ec2 shutdown future complete")
                         worker_shutdown: WorkerShutdown | None = future.result()
                         # We only stop the other threads if we detected an imminent EC2 shutdown.
-                        # The monitoring thread returns None if:
-                        #     1. The Worker is not on EC2, or IMDS is not turned on
-                        #     2. The monitor thread was stopped by the OS signal handler
+                        # The monitoring thread returns None if the monitor thread was stopped by the OS signal handler
                         if worker_shutdown:
                             self._stop.set()
                             self._scheduler.shutdown(
@@ -322,7 +320,7 @@ class Worker:
                     "IMDS unavailable - unable to monitor for spot interruption or ASG life-cycle "
                     "changes"
                 )
-                return None
+                continue
 
             # Check for spot interruption or shutdown
             if (


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Worker agent does not gracefully handle IMDS disruptions

### What was the solution? (How)
Gracefully continue looping in case of IMDS disruptions to try and fetch the IMDS V2 token until ``_stop`` is called from outside

### What is the impact of this change?
Worker Agent does not crash in case of a temporary IMDS disruption

### How was this change tested?
Modified existing Unit tests to check that only the external ``stop`` wait causes the ``Worker._monitor_ec2_shutdown`` to return None in case of an IMDS disruption.

### Was this change documented?
N/A

### Is this a breaking change?
No