### PR TITLE
chore: add website to PyPI package listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ classifiers = [
   "Intended Audience :: End Users/Desktop",
 ]
 
+[project.urls]
+Homepage = "https://github.com/aws-deadline/deadline-cloud-worker-agent"
+Source = "https://github.com/aws-deadline/deadline-cloud-worker-agent"
+
 [project.scripts]
 deadline-worker-agent = "deadline_worker_agent:entrypoint"
 install-deadline-worker = "deadline_worker_agent:install"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `pyproject.toml` did not list any websites. We are about to publish the worker agent publicly to PyPI and there will be no website linked.

### What was the solution? (How)

Add a link for the website and source code to `pyproject.toml`

### What is the impact of this change?

Visitors to PyPI will be able to easily navigate to our GitHub repository.

### How was this change tested?

Ran `hatch build`

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*