### PR TITLE
fix: provide region in queue AWS configuration

### DIFF
--- a/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
+++ b/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
@@ -102,6 +102,7 @@ class QueueBoto3Session(BaseBoto3Session):
     _role_arn: str
     _os_user: Optional[SessionUser]
     _interrupt_event: Event
+    _region: str
 
     # Name of the profile written to the user's AWS configuration for the
     # credentials process
@@ -135,6 +136,7 @@ class QueueBoto3Session(BaseBoto3Session):
         os_user: Optional[SessionUser] = None,
         interrupt_event: Event,
         worker_persistence_dir: Path,
+        region: str,
     ) -> None:
         super().__init__()
 
@@ -146,6 +148,7 @@ class QueueBoto3Session(BaseBoto3Session):
         self._role_arn = role_arn
         self._os_user = os_user
         self._interrupt_event = interrupt_event
+        self._region = region
 
         self._profile_name = f"deadline-{self._queue_id}"
 
@@ -162,9 +165,14 @@ class QueueBoto3Session(BaseBoto3Session):
 
         self._create_credentials_directory(os_user)
 
-        self._aws_config = AWSConfig(os_user=self._os_user, parent_dir=self._credential_dir)
+        self._aws_config = AWSConfig(
+            os_user=self._os_user,
+            parent_dir=self._credential_dir,
+            region=self._region,
+        )
         self._aws_credentials = AWSCredentials(
-            os_user=self._os_user, parent_dir=self._credential_dir
+            os_user=self._os_user,
+            parent_dir=self._credential_dir,
         )
 
         self._install_credential_process()

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -1151,6 +1151,7 @@ class WorkerScheduler:
                         os_user=os_user,
                         interrupt_event=self._shutdown,
                         worker_persistence_dir=self._worker_persistence_dir,
+                        region=self._boto_session.region_name,
                     )
                 except (DeadlineRequestWorkerOfflineError, DeadlineRequestUnrecoverableError):
                     # These are terminal errors for the Session. We need to fail it, without attempting,

--- a/test/unit/aws_credentials/test_queue_boto3_session.py
+++ b/test/unit/aws_credentials/test_queue_boto3_session.py
@@ -64,6 +64,11 @@ def os_user() -> Optional[SessionUser]:
         return WindowsSessionUser(user="user", password="fakepassword")
 
 
+@pytest.fixture
+def region() -> str:
+    return "us-west-2"
+
+
 class TestInit:
     def test_construction(
         self,
@@ -73,6 +78,7 @@ class TestInit:
         worker_id: str,
         queue_id: str,
         os_user: Optional[SessionUser],
+        region: str,
     ) -> None:
         # Just testing basic construction.
         # Make sure that the required instance methods are called and that we
@@ -98,6 +104,7 @@ class TestInit:
                 os_user=os_user,
                 interrupt_event=event,
                 worker_persistence_dir=Path("/var/lib/deadline"),
+                region=region,
             )
 
             # THEN
@@ -123,6 +130,7 @@ class TestInit:
         worker_id: str,
         queue_id: str,
         os_user: Optional[SessionUser],
+        region: str,
     ) -> None:
         # Make sure that we cleanup when the refresh_credentials() method raises an exception
 
@@ -149,6 +157,7 @@ class TestInit:
                     os_user=os_user,
                     interrupt_event=event,
                     worker_persistence_dir=Path("/var/lib/deadline"),
+                    region=region,
                 )
 
             # THEN
@@ -165,6 +174,7 @@ class TestCleanup:
         fleet_id: str,
         worker_id: str,
         queue_id: str,
+        region: str,
     ) -> None:
         # Regression test to make sure that cleanup always:
         # 1. Uninstalls the credential process from the user's AWS configuration
@@ -191,6 +201,7 @@ class TestCleanup:
                 os_user=None,
                 interrupt_event=event,
                 worker_persistence_dir=Path("/var/lib/deadline"),
+                region=region,
             )
 
             # WHEN
@@ -211,6 +222,7 @@ class TestHasCredentials:
         worker_id: str,
         queue_id: str,
         expired: bool,
+        region: str,
     ) -> None:
         # GIVEN
         event = Event()
@@ -236,6 +248,7 @@ class TestHasCredentials:
                 os_user=None,
                 interrupt_event=event,
                 worker_persistence_dir=Path("/var/lib/deadline"),
+                region=region,
             )
 
             # WHEN
@@ -265,6 +278,7 @@ class TestRefreshCredentials:
         file_cache_cls_mock: MagicMock,
         temporary_credentials_cls_mock: MagicMock,
         os_user: SessionUser,
+        region: str,
     ) -> None:
         # Test that if the Session contains credentials that ARE expired,
         # then it will use the given bootstrap_session credentials to do the refresh.
@@ -287,6 +301,7 @@ class TestRefreshCredentials:
                 os_user=os_user,
                 interrupt_event=event,
                 worker_persistence_dir=Path("/var/lib/deadline"),
+                region=region,
             )
         with (
             # Relevant mocks for the test
@@ -376,6 +391,7 @@ class TestRefreshCredentials:
         worker_id: str,
         queue_id: str,
         exception: Exception,
+        region: str,
     ) -> None:
         # Test that if the assume-role raises an exception that we re-raise it..
 
