### PR TITLE
feat!: public release

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -16,27 +16,11 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
-    env:
-        PYTHON: ${{ matrix.python-version }}
-        CODEARTIFACT_REGION: "us-west-2"
-        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
     - uses: actions/checkout@v4
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-        aws-region: us-west-2
-        mask-aws-account-id: true
     
     - name: Install Hatch
       run: |
-        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
         pip install --upgrade hatch
 
     - name: Run Windows Integration Tests

--- a/.github/workflows/release_integration_canary.yml
+++ b/.github/workflows/release_integration_canary.yml
@@ -15,27 +15,11 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
-    env:
-        PYTHON: ${{ matrix.python-version }}
-        CODEARTIFACT_REGION: "us-west-2"
-        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
     - uses: actions/checkout@v4
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-        aws-region: us-west-2
-        mask-aws-account-id: true
     
     - name: Install Hatch
       run: |
-        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
         pip install --upgrade hatch
 
     - name: Run Windows Integration Tests

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -41,11 +41,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    env:
-      CODEARTIFACT_REGION: "us-west-2"
-      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -88,18 +83,9 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-          aws-region: us-west-2
-          mask-aws-account-id: true
-
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-          pip install --upgrade hatch
           hatch -v build
 
       - name: Configure AWS credentials
@@ -187,9 +173,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
           pip install --upgrade hatch
           pip install --upgrade twine
 
@@ -210,8 +193,7 @@ jobs:
           export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CUSTOMER_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
           twine upload dist/*
 
-      # TODO: Uncomment this block to publish to PyPI once this package is public
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         

--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -22,10 +22,6 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     env:
       PYTHON: ${{ matrix.python-version }}
-      CODEARTIFACT_REGION: "us-west-2"
-      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
     - uses: actions/checkout@v4
       if: ${{ !inputs.branch && !inputs.commit }}
@@ -46,28 +42,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-        aws-region: us-west-2
-        mask-aws-account-id: true
-
-    - name: Install Hatch Posix
-      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'}}
-      shell: bash
+    - name: Install Hatch
       run: |
-        CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
-        pip install --upgrade hatch
-
-    - name: Install Hatch Windows
-      if: ${{ matrix.os == 'windows-latest'}}
-      run: |
-        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
         pip install --upgrade hatch
 
     - name: Run Linting

--- a/.github/workflows/windows_integration.yml
+++ b/.github/workflows/windows_integration.yml
@@ -12,27 +12,11 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
-    env:
-        PYTHON: ${{ matrix.python-version }}
-        CODEARTIFACT_REGION: "us-west-2"
-        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
     - uses: actions/checkout@v4
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-        aws-region: us-west-2
-        mask-aws-account-id: true
     
     - name: Install Hatch
       run: |
-        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
         pip install --upgrade hatch
 
     - name: Run Windows Integration Tests

--- a/hatch.toml
+++ b/hatch.toml
@@ -37,11 +37,7 @@ sync = "pip install -r requirements-research.txt"
 python = ["3.9", "3.10", "3.11"]
 
 [envs.default.env-vars]
-PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
 RUN_AS_ADMIN="true"
-
-[envs.codebuild.env-vars]
-PIP_INDEX_URL=""
 
 [envs.codebuild.scripts]
 build = "hatch build {args:}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
     "requests ~= 2.31",
-    "boto3 >= 1.28.80",
-    "deadline == 0.46.*",
+    "boto3 >= 1.34.75",
+    "deadline == 0.47.*",
     "openjd-sessions == 0.7.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
@@ -23,7 +23,7 @@ dependencies = [
     "pywin32 == 306; platform_system == 'Windows'",
     "requests == 2.31.*",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 description = "The AWS Deadline Cloud worker agent can be used to run a worker in an AWS Deadline Cloud fleet"
 # https://pypi.org/classifiers/
 classifiers = [

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,6 +1,6 @@
 coverage[toml] ~= 7.4
 coverage-conditional-plugin == 0.9.*
-deadline-cloud-test-fixtures == 0.5.*
+deadline-cloud-test-fixtures == 0.6.*
 pytest ~= 8.1
 pytest-cov == 5.0.*
 pytest-timeout == 2.3.*

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -837,9 +837,12 @@ class TestSessionSyncAssetInputs:
         mock_asset_sync.sync_inputs = mock_sync_inputs
         mock_cancel = MagicMock(spec=Event)
 
-        with patch.object(session, "update_action") as mock_update_action, patch.object(
-            session_mod, "record_sync_inputs_fail_telemetry_event"
-        ) as mock_record_sync_inputs_fail_telemetry_event:
+        with (
+            patch.object(session, "update_action") as mock_update_action,
+            patch.object(
+                session_mod, "record_sync_inputs_fail_telemetry_event"
+            ) as mock_record_sync_inputs_fail_telemetry_event,
+        ):
             session.sync_asset_inputs(
                 cancel=mock_cancel,
                 job_attachment_details=JobAttachmentDetails(
@@ -1471,9 +1474,10 @@ class TestSessionActionUpdatedImpl:
         def mock_now(*arg, **kwarg) -> datetime:
             return action_complete_time
 
-        with patch.object(session_mod, "datetime") as mock_datetime, patch.object(
-            session, "_sync_asset_outputs"
-        ) as mock_sync_asset_outputs:
+        with (
+            patch.object(session_mod, "datetime") as mock_datetime,
+            patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs,
+        ):
             mock_datetime.now.side_effect = mock_now
 
             # Assert that reporting the action update happens AFTER syncing the output job
@@ -1552,9 +1556,12 @@ class TestSessionActionUpdatedImpl:
         def mock_now(*arg, **kwarg) -> datetime:
             return action_complete_time
 
-        with patch.object(session_mod, "datetime") as mock_datetime, patch.object(
-            session, "_sync_asset_outputs", side_effect=sync_outputs_exception
-        ) as mock_sync_asset_outputs:
+        with (
+            patch.object(session_mod, "datetime") as mock_datetime,
+            patch.object(
+                session, "_sync_asset_outputs", side_effect=sync_outputs_exception
+            ) as mock_sync_asset_outputs,
+        ):
             mock_datetime.now.side_effect = mock_now
 
             # WHEN


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We're about to publicly release this library. We need to prep the build process for that.

### What was the solution? (How)

- Bump to boto3 to `1.34.75` and deadline-test-fixtures to `0.6.0`

- Update the build script to no longer define a PIP_INDEX_URL -- the environment variable
  that we used to interface with our internal repository during private development.

- Update the code quality check to pull deps from the public PyPI, so
  that we're testing as customers would use it.

- Use the public PyPI in the release flows since all deps are now
  available publicly. This ensures that the artifact we release can be
  built & used by anyone using PyPI.

### What is the impact of this change?

Release readiness

### How was this change tested?

Tests will not pass until boto3 1.34.75 is released

### Was this change documented?

No

### Is this a breaking change?

No, but it is being marked as one to force a minor version bump when we release.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*