### PR TITLE
fix: stop the running service before re-installation.

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -86,6 +86,7 @@ jobs:
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
+          pip install --upgrade hatch
           hatch -v build
 
       - name: Configure AWS credentials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.26.0 (2024-04-02)
+
+### BREAKING CHANGES
+* public release (#271) ([`ed1e14d`](https://github.com/aws-deadline/deadline-cloud-worker-agent/commit/ed1e14df818e8161490a5c6b884320eeb7b6832e))
+* remove deprecated features (#277) ([`d984094`](https://github.com/aws-deadline/deadline-cloud-worker-agent/commit/d984094f74b9ad60dd0bc82ec3eb917cda4e138d))
+
+
+### Bug Fixes
+* example config file inaccurately documents allow_ec2_instance_profile (#278) ([`1d1ecc1`](https://github.com/aws-deadline/deadline-cloud-worker-agent/commit/1d1ecc165384c6f14ace4465236460ba12b176ee))
+
 ## 0.25.2 (2024-03-29)
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Windows installer fails to update the Windows service if it is already running. 

### What was the solution? (How)
Stop the running service before re-installation.

### What is the impact of this change?
Installer can update the service even if the service is running.

### How was this change tested?
Install the service -> Start the service -> Reinstall the Service to ensure it can be updated.

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*