### PR TITLE
chore(deps): deadline-cloud==0.43.* to 0.45.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
-    "deadline == 0.44.*",
+    "deadline == 0.45.*",
     "openjd-sessions == 0.7.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
update deadline-cloud dependency

### What was the solution? (How)

update deadline-cloud dependency 0.45.*

### What is the impact of this change?
Updated dependency

### How was this change tested?
`hatch run test`

### Was this change documented?
no

### Is this a breaking change?
no