### PR TITLE
docs: improve and organize documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,10 @@ reported the issue. Please try to include as much information as you can. Detail
 
 
 ## Contributing via Pull Requests
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+Contributions via pull requests are much appreciated. Consult [`DEVELOPMENT.md`](./DEVELOPMENT.md)
+for developer documentation.
+
+Before sending us a pull request, please ensure that:
 
 1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.

--- a/README.md
+++ b/README.md
@@ -1,106 +1,194 @@
-# DeadlineWorkerAgent
+# AWS Deadline Cloud Worker Agent
 
-This package has two active branches:
+[![pypi](https://img.shields.io/pypi/v/deadline-cloud-worker-agent.svg)](https://pypi.python.org/pypi/deadline-cloud-worker-agent)
 
-- `mainline` -- For active development. This branch is not intended to be consumed by other packages.
-   Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer
-   without notice.
-- `release` -- The official release of the package intended for consumers. Any breaking releases will
-   be accompanied with an increase to this package's interface version.
+The AWS Deadline Cloud worker agent can be used to run a worker in an
+[AWS Deadline Cloud][deadline-cloud] fleet. This includes managing the life-cycle of a worker and
+its assigned work both in the service and on the worker's host.
 
-## Overview
+Deadline Cloud schedules work as worker sessions which are an extension of
+[Open Description (OpenJD)][openjd] sessions specific to AWS Deadline Cloud. The worker agent
+initiates session actions, monitors them, and reports the status of running and completed session
+actions to the service including progress, logs, process exit code, and indicates if the work was
+canceled or interrupted.
 
-The DeadlineWorkerAgent package contains the worker agent software that is installed on worker nodes
-to interact with AWS Deadline Cloud and perform tasks.
+The worker agent behavior follows the AWS Deadline Cloud [worker API protocol][protocol] that
+specifies the expectation of how the service and workers behave and collaborate through Deadline
+Cloud's worker APIs.
+
+For guidance on setting up the worker agent for use in a customer-managed fleet, see the
+["Manage Deadline Cloud customer-managed fleets"][manage-cmf-docs] topic in the AWS Deadline Cloud
+User Guide 
+
+[deadline-cloud]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html
+[manage-cmf-docs]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/manage-cmf.html
+[openjd]: https://github.com/OpenJobDescription/openjd-specifications/wiki
+[protocol]: https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/docs/worker_api_protocol.md
+
+## Compatibility
+
+The worker agent requires Python 3.9 or higher. There are additional platform-specific requirements
+listed below:
+
+**Linux:**
+
+*   Amazon Linux 2 and 2023 are recommended and tested
+*   `sudo` must be installed
+
+**Windows:**
+
+*   Windows Server 2022 is recommended and tested
+*   Requires CPython implementation of Python
+*   **Python must be installed for all users** (e.g. in `C:\Program Files`)
+
+**MacOS is intended to be used for testing only and is subject to change.**
 
 ## Versioning
 
-This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its
-initial development, thus backwards incompatible versions are denoted by minor version bumps. To help illustrate how
-versions will increment during this initial development stage, they are described below:
+This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still
+considered to be in its initial development, thus backwards incompatible versions are denoted by
+minor version bumps. To help illustrate how versions will increment during this initial development
+stage, they are described below:
 
 1. The MAJOR version is currently 0, indicating initial development
 2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API.
 3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API.
 
+## Installing program files
+
+### Linux
+
+We recommend installing the agent in a Python virtual environment (e.g. using [`venv`][venv]). For
+this, run:
+
+```sh
+# Create venv
+python -m venv /opt/deadline/worker
+
+# Activate the virtual environment - you can later type "deactivate" to exit the environment
+source /opt/deadline/worker/bin/activate
+
+# Install worker agent program files into the virtual environment
+pip install deadline-cloud-worker-agent
+```
+
+[venv]: https://docs.python.org/3/library/venv.html
+
+### Windows
+
+The worker agent runs as a Windows Service which leads to a few installation constraints:
+
+*   Python virtual environments are not supported
+*   Python must be installed for all users
+
+To obtain the program files, run this command in an administrator command-prompt:
+
+```sh
+pip install deadline-cloud-worker-agent
+```
+
+
+## Setup worker host
+
+The worker host can be prepared to be run using the provided `install-deadline-worker` command. This
+command performs certain functions to setup the worker host based on arguments provided. The
+command performs all worker host setup activities, such as:
+
+*   creates an operating system user account (specified by the `--user` argument) on the worker
+    host that the worker will run as. `install-deadline-worker` accepts a previously created user.
+    The user defaults to `deadline-worker-agent` on Linux and `deadline-worker` on Windows.
+*   creates a job user group (specified by `--group`, defaults to `deadline-job-users`) if required. The
+    `install-deadline-worker` accepts an existing group.
+*   creates cache, log, and config directories, and an example config file
+*   [optionally] initializes the config file
+*   modifies the config file using provided arguments
+*   [optionally] install/update an operating system service
+    *   [optionally] start the operating system service
+
+---
+
+**NOTE:** The `install-deadline-worker` command does not support MacOS at this time.
+
+---
+
+To see the available command-line arguments, run:
+
+**On Linux:**
+
+Assuming you have installed the worker agent to a Python venv in `/opt/deadline/worker`, run:
+
+```sh
+/opt/deadline/worker/bin/install-deadline-worker --help
+```
+
+**On Windows:**
+
+Run the following command in an administrator command-prompt:
+
+```bat
+install-deadline-worker --help
+``` 
+
+## Configuration
+
+[See configuration](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/docs/configuration.md)
+
+## State
+
+[See state](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/docs/state.md)
+
+## Running
+
+Setting up the worker host using the `install-deadline-worker` command (see "Setup worker host"
+above) installs an operating system service. On Linux, this is a systemd service and on Windows this
+is a Windows service.
+
+The following commands demonstrate how to manually control the operating system service.
+
+**On Linux:**
+
+```sh
+# Start the worker agent
+systemctl start dealine-worker
+
+# Stop the worker agent
+systemctl stop dealine-worker
+
+# Configure the worker agent to start on boot
+systemctl enable dealine-worker
+
+# Configure the worker agent to NOT start on boot
+systemctl disable dealine-worker
+```
+
+**On Windows:**
+
+Using an admin command-prompt:
+
+```bat
+REM start the service
+sc.exe start DeadlineWorker
+
+REM stop the service
+sc.exe stop DeadlineWorker
+```
+
 ## Logging
 
-The AWS Deadline Cloud Worker Agent logs information about its operation to files on its host and to
-[AWS CloudWatch Logs](https://docs.aws.amazon.com/cloudwatch/#amazon-cloudwatch-logs) as it is running. There are two kinds of
-logs that it creates:
+[See logging](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/docs/logging.md)
 
-1. Agent logs: These are logs to assist in understanding, troubleshooting, and debugging the operation of the Agent software itself.
-    - Platform-specific locations:
-        - Linux:
-            - `/var/log/amazon/deadline/worker-agent-bootstrap.log`: Logs of solely the bootup phase of the Worker Agent.
-            - `/var/log/amazon/deadline/worker-agent.log`: Complete logs of the Worker Agent's operation.
-        - Windows:
-            - `%PROGRAMDATA%\Amazon\Deadline\Logs\worker-agent-bootstrap.log`: Logs of solely the bootup phase of the Worker Agent.
-            - `%PROGRAMDATA%\Amazon\Deadline\Logs\worker-agent.log`: Complete logs of the Worker Agent's operation.
-    - AWS CloudWatch Logs -- all logs are also stored in CloudWatch Logs in your account.
-        - Log group name: `/aws/deadline/<farm-id>/<fleet-id>/`
-        - Log stream name: `<worker-id>`
-2. Session Logs: These are the logs for the Job workloads that are run by the Worker Agent on the host. A separate log file is
-   created for each Session that is run on the host, and is identified by that Session's ID.
-    - Platform-specific locations:
-        - Linux: `/var/log/amazon/deadline/<queue-id>/<session-id>.log`
-        - Windows: `%PROGRAMDATA%\Amazon\Deadline\Logs\<queue-id>\<session-id>.log`
-    - AWS CloudWatch Logs -- all logs are also stored in CloudWatch Logs in your account.
-        - Log group name: `/aws/deadline/<farm-id>/<queue-id>/`
-        - Log stream name: `<session-id>`
+## Contributing
 
-### Structured Agent Logs
-
-The Agent logs emited to AWS CloudWatch Logs are structured, and the logs emited to local file and stdout are
-unstructured by default. Each structured log event contains a single JSON-encoded dictionary
-with information about the specific log event.
-
-All log events structures contain:
-
-- A `level` field that indicates the severity of the log event, following the typical Python Logger
-  semantics: INFO, WARNING, ERROR, EXCEPTION, and CRITICAL.
-
-Log events may also contain a `type`, `subtype`, icon (`ti`), and additional fields as indicated in the following table.
-
-| type | subtype | ti | fields | purpose |
-| --- | --- | --- | --- | --- |
-| None | None | None | message | A simple status message or update and its log level. These messages may change at any time and must not be relied upon for automation. |
-| Action | Start | 🟢 | session_id; queue_id; job_id; action_id; kind; message | A SessionAction has started running. |
-| Action | Cancel/Interrupt | 🟨 | session_id; queue_id; job_id; action_id; kind; message | A cancel/interrupt of a SessionAction has been initiated. |
-| Action | End | 🟣 | session_id; queue_id; job_id; action_id; kind; status; message | A SessionAction has completed running. |
-| AgentInfo | None | None | platform; python[interpreter,version]; agent[version,installedAt,runningAs]; depenencies | Information about the running Agent software. |
-| API | Req | 📤 | operation; request_url; params; resource (optional) | A request to an AWS API. Only requests to AWS Deadline Cloud APIs contain a resource field. |
-| API | Resp | 📥 | operation; params; status_code, request_id; error (optional) | A response from an AWS API request. |
-| FileSystem | Read/Write/Create/Delete | 💾 | filepath; message | A filesystem operation. |
-| AWSCreds | Load/Install/Delete | 🔑 | resource; message; role_arn (optional) | Related to an operation for AWS Credentials. |
-| AWSCreds | Query | 🔑 | resource; message; role_arn (optional); expiry (optional) | Related to an operation for AWS Credentials. |
-| AWSCreds | Refresh | 🔑 | resource; message; role_arn (optional); expiry (optional); scheduled_time (optional) | Related to an operation for AWS Credentials. |
-| Metrics | System | 📊 | many | System metrics. |
-| Session | Starting/Failed/AWSCreds/Complete/Info | 🔷 | queue_id; job_id; session_id | An update or information related to a Session. |
-| Session | Add/Remove | 🔷 | queue_id; job_id; session_id; action_ids; queued_actions | Adding or removing SessionActions in a Session. |
-| Session | Logs | 🔷 | queue_id; job_id; session_id; log_dest | Information regarding where the Session logs are located. |
-| Session | User | 🔷 | queue_id; job_id; session_id; user | The user that a Session is running Actions as. |
-| Worker | Create/Load/ID/Status/Delete | 💻 | farm_id; fleet_id; worker_id (optional); message | A notification related to a Worker resource within AWS Deadline Cloud. |
-
-If you prefer structured logs to be emited on your host, then you can configure your Worker Agent to emit structured logs instead. Please see the
-`structured_logs` option in the [example configuration file](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/installer/worker.toml.example)
-for information on how to configure your agent in this way.
+See [`CONTRIBUTING.md`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/CONTRIBUTING.md)
+for information on reporting issues, requesting features, and developer information.
 
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+See [security issue notifications](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## Telemetry
 
-This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
-
-You can opt out of telemetry data collection by either:
-
-1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
-2. Providing the installer flag: `--telemetry-opt-out`
-3. Setting the config file: `deadline config set telemetry.opt_out true`
-
-Note that setting the environment variable supersedes the config file setting.
+[See telemetry](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/docs/telemetry.md)
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,43 @@
+# Configuration
+
+The Worker agent configuration is loaded when the program starts. The configuration system has
+three configuration sources which are checked in the following order:
+
+1.  Command-line arguments
+2.  Environment variables
+3.  Configuration file
+4.  Default (if available)
+
+## 1. Command-line arguments
+
+The agent can be run with command-line arguments. To see the list of available arguments, run:
+
+```
+deadline-worker-agent --help
+```
+
+## 2. Environment variables
+
+The agent accepts environment variables of the form `DEADLINE_WORKER_<SETTING_NAME>`.
+
+See [`worker.toml.example`](../src/deadline_worker_agent/installer/worker.toml.example) for details
+about the supported environment variables.
+
+## 3.  Config file
+
+Configuration is stored in the following directories by default:
+
+| Platform | Default config directory |
+| --- | --- |
+| Linux | `/etc/amazon/deadline` |
+| MacOS | `/etc/amazon/deadline` |
+| Windows | `C:\ProgramData\Amazon\Deadline\Config` |
+
+When running `install-deadline-worker`, an example configuration file `worker.toml.example` is
+installed to the configuration directory. If a `worker.toml` config file does not pre-exist (e.g.
+from a prior setup), it will create one by copying the installed example file. The
+`install-deadline-worker` command then modifies the configuration file based on its program
+arguments.
+
+Consult [`worker.toml.example`](../src/deadline_worker_agent/installer/worker.toml.example) which
+contains embedded documentation in comments.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,91 @@
+# Logging
+
+The AWS Deadline Cloud worker agent logs information about its operation to files on its host and to
+[AWS CloudWatch Logs](https://docs.aws.amazon.com/cloudwatch/#amazon-cloudwatch-logs) as it is
+running. There are two kinds of logs that it creates:
+
+## Worker logs
+
+These logs are intended to describe the activities of the worker. These are useful to understand
+what the worker does, what information it has, what software package versions it runs, and other
+information useful for diagnosis and troubleshooting workers.
+
+The default locations for worker logs are:
+
+| Platform | Default worker log path |
+| --- | --- |
+| Linux | `/var/log/amazon/deadline/logs` |
+| MacOS | `/var/log/amazon/deadline/logs` |
+| Windows | `C:\ProgramData\Amazon\Deadline\Logs` |
+
+The worker agent maintains two sets of rotating log files:
+
+*   `worker-agent-bootstrap.log` &mdash; Logs of solely the bootup phase of the Worker Agent.
+*   `worker-agent.log` &mdash; Complete logs of the Worker Agent's operation.
+
+The service creates and provides the worker with a conventionally-named AWS CloudWatch log group
+and stream created in your account:
+
+**Log group:** `/aws/deadline/<farm-id>/<fleet-id>`  
+**Log stream:** `<worker-id>`
+
+As the worker agent is running, it uploads its logs to this CloudWatch log stream.
+
+### Structured worker logs
+
+The worker logs emited to AWS CloudWatch Logs are structured, and the logs emited to local file and
+stderr are unstructured by default. Each structured log event contains a single JSON-encoded
+dictionary with information about the specific log event.
+
+All log events structures contain:
+
+- A `level` field that indicates the severity of the log event, following the typical Python Logger
+  semantics: INFO, WARNING, ERROR, EXCEPTION, and CRITICAL.
+
+Log events may also contain a `type`, `subtype`, icon (`ti`), and additional fields as indicated in the following table.
+
+| type | subtype | ti | fields | purpose |
+| --- | --- | --- | --- | --- |
+| None | None | None | message | A simple status message or update and its log level. These messages may change at any time and must not be relied upon for automation. |
+| Action | Start | 🟢 | session_id; queue_id; job_id; action_id; kind; message | A SessionAction has started running. |
+| Action | Cancel/Interrupt | 🟨 | session_id; queue_id; job_id; action_id; kind; message | A cancel/interrupt of a SessionAction has been initiated. |
+| Action | End | 🟣 | session_id; queue_id; job_id; action_id; kind; status; message | A SessionAction has completed running. |
+| AgentInfo | None | None | platform; python[interpreter,version]; agent[version,installedAt,runningAs]; depenencies | Information about the running Agent software. |
+| API | Req | 📤 | operation; request_url; params; resource (optional) | A request to an AWS API. Only requests to AWS Deadline Cloud APIs contain a resource field. |
+| API | Resp | 📥 | operation; params; status_code, request_id; error (optional) | A response from an AWS API request. |
+| FileSystem | Read/Write/Create/Delete | 💾 | filepath; message | A filesystem operation. |
+| AWSCreds | Load/Install/Delete | 🔑 | resource; message; role_arn (optional) | Related to an operation for AWS Credentials. |
+| AWSCreds | Query | 🔑 | resource; message; role_arn (optional); expiry (optional) | Related to an operation for AWS Credentials. |
+| AWSCreds | Refresh | 🔑 | resource; message; role_arn (optional); expiry (optional); scheduled_time (optional) | Related to an operation for AWS Credentials. |
+| Metrics | System | 📊 | many | System metrics. |
+| Session | Starting/Failed/AWSCreds/Complete/Info | 🔷 | queue_id; job_id; session_id | An update or information related to a Session. |
+| Session | Add/Remove | 🔷 | queue_id; job_id; session_id; action_ids; queued_actions | Adding or removing SessionActions in a Session. |
+| Session | Logs | 🔷 | queue_id; job_id; session_id; log_dest | Information regarding where the Session logs are located. |
+| Session | User | 🔷 | queue_id; job_id; session_id; user | The user that a Session is running Actions as. |
+| Worker | Create/Load/ID/Status/Delete | 💻 | farm_id; fleet_id; worker_id (optional); message | A notification related to a Worker resource within AWS Deadline Cloud. |
+
+If you prefer structured logs to be emited on your host, then you can configure your Worker Agent to emit structured logs instead. Please see the
+`structured_logs` option in the [`worker.toml.example`](../src/deadline_worker_agent/installer/worker.toml.example)
+for information on how to configure your agent in this way.
+
+## Worker session logs
+
+These are the logs for the Job workloads that are run by the worker agent on the host. A separate
+log file is created for each session that is run on the host, and is identified by that Session's
+ID.
+
+The default paths for worker logs are:
+
+| Platform | Default session log Path |
+| --- | --- |
+| Linux | `/var/log/amazon/deadline/<queue-id>/<session-id>.log` |
+| MacOS | `/var/log/amazon/deadline/<queue-id>/<session-id>.log` |
+| Windows | `%PROGRAMDATA%\Amazon\Deadline\Logs\<queue-id>\<session-id>.log` |
+
+The service creates and provides the worker with an AWS CloudWatch log group and stream for each
+worker session created in your account. The CloudWatch log group and stream are:
+
+**Log group name:** `/aws/deadline/<farm-id>/<queue-id>/`  
+**Log stream name:** `<session-id>`
+
+As the worker session runs, the agent uploads its logs to this CloudWatch log stream.

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,0 +1,165 @@
+# State
+
+The worker agent writes files to disk containing data about the worker state.
+
+## Persistence Directory
+
+The **persistence directory** (also referred to as the cache directory) is created by the
+`install-deadline-worker` command (see the "Setup worker host" in the top-level
+[`README.md`](../README.md)) and used by the worker agent and runtime.
+
+It defaults to the following paths based on the host platform:
+
+| Platform | Default persistence directory path |
+| --- | --- |
+| Linux | `/var/lib/deadline` |
+| MacOS | `/var/lib/deadline` |
+| Windows| `%PROGRAMDATA%/Amazon/Deadline/Cache` |
+
+The structure of the persistence directory is:
+
+```txt
+<PERSISTENT_DIR>/
+├── credentials/
+│   ├── <WORKER_ID>.json
+├── queues/
+│   ├── <QUEUE_1_ID>
+│   │   ├── get_aws_credentials.sh
+│   │   └── iam_credentials.json
+│   └── <QUEUE_2_ID>
+│       ├── get_aws_credentials.sh
+│       └── iam_credentials.json
+└── worker.json
+```
+
+### Worker state file
+
+Path: `<PERSISTENCE_DIR>/worker.json`
+
+The worker maintains a worker state which is a JSON representation of the following structure:
+
+```jsonc
+{
+    "worker_id": "<WORKER_ID>"
+}
+```
+
+#### `worker_id`
+
+This contains a unique identifier that represents the worker in your AWS Deadline Cloud fleet.
+
+When the agent starts up, it checks for the worker state file and this value. If a `worker_id` is
+found, the worker agent will transition the worker to the `RUNNING` state and begin running as the
+worker.
+
+If the worker state file is not found or contains no value for `worker_id`, then the worker agent
+will create a new worker in the AWS Deadline Cloud fleet and persist the `worker_id` to the worker
+state file.
+
+If you are preparing an Amazon Machine Image (AMI) or a disk image, be sure that the `worker_id` is
+not persisted before making the image - otherwise all hosts using the image will attempt to run as
+the same worker and error.
+
+## Worker AWS credentials
+
+Path: `<PERSISTENCE_DIR>/credentials/<WORKER_ID>.json`
+
+The worker agent assumes the fleet role scoped down with permissions for its specific worker. This
+is done my making an `AssumeFleetRoleForWorker` API request. This returns temporary IAM credentials
+for the worker assume role session.
+
+The worker agent persists these temporary credentials to disk in the event that the worker agent
+program exits and needs to be restarted to avoid the need to make an additional
+`AssumeFleetRoleForWorker` API request.
+
+The structure of these files is:
+
+```json
+{
+    "Version": 1,
+    "AccessKeyId": "...",
+    "SecretAccessKey": "...",
+    "SessionToken": "...",
+    "Expiration": "<YYYY>-<MM>-<DD>T<HH>:<MM>:<SS>Z"
+}
+```
+
+These credentials can be used to grant IAM permissions for the worker. The worker agent assigns the
+file to only be accessed by the worker agent user. Review
+["Security best practices in IAM"][iam-security-best-practices] when handling worker AWS credentials
+files.
+
+[iam-security-best-practices]: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#bp-workloads-use-roles
+
+## Queue AWS credentials
+
+Structure:
+
+```txt
+<PERSISTENT_DIR>/
+└── queues/
+    └── <QUEUE_ID>
+        ├── config
+        ├── credentials
+        ├── get_aws_credentials.sh    # POSIX
+        ├── get_aws_credentials.cmd   # Windows
+        └── iam_credentials.json
+```
+
+When the worker agent is assigned a worker session for a queue with an associate IAM role, the
+worker agent will assume the queue role and make the AWS credentials available to the session
+actions it runs as subprocesses.
+
+This is done using the following procedure:
+
+1.  create a queue AWS credentials directory
+2.  write `config` file
+3.  write `credentials` file
+4.  write `get_aws_credentials.sh` on POSIX or `get_aws_credentials.cmd` on Windows
+5.  write `iam_credentials.json` containing the temporary credentials in the format expected
+    by the AWS CLI and SDKs
+
+
+When the worker agent creates subprocesses for session actions, it specifies the path to the
+`config` and `credentials` files in the queue AWS credentials directory in the `AWS_CONFIG_FILE` and
+`AWS_SHARED_CREDENTIALS_FILE` environment variables supported by official AWS SDKs & Tools
+([docs][aws-config-credentials-path-override]).
+
+These credentials can be used to grant IAM permissions for the queue. The worker agent assigns the
+file to only be accessed by the worker agent user. Review ["Security best practices in
+IAM"][iam-security-best-practices] when handling worker AWS credentials files.
+
+[aws-config-credentials-path-override]: https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html#file-location-change
+
+## Session directories
+
+The worker agent creates a session directory for each worker session it runs. The session
+directories are created in a platform-specific path:
+
+| Platform | Session directory path |
+| --- | --- |
+| POSIX | `/sessions/<SESSION_ID>` |
+| Windows | `C:\ProgramData\Amazon\OpenJD\<SESSION_ID>` |
+
+These directories are populated by the worker agent with files created to run the session. This
+includes:
+
+*   materialized [Open Job Description `<EmbeddedFile>s`][openjd-embedded-files]
+*   input/output job attachments
+
+[openjd-embedded-files]: https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#6-embeddedfile
+
+By default, the worker agent deletes worker session directories after they are completed. The
+directories may be kept if the agent exits abnormally or if the agent is configured to retain
+worker session directories using:
+
+*   `--retain-session-dir` command-line argument
+*   `DEADLINE_WORKER_RETAIN_SESSION_DIR` environment variable
+*   the `[os]` &rarr; `retain_session_dir` setting in the worker agent config file (see [configuration][])
+
+[configuration]: ./configuration.md
+
+These directories contain job data and should be secured accordingly. Consult the
+[security best practices][aws-deadline-cloud-security-best-practices].
+
+[aws-deadline-cloud-security-best-practices]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/security-best-practices.html#worker-hosts

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,12 @@
+# Telemetry
+
+The AWS Deadline Cloud worker agent collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our
+software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Providing the installer flag: `--telemetry-opt-out`
+3. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.

--- a/docs/worker_api_protocol.md
+++ b/docs/worker_api_protocol.md
@@ -1,4 +1,4 @@
-# AWS Deadline Cloud Worker API Workflows Contract
+# AWS Deadline Cloud Worker API Protocol
 
 This document outlines the various workflows that a Worker Agent for AWS Deadline Cloud
 must perform, and the formal requirement for how those workflows are implemented in terms


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We are preparing for the first public release of the worker agent which includes publishing our distribution artifacts to PyPI. The description of the packe on PyPI will include the `README.md` contents of this repository. Any links in the `README.md` that are relative need to be made absolute since they will not resolve correctly on PyPI. When choosing the absolute link, the link must refer to the correct branch (`mainline` vs `release`) depending on the context of the link.

Additionally, once the repository becomes public, visitors will be looking for basic information about the project such as:

*   what is it?
*   what can it be used for?
*   how can it be used and operated?
*   how can people interact with the project?

### What was the solution? (How)

*   Populate missing information in the `README.md`
*   Organize some more in-depth usage information into new/exiting `docs/*.md` files to keep the `README.md` concise for PyPI
*   Switched to absolute links in the project's `README.md`

### What is the impact of this change?

Readers landing on our published PyPI and GitHub pages will have a more clear and curated introduction to the project, emphasizing why they might find it important and providing information to help them get started using it and contributing to it.

### How was this change tested?

*   Using Visual Studio Code's markdown preview feature
*   Reviewing GitHub's markdown rendered version

### Was this change documented?

This change is documentation :)

### Is this a breaking change?

No