### PR TITLE
ci: add e2e test

### DIFF
--- a/.github/workflows/mainline_e2e_test.yml
+++ b/.github/workflows/mainline_e2e_test.yml
@@ -1,9 +1,10 @@
-name: Release Integration Canary
+name: Mainline E2E Test
 
 on:
-  schedule:
-    - cron: '0 */4 * * *'
   workflow_dispatch:
+  push:
+    branches:
+      - 'mainline'
 
 jobs:
   WindowsIntegrationTests:
@@ -24,14 +25,15 @@ jobs:
     - name: Run Windows Integration Tests
       run: hatch run integ-windows
       
-  ReleaseIntegrationCanary:
-    name: Release Canary
+  MainlineLinuxE2ETest:
+    name: Linux E2E Test
     permissions:
       id-token: write
       contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_canary.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_e2e_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      branch: release
-      environment: canary
+      branch: mainline
+      environment: mainline
+      os: linux

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -42,21 +42,22 @@ jobs:
     - name: Run Windows Integration Tests
       run: hatch run integ-windows
 
-  IntegrationTests:
+  LinuxE2ETests:
     needs: UnitTests
-    name: Integration Test
+    name: Linux E2E Test
     permissions:
       id-token: write
       contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_e2e_test.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
       branch: mainline
       environment: mainline
+      os: linux
 
   Bump:
-    needs: IntegrationTests
+    needs: LinuxE2ETests
     name: Version Bump
     uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
     secrets: inherit

--- a/.github/workflows/release_e2e_canary.yml
+++ b/.github/workflows/release_e2e_canary.yml
@@ -1,10 +1,9 @@
-name: Mainline Integration Test
+name: Release Canary
 
 on:
+  schedule:
+    - cron: '0 */4 * * *'
   workflow_dispatch:
-  push:
-    branches:
-      - 'mainline'
 
 jobs:
   WindowsIntegrationTests:
@@ -25,14 +24,15 @@ jobs:
     - name: Run Windows Integration Tests
       run: hatch run integ-windows
       
-  MainlineIntegrationTest:
-    name: Integration Test
+  ReleaseLinuxE2ECanary:
+    name: Release Linux Canary
     permissions:
       id-token: write
       contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_canary.yml@mainline
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      branch: mainline
-      environment: mainline
+      branch: release
+      environment: canary
+      os: linux

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Set the -e option
+set -e
+
+pip install --upgrade pip
+pip install --upgrade hatch
+
+if [ $TEST_TYPE ]
+then
+  if [ $TEST_TYPE = "WHEEL" ]
+  then
+    hatch run codebuild:build
+    export WORKER_AGENT_WHL_PATH=dist/`hatch run codebuild\:metadata name | sed 's/-/_/g'`-`hatch run codebuild\:version`-py3-none-any.whl
+    echo "Set WORKER_AGENT_WHL_PATH to $WORKER_AGENT_WHL_PATH"
+  fi
+else
+  continue
+fi
+
+hatch run codebuild:integ-test


### PR DESCRIPTION
# DO NOT MERGE YET

### What was the problem/requirement? (What/Why)
1. The existing worker agent integration tests should be classified as e2e tests.
2. The test reusable workflows nows require the operating system to be passed in.

### What was the solution? (How)
1. Change the Integration Tests to E2E tests and point to the e2e test reusable workflow. Create a e2e.sh pipeline file.
2. Pass the os to the reusable workflow

### What is the impact of this change?
There is now accurate naming of testing being run and we can differentiate operating systems for test jobs.

### How was this change tested?


### Was this change documented?

### Is this a breaking change?
This change is dependent on https://github.com/aws-deadline/.github/pull/9 being merged.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*