### PR TITLE
chore: set the package author to AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # AWS Deadline Cloud Worker Agent
 
 [![pypi](https://img.shields.io/pypi/v/deadline-cloud-worker-agent.svg)](https://pypi.python.org/pypi/deadline-cloud-worker-agent)
+[![python](https://img.shields.io/pypi/pyversions/deadline-cloud-worker-agent.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-worker-agent)
+[![license](https://img.shields.io/pypi/l/deadline-cloud-worker-agent.svg?style=flat)](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/LICENSE)
 
 The AWS Deadline Cloud worker agent can be used to run a worker in an
 [AWS Deadline Cloud][deadline-cloud] fleet. This includes managing the life-cycle of a worker and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "deadline-cloud-worker-agent"
+authors = [
+  {name = "Amazon Web Services"},
+]
 dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The package author is "Amazon Web Services", so we should set the field in the pyproject.toml so that it shows up with that author on PyPI.org when published.

### What was the solution? (How)

Set the authors field, and also add a couple more badges to the README while at it.

### What is the impact of this change?

Author identified.

### How was this change tested?

N/A

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*