### PR TITLE
fix: ignore job-entity run-as value when agent has a job user override

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -5,7 +5,7 @@ pre-install-commands = [
 
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
-test = "pytest {args:test/unit --numprocesses=auto}"
+test = "pytest test/unit --numprocesses=auto {args}"
 # Don't pass --numprocesses here so that tests run sequentially.
 # pytest-xdist does not allow live output of stdout, meaning integ tests only show output after the test is done
 # See: https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -890,6 +890,7 @@ class WorkerScheduler:
                 job_id=job_id,
                 deadline_client=self._deadline,
                 windows_credentials_resolver=self._windows_credentials_resolver,
+                job_run_as_user_override=self._job_run_as_user_override,
             )
             # TODO: Would be great to merge Session + SessionActionQueue
             # and move all job entities calls within the Session thread.

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -33,6 +33,7 @@ from ...api_models import (
 )
 from .job_entity_type import JobEntityType
 from .validation import Field, validate_object
+from ...startup.config import JobsRunAsUserOverride
 
 
 def parameters_from_api_response(
@@ -272,7 +273,9 @@ class JobDetails:
         )
 
     @classmethod
-    def validate_entity_data(cls, entity_data: dict[str, Any]) -> JobDetailsData:
+    def validate_entity_data(
+        cls, entity_data: dict[str, Any], job_user_override: JobsRunAsUserOverride | None
+    ) -> JobDetailsData:
         """Performs input validation on a response element received from boto3's call to
         the BatchGetJobEntity AWS Deadline Cloud API.
 
@@ -373,8 +376,11 @@ class JobDetails:
                     ),
                 )
 
-        # Validate jobRunAsUser -> runAs is one of ("QUEUE_CONFIGURED_USER" / "WORKER_AGENT_USER")
-        if run_as_value := entity_data.get("jobRunAsUser", dict()).get("runAs", None):
+        if job_user_override is not None:
+            # If there is an override, we don't care about the job details jobRunAsUser
+            entity_data.pop("jobRunAsUser", None)
+        elif run_as_value := entity_data.get("jobRunAsUser", dict()).get("runAs", None):
+            # Validate jobRunAsUser -> runAs is one of ("QUEUE_CONFIGURED_USER" / "WORKER_AGENT_USER")
             if run_as_value not in ("QUEUE_CONFIGURED_USER", "WORKER_AGENT_USER"):
                 raise ValueError(
                     f'Expected "jobRunAs" -> "runAs" to be one of "QUEUE_CONFIGURED_USER", "WORKER_AGENT_USER" but got "{run_as_value}"'

--- a/src/deadline_worker_agent/sessions/job_entities/job_entities.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_entities.py
@@ -35,6 +35,7 @@ from .job_details import JobDetails
 from .job_entity_type import JobEntityType
 from .step_details import StepDetails
 from .environment_details import EnvironmentDetails
+from ...startup.config import JobsRunAsUserOverride
 
 if TYPE_CHECKING:
     from ...api_models import (
@@ -109,6 +110,7 @@ class JobEntities:
         job_id: str,
         deadline_client: DeadlineClient,
         windows_credentials_resolver: Optional[WindowsCredentialsResolver],
+        job_run_as_user_override: Optional[JobsRunAsUserOverride],
     ) -> None:
         self._job_id = job_id
         self._farm_id = farm_id
@@ -117,6 +119,7 @@ class JobEntities:
         self._deadline_client = deadline_client
         self._windows_credentials_resolver = windows_credentials_resolver
         self._entity_record_map = {}
+        self._job_run_as_user_override = job_run_as_user_override
 
     def request(self, *, identifier: EntityIdentifier) -> dict[str, Any]:
         """Given an identifier, grab the associated data from the
@@ -322,7 +325,7 @@ class JobEntities:
         )
 
         result = self.request(identifier=identifier)
-        job_details_data = JobDetails.validate_entity_data(result)
+        job_details_data = JobDetails.validate_entity_data(result, self._job_run_as_user_override)
         job_details = JobDetails.from_boto(job_details_data)
 
         # if JobRunAsUser specifies a windows user resolve the credentials here

--- a/test/unit/sessions/job_entities/test_job_details.py
+++ b/test/unit/sessions/job_entities/test_job_details.py
@@ -230,7 +230,7 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
 )
 def test_input_validation_success(data: dict[str, Any]) -> None:
     """Test that validate_entity_data() can successfully handle valid input data."""
-    JobDetails.validate_entity_data(entity_data=data)
+    JobDetails.validate_entity_data(entity_data=data, job_user_override=None)
 
 
 @pytest.mark.parametrize(
@@ -665,4 +665,4 @@ def test_convert_job_user_from_boto(data: JobDetailsData, expected: JobDetails, 
 def test_input_validation_failure(data: dict[str, Any]) -> None:
     """Test that validate_entity_data() raises a ValueError when nonvalid input data is provided."""
     with pytest.raises(ValueError):
-        JobDetails.validate_entity_data(entity_data=data)
+        JobDetails.validate_entity_data(entity_data=data, job_user_override=None)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The worker agent was validating the `jobRunAsUser` field in the `BatchGetJobEntity` API response, even when the worker agent was configured with a job user override. 

This would lead to issues if a queue was configured with *only* the opposite system type in the `jobRunAsUser`. For example, a linux worker with the `posix_job_user` [configuration](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/src/deadline_worker_agent/installer/worker.toml.example#L202) receives a job, which has a `jobRunAsUser` value of: 

```
{
    "runAs": "QUEUE_CONFIGURED_USER",
    "windows": {
        "user": "windows-job-user",
        "passwordArn": "<password arn>"
    }
}
```

Then the worker agent would throw an error [here](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/9367c10713391caca6bf6e256a4eb595ecda0165/src/deadline_worker_agent/sessions/job_entities/job_details.py#L390) because there is no `posix` `runAs` field available, even though it shouldn't matter due to the override.

### What was the solution? (How)

Ignore the `jobRunAsUser` field if the worker agent has a job user override

### What is the impact of this change?

The erroneous behavior above no longer occurs.

### How was this change tested?

Unit tests added. 

Tested on a CMF worker with and without this change. 

Confirmed that the worker with this change had a successful job run, while the worker without this change encountered the  ```Expected "jobRunAs" -> "posix" to exist when "jobRunAs" -> "runAs" is "QUEUE_CONFIGURED_USER" but it was not present``` error

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*