### PR TITLE
chore(deps): deadline==0.45.* to 0.46.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.28.80",
-    "deadline == 0.45.*",
+    "deadline == 0.46.*",
     "openjd-sessions == 0.7.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Need to update worker agent's dependency on deadline

### What was the solution? (How)
bump dep

### What is the impact of this change?
Will use new version

### How was this change tested?
built, ran tests, installed both on a CMF instance, ran jobs successfully

### Was this change documented?
No
### Is this a breaking change?
No