### PR TITLE
fix: return sessionactions if Session is stopped

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -13,7 +13,7 @@ integ-test = "pytest test/integ {args}"
 integ-windows = "pytest --no-cov test/integ/installer {args:}"
 typing = "mypy {args:src test}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [

--- a/test/unit/aws_credentials/test_credentials_refresher.py
+++ b/test/unit/aws_credentials/test_credentials_refresher.py
@@ -205,9 +205,9 @@ class TestAwsCredentialRefresherInit:
             # THEN
             callback.assert_called_once()
             assert len(callback.call_args.args) == 1
-            callback_arg = callback.call_args.args[0]
-            assert isinstance(callback_arg, TimeoutError)
-            assert callback_arg.args[0] == credentials.expiry
+            callback_first_call_arg = callback.call_args.args[0]
+            assert isinstance(callback_first_call_arg, TimeoutError)
+            assert callback_first_call_arg.args[0] == credentials.expiry
 
     @pytest.mark.parametrize(
         "exception, invokes_callback",

--- a/testing_containers/posix_ldap_multiuser/setup.sh
+++ b/testing_containers/posix_ldap_multiuser/setup.sh
@@ -8,6 +8,9 @@ mkdir -p /var/log/amazon/deadline
 chown ${AGENT_USER}:${AGENT_USER} /var/log/amazon/deadline
 chmod 700 /var/log/amazon/deadline
 mkdir -p /var/lib/deadline
+mkdir -p /sessions
+chown ${AGENT_USER}:${SHARED_GROUP} /sessions
+chmod 755 /sessions
 # Shared directory for sharing credentials process with the job user.
 mkdir -p /var/lib/deadline/queues
 chown ${AGENT_USER}:${SHARED_GROUP} /var/lib/deadline /var/lib/deadline/queues

--- a/testing_containers/posix_local_multiuser/Dockerfile
+++ b/testing_containers/posix_local_multiuser/Dockerfile
@@ -29,9 +29,9 @@ RUN chmod 777 /code /aws && \
     chown ${AGENT_USER}:${AGENT_USER} /var/log/amazon/deadline && \
     chmod 700 /var/log/amazon/deadline && \
     mkdir -p /var/lib/deadline && \
-    mkdir -p /var/tmp/openjd && \
-    chown ${AGENT_USER}:${SHARED_GROUP} /var/tmp/openjd && \
-    chmod 755 /var/tmp/openjd && \
+    mkdir -p /sessions && \
+    chown ${AGENT_USER}:${SHARED_GROUP} /sessions && \
+    chmod 755 /sessions && \
     # Shared directory for sharing credentials process with the job user.
     mkdir -p /var/lib/deadline/queues && \
     chown ${AGENT_USER}:${SHARED_GROUP} /var/lib/deadline /var/lib/deadline/queues && \

--- a/testing_containers/posix_local_multiuser_jobRunAsUser/Dockerfile
+++ b/testing_containers/posix_local_multiuser_jobRunAsUser/Dockerfile
@@ -29,9 +29,9 @@ RUN chmod 777 /code /aws && \
     chown ${AGENT_USER}:${AGENT_USER} /var/log/amazon/deadline && \
     chmod 700 /var/log/amazon/deadline && \
     mkdir -p /var/lib/deadline && \
-    mkdir -p /var/tmp/openjd && \
-    chown ${AGENT_USER}:${SHARED_GROUP} /var/tmp/openjd && \
-    chmod 755 /var/tmp/openjd && \
+    mkdir -p /sessions && \
+    chown ${AGENT_USER}:${SHARED_GROUP} /sessions && \
+    chmod 755 /sessions && \
     # Shared directory for sharing credentials process with the job user.
     mkdir -p /var/lib/deadline/queues && \
     chown ${AGENT_USER}:${SHARED_GROUP} /var/lib/deadline /var/lib/deadline/queues && \


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

It's possible during error or drain flows for the Worker Agent's "Session" main thread to have exited. Generally, the Agent will return all pipelined sessionactions when this happens. But, it's possible that the response to returning those sessionactions contains additional session actions to pipeline, since the service doesn't know that the agent hit a problem. If that happens, then the Agent currently queues up those new sessionactions in the Session, but that Session's main thread is dead so it'll never run them. The result is, effectively, a deadlock; the service is waiting for the Agent to return terminal statuses for each of the new sessionactions, but the Agent isn't going to ever run those sessionactions.

### What was the solution? (How)

This is a bit of a hack, but it gets around the immediate issue. Now, when the Agent is given new sessionactions for a Session it'll check if the Session's main thread has exited (by checking that the future that's running it has exited). If the future has exited, then the Agent will no longer queue up those sessionactions, but will instead immediately return them to the service. The first action will be marked FAILED so that the service knows that this Session has terminated.

### What is the impact of this change?

A source of overspend risk for customers should now be closed off.

### How was this change tested?

I added a unit test for the logic of the new function that was added. I also recreated the scenario that led to the deadlock and tested against a live service.

The live service test consisted of modifying the `AwsCredentialsRefresher` to throw an exception rather than refresh credentials -- this would kick off the chain of events that leads to the Agent's Session's main thread being stopped and the service returning the ENV_EXIT actions for the Session.

#### Test 1

This is exactly the situation that we saw that prompted this fix.

Modified the credentials refresher [here](https://github.com/casillas2/deadline-cloud-worker-agent/blob/06ade24dc446b16661284c7dee4f632e44a4882d/src/deadline_worker_agent/aws_credentials/credentials_refresher.py#L158) to be:

```
            # Chaos monkey! DO NOT MERGE THIS
            from .queue_boto3_session import QueueBoto3Session
            from ..aws.deadline import update_worker
            from ..api_models import WorkerStatus

            if isinstance(self._session, QueueBoto3Session):
                try:
                    update_worker(
                        deadline_client=self._session._deadline_client,
                        farm_id=self._session._farm_id,
                        fleet_id=self._session._fleet_id,
                        worker_id=self._session._worker_id,
                        status=WorkerStatus.STOPPING
                    )
                except:
                    pass
                raise DeadlineRequestConditionallyRecoverableError("No credentials for you!")
            # ---
            self._session.refresh_credentials()
```

Resulting log:

```
2024-03-23 06:09:37,408 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-621ad0b129fa4c1b93635ce27c9937d7-50': {'startedAt': datetime.datetime(2024, 3, 23, 6, 8, 51, 732345, tzinfo=datetime.timezone.utc), 'updatedAt': datetime.datetime(2024, 3, 23, 6, 9, 36, 845871, tzinfo=datetime.timezone.utc), 'progressPercent': 80.35714285714289}}
2024-03-23 06:09:37,408 INFO [deadline_worker_agent.session_events] {"log_type": "boto_request", "operation": "deadline.UpdateWorkerSchedule", "params": {"updatedSessionActions": {"sessionaction-621ad0b129fa4c1b93635ce27c9937d7-50": {"startedAt": "2024-03-23T06:08:51.732345Z", "updatedAt": "2024-03-23T06:09:36.845871Z", "progressPercent": 80.35714285714289}}}, "request_url": "*REMOVED*/workers/worker-f5ba285eefc548dbbad88971544296dd/schedule"}
2024-03-23 06:09:37,564 INFO [deadline_worker_agent.session_events] {"log_type": "boto_response", "operation": "deadline.UpdateWorker", "status_code": 200, "params": {}, "request_id": "c3624d10-71e0-4a50-8ca5-7bca88a603ec"}
2024-03-23 06:09:37,565 INFO [deadline_worker_agent.aws.deadline] Worker worker-f5ba285eefc548dbbad88971544296dd successfully set to status WorkerStatus.STOPPING
2024-03-23 06:09:37,565 INFO [deadline_worker_agent.aws_credentials.credentials_refresher] Refresh of AWS Credentials for Queue queue-f9848b67822d49299296e3e47d8cc523 Credentials for Role arn:aws:iam::985054580297:role/BealineTestingQueueRole scheduled for 2024-03-23T06:10:37.565529+00:00
2024-03-23 06:09:37,566 INFO [deadline_worker_agent.sessions.session] [session-621ad0b129fa4c1b93635ce27c9937d7] [sessionaction-621ad0b129fa4c1b93635ce27c9937d7-50] (step[step-8d7409676cc34924928f060a9810ea37].run(Iteration='97')): Canceling action
2024-03-23 06:09:37,652 INFO [deadline_worker_agent.session_events] {"log_type": "boto_response", "operation": "deadline.UpdateWorkerSchedule", "status_code": 200, "params": {"assignedSessions": {"session-621ad0b129fa4c1b93635ce27c9937d7": {"queueId": "queue-f9848b67822d49299296e3e47d8cc523", "jobId": "job-fbd4875c8eea4674bf7482e6fe6ac640", "sessionActions": [{"sessionActionId": "sessionaction-621ad0b129fa4c1b93635ce27c9937d7-50", "definition": {"taskRun": {"taskId": "task-8d7409676cc34924928f060a9810ea37-96", "stepId": "step-8d7409676cc34924928f060a9810ea37", "parameters": "*REDACTED*"}}}], "logConfiguration": {"logDriver": "awslogs", "options": {"logGroupName": "/aws/deadline/farm-1b84ca8d938d47d99a00675ff4eedd41/queue-f9848b67822d49299296e3e47d8cc523", "logStreamName": "session-621ad0b129fa4c1b93635ce27c9937d7"}, "parameters": {}}}}, "cancelSessionActions": {}, "updateIntervalSeconds": 15}, "request_id": "d22a9b2a-7ea2-48e6-8901-74f558e868d0"}
2024-03-23 06:09:37,852 INFO [deadline_worker_agent.scheduler] Done synchronizing with service
2024-03-23 06:09:37,887 INFO [deadline_worker_agent.sessions.session] cancel running action successful
2024-03-23 06:09:38,196 INFO [deadline_worker_agent.sessions.session] exit environment STEP:step-8d7409676cc34924928f060a9810ea37:myenv2 successful
2024-03-23 06:09:38,504 INFO [deadline_worker_agent.sessions.session] exit environment STEP:step-8d7409676cc34924928f060a9810ea37:myenv successful
2024-03-23 06:09:38,812 INFO [deadline_worker_agent.sessions.session] exit environment JOB:job-fbd4875c8eea4674bf7482e6fe6ac640:TestEnvironment successful
2024-03-23 06:09:38,834 INFO [deadline_worker_agent.sessions.session] [session-621ad0b129fa4c1b93635ce27c9937d7]: Session complete
2024-03-23 06:09:38,834 INFO [deadline_worker_agent.scheduler] Synchronizing with service (sending UpdateWorkerSchedule)
2024-03-23 06:09:38,835 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-621ad0b129fa4c1b93635ce27c9937d7-50': {'startedAt': datetime.datetime(2024, 3, 23, 6, 8, 51, 732345, tzinfo=datetime.timezone.utc), 'completedStatus': 'INTERRUPTED', 'progressMessage': 'Fatal error attempting to refresh AWS Credentials for the Queue. Please see logs for details.', 'endedAt': datetime.datetime(2024, 3, 23, 6, 9, 37, 565899, tzinfo=datetime.timezone.utc)}}
2024-03-23 06:09:38,836 INFO [deadline_worker_agent.session_events] {"log_type": "boto_request", "operation": "deadline.UpdateWorkerSchedule", "params": {"updatedSessionActions": {"sessionaction-621ad0b129fa4c1b93635ce27c9937d7-50": {"startedAt": "2024-03-23T06:08:51.732345Z", "completedStatus": "INTERRUPTED", "progressMessage": "*REDACTED*", "endedAt": "2024-03-23T06:09:37.565899Z"}}}, "request_url": "*REMOVED*/workers/worker-f5ba285eefc548dbbad88971544296dd/schedule"}
2024-03-23 06:09:39,103 INFO [deadline_worker_agent.session_events] {"log_type": "boto_response", "operation": "deadline.UpdateWorkerSchedule", "status_code": 200, "params": {"assignedSessions": {"session-621ad0b129fa4c1b93635ce27c9937d7": {"queueId": "queue-f9848b67822d49299296e3e47d8cc523", "jobId": "job-fbd4875c8eea4674bf7482e6fe6ac640", "sessionActions": [{"sessionActionId": "sessionaction-621ad0b129fa4c1b93635ce27c9937d7-51", "definition": {"envExit": {"environmentId": "STEP:step-8d7409676cc34924928f060a9810ea37:myenv2"}}}, {"sessionActionId": "sessionaction-621ad0b129fa4c1b93635ce27c9937d7-52", "definition": {"envExit": {"environmentId": "STEP:step-8d7409676cc34924928f060a9810ea37:myenv"}}}, {"sessionActionId": "sessionaction-621ad0b129fa4c1b93635ce27c9937d7-53", "definition": {"envExit": {"environmentId": "JOB:job-fbd4875c8eea4674bf7482e6fe6ac640:TestEnvironment"}}}], "logConfiguration": {"logDriver": "awslogs", "options": {"logGroupName": "/aws/deadline/farm-1b84ca8d938d47d99a00675ff4eedd41/queue-f9848b67822d49299296e3e47d8cc523", "logStreamName": "session-621ad0b129fa4c1b93635ce27c9937d7"}, "parameters": {}}}}, "cancelSessionActions": {}, "updateIntervalSeconds": 15}, "request_id": "09700c51-75ce-455c-9525-c7918ad5107c"}
2024-03-23 06:09:39,103 INFO [deadline_worker_agent.scheduler] Done synchronizing with service
2024-03-23 06:09:39,103 INFO [deadline_worker_agent.scheduler] Synchronizing with service (sending UpdateWorkerSchedule)
2024-03-23 06:09:39,104 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-621ad0b129fa4c1b93635ce27c9937d7-51': {'startedAt': datetime.datetime(2024, 3, 23, 6, 9, 39, 103729, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'progressMessage': 'Session has previously been stopped.', 'endedAt': datetime.datetime(2024, 3, 23, 6, 9, 39, 103729, tzinfo=datetime.timezone.utc)}, 'sessionaction-621ad0b129fa4c1b93635ce27c9937d7-52': {'startedAt': datetime.datetime(2024, 3, 23, 6, 9, 39, 103756, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'progressMessage': 'Session has previously been stopped.', 'endedAt': datetime.datetime(2024, 3, 23, 6, 9, 39, 103756, tzinfo=datetime.timezone.utc)}, 'sessionaction-621ad0b129fa4c1b93635ce27c9937d7-53': {'startedAt': datetime.datetime(2024, 3, 23, 6, 9, 39, 103762, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'progressMessage': 'Session has previously been stopped.', 'endedAt': datetime.datetime(2024, 3, 23, 6, 9, 39, 103762, tzinfo=datetime.timezone.utc)}}
2024-03-23 06:09:39,104 INFO [deadline_worker_agent.session_events] {"log_type": "boto_request", "operation": "deadline.UpdateWorkerSchedule", "params": {"updatedSessionActions": {"sessionaction-621ad0b129fa4c1b93635ce27c9937d7-51": {"startedAt": "2024-03-23T06:09:39.103729Z", "completedStatus": "FAILED", "progressMessage": "*REDACTED*", "endedAt": "2024-03-23T06:09:39.103729Z"}, "sessionaction-621ad0b129fa4c1b93635ce27c9937d7-52": {"startedAt": "2024-03-23T06:09:39.103756Z", "completedStatus": "FAILED", "progressMessage": "*REDACTED*", "endedAt": "2024-03-23T06:09:39.103756Z"}, "sessionaction-621ad0b129fa4c1b93635ce27c9937d7-53": {"startedAt": "2024-03-23T06:09:39.103762Z", "completedStatus": "FAILED", "progressMessage": "*REDACTED*", "endedAt": "2024-03-23T06:09:39.103762Z"}}}, "request_url": "*REMOVED*/workers/worker-f5ba285eefc548dbbad88971544296dd/schedule"}
2024-03-23 06:09:39,307 INFO [deadline_worker_agent.session_events] {"log_type": "boto_response", "operation": "deadline.UpdateWorkerSchedule", "status_code": 200, "params": {"assignedSessions": {}, "cancelSessionActions": {}, "desiredWorkerStatus": "STOPPED", "updateIntervalSeconds": 15}, "request_id": "7faabd87-dbb0-492d-9999-e61cb848cfff"}
2024-03-23 06:09:39,307 INFO [deadline_worker_agent.scheduler] Cleaning up remaining session user processes for 'jobuser'
2024-03-23 06:09:39,318 INFO [deadline_worker_agent.scheduler] No processes stopped because none were found running as 'jobuser'
2024-03-23 06:09:39,319 WARNING [deadline_worker_agent.scheduler] Service requested shutdown initiated
```

Importantly, what we see here is that:
1. The Agent's Session is terminated ("[session-621ad0b129fa4c1b93635ce27c9937d7]: Session complete"); then
2. The service responds with two new ENV_EXITs (see "deadline.UpdateWorkerSchedule" boto_response at 2024-03-23 06:09:39,103)
3. Both new ENV_EXITs are returned as FAILED (see "deadline.UpdateWorkerSchedule" boto_request at 2024-03-23 06:09:39,104)

Previously, instead of (3) we would see repeated UpdateWorkerSchedule requests with an empty payload followed by a response that contains the two ENV_EXITs. This would continue indefinitely.

#### Test 2

Modified the credentials refresher [here](https://github.com/casillas2/deadline-cloud-worker-agent/blob/06ade24dc446b16661284c7dee4f632e44a4882d/src/deadline_worker_agent/aws_credentials/credentials_refresher.py#L158) to be:

```
            # Chaos monkey! DO NOT MERGE THIS
            from .queue_boto3_session import QueueBoto3Session

            if isinstance(self._session, QueueBoto3Session):
                raise DeadlineRequestUnrecoverableError("No credentials for you!")
            # ---
            self._session.refresh_credentials()
```

Resulting log:

```
2024-03-23 15:25:03,764 INFO [deadline_worker_agent.scheduler] Done synchronizing with service
2024-03-23 15:25:12,000 INFO [deadline_worker_agent.sessions.session] [session-6dfc049b02be4cb089c55f285116f72e] [sessionaction-6dfc049b02be4cb089c55f285116f72e-50] (step[step-8d7409676cc34924928f060a9810ea37].run(Iteration='144')): Canceling action
2024-03-23 15:25:12,321 INFO [deadline_worker_agent.sessions.session] cancel running action successful
2024-03-23 15:25:12,630 INFO [deadline_worker_agent.sessions.session] exit environment STEP:step-8d7409676cc34924928f060a9810ea37:myenv2 successful
2024-03-23 15:25:12,938 INFO [deadline_worker_agent.sessions.session] exit environment STEP:step-8d7409676cc34924928f060a9810ea37:myenv successful
2024-03-23 15:25:13,246 INFO [deadline_worker_agent.sessions.session] exit environment JOB:job-fbd4875c8eea4674bf7482e6fe6ac640:TestEnvironment successful
2024-03-23 15:25:13,267 INFO [deadline_worker_agent.sessions.session] [session-6dfc049b02be4cb089c55f285116f72e]: Session complete
2024-03-23 15:25:13,267 INFO [deadline_worker_agent.scheduler] Synchronizing with service (sending UpdateWorkerSchedule)
2024-03-23 15:25:13,267 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-6dfc049b02be4cb089c55f285116f72e-50': {'startedAt': datetime.datetime(2024, 3, 23, 15, 24, 33, 50863, tzinfo=datetime.timezone.utc), 'completedStatus': 'INTERRUPTED', 'progressMessage': 'Fatal error attempting to refresh AWS Credentials for the Queue. Please see logs for details.', 'endedAt': datetime.datetime(2024, 3, 23, 15, 25, 12, 833, tzinfo=datetime.timezone.utc)}}
2024-03-23 15:25:13,269 INFO [deadline_worker_agent.session_events] {"log_type": "boto_request", "operation": "deadline.UpdateWorkerSchedule", "params": {"updatedSessionActions": {"sessionaction-6dfc049b02be4cb089c55f285116f72e-50": {"startedAt": "2024-03-23T15:24:33.050863Z", "completedStatus": "INTERRUPTED", "progressMessage": "*REDACTED*", "endedAt": "2024-03-23T15:25:12.000833Z"}}}, "request_url": "*REMOVED*/workers/worker-c44fb66940ac41f1b59909e983c1ecaa/schedule"}
2024-03-23 15:25:13,543 INFO [deadline_worker_agent.session_events] {"log_type": "boto_response", "operation": "deadline.UpdateWorkerSchedule", "status_code": 200, "params": {"assignedSessions": {"session-6dfc049b02be4cb089c55f285116f72e": {"queueId": "queue-f9848b67822d49299296e3e47d8cc523", "jobId": "job-fbd4875c8eea4674bf7482e6fe6ac640", "sessionActions": [{"sessionActionId": "sessionaction-6dfc049b02be4cb089c55f285116f72e-51", "definition": {"envExit": {"environmentId": "STEP:step-8d7409676cc34924928f060a9810ea37:myenv2"}}}, {"sessionActionId": "sessionaction-6dfc049b02be4cb089c55f285116f72e-52", "definition": {"envExit": {"environmentId": "STEP:step-8d7409676cc34924928f060a9810ea37:myenv"}}}, {"sessionActionId": "sessionaction-6dfc049b02be4cb089c55f285116f72e-53", "definition": {"envExit": {"environmentId": "JOB:job-fbd4875c8eea4674bf7482e6fe6ac640:TestEnvironment"}}}], "logConfiguration": {"logDriver": "awslogs", "options": {"logGroupName": "/aws/deadline/farm-1b84ca8d938d47d99a00675ff4eedd41/queue-f9848b67822d49299296e3e47d8cc523", "logStreamName": "session-6dfc049b02be4cb089c55f285116f72e"}, "parameters": {}}}}, "cancelSessionActions": {}, "updateIntervalSeconds": 15}, "request_id": "808533ff-5d04-4b65-a76d-143ddb7c4b54"}
2024-03-23 15:25:13,543 INFO [deadline_worker_agent.scheduler] Done synchronizing with service
2024-03-23 15:25:13,543 INFO [deadline_worker_agent.scheduler] Synchronizing with service (sending UpdateWorkerSchedule)
2024-03-23 15:25:13,544 INFO [deadline_worker_agent.scheduler] Updating actions: {'sessionaction-6dfc049b02be4cb089c55f285116f72e-51': {'startedAt': datetime.datetime(2024, 3, 23, 15, 25, 13, 543720, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'progressMessage': 'Session has previously been stopped.', 'endedAt': datetime.datetime(2024, 3, 23, 15, 25, 13, 543720, tzinfo=datetime.timezone.utc)}, 'sessionaction-6dfc049b02be4cb089c55f285116f72e-52': {'startedAt': datetime.datetime(2024, 3, 23, 15, 25, 13, 543748, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'progressMessage': 'Session has previously been stopped.', 'endedAt': datetime.datetime(2024, 3, 23, 15, 25, 13, 543748, tzinfo=datetime.timezone.utc)}, 'sessionaction-6dfc049b02be4cb089c55f285116f72e-53': {'startedAt': datetime.datetime(2024, 3, 23, 15, 25, 13, 543755, tzinfo=datetime.timezone.utc), 'completedStatus': 'FAILED', 'progressMessage': 'Session has previously been stopped.', 'endedAt': datetime.datetime(2024, 3, 23, 15, 25, 13, 543755, tzinfo=datetime.timezone.utc)}}
2024-03-23 15:25:13,544 INFO [deadline_worker_agent.session_events] {"log_type": "boto_request", "operation": "deadline.UpdateWorkerSchedule", "params": {"updatedSessionActions": {"sessionaction-6dfc049b02be4cb089c55f285116f72e-51": {"startedAt": "2024-03-23T15:25:13.543720Z", "completedStatus": "FAILED", "progressMessage": "*REDACTED*", "endedAt": "2024-03-23T15:25:13.543720Z"}, "sessionaction-6dfc049b02be4cb089c55f285116f72e-52": {"startedAt": "2024-03-23T15:25:13.543748Z", "completedStatus": "FAILED", "progressMessage": "*REDACTED*", "endedAt": "2024-03-23T15:25:13.543748Z"}, "sessionaction-6dfc049b02be4cb089c55f285116f72e-53": {"startedAt": "2024-03-23T15:25:13.543755Z", "completedStatus": "FAILED", "progressMessage": "*REDACTED*", "endedAt": "2024-03-23T15:25:13.543755Z"}}}, "request_url": "*REMOVED*/workers/worker-c44fb66940ac41f1b59909e983c1ecaa/schedule"}
2024-03-23 15:25:13,981 INFO [deadline_worker_agent.session_events] {"log_type": "boto_response", "operation": "deadline.UpdateWorkerSchedule", "status_code": 200, "params": {"assignedSessions": {"session-f91dc26f521541009f725c893dc0d9d8": {"queueId": "queue-f9848b67822d49299296e3e47d8cc523", "jobId": "job-fbd4875c8eea4674bf7482e6fe6ac640", "sessionActions": [{"sessionActionId": "sessionaction-f91dc26f521541009f725c893dc0d9d8-0", "definition": {"envEnter": {"environmentId": "JOB:job-fbd4875c8eea4674bf7482e6fe6ac640:TestEnvironment"}}}, {"sessionActionId": "sessionaction-f91dc26f521541009f725c893dc0d9d8-1", "definition": {"envEnter": {"environmentId": "STEP:step-8d7409676cc34924928f060a9810ea37:myenv"}}}, {"sessionActionId": "sessionaction-f91dc26f521541009f725c893dc0d9d8-2", "definition": {"envEnter": {"environmentId": "STEP:step-8d7409676cc34924928f060a9810ea37:myenv2"}}}, {"sessionActionId": "sessionaction-f91dc26f521541009f725c893dc0d9d8-3", "definition": {"taskRun": {"taskId": "task-8d7409676cc34924928f060a9810ea37-143", "stepId": "step-8d7409676cc34924928f060a9810ea37", "parameters": "*REDACTED*"}}}], "logConfiguration": {"logDriver": "awslogs", "options": {"logGroupName": "/aws/deadline/farm-1b84ca8d938d47d99a00675ff4eedd41/queue-f9848b67822d49299296e3e47d8cc523", "logStreamName": "session-f91dc26f521541009f725c893dc0d9d8"}, "parameters": {}}}}, "cancelSessionActions": {}, "updateIntervalSeconds": 15}, "request_id": "2ffeb4af-063e-49c4-8143-206b44c04594"}
2024-03-23 15:25:13,982 INFO [deadline_worker_agent.scheduler] Cleaning up remaining session user processes for 'jobuser'
2024-03-23 15:25:13,992 INFO [deadline_worker_agent.scheduler] No processes stopped because none were found running as 'jobuser'
2024-03-23 15:25:13,994 INFO [deadline_worker_agent.session_events] {"log_type": "boto_request", "operation": "deadline.BatchGetJobEntity", "params": {"identifiers": [{"jobDetails": {"jobId": "job-fbd4875c8eea4674bf7482e6fe6ac640"}}]}, "request_url": "*REMOVED*/workers/worker-c44fb66940ac41f1b59909e983c1ecaa/batchGetJobEntity"}
2024-03-23 15:25:18,826 INFO [deadline_worker_agent.session_events] {"log_type": "boto_response", "operation": "deadline.BatchGetJobEntity", "status_code": 200, "params": {"entities": [{"jobDetails": {"jobId": "job-fbd4875c8eea4674bf7482e6fe6ac640", "jobAttachmentSettings": {"s3BucketName": "neilsd-job-attach-assets-testing", "rootPrefix": "assets/"}, "jobRunAsUser": {"posix": {"user": "jobuser", "group": "jobuser"}, "runAs": "QUEUE_CONFIGURED_USER"}, "logGroupName": "/aws/deadline/farm-1b84ca8d938d47d99a00675ff4eedd41/queue-f9848b67822d49299296e3e47d8cc523", "queueRoleArn": "arn:aws:iam::985054580297:role/BealineTestingQueueRole", "parameters": "*REDACTED*", "schemaVersion": "jobtemplate-2023-09"}}], "errors": []}, "request_id": "78a4bfbc-040e-4820-b190-9213b2b49af0"}
2024-03-23 15:25:18,826 INFO [deadline_worker_agent.sessions.job_entities.job_entities] Fetched jobDetails(job-fbd4875c8eea4674bf7482e6fe6ac640)
2024-03-23 15:25:18,826 INFO [deadline_worker_agent.scheduler.session_queue] Enqueued new action: {'sessionActionId': 'sessionaction-f91dc26f521541009f725c893dc0d9d8-0', 'actionType': 'ENV_ENTER', 'environmentId': 'JOB:job-fbd4875c8eea4674bf7482e6fe6ac640:TestEnvironment'}
2024-03-23 15:25:18,827 INFO [deadline_worker_agent.scheduler.session_queue] Enqueued new action: {'sessionActionId': 'sessionaction-f91dc26f521541009f725c893dc0d9d8-1', 'actionType': 'ENV_ENTER', 'environmentId': 'STEP:step-8d7409676cc34924928f060a9810ea37:myenv'}
2024-03-23 15:25:18,827 INFO [deadline_worker_agent.scheduler.session_queue] Enqueued new action: {'sessionActionId': 'sessionaction-f91dc26f521541009f725c893dc0d9d8-2', 'actionType': 'ENV_ENTER', 'environmentId': 'STEP:step-8d7409676cc34924928f060a9810ea37:myenv2'}
2024-03-23 15:25:18,827 INFO [deadline_worker_agent.scheduler.session_queue] Enqueued new action: {'sessionActionId': 'sessionaction-f91dc26f521541009f725c893dc0d9d8-3', 'actionType': 'TASK_RUN', 'taskId': 'task-8d7409676cc34924928f060a9810ea37-143', 'stepId': 'step-8d7409676cc34924928f060a9810ea37', 'parameters': {'Iteration': {'int': '144'}}}
2024-03-23 15:25:18,972 INFO [deadline_worker_agent.aws_credentials.queue_boto3_session] Installing Credential Process for Queue queue-f9848b67822d49299296e3e47d8cc523 as profile deadline-queue-f9848b67822d49299296e3e47d8cc523.
2024-03-23 15:25:18,973 INFO [deadline_worker_agent.aws_credentials.aws_configs] Writing updated /home/jobuser/.aws/config to disk.
2024-03-23 15:25:18,973 INFO [deadline_worker_agent.aws_credentials.aws_configs] Writing updated /home/jobuser/.aws/credentials to disk.
2024-03-23 15:25:18,973 INFO [deadline_worker_agent.aws_credentials.queue_boto3_session] Requesting AWS Credentials for Queue queue-f9848b67822d49299296e3e47d8cc523 on behalf of Worker worker-c44fb66940ac41f1b59909e983c1ecaa via AssumeQueueRoleForWorker
2024-03-23 15:25:18,974 INFO [deadline_worker_agent.session_events] {"log_type": "boto_request", "operation": "deadline.AssumeQueueRoleForWorker", "params": {}, "request_url": "*REMOVED*/workers/worker-c44fb66940ac41f1b59909e983c1ecaa/queue-roles?queueId=queue-f9848b67822d49299296e3e47d8cc523"}
2024-03-23 15:25:23,226 INFO [deadline_worker_agent.session_events] {"log_type": "boto_response", "operation": "deadline.AssumeQueueRoleForWorker", "status_code": 200, "params": {"credentials": {"accessKeyId": "ASIA6KWOUBZEVCC5R2FC", "secretAccessKey": "*REDACTED*", "sessionToken": "*REDACTED*", "expiration": "2024-03-23 16:25:23+00:00"}}, "request_id": "39584d17-31d6-4760-b163-2a766ef8997b"}
2024-03-23 15:25:23,226 INFO [deadline_worker_agent.aws_credentials.queue_boto3_session] New temporary Queue AWS Credentials obtained for Queue queue-f9848b67822d49299296e3e47d8cc523. They expire at 2024-03-23 16:25:23+00:00.
2024-03-23 15:25:23,227 INFO [deadline_worker_agent.scheduler] [session-f91dc26f521541009f725c893dc0d9d8] AWS Credentials are available for Queue queue-f9848b67822d49299296e3e47d8cc523 with IAM Role arn:aws:iam::985054580297:role/BealineTestingQueueRole.
2024-03-23 15:25:23,376 INFO [deadline_worker_agent.scheduler] Done synchronizing with service
2024-03-23 15:25:23,380 INFO [deadline_worker_agent.sessions.log_config] [session-f91dc26f521541009f725c893dc0d9d8] logs streamed to CloudWatch target: /aws/deadline/farm-1b84ca8d938d47d99a00675ff4eedd41/queue-f9848b67822d49299296e3e47d8cc523/session-f91dc26f521541009f725c893dc0d9d8
2024-03-23 15:25:23,381 INFO [deadline_worker_agent.sessions.log_config] [session-f91dc26f521541009f725c893dc0d9d8] local logs target: /var/log/amazon/deadline/queue-f9848b67822d49299296e3e47d8cc523/session-f91dc26f521541009f725c893dc0d9d8.log
2024-03-23 15:25:23,381 INFO [deadline_worker_agent.aws_credentials.credentials_refresher] Refresh of AWS Credentials for Queue queue-f9848b67822d49299296e3e47d8cc523 Credentials for Role arn:aws:iam::985054580297:role/BealineTestingQueueRole scheduled for 2024-03-23T16:10:23+00:00
2024-03-23 15:25:23,381 INFO [deadline_worker_agent.sessions.session] Warming Job Entity Cache
```

Importantly here, we see:
1. The Agent's Session was terminated -- "[session-6dfc049b02be4cb089c55f285116f72e]: Session complete" at 2024-03-23 15:25:13,267
2. The Agent got a new/fresh Session -- "Fetched jobDetails(job-fbd4875c8eea4674bf7482e6fe6ac640)" at 2024-03-23 15:25:18,826 
3. The Agent recreated the Queue credentials object -- "Installing Credential Process for Queue..." at 2024-03-23 15:25:18,972

### Was this change documented?

N/A

### Is this a breaking change?

No, it is not.
