### PR TITLE
fix: agent not logging events with emojis on Windows due to default encoding

### DIFF
--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -388,6 +388,7 @@ def _configure_base_logging(
         # Daily rotation
         when="d",
         interval=1,
+        encoding="utf-8",
     )
     # Bootstrap file should always be json. It's primarily intended
     # for use by Service Managed Fleet workers, and needs to be queryable
@@ -402,6 +403,7 @@ def _configure_base_logging(
         # Daily rotation
         when="d",
         interval=1,
+        encoding="utf-8",
     )
     rotating_file_handler.formatter = logging.Formatter(fmt_str)
     root_logger.addHandler(rotating_file_handler)

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -364,6 +364,7 @@ def test_log_configuration(
             _config_mock.load().worker_logs_dir / "worker-agent.log",
             when="d",
             interval=1,
+            encoding="utf-8",
         )
         root_logger.addHandler.assert_any_call(mock_file_logger)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We noticed that the agent log files on windows did not contain any of the log records that contain emojis.

### What was the solution? (How)

Explicitly specify the file encoding as utf-8.

### What is the impact of this change?

Agent log files on Windows actually contain useful logging information.

### How was this change tested?

We modified an agent on Windows to include the two changed lines and verified that the log files now properly contain all log records.

### Was this change documented?

No

### Is this a breaking change?

No
