### PR TITLE
chore: fix docker-based testing scripts for docker-25

### DIFF
--- a/scripts/create_service_resources.sh
+++ b/scripts/create_service_resources.sh
@@ -177,7 +177,7 @@ then
     "configuration": {
         "customerManaged": {
             "mode": "NO_SCALING", 
-            "workerRequirements": {
+            "workerCapabilities": {
                 "vCpuCount": {
                     "min": 1
                 },

--- a/scripts/run_posix_docker.sh
+++ b/scripts/run_posix_docker.sh
@@ -114,6 +114,10 @@ if test "${PIP_INDEX_URL:-}" != ""; then
     echo "PIP_INDEX_URL=${PIP_INDEX_URL}" >> $TMP_ENV_FILE
 fi
 
+if test "${AWS_ENDPOINT_URL_DEADLINE}" != ""; then
+    echo "AWS_ENDPOINT_URL_DEADLINE=${AWS_ENDPOINT_URL_DEADLINE}" >> $TMP_ENV_FILE
+fi
+
 docker run --rm \
     --name test_worker_agent \
     -v $(pwd):/code:ro \

--- a/testing_containers/posix_ldap_multiuser/Dockerfile
+++ b/testing_containers/posix_ldap_multiuser/Dockerfile
@@ -6,9 +6,6 @@ ENV AGENT_USER=agentuser
 ENV JOB_USER=jobuser
 ENV SHARED_GROUP=sharedgroup
 
-# Use a docker volume to mount the root of the repo to this directory
-VOLUME /code /aws
-
 WORKDIR /config
 
 COPY changePassword.ldif /config
@@ -27,7 +24,8 @@ COPY term_agent.sh /config
 # These accounts belong to the following groups:
 #   agentuser: agentuser, sharedgroup
 #   jobuser: jobuser, sharedgroup
-RUN chmod 777 /code /aws && \
+RUN mkdir /code /aws && \
+    chmod 777 /code /aws && \
     echo $(grep $(hostname) /etc/hosts | cut -f1) ldap.environment.internal >> /etc/hosts && \
     apt-get update && export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y vim screen slapd ldap-utils && \
@@ -65,6 +63,8 @@ RUN chmod 777 /code /aws && \
     apt-get install sudo-ldap && \
     echo "${AGENT_USER} ALL=(${JOB_USER},${AGENT_USER}) NOPASSWD: ALL" > /etc/sudoers.d/${AGENT_USER}
 
+# Use a docker volume to mount the root of the repo to this directory
+VOLUME /code /aws
 
 WORKDIR /home/agentuser
 

--- a/testing_containers/posix_ldap_multiuser/run_agent.sh
+++ b/testing_containers/posix_ldap_multiuser/run_agent.sh
@@ -9,6 +9,8 @@ python -m venv .venv
 source .venv/bin/activate
 pip install /code/dist/deadline_cloud_worker_agent-*-py3-none-any.whl
 
+ln -s /aws ~/.aws
+
 deadline-worker-agent \
     --posix-job-user jobuser:sharedgroup \
     --no-shutdown \

--- a/testing_containers/posix_local_multiuser/Dockerfile
+++ b/testing_containers/posix_local_multiuser/Dockerfile
@@ -6,9 +6,6 @@ ENV AGENT_USER=agentuser
 ENV JOB_USER=jobuser
 ENV SHARED_GROUP=sharedgroup
 
-# Use a docker volume to mount the root of the repo to this directory
-VOLUME /code /aws
-
 # We set up two users:
 #  1) agentuser -- the user that will be running the Worker Agent.
 #  2) jobuser -- the user that we'll be running Jobs as.
@@ -17,7 +14,8 @@ VOLUME /code /aws
 #   agentuser: agentuser, sharedgroup
 #   jobuser: jobuser, sharedgroup
 
-RUN chmod 777 /code /aws && \
+RUN mkdir /code /aws && \
+    chmod 777 /code /aws && \
     apt-get update && apt-get install sudo && \
     rm -rf /var/lib/apt/lists/* && \
     addgroup ${SHARED_GROUP} &&  \
@@ -36,6 +34,9 @@ RUN chmod 777 /code /aws && \
     mkdir -p /var/lib/deadline/queues && \
     chown ${AGENT_USER}:${SHARED_GROUP} /var/lib/deadline /var/lib/deadline/queues && \
     chmod 750 /var/lib/deadline /var/lib/deadline/queues
+
+# Use a docker volume to mount the root of the repo to this directory
+VOLUME /code /aws
 
 WORKDIR /home/agentuser
 

--- a/testing_containers/posix_local_multiuser/run_agent.sh
+++ b/testing_containers/posix_local_multiuser/run_agent.sh
@@ -9,6 +9,8 @@ python -m venv .venv
 source .venv/bin/activate
 pip install /code/dist/deadline_cloud_worker_agent-*-py3-none-any.whl
 
+ln -s /aws ~/.aws
+
 deadline-worker-agent \
     --posix-job-user jobuser:sharedgroup \
     --no-shutdown \

--- a/testing_containers/posix_local_multiuser_jobRunAsUser/Dockerfile
+++ b/testing_containers/posix_local_multiuser_jobRunAsUser/Dockerfile
@@ -6,9 +6,6 @@ ENV AGENT_USER=agentuser
 ENV JOB_USER=jobuser
 ENV SHARED_GROUP=sharedgroup
 
-# Use a docker volume to mount the root of the repo to this directory
-VOLUME /code /aws
-
 # We set up two users:
 #  1) agentuser -- the user that will be running the Worker Agent.
 #  2) jobuser -- the user that we'll be running Jobs as.
@@ -17,7 +14,8 @@ VOLUME /code /aws
 #   agentuser: agentuser, sharedgroup
 #   jobuser: jobuser, sharedgroup
 
-RUN chmod 777 /code /aws && \
+RUN mkdir /code /aws && \
+    chmod 777 /code /aws && \
     apt-get update && apt-get install sudo && \
     rm -rf /var/lib/apt/lists/* && \
     addgroup ${SHARED_GROUP} &&  \
@@ -36,6 +34,9 @@ RUN chmod 777 /code /aws && \
     mkdir -p /var/lib/deadline/queues && \
     chown ${AGENT_USER}:${SHARED_GROUP} /var/lib/deadline /var/lib/deadline/queues && \
     chmod 750 /var/lib/deadline /var/lib/deadline/queues
+
+# Use a docker volume to mount the root of the repo to this directory
+VOLUME /code /aws
 
 WORKDIR /home/agentuser
 

--- a/testing_containers/posix_local_multiuser_jobRunAsUser/run_agent.sh
+++ b/testing_containers/posix_local_multiuser_jobRunAsUser/run_agent.sh
@@ -12,6 +12,8 @@ python -m venv .venv
 source .venv/bin/activate
 pip install /code/dist/deadline_cloud_worker_agent-*-py3-none-any.whl
 
+ln -s /aws ~/.aws
+
 deadline-worker-agent \
     --no-shutdown \
     --farm-id $FARM_ID \


### PR DESCRIPTION
Summary:


### What was the problem/requirement? (What/Why)

This fixes a couple of issues with our scripting:
1. The existing Dockerfiles do not work with Docker 25; they were written for Docker 20. The behavior of the VOLUME directive has changed to no longer automatically create the directories listed.
2. create_service_resources.sh was using an incorrect name for a request parameter; the name was changed in the run-up to GA.
3. The scripts could no longer be used with model & endpoint overrides for the deadline service. This functionality broke with GA and the inclusion of the model in boto3.

### What was the solution? (How)

Updates to the scripting files to fix the issues.
1. Explicitly creating the required VOLUME directories.
2. Changing the name of the erroneous request parameter.
3. Creating a symbolic link to the agentuser's `~/.aws` directory to ensure that it contains the imported `/aws` directory's content, and exporting the endpoint-url env var into the container when running it.

### What is the impact of this change?

The scripting should be usable with Docker 25 and the post-GA service.

### How was this change tested?

By running the scripting as I fixed things.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*