### PR TITLE
ci: remove codertifact setup from bump workflow

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -33,25 +33,11 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
     env:
         PYTHON: ${{ matrix.python-version }}
-        CODEARTIFACT_REGION: "us-west-2"
-        CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
-        CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
-        CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
     - uses: actions/checkout@v4
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
-        aws-region: us-west-2
-        mask-aws-account-id: true
     
     - name: Install Hatch
       run: |
-        $CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
-        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
-        echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $env:GITHUB_ENV
         pip install --upgrade hatch
 
     - name: Run Windows Integration Tests


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We no longer configure codeartifact for the windows integration tests

### What was the solution? (How)
remove the code artifact setup

### What is the impact of this change?
fix bump workflow

### How was this change tested?
n/a

### Was this change documented?
n/a

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*