### PR TITLE
test: change worker config fleet

### DIFF
--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -171,7 +171,7 @@ def worker_config(
 
         yield DeadlineWorkerConfiguration(
             farm_id=deadline_resources.farm.id,
-            fleet_id=deadline_resources.scaling_fleet.id,
+            fleet_id=deadline_resources.fleet.id,
             region=region,
             user=os.getenv("WORKER_POSIX_USER", "deadline-worker"),
             group=os.getenv("WORKER_POSIX_SHARED_GROUP", "shared-group"),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Deadline workfer configuration is set to use the incorrect fleet id.

### What was the solution? (How)
Change to using the non scaling fleet.

### What is the impact of this change?
correct fleet will be used in tests

### How was this change tested?
`hatch run integ-test`

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*