### PR TITLE
fix: handle case where BatchGetJobEntity returns no jobRunAsUser

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -253,7 +253,7 @@ class WindowsUser(TypedDict):
 class JobRunAsUser(TypedDict):
     posix: NotRequired[PosixUser]
     windows: NotRequired[WindowsUser]
-    runAs: NotRequired[Literal["QUEUE_CONFIGURED_USER", "WORKER_AGENT_USER"]]
+    runAs: Literal["QUEUE_CONFIGURED_USER", "WORKER_AGENT_USER"]
 
 
 class JobDetailsData(JobDetailsIdentifierFields):

--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -260,7 +260,7 @@ class JobDetailsData(JobDetailsIdentifierFields):
     jobAttachmentSettings: NotRequired[JobAttachmentQueueSettings]
     """The queue's job attachment settings"""
 
-    jobRunAsUser: JobRunAsUser
+    jobRunAsUser: NotRequired[JobRunAsUser]
     """The queue's info on how to run the job processes (ie. posix or windows user/group)"""
 
     logGroupName: str

--- a/src/deadline_worker_agent/boto/shim.py
+++ b/src/deadline_worker_agent/boto/shim.py
@@ -253,6 +253,7 @@ class DeadlineClient:
                             },
                             "logGroupName": "/aws/deadline/queue-abc",
                             "jobRunAsUser": {
+                                "runAs": "QUEUE_CONFIGURED_USER",
                                 "posix": {
                                     "user": "job-user",
                                     "group": "job-group",

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -756,7 +756,7 @@ class WorkerScheduler:
                     job_id=job_id,
                     session_id=session_id,
                     user=user_to_log,
-                    message="Running as the Worker Agent's user.",
+                    message="Running as the Worker Agent's user. This configuration is not recommended; please see the Security chapter of the User Guide.",
                 )
             )
         return os_user

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -37,6 +37,7 @@ from ..sessions.log_config import (
     LogProvisioningError,
     SessionLogConfigurationParameters,
 )
+from ..sessions.job_entities.job_details import JobRunAsUser
 from ..api_models import (
     AssignedSession,
     UpdateWorkerScheduleResponse,
@@ -668,6 +669,98 @@ class WorkerScheduler:
         )
         self._wakeup.set()
 
