### PR TITLE
fix: handle errors when detecting GPU capabilities

### DIFF
--- a/src/deadline_worker_agent/startup/capabilities.py
+++ b/src/deadline_worker_agent/startup/capabilities.py
@@ -84,6 +84,16 @@ def _get_gpu_count(*, verbose: bool = True) -> int:
         if verbose:
             _logger.warning("Could not detect GPU count, error running nvidia-smi")
         return 0
+    except PermissionError:
+        if verbose:
+            _logger.warning(
+                "Could not detect GPU count, permission denied trying to run nvidia-smi"
+            )
+        return 0
+    except Exception:
+        if verbose:
+            _logger.warning("Could not detect GPU count, unexpected error running nvidia-smi")
+        return 0
     else:
         if verbose:
             _logger.info("Number of GPUs: %s", output.decode().strip())
@@ -110,6 +120,16 @@ def _get_gpu_memory(*, verbose: bool = True) -> int:
     except subprocess.CalledProcessError:
         if verbose:
             _logger.warning("Could not detect GPU memory, error running nvidia-smi")
+        return 0
+    except PermissionError:
+        if verbose:
+            _logger.warning(
+                "Could not detect GPU memory, permission denied trying to run nvidia-smi"
+            )
+        return 0
+    except Exception:
+        if verbose:
+            _logger.warning("Could not detect GPU memory, unexpected error running nvidia-smi")
         return 0
     else:
         if verbose:

--- a/test/unit/startup/test_capabilities.py
+++ b/test/unit/startup/test_capabilities.py
@@ -252,6 +252,8 @@ class TestGetGPUCount:
         (
             pytest.param(FileNotFoundError("nvidia-smi not found"), 0, id="FileNotFoundError"),
             pytest.param(subprocess.CalledProcessError(1, "command"), 0, id="CalledProcessError"),
+            pytest.param(PermissionError("Permission denied"), 0, id="PermissionError"),
+            pytest.param(Exception("something went wrong"), 0, id="OSError"),
         ),
     )
     @patch.object(capabilities_mod.subprocess, "check_output")
@@ -304,6 +306,8 @@ class TestGetGPUMemory:
         (
             pytest.param(FileNotFoundError("nvidia-smi not found"), 0, id="FileNotFoundError"),
             pytest.param(subprocess.CalledProcessError(1, "command"), 0, id="CalledProcessError"),
+            pytest.param(PermissionError("Permission denied"), 0, id="PermissionError"),
+            pytest.param(Exception("something went wrong"), 0, id="OSError"),
         ),
     )
     @patch.object(capabilities_mod.subprocess, "check_output")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The worker agent is crashing while detecting GPU capabilities due to an unhandled `OSError` (I specifically ran into `PermissionError` when testing on AL2023):
```
$ deadline-worker-agent
[    INFO] Worker Agent starting
[    INFO] Python Interpreter: /home/deadline-worker-agent/.venv/bin/python3
[    INFO] Python Version: 3.9.16 (main, Sep  8 2023, 00:00:00)  - [GCC 11.4.1 20230605 (Red Hat 11.4.1-2)]
[    INFO] Platform: linux
[    INFO] Agent Version: 0.23.0.post1.dev2
[    INFO] Installed at: /home/deadline-worker-agent/.venv/lib/python3.9/site-packages/deadline_worker_agent
[    INFO] Running as: deadline-worker-agent
[    INFO] Dependency versions installed:
[    INFO]      openjd.model: 0.4.1
[    INFO]      openjd.sessions: 0.7.0
[    INFO]      deadline.job_attachments: 0.42.0
[CRITICAL] [Errno 13] Permission denied: 'nvidia-smi'
Traceback (most recent call last):
  File "/home/deadline-worker-agent/.venv/lib64/python3.9/site-packages/deadline_worker_agent/startup/entrypoint.py", line 74, in entrypoint
    system_capabilities = detect_system_capabilities()
  File "/home/deadline-worker-agent/.venv/lib64/python3.9/site-packages/deadline_worker_agent/startup/capabilities.py", line 49, in detect_system_capabilities
    amounts[AmountCapabilityName("amount.worker.gpu")] = _get_gpu_count()
  File "/home/deadline-worker-agent/.venv/lib64/python3.9/site-packages/deadline_worker_agent/startup/capabilities.py", line 76, in _get_gpu_count
    output = subprocess.check_output(
  File "/usr/lib64/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib64/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
PermissionError: [Errno 13] Permission denied: 'nvidia-smi'
[    INFO] enabled.
[    INFO] Worker Agent exiting
```

### What was the solution? (How)
We should handle `PermissionError` and any other unexpected `Exception` since this operation is meant to be best-effort and should not crash the Worker agent

### What is the impact of this change?
Worker agent no longer crashes when detecting GPU capabilities

### How was this change tested?
- Unit tests
- Manually verified the fix on AL2023, where I discovered the issue

### Was this change documented?
No

### Is this a breaking change?
No