### PR TITLE
chore: add package author

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "deadline-cloud-worker-agent"
+description = "The AWS Deadline Cloud worker agent can be used to run a worker in an AWS Deadline Cloud fleet"
+authors = [
+  {name = "Amazon Web Services"},
+]
 dynamic = ["version"]
 dependencies = [
     "requests ~= 2.31",
@@ -19,7 +23,6 @@ dependencies = [
     "requests == 2.31.*",
 ]
 requires-python = ">=3.7"
-description = "The AWS Deadline Cloud worker agent can be used to run a worker in an AWS Deadline Cloud fleet"
 # https://pypi.org/classifiers/
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent lacked an author. We are about to publish this package publicly on PyPI and must include the author.

### What was the solution? (How)

Added the author ("Amazon Web Services")

### What is the impact of this change?

We will be able to publish the worker agent to PyPI with the author properly attributed.

### How was this change tested?

Ran:

```
hatch build
```

I then extracted the packaged archives in `dist` to ensure the author was included correctly.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*