+    @staticmethod
+    def _determine_user_for_session(
+        *,
+        host_is_posix: bool,
+        job_run_as_user: Optional[JobRunAsUser],
+        job_run_as_user_override: JobsRunAsUserOverride,
+        queue_id: str,
+        job_id: str,
+        session_id: str,
+    ) -> Optional[SessionUser]:
+        # Called only in self._create_new_sessions() to determine what os_user the Session should
+        # run as.
+        # Raises a ValueError if an impossible situation arises and we need to fail the Session.
+        os_user: Optional[SessionUser] = None
+        if not job_run_as_user_override.run_as_agent:
+            if job_run_as_user_override.job_user is not None:
+                os_user = job_run_as_user_override.job_user
+                logger.info(
+                    SessionLogEvent(
+                        subtype=SessionLogEventSubtype.USER,
+                        queue_id=queue_id,
+                        job_id=job_id,
+                        session_id=session_id,
+                        user=os_user.user,
+                        message="Running as host-configured override user.",
+                    )
+                )
+            elif job_run_as_user is None:
+                # Terminal error. We need to fail the Session.
+                # This should *never* happen; it occuring would mean that a service invariant has
+                # been violated.
+                message = (
+                    "FATAL: Queue does not have a jobRunAsUser. This should not be possible. "
+                    "Please report this to the service team."
+                )
+                raise ValueError(message)
+            elif not job_run_as_user.is_worker_agent_user:
+                # If we do not have a job-user override & we're not explicitly running
+                # as the agent's user, then we *MUST* have a jobRunAsUser from the JobDetails.
+                # Reasons:
+                #  1) The service always allows service-managed Fleets to associate with
+                #     a Queue. The SMF Worker Agent is *always* run with a local user override.
+                #  2) The service only allows a customer-managed Fleet to associate with a
+                #     Queue if either:
+                #       a) The jobRunAsUser is explicitly set to WORKER_AGENT_USER; or
+                #       b) The jobRunAsUser is explicitly set to QUEUE_CONFIGURED_USER and
+                #          a user has been defined for the CMF's OS Platform (Linux/MacOS Fleets must
+                #          have a "posix" user; and Windows Fleets must have a "windows" user)
+                #  3) The service does not allow a Queue's jobRunAsUser to be updated if the constraint
+                #     imposed by (2) above would be violated for one or more of that Queue's current QFAs.
+                if host_is_posix:
+                    os_user = job_run_as_user.posix
+                else:
+                    os_user = job_run_as_user.windows
+                if os_user is None:
+                    # Terminal error. We need to fail the Session.
+                    # This should *never* happen; it occuring would mean that a service invariant has
+                    # been violated.
+                    message = (
+                        "FATAL: Queue's jobRunAsUser does not define a QUEUE_CONFIGURED_USER for this platform. "
+                        "Please report this to the service team."
+                    )
+                    raise ValueError(message)
+                else:
+                    logger.info(
+                        SessionLogEvent(
+                            subtype=SessionLogEventSubtype.USER,
+                            queue_id=queue_id,
+                            job_id=job_id,
+                            session_id=session_id,
+                            user=os_user.user,
+                            message="Running as Queue's jobRunAsUser.",
+                        )
+                    )
+        if os_user is None:
+            try:
+                user_to_log = getpass.getuser()
+            except Exception:
+                # This is best-effort. If we cannot determine the user we will not log
+                user_to_log = "UNKNOWN"
+            logger.warning(
+                SessionLogEvent(
+                    subtype=SessionLogEventSubtype.USER,
+                    queue_id=queue_id,
+                    job_id=job_id,
+                    session_id=session_id,
+                    user=user_to_log,
+                    message="Running as the Worker Agent's user.",
+                )
+            )
+        return os_user
+
     def _create_new_sessions(
         self,
         *,
@@ -842,52 +935,28 @@ class WorkerScheduler:
             queue.replace(actions=session_spec["sessionActions"])
 
             os_user: Optional[SessionUser] = None
-            if not self._job_run_as_user_override.run_as_agent:
-                if self._job_run_as_user_override.job_user is not None:
-                    os_user = self._job_run_as_user_override.job_user
-                    logger.info(
-                        SessionLogEvent(
-                            subtype=SessionLogEventSubtype.USER,
-                            queue_id=queue_id,
-                            job_id=job_id,
-                            session_id=new_session_id,
-                            user=os_user.user,
-                            message="Running as host-configured override user.",
-                        )
-                    )
-                elif job_details.job_run_as_user:
-                    if os.name == "posix":
-                        os_user = job_details.job_run_as_user.posix
-                    else:
-                        os_user = job_details.job_run_as_user.windows
-                    if os_user is not None:
-                        logger.info(
-                            SessionLogEvent(
-                                subtype=SessionLogEventSubtype.USER,
-                                queue_id=queue_id,
-                                job_id=job_id,
-                                session_id=new_session_id,
-                                user=os_user.user,
-                                message="Running as Queue's jobRunAsUser.",
-                            )
-                        )
-
-            if os_user is None:
-                try:
-                    user_to_log = getpass.getuser()
-                except Exception:
-                    # This is best-effort. If we cannot determine the user we will not log
-                    user_to_log = "UNKNOWN"
-                logger.warning(
+            try:
+                os_user = self._determine_user_for_session(
+                    host_is_posix=os.name == "posix",
+                    job_run_as_user=job_details.job_run_as_user,
+                    job_run_as_user_override=self._job_run_as_user_override,
+                    queue_id=queue_id,
+                    job_id=job_id,
+                    session_id=new_session_id,
+                )
+            except ValueError as e:
+                message = str(e)
+                self._fail_all_actions(session_spec, message)
+                logger.error(
                     SessionLogEvent(
                         subtype=SessionLogEventSubtype.USER,
                         queue_id=queue_id,
                         job_id=job_id,
                         session_id=new_session_id,
-                        user=user_to_log,
-                        message="Running as the Worker Agent's user.",
+                        message=message,
                     )
                 )
+                continue
 
             queue_credentials: QueueAwsCredentials | None = None
             asset_sync: AssetSync | None = None

--- a/test/unit/sessions/job_entities/test_job_details.py
+++ b/test/unit/sessions/job_entities/test_job_details.py
@@ -66,84 +66,8 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                 "jobId": "job-0000",
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-0000-00",
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "user1",
-                        "group": "group1",
-                    },
-                },
             },