@@ -397,6 +413,7 @@ class TestRefreshCredentials:
                 os_user=None,
                 interrupt_event=event,
                 worker_persistence_dir=Path("/var/lib/deadline"),
+                region=region,
             )
         with (
             # Relevant mocks for the test
@@ -428,6 +445,7 @@ class TestRefreshCredentials:
         queue_id: str,
         temporary_credentials_cls_mock: MagicMock,
         exception: Exception,
+        region: str,
     ) -> None:
         # Test that if the parsing of the API response fails then we raise an exception.
 
@@ -449,6 +467,7 @@ class TestRefreshCredentials:
                 os_user=None,
                 interrupt_event=event,
                 worker_persistence_dir=Path("/var/lib/deadline"),
+                region=region,
             )
         with (
             # Relevant mocks for the test
@@ -479,6 +498,7 @@ class TestCreateCredentialsDirectory:
         worker_id: str,
         queue_id: str,
         os_user: Optional[SessionUser],
+        region: str,
     ) -> None:
         # Test that the directory is created securely.
 
@@ -507,6 +527,7 @@ class TestCreateCredentialsDirectory:
                 os_user=os_user,
                 interrupt_event=event,
                 worker_persistence_dir=worker_persistence_dir,
+                region=region,
             )
 
         # THEN
@@ -556,6 +577,7 @@ class TestCreateCredentialsDirectory:
         fleet_id: str,
         worker_id: str,
         queue_id: str,
+        region: str,
     ) -> None:
         # Test that a failure to create the directory is re-raised.
 
@@ -580,6 +602,7 @@ class TestCreateCredentialsDirectory:
                 os_user=None,
                 interrupt_event=event,
                 worker_persistence_dir=mock_path,
+                region=region,
             )
 
         mock_path.mkdir.side_effect = OSError("Boom!")
@@ -601,6 +624,7 @@ class TestDeleteCredentialsDirectory:
         worker_id: str,
         queue_id: str,
         exists: bool,
+        region: str,
     ) -> None:
         # Test that the directory is created securely.
 
@@ -624,6 +648,7 @@ class TestDeleteCredentialsDirectory:
                 os_user=None,
                 interrupt_event=event,
                 worker_persistence_dir=Path(tmpdir),
+                region=region,
             )
 
             if exists:
@@ -651,6 +676,7 @@ class TestInstallCredentialProcess:
         os_user: Optional[SessionUser],
         aws_config_cls_mock: MagicMock,
         aws_credentials_cls_mock: MagicMock,
+        region: str,
     ) -> None:
         # Test that the directory is created securely.
 
@@ -674,6 +700,7 @@ class TestInstallCredentialProcess:
                 os_user=os_user,
                 interrupt_event=event,
                 worker_persistence_dir=Path(tmpdir),
+                region=region,
             )
 
         aws_config_mock = aws_config_cls_mock.return_value
@@ -749,6 +776,7 @@ class TestUninstallCredentialProcess:
         os_user: Optional[SessionUser],
         aws_config_cls_mock: MagicMock,
         aws_credentials_cls_mock: MagicMock,
+        region: str,
     ) -> None:
         # Test that we call the correct methods to see the credentials process removed from
         # the user's AWS configuration.
@@ -776,6 +804,7 @@ class TestUninstallCredentialProcess:
                 os_user=os_user,
                 interrupt_event=event,
                 worker_persistence_dir=Path("/var/lib/deadline"),
+                region=region,
             )
 
         aws_config_mock = aws_config_cls_mock.return_value

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -1031,7 +1031,11 @@ class TestQueueAwsCredentialsManagement:
         # THEN
         assert result is creds
 
-    def test_creates_new_credentials(self, scheduler: WorkerScheduler) -> None:
+    def test_creates_new_credentials(
+        self,
+        scheduler: WorkerScheduler,
+        boto_session: MagicMock,
+    ) -> None:
         """Test that we create a new set of Queue credentials in _get_queue_aws_credentials
         when we don't already have one cached for the queue.
         """
@@ -1066,6 +1070,7 @@ class TestQueueAwsCredentialsManagement:
                 os_user=None,
                 interrupt_event=scheduler._shutdown,
                 worker_persistence_dir=Path("/var/lib/deadline"),
+                region=boto_session.region_name,
             )
             mock_cred_refresh_cls.assert_called_once_with(
                 resource={"resource": queue_id, "role_arn": role_arn},


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent was not specifying a `region` in the `config` file it provides in the [queue AWS credentials directory](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/docs/state.md#queue-aws-credentials).

If the worker host had not been provisioned in a way where AWS SDKs could resolve the region, then this would cause jobs to fail with:

```
ERROR: You must specify a region.
```

### What was the solution? (How)

Write the `config` file with a `region` set to the same region that the agent is configured to use.

### What is the impact of this change?

The actions within worker sessions will be configured to have the same region as the worker agent is using. Customers can override this behavior with a queue environment,

### How was this change tested?

*   Unit tests were updated and pass
*   Ran the agent in a customer-managed fleet and confirmed that adaptors could successfully make boto calls that require a region

### Was this change documented?

No. This was the intended behavior. Session actions should be pre-configured such that if they use AWS SDKs, those SDKs will use the same region as the worker.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*