### PR TITLE
feat(installer)!: allow ec2 instance profile by default

### DIFF
--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -87,6 +87,7 @@ def install() -> None:
             allow_shutdown=args.allow_shutdown,
             parser=arg_parser,
             grant_required_access=args.grant_required_access,
+            allow_ec2_instance_profile=not args.disallow_instance_profile,
         )
         if args.user:
             installer_args.update(user_name=args.user)
@@ -127,6 +128,8 @@ def install() -> None:
             cmd.append("--no-install-service")
         if args.telemetry_opt_out:
             cmd.append("--telemetry-opt-out")
+        if args.disallow_instance_profile:
+            cmd.append("--disallow-instance-profile")
 
         try:
             run(
@@ -153,6 +156,7 @@ class ParsedCommandLineArguments(Namespace):
     telemetry_opt_out: bool
     vfs_install_path: str
     grant_required_access: bool
+    disallow_instance_profile: bool
 
 
 def get_argument_parser() -> ArgumentParser:  # pragma: no cover
@@ -231,6 +235,17 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
     parser.add_argument(
         "--vfs-install-path",
         help="Absolute path for the install location of the deadline vfs.",
+    )
+    parser.add_argument(
+        "--disallow-instance-profile",
+        help=(
+            "Disallow running the worker agent with an EC2 instance profile. When this is provided, the worker "
+            "agent makes requests to the EC2 instance meta-data service (IMDS) to check for an instance profile. "
+            "If an instance profile is detected, the worker agent will stop and exit. When this is not provided, "
+            "the worker agent no longer performs these checks, allowing it to run with an EC2 instance profile."
+        ),
+        action="store_true",
+        default=False,
     )
 
     if sys.platform == "win32":

--- a/src/deadline_worker_agent/startup/cli_args.py
+++ b/src/deadline_worker_agent/startup/cli_args.py
@@ -19,7 +19,7 @@ class ParsedCommandLineArguments(Namespace):
     no_impersonation: bool | None = None
     run_jobs_as_agent_user: bool | None = None
     posix_job_user: str | None = None
-    allow_instance_profile: bool | None = None
+    disallow_instance_profile: bool | None = None
     logs_dir: Path | None = None
     local_session_logs: bool | None = None
     persistence_dir: Path | None = None
@@ -118,12 +118,21 @@ def get_argument_parser() -> ArgumentParser:
         action="store_true",
         dest="no_allow_instance_profile",
     )