-            id="only required fields - posix",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-0000-00",
-                "jobRunAsUser": {
-                    "windows": {
-                        "user": "user1",
-                        "passwordArn": "anarn",
-                    },
-                },
-            },
-            id="only required fields - windows",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-0000-00",
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "",
-                        "group": "",
-                    },
-                },
-            },
-            id="only required fields, empty user",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-0000-00",
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "",
-                        "group": "",
-                    },
-                },
-            },
-            id="only required fields, empty user",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-0000-00",
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "",
-                        "group": "",
-                    },
-                },
-            },
-            id="only required fields, empty user",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-0000-00",
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "",
-                        "group": "",
-                    },
-                },
-            },
-            id="only required fields, empty user",
+            id="only required fields",
         ),
         pytest.param(
             {
@@ -158,12 +82,6 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                         "path": "param2value",
                     },
                 },
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "user1",
-                        "group": "group1",
-                    },
-                },
             },
             id="valid parameters",
         ),
@@ -173,12 +91,6 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-0000-00",
                 "pathMappingRules": [],
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "user1",
-                        "group": "group1",
-                    },
-                },
             },
             id="valid pathMappingRules - empty list",
         ),
@@ -194,12 +106,6 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                         "destinationPath": "/destination/path",
                     },
                 ],
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "user1",
-                        "group": "group1",
-                    },
-                },
             },
             id="valid pathMappingRules",
         ),
@@ -208,9 +114,11 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                 "jobId": "job-0000",
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-0000-00",
-                "jobRunAsUser": {},
+                "jobRunAsUser": {
+                    "runAs": "WORKER_AGENT_USER",
+                },
             },
-            id="valid jobRunAsUser - empty dict",
+            id="valid agent user",
         ),
         pytest.param(
             {
@@ -218,14 +126,17 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-0000-00",
                 "jobRunAsUser": {
+                    "runAs": "QUEUE_CONFIGURED_USER",
                     "posix": {
                         "user": "user1",
                         "group": "group1",
                     },
-                    # (no "runAs" here)
                 },
             },
-            id="valid old jobRunAsUser",
+            marks=pytest.mark.skipif(
+                os.name != "posix", reason="validation logic is platform-specific"
+            ),
+            id="valid new jobRunAsUser - posix only",
         ),
         pytest.param(
             {
@@ -233,6 +144,25 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-0000-00",
                 "jobRunAsUser": {
+                    "runAs": "QUEUE_CONFIGURED_USER",
+                    "windows": {
+                        "user": "user1",
+                        "passwordArn": "anarn",
+                    },
+                },
+            },
+            marks=pytest.mark.skipif(
+                os.name == "posix", reason="validation logic is platform-specific"
+            ),
+            id="valid new jobRunAsUser - windows only",
+        ),
+        pytest.param(
+            {
+                "jobId": "job-0000",
+                "logGroupName": "/aws/deadline/queue-0000",
+                "schemaVersion": "jobtemplate-0000-00",
+                "jobRunAsUser": {
+                    "runAs": "QUEUE_CONFIGURED_USER",
                     "posix": {
                         "user": "user1",
                         "group": "group1",
@@ -241,10 +171,9 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                         "user": "user1",
                         "passwordArn": "anarn",
                     },
-                    "runAs": "QUEUE_CONFIGURED_USER",
                 },
             },
-            id="valid new jobRunAsUser",
+            id="valid new jobRunAsUser - all platforms",
         ),
         pytest.param(
             {
@@ -255,12 +184,6 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                     "s3BucketName": "mybucket",
                     "rootPrefix": "myprefix",
                 },
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "user1",
-                        "group": "group1",
-                    },
-                },
             },
             id="valid jobAttachmentSettings",
         ),
