### PR TITLE
fix: unhandled exception unloading user profile

### DIFF
--- a/src/deadline_worker_agent/windows/win_credentials_resolver.py
+++ b/src/deadline_worker_agent/windows/win_credentials_resolver.py
@@ -143,7 +143,7 @@ class WindowsCredentialsResolver:
                     )
                     if user.user_profile:
                         # https://timgolden.me.uk/pywin32-docs/win32profile__UnloadUserProfile_meth.html
-                        UnloadUserProfile(user.windows_session_user.logon_token, user.user_profile)
+                        UnloadUserProfile(user.logon_token, user.user_profile)
                     assert user.logon_token is not None
                     user.logon_token.Close()
         self._user_cache.clear()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When the worker agent runs as a Windows service and is shutting down, it attempts to unload user profiles of queue `jobRunAsUser` accounts that it has open before closing the logon token handles it also keeps open.

This had a bug where it was trying to call pywin32's `UnloadUserProfile(token, profile)` function but passing a `ctypes` handle into the `token` argument where it expects a `PyHANDLE`. We maintain both handle types because the `openjd-sessions` Python library expects a ctypes handle instead.

This resulted in the following error in the logs:

```
Traceback (most recent call last):
  File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 287, in run
    interval = self._sync(interruptable=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 447, in _sync
    raise ServiceShutdown()
deadline_worker_agent.errors.ServiceShutdown

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\startup\entrypoint.py", line 164, in entrypoint
    worker_sessions.run()
  File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\worker.py", line 252, in run
    future.result()
  File "C:\Program Files\Python312\Lib\concurrent\futures\_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\concurrent\futures\_base.py", line 401, in __get_result
    raise self._exception
  File "C:\Program Files\Python312\Lib\concurrent\futures\thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\scheduler\scheduler.py", line 311, in run
    self._windows_credentials_resolver.clear()
  File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\windows\win_credentials_resolver.py", line 146, in clear
    UnloadUserProfile(user.windows_session_user.logon_token, user.user_profile)
TypeError: The object is not a PyHANDLE object
```

When the worker is part of an EC2 auto-scaling CMF fleet, this would crash before the agent got to the code to shutdown the host, leaving the worker host still running without any work. This would lead to a situation where instances are left running but not doing anything.

### What was the solution? (How)

Pass in a reference to the pywin32 logon token handle instead of the ctypes one required by `openjd-sessions`.

### What is the impact of this change?

The worker agent will not crash when trying to unload the user profile and properly shut down the worker host in a scale-in event.

### How was this change tested?

1.  Ran the modified worker agent inside the Windows service with the modified code
2. Submitted a job to a queue with a `jobRunAsUser` to make the agent load the user profile
3. Stopped the windows service
4. Confirmed the exception is no longer encountered

### Was this change documented?

No

### Is this a breaking change?

No