### PR TITLE
chore: fix retry formula to conform to botocore(70514ef)

### DIFF
--- a/test/unit/boto/test_retries.py
+++ b/test/unit/boto/test_retries.py
@@ -66,7 +66,7 @@ class TestNoOverflowExponentialBackoff:
             random_between=random_between,
         )
         if is_exponential:
-            expected = min(max_backoff, random_value * base ** (attempt_number - 1))
+            expected = random_value * min(max_backoff, base ** (attempt_number - 1))
         else:
             expected = random_value
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
[Delay tests](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/test/unit/boto/test_retries.py#L52) are failing due to a change up steam in [botocore](https://github.com/boto/botocore/commit/70514effeb6a77e12993c0fbaa907c0b92aae342#diff-d3e80b391c9677c720b0d2d6328856e2c4aae989f737c78f0acf7f36bd706688L266)

### What was the solution? (How)
change the `expected` formula in the unit tests to match the botocore formula

### What is the impact of this change?
tests fixed, PRs and release workflows are unblocked

### How was this change tested?
`hatch run test`

### Was this change documented?
no

### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*