@@ -269,7 +192,6 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                 "jobId": "job-0000",
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-0000-00",
-                "osUser": "",
                 "parameters": {
                     "param1": {
                         "string": "param1value",
@@ -286,9 +208,14 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                     },
                 ],
                 "jobRunAsUser": {
+                    "runAs": "QUEUE_CONFIGURED_USER",
                     "posix": {
                         "user": "user1",
                         "group": "group1",
+                    },
+                    "windows": {
+                        "user": "user1",
+                        "passwordArn": "anarn",
                     },
                 },
                 "jobAttachmentSettings": {
@@ -315,6 +242,7 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-2023-09",
                 "jobRunAsUser": {
+                    "runAs": "QUEUE_CONFIGURED_USER",
                     "posix": {
                         "user": "user1",
                         "group": "group1",
@@ -327,26 +255,6 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
             },
             "job_details_with_user",
             id="only required fields",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-2023-09",
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "user1",
-                        "group": "group1",
-                    },
-                    "windows": {
-                        "user": "user1",
-                        "passwordArn": "anarn",
-                    },
-                    "runAs": "QUEUE_CONFIGURED_USER",
-                },
-            },
-            "job_details_with_user",
-            id="required fields with runAs QUEUE_CONFIGURED_USER",
         ),
         pytest.param(
             {
@@ -388,30 +296,9 @@ def test_input_validation_success(data: dict[str, Any]) -> None:
                 "jobId": "job-0000",
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-2023-09",
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "",
-                        "group": "",
-                    },
-                },
             },
             "job_details_no_user",
