### PR TITLE
docs: fix incorrect default log path on Linux/MacOS

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -14,8 +14,8 @@ The default locations for worker logs are:
 
 | Platform | Default worker log path |
 | --- | --- |
-| Linux | `/var/log/amazon/deadline/logs` |
-| MacOS | `/var/log/amazon/deadline/logs` |
+| Linux | `/var/log/amazon/deadline` |
+| MacOS | `/var/log/amazon/deadline` |
 | Windows | `C:\ProgramData\Amazon\Deadline\Logs` |
 
 The worker agent maintains two sets of rotating log files:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The documentation stated an incorrect default log path for Linux/MacOS:

```
/var/log/amazon/deadline/logs
```

The source of truth for the actual default log path is here:

https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/68dfc2c9c0521cca47ad1ff3bbe06fd323c18852/src/deadline_worker_agent/startup/settings.py#L18

### What was the solution? (How)

Fix the documented default log path for Linux/MacOS with the correct value.

### What is the impact of this change?

People reading the worker agent documentation will have accurate information about the default log paths on Linux/MacOS

### How was this change tested?

View the change in GitHub markdown preview and visually confirm the path matches the  code

### Was this change documented?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*