### PR TITLE
chore(deps): make pywin32 v306 an explicit runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "typing_extensions ~= 4.8",
     "psutil ~= 5.9",
     "pydantic ~= 1.10.0",
+    "pywin32 == 306; platform_system == 'Windows'",
     "requests == 2.31.*",
 ]
 requires-python = ">=3.7"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent did not declare an explicit dependency on `pywin32`. This package is being used directly by our code and we were implicitly installing it through a transitive dependency on `openjd-sessions`.

If our transitive dependency disappeared in a future update, our code would no longer function.

### What was the solution? (How)

Declare an explicit dependency on `pywin32==306`. This is the latest release and matches the version used by `openjd-sessions`.

### What is the impact of this change?

Users rely on the agent declaring and pinning dependencies correctly. With an explicit dependency, we protect our customers from a situation where our dependency packages remove their dependence on `pywin32` and rightfully bump their version as a non-breaking change which would cause our customers to encounter import errors at run-time.

### How was this change tested?

*   Installed the package on Windows successfully
*   Ran the Windows worker agent and confirmed it started and ran as expected

### Was this change documented?

No

### Is this a breaking change?

No