-            id="required with empty posix user/group",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-2023-09",
-                "jobRunAsUser": {
-                    "windows": {
-                        "user": "",
-                        "passwordArn": "",
-                    },
-                },
-            },
-            "job_details_no_user",
-            id="required with empty windows user",
+            id="required with no user",
         ),
         pytest.param(
             {
@@ -672,14 +559,6 @@ def test_convert_job_user_from_boto(data: JobDetailsData, expected: JobDetails, 
                 ],
             },
             id="nonvalid jobRunAsUser - not dict",
-        ),
-        pytest.param(
-            {
-                "jobId": "job-0000",
-                "logGroupName": "/aws/deadline/queue-0000",
-                "schemaVersion": "jobtemplate-0000-00",
-            },
-            id="missing jobRunAsUser",
         ),
         pytest.param(
             {

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -209,16 +209,6 @@ class TestJobEntity:
                 "jobId": job_id,
                 "schemaVersion": "jobtemplate-2023-09",
                 "logGroupName": "fake-name",
-                "jobRunAsUser": {
-                    "posix": {
-                        "user": "job-user",
-                        "group": "job-group",
-                    },
-                    "windows": {
-                        "user": "job-user",
-                        "passwordArn": "job-password-arn",
-                    },
-                },
             },
         )
         response: BatchGetJobEntityResponse = {
@@ -261,6 +251,7 @@ class TestJobEntity:
         api_response: dict = {
             "jobId": "job-123",
             "jobRunAsUser": {
+                "runAs": "QUEUE_CONFIGURED_USER",
                 "posix": {
                     "user": expected_user,
                     "group": expected_group,
@@ -306,6 +297,7 @@ class TestDetails:
                 "schemaVersion": "jobtemplate-2023-09",
                 "logGroupName": "/aws/deadline/queue-0000",
                 "jobRunAsUser": {
+                    "runAs": "QUEUE_CONFIGURED_USER",
                     "posix": {
                         "user": "user",
                         "group": "group",

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -591,6 +591,7 @@ class TestCaching:
             "logGroupName": "/aws/service/loggroup",
             "schemaVersion": "jobtemplate-2023-09",
             "jobRunAsUser": {
+                "runAs": "QUEUE_CONFIGURED_USER",
                 "posix": {
                     "user": "job-user",
                     "group": "job-group",


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The jobRunAsUser response field of the JobDetailsEntity structure within a BatchGetJobEntity request is an optional field. This Worker Agent currently treats it as a required field; resulting in failed Sessions when the field is absent.

### What was the solution? (How)

Handle the case of missing the jobRunAsUser field in the response. It is a service invariant that this field is always be present when the Worker is within a CMF. When the Worker is running within an SMF, then the field may be optional; but, further, in this case the Agent will always be running with a local jobRunAsUser override. We fail Sessions when this invariant is violated.

### What is the impact of this change?

Sessions should no longer fail if a Queue is configured to not have a `jobRunAsUser` and the Worker is running within a service managed fleet.

### How was this change tested?

I've added unit test coverage of all cases, and also ran the code locally against a CMF under a variety of configurations and submitted a sleep job to queues to test.

In these tests `queue-fcda40de72c64476aac2addf8e997a85` is configured with `QUEUE_CONFIGURED_USER`, and `queue-e17782957b0d49a5acef1a6ed690b392` is configured for `WORKER_AGENT_USER`.

1. Submitting the sleep job to both queues, and picking them up with a "normally" configured worker:
```
+ deadline-worker-agent --no-shutdown --farm-id farm-591c678b072c493c90622087500add9c --fleet-id fleet-e1736871b91b47148d1b25bc7929b866
...
[2024-04-10 16:29:10,931][INFO    ] 🔷 Session.User 🔷 [session-9ec374d3d45b4ee19132965165258560] Running as Queue's jobRunAsUser. (User: jobuser) [queue-fcda40de72c64476aac2addf8e997a85/job-fb01ad60cfd040e491fd64127897f1f6]
...
[2024-04-10 16:29:44,091][WARNING ] 🔷 Session.User 🔷 [session-33279e091c2a4ef89d4cef5a1f85ba13] Running as the Worker Agent's user. (User: agentuser) [queue-e17782957b0d49a5acef1a6ed690b392/job-6bed0407db9b4320a579cf7788f0b814]
...
```

2. Configuring the worker agent to run all as the agent user and submitting to the `QUEUE_CONFIGURED_USER` queue:

```
+ deadline-worker-agent --no-shutdown --farm-id farm-591c678b072c493c90622087500add9c --fleet-id fleet-e1736871b91b47148d1b25bc7929b866 --run-jobs-as-agent-user
...
[2024-04-10 16:32:36,092][WARNING ] 🔷 Session.User 🔷 [session-b442b4d20eba45eaa672588307d07025] Running as the Worker Agent's user. (User: agentuser) [queue-fcda40de72c64476aac2addf8e997a85/job-bffead121b674cea89ae6fdfc29c2b10]
...
```

3. Configuring the worker agent to override the jobRunAsUser and submitting to the `WORKER_AGENT_USER` queue:

```
+ deadline-worker-agent --no-shutdown --farm-id farm-591c678b072c493c90622087500add9c --fleet-id fleet-e1736871b91b47148d1b25bc7929b866 --posix-job-user jobuser:jobuser
...
[2024-04-10 16:35:46,601][INFO    ] 🔷 Session.User 🔷 [session-91b6bf4e58fd47de83d9c3e358611dfc] Running as host-configured override user. (User: jobuser) [queue-e17782957b0d49a5acef1a6ed690b392/job-a2798841947c4cca85824aed8674429e]
...
```

### Was this change documented?

N/A

### Is this a breaking change?

No, it should not be.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*