+    # TODO: This is deprecated. Remove this eventually
     parser.add_argument(
         "--allow-instance-profile",
-        help="Turns off validation that the host EC2 instance profile is disassociated before starting",
+        help="DEPRECATED. This does nothing",
         action="store_const",
         const=True,
         dest="allow_instance_profile",
+        default=None,
+    )
+    parser.add_argument(
+        "--disallow-instance-profile",
+        help="Turns on validation that the host EC2 instance profile is disassociated before starting",
+        action="store_const",
+        const=True,
+        dest="disallow_instance_profile",
         default=None,
     )
     parser.add_argument(

--- a/src/deadline_worker_agent/startup/config.py
+++ b/src/deadline_worker_agent/startup/config.py
@@ -124,8 +124,10 @@ class Configuration:
             settings_kwargs["run_jobs_as_agent_user"] = parsed_cli_args.no_impersonation
         if parsed_cli_args.posix_job_user is not None:
             settings_kwargs["posix_job_user"] = parsed_cli_args.posix_job_user
-        if parsed_cli_args.allow_instance_profile is not None:
-            settings_kwargs["allow_instance_profile"] = parsed_cli_args.allow_instance_profile
+        if parsed_cli_args.disallow_instance_profile is not None:
+            settings_kwargs[
+                "allow_instance_profile"
+            ] = not parsed_cli_args.disallow_instance_profile
         if parsed_cli_args.logs_dir is not None:
             settings_kwargs["worker_logs_dir"] = parsed_cli_args.logs_dir.absolute()
         if parsed_cli_args.persistence_dir is not None:

--- a/src/deadline_worker_agent/startup/settings.py
+++ b/src/deadline_worker_agent/startup/settings.py
@@ -57,10 +57,11 @@ class WorkerSettings(BaseSettings):
     windows_job_user_password_arn : str
         The ARN of an AWS Secrets Manager secret containing the password of the job user for Windows.
     allow_instance_profile : bool
-        If false (the default) and the worker is running on an EC2 instance with IMDS, then the
+        If false and the worker is running on an EC2 instance with IMDS, then the
         worker will wait until the instance profile is disassociated before running worker sessions.
         This will repeatedly attempt to make requests to IMDS. If the instance profile is still
-        associated after some threshold, the worker agent program will log the error and exit .
+        associated after some threshold, the worker agent program will log the error and exit.
+        Default is true.
     capabilities : deadline_worker_agent.startup.Capabilities
         A set of capabilities that will be declared when the worker starts. These capabilities
         can be used by the service to determine if the worker is eligible to run sessions for a
@@ -96,7 +97,7 @@ class WorkerSettings(BaseSettings):
     windows_job_user_password_arn: Optional[str] = Field(
         regex=r"^arn:aws:secretsmanager:[a-z0-9\-]+:\d{12}:secret\/[a-zA-Z0-9/_+=.@-]+$"
     )
-    allow_instance_profile: bool = False
+    allow_instance_profile: bool = True
     capabilities: Capabilities = Field(
         default_factory=lambda: Capabilities(amounts={}, attributes={})
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -84,6 +84,11 @@ def grant_required_access() -> bool:
 
 
 @pytest.fixture
+def disallow_instance_profile() -> bool:
+    return True
+
+
+@pytest.fixture
 def parsed_args(
     farm_id: str,
     fleet_id: str,
@@ -98,6 +103,7 @@ def parsed_args(
     telemetry_opt_out: bool,
     vfs_install_path: str,
     grant_required_access: bool,
+    disallow_instance_profile: bool,
 ) -> ParsedCommandLineArguments:
     parsed_args = ParsedCommandLineArguments()
     parsed_args.farm_id = farm_id
@@ -113,6 +119,7 @@ def parsed_args(
     parsed_args.telemetry_opt_out = telemetry_opt_out
     parsed_args.vfs_install_path = vfs_install_path
     parsed_args.grant_required_access = grant_required_access
+    parsed_args.disallow_instance_profile = disallow_instance_profile
     return parsed_args
 
 

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -77,6 +77,8 @@ def expected_cmd(
         expected_cmd.append("--allow-shutdown")
     if parsed_args.telemetry_opt_out:
         expected_cmd.append("--telemetry-opt-out")
+    if parsed_args.disallow_instance_profile:
+        expected_cmd.append("--disallow-instance-profile")
     return expected_cmd
 
 

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -52,6 +52,7 @@ def test_start_windows_installer(
                 allow_shutdown=parsed_args.allow_shutdown,
                 telemetry_opt_out=parsed_args.telemetry_opt_out,
                 grant_required_access=parsed_args.grant_required_access,
+                allow_ec2_instance_profile=not parsed_args.disallow_instance_profile,
             )
 
 

--- a/test/unit/startup/test_bootstrap.py
+++ b/test/unit/startup/test_bootstrap.py
@@ -119,7 +119,7 @@ def config(
         cli_args.no_shutdown = no_shutdown
         cli_args.profile = profile
         cli_args.verbose = verbose
-        cli_args.allow_instance_profile = allow_instance_profile
+        cli_args.disallow_instance_profile = not allow_instance_profile
         # Direct the logs and persistence state into a temporary directory
         cli_args.logs_dir = Path(tempdir) / "temp-logs-dir"
         cli_args.persistence_dir = Path(tempdir) / "temp-persist-dir"

--- a/test/unit/startup/test_config.py
+++ b/test/unit/startup/test_config.py
@@ -224,20 +224,20 @@ class TestLoad:
         assert config.no_shutdown == no_shutdown
 
     @pytest.mark.parametrize(
-        ("allow_instance_profile",),
+        ("disallow_instance_profile",),
         (
             pytest.param(True, id="TrueArgument"),
             pytest.param(False, id="FalseArgument"),
         ),
     )
-    def test_uses_parsed_allow_instance_profile(
+    def test_uses_parsed_disallow_instance_profile(
         self,
         parsed_args: config_mod.ParsedCommandLineArguments,
-        allow_instance_profile: bool,
+        disallow_instance_profile: bool,
     ) -> None:
         """Tests that the parsed allow_instance_profile argument is returned"""
         # GIVEN
-        parsed_args.allow_instance_profile = allow_instance_profile
+        parsed_args.disallow_instance_profile = disallow_instance_profile
         # Must be present or a ConfigurationError is raised
         parsed_args.fleet_id = "fleet_id"
         parsed_args.farm_id = "farm_id"
@@ -246,7 +246,7 @@ class TestLoad:
         config = config_mod.Configuration.load()
 
         # THEN
-        assert config.allow_instance_profile == allow_instance_profile
+        assert config.allow_instance_profile == (not disallow_instance_profile)
 
     @pytest.mark.parametrize(
         ("cleanup_session_user_processes",),
@@ -689,21 +689,21 @@ class TestInit:
             assert "posix_job_user" not in call.kwargs
 
     @pytest.mark.parametrize(
-        argnames="allow_instance_profile",
+        argnames="disallow_instance_profile",
         argvalues=(
             True,
             False,
             None,
         ),
     )
-    def test_allow_instance_profile_passed_to_settings_initializer(
+    def test_disallow_instance_profile_passed_to_settings_initializer(
         self,
-        allow_instance_profile: bool | None,
+        disallow_instance_profile: bool | None,
         parsed_args: ParsedCommandLineArguments,
         mock_worker_settings_cls: MagicMock,
     ) -> None:
         # GIVEN
-        parsed_args.allow_instance_profile = allow_instance_profile
+        parsed_args.disallow_instance_profile = disallow_instance_profile
 
         # WHEN
         config_mod.Configuration(parsed_cli_args=parsed_args)
@@ -712,9 +712,9 @@ class TestInit:
         mock_worker_settings_cls.assert_called_once()
         call = mock_worker_settings_cls.call_args_list[0]
 
-        if allow_instance_profile is not None:
+        if disallow_instance_profile is not None:
             assert "allow_instance_profile" in call.kwargs
-            assert call.kwargs.get("allow_instance_profile") == allow_instance_profile
+            assert call.kwargs.get("allow_instance_profile") == (not disallow_instance_profile)
         else:
             assert "allow_instance_profile" not in call.kwargs
 

--- a/test/unit/startup/test_settings.py
+++ b/test/unit/startup/test_settings.py
@@ -106,7 +106,7 @@ FIELD_TEST_CASES: list[FieldTestCaseParams] = [
         field_name="allow_instance_profile",
         expected_type=bool,
         expected_required=False,
-        expected_default=False,
+        expected_default=True,
         expected_default_factory_return_value=None,
     ),
     FieldTestCaseParams(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When users run the installer in a CMF context, they currently have to manually configure the `allow_ec2_instance_profile` option to `true` in the worker configuration file. This is manual work that we know is required for any customer wanting to setup the worker in CMF, and we should change the default value to remove this manual step.

### What was the solution? (How)
Change the default value of `allow_ec2_instance_profile` in the Worker config. Also add an installer option to explicitly `--disallow-instance-profile`, which we will use in an SMF context.

### What is the impact of this change?
 CMF users no longer need to manually configure `allow_ec2_instance_profile` to true after running the installer.

### How was this change tested?
- Updated unit tests
- E2E tests on Windows and Linux for the installer changes (logs below)
- E2E tests on Windows and Linux for `allow_ec2_instance_profile` changes verified the below test cases

**Windows tests**
- [x] Confirm default behavior is to allow EC2 instance profiles
- [x] Confirm `allow_ec2_instance_profile` config file option makes EC2 instance profile allowed when set to `true`
- [x] Confirm `allow_ec2_instance_profile` config file option makes EC2 instance profile not allowed when set to `false`
- [x] Confirm `DEADLINE_WORKER_ALLOW_INSTANCE_PROFILE` environment variable makes EC2 instance profile allowed when set to `true`
- [x] Confirm `DEADLINE_WORKER_ALLOW_INSTANCE_PROFILE` environment variable makes EC2 instance profile not allowed when set to `false`
- [x] Confirm `--disallow-ec2-instance-profile` CLI argument makes EC2 instance profile not allowed

**Linux tests**
- [x] Confirm default behavior is to allow EC2 instance profiles
- [x] Confirm `allow_ec2_instance_profile` config file option makes EC2 instance profile allowed when set to `true`
- [x] Confirm `allow_ec2_instance_profile` config file option makes EC2 instance profile not allowed when set to `false`
- [x] Confirm `DEADLINE_WORKER_ALLOW_INSTANCE_PROFILE` environment variable makes EC2 instance profile allowed when set to `true`
- [x] Confirm `DEADLINE_WORKER_ALLOW_INSTANCE_PROFILE` environment variable makes EC2 instance profile not allowed when set to `false`
- [x] Confirm `--disallow-ec2-instance-profile` CLI argument makes EC2 instance profile not allowed

### Was this change documented?
No

### Is this a breaking change?
Yes

### Installer testing

#### Linux test - default (allow instance profile)

```
$ install-deadline-worker --farm-id $FARM_ID --fleet-id $FLEET_ID
===========================================================
|      AWS Deadline Cloud Worker Agent Installer       |
===========================================================

Farm ID: farm-9476acb9a64443e580089ce53c8dd2a4
Fleet ID: fleet-6e184b9bea1647649246a76619951f45
Region: us-west-2
Worker agent user: deadline-worker-agent
Worker job group: deadline-job-users
Scripts path: /home/ec2-user/.venv/bin
Worker agent program path: /home/ec2-user/.venv/bin/deadline-worker-agent
Deadline client program path: /home/ec2-user/.venv/bin/deadline
Allow worker agent shutdown: no
Start systemd service: no
Telemetry opt-out: no
VFS install path: unset
Disallow EC2 instance profile: no
Confirm install with the above settings (y/n):y

Worker agent user deadline-worker-agent already exists
Job group deadline-job-users already exists
Worker agent user (deadline-worker-agent) is alread in job group (deadline-job-users)
No prior sudoers shutdown rule at /etc/sudoers.d/deadline-worker-shutdown
Provisioning log directory (/var/log/amazon/deadline)
Done provisioning log directory (/var/log/amazon/deadline)
Provisioning persistence directory (/var/lib/deadline)
Done provisioning persistence directory (/var/lib/deadline)
Provisioning root directory for OpenJD Sessions (/sessions)
Provisioning configuration directory (/etc/amazon/deadline)
Done provisioning configuration directory
Configuring farm and fleet
Configuring shutdown on stop
Configuring allow ec2 instance profile
farm_id = "farm-9476acb9a64443e580089ce53c8dd2a4"
fleet_id = "fleet-6e184b9bea1647649246a76619951f45"
shutdown_on_stop = false
allow_ec2_instance_profile = true
Done configuring farm and fleet
Done configuring shutdown on stop
Done configuring allow ec2 instance profile
Installing systemd service to /etc/systemd/system/deadline-worker.service
Done installing systemd service
Reloading systemd
Done reloading systemd
Done

$ sudo grep ec2 /etc/amazon/deadline/worker.toml
# The "allow_ec2_instance_profile" setting controls whether the Worker will run with an EC2 instance
allow_ec2_instance_profile = true
```

#### Linux test - disallow instance profile

```
$ install-deadline-worker --farm-id $FARM_ID --fleet-id $FLEET_ID --disallow-instan
ce-profile
===========================================================
|      AWS Deadline Cloud Worker Agent Installer       |
===========================================================

Farm ID: farm-9476acb9a64443e580089ce53c8dd2a4
Fleet ID: fleet-6e184b9bea1647649246a76619951f45
Region: us-west-2
Worker agent user: deadline-worker-agent
Worker job group: deadline-job-users
Scripts path: /home/ec2-user/.venv/bin
Worker agent program path: /home/ec2-user/.venv/bin/deadline-worker-agent
Deadline client program path: /home/ec2-user/.venv/bin/deadline
Allow worker agent shutdown: no
Start systemd service: no
Telemetry opt-out: no
VFS install path: unset
Disallow EC2 instance profile: yes
Confirm install with the above settings (y/n):y

Worker agent user deadline-worker-agent already exists
Job group deadline-job-users already exists
Worker agent user (deadline-worker-agent) is alread in job group (deadline-job-users)
No prior sudoers shutdown rule at /etc/sudoers.d/deadline-worker-shutdown
Provisioning log directory (/var/log/amazon/deadline)
Done provisioning log directory (/var/log/amazon/deadline)
Provisioning persistence directory (/var/lib/deadline)
Done provisioning persistence directory (/var/lib/deadline)
Provisioning root directory for OpenJD Sessions (/sessions)
Provisioning configuration directory (/etc/amazon/deadline)
Done provisioning configuration directory
Configuring farm and fleet
Configuring shutdown on stop
Configuring allow ec2 instance profile
farm_id = "farm-9476acb9a64443e580089ce53c8dd2a4"
fleet_id = "fleet-6e184b9bea1647649246a76619951f45"
shutdown_on_stop = false
allow_ec2_instance_profile = false
Done configuring farm and fleet
Done configuring shutdown on stop
Done configuring allow ec2 instance profile
Installing systemd service to /etc/systemd/system/deadline-worker.service
Done installing systemd service
Reloading systemd
Done reloading systemd
Done

$ sudo grep ec2 /etc/amazon/deadline/worker.toml
# The "allow_ec2_instance_profile" setting controls whether the Worker will run with an EC2 instance
allow_ec2_instance_profile = false
```

### Windows tesing

#### Windows test - default (allow instance profile)

```
> install-deadline-worker --farm-id $env:FARM_ID --fleet-id $env:FLEET_ID --password "REDACTED"
===========================================================
|      AWS Deadline Cloud Worker Agent Installer       |
===========================================================

Farm ID: farm-9476acb9a64443e580089ce53c8dd2a4
Fleet ID: fleet-6e184b9bea1647649246a76619951f45
Region: us-west-2
Worker agent user: deadline-worker
Worker job group: deadline-job-users
Allow worker agent shutdown: False
Install Windows service: True
Start service: False
Telemetry opt-out: False
Disallow EC2 instance profile: False

Confirm install (y/n):y
INFO: Using existing user (deadline-worker) as worker agent user
INFO: Loading user profile for 'deadline-worker'
INFO: Successfully loaded user profile
INFO: Agent user 'deadline-worker' is already an administrator
INFO: Agent user 'deadline-worker' has all required user rights
INFO: Using existing group (deadline-job-users) as the queue user group.
INFO: Agent user 'deadline-worker' is already in group 'deadline-job-users'
INFO: Provisioning root directory (C:\ProgramData\Amazon\Deadline)
INFO: Done provisioning root directory (C:\ProgramData\Amazon\Deadline)
INFO: Provisioning log directory (C:\ProgramData\Amazon\Deadline\Logs)
INFO: Done provisioning log directory (C:\ProgramData\Amazon\Deadline\Logs)
INFO: Provisioning persistence directory (C:\ProgramData\Amazon\Deadline\Cache)
INFO: Done provisioning persistence directory (C:\ProgramData\Amazon\Deadline\Cache)
INFO: Provisioning config directory (C:\ProgramData\Amazon\Deadline\Config)
INFO: Done provisioning config directory (C:\ProgramData\Amazon\Deadline\Config)
INFO: Updating configuration file
INFO: Done configuring ['farm_id', 'fleet_id', 'shutdown_on_stop', 'allow_ec2_instance_profile'] in C:\ProgramData\Amazon\Deadline\Config\worker.toml
INFO: Configuring Windows Service "AWS Deadline Cloud Worker"...
copying host exe 'C:\Program Files\Python312\Lib\site-packages\win32\pythonservice.exe' -> 'C:\Program Files\Python312\pythonservice.exe'
INFO: Service "AWS Deadline Cloud Worker" already exists, updating instead...
copying host exe 'C:\Program Files\Python312\Lib\site-packages\win32\pythonservice.exe' -> 'C:\Program Files\Python312\pythonservice.exe'
INFO: Successfully updated Windows Service "AWS Deadline Cloud Worker"
INFO: Configuring the failure actions of Windows Service "AWS Deadline Cloud Worker"...
INFO: Successfully configured the failure actions for Window Service "AWS Deadline Cloud Worker"
INFO: Setting region to us-west-2 for DeadlineWorker service
INFO: Setting 'Environment' in registry key 'HKEY_LOCAL_MACHINE:SYSTEM\CurrentControlSet\Services\DeadlineWorker'
INFO: Successfully set 'Environment' in registry key 'HKEY_LOCAL_MACHINE:SYSTEM\CurrentControlSet\Services\DeadlineWorker'
INFO: Successfully set region to us-west-2 for DeadlineWorker service

> type C:\ProgramData\Amazon\Deadline\Config\worker.toml | findstr ec2
# The "allow_ec2_instance_profile" setting controls whether the Worker will run with an EC2 instance
allow_ec2_instance_profile = true
```

#### Windows test - disallow instance profile

```
> install-deadline-worker --farm-id $env:FARM_ID --fleet-id $env:FLEET_ID --password "REDACTED" --disallow-instance-profile
===========================================================
|      AWS Deadline Cloud Worker Agent Installer       |
===========================================================

Farm ID: farm-9476acb9a64443e580089ce53c8dd2a4
Fleet ID: fleet-6e184b9bea1647649246a76619951f45
Region: us-west-2
Worker agent user: deadline-worker
Worker job group: deadline-job-users
Allow worker agent shutdown: False
Install Windows service: True
Start service: False
Telemetry opt-out: False
Disallow EC2 instance profile: True

Confirm install (y/n):y
INFO: Using existing user (deadline-worker) as worker agent user
INFO: Loading user profile for 'deadline-worker'
INFO: Successfully loaded user profile
INFO: Agent user 'deadline-worker' is already an administrator
INFO: Agent user 'deadline-worker' has all required user rights
INFO: Using existing group (deadline-job-users) as the queue user group.
INFO: Agent user 'deadline-worker' is already in group 'deadline-job-users'
INFO: Provisioning root directory (C:\ProgramData\Amazon\Deadline)
INFO: Done provisioning root directory (C:\ProgramData\Amazon\Deadline)
INFO: Provisioning log directory (C:\ProgramData\Amazon\Deadline\Logs)
INFO: Done provisioning log directory (C:\ProgramData\Amazon\Deadline\Logs)
INFO: Provisioning persistence directory (C:\ProgramData\Amazon\Deadline\Cache)
INFO: Done provisioning persistence directory (C:\ProgramData\Amazon\Deadline\Cache)
INFO: Provisioning config directory (C:\ProgramData\Amazon\Deadline\Config)
INFO: Done provisioning config directory (C:\ProgramData\Amazon\Deadline\Config)
INFO: Updating configuration file
INFO: Done configuring ['farm_id', 'fleet_id', 'shutdown_on_stop', 'allow_ec2_instance_profile'] in C:\ProgramData\Amazon\Deadline\Config\worker.toml
INFO: Configuring Windows Service "AWS Deadline Cloud Worker"...
copying host exe 'C:\Program Files\Python312\Lib\site-packages\win32\pythonservice.exe' -> 'C:\Program Files\Python312\pythonservice.exe'
INFO: Service "AWS Deadline Cloud Worker" already exists, updating instead...
copying host exe 'C:\Program Files\Python312\Lib\site-packages\win32\pythonservice.exe' -> 'C:\Program Files\Python312\pythonservice.exe'
INFO: Successfully updated Windows Service "AWS Deadline Cloud Worker"
INFO: Configuring the failure actions of Windows Service "AWS Deadline Cloud Worker"...
INFO: Successfully configured the failure actions for Window Service "AWS Deadline Cloud Worker"
INFO: Setting region to us-west-2 for DeadlineWorker service
INFO: Setting 'Environment' in registry key 'HKEY_LOCAL_MACHINE:SYSTEM\CurrentControlSet\Services\DeadlineWorker'
INFO: Successfully set 'Environment' in registry key 'HKEY_LOCAL_MACHINE:SYSTEM\CurrentControlSet\Services\DeadlineWorker'
INFO: Successfully set region to us-west-2 for DeadlineWorker service

> type C:\ProgramData\Amazon\Deadline\Config\worker.toml | findstr ec2
# The "allow_ec2_instance_profile" setting controls whether the Worker will run with an EC2 instance
allow_ec2_instance_profile = false
```