### PR TITLE
revert: "fix: fail on BatchGetJobEntity jobRunAsUser validation with …

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -5,7 +5,7 @@ pre-install-commands = [
 
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
-test = "pytest test/unit --numprocesses=auto {args}"
+test = "pytest {args:test/unit --numprocesses=auto}"
 # Don't pass --numprocesses here so that tests run sequentially.
 # pytest-xdist does not allow live output of stdout, meaning integ tests only show output after the test is done
 # See: https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -890,7 +890,6 @@ class WorkerScheduler:
                 job_id=job_id,
                 deadline_client=self._deadline,
                 windows_credentials_resolver=self._windows_credentials_resolver,
-                job_run_as_user_override=self._job_run_as_user_override,
             )
             # TODO: Would be great to merge Session + SessionActionQueue
             # and move all job entities calls within the Session thread.

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -33,7 +33,6 @@ from ...api_models import (
 )
 from .job_entity_type import JobEntityType
 from .validation import Field, validate_object
-from ...startup.config import JobsRunAsUserOverride
 
 
 def parameters_from_api_response(
@@ -273,9 +272,7 @@ class JobDetails:
         )
 
     @classmethod
-    def validate_entity_data(
-        cls, entity_data: dict[str, Any], job_user_override: JobsRunAsUserOverride | None
-    ) -> JobDetailsData:
+    def validate_entity_data(cls, entity_data: dict[str, Any]) -> JobDetailsData:
         """Performs input validation on a response element received from boto3's call to
         the BatchGetJobEntity AWS Deadline Cloud API.
 
@@ -376,11 +373,8 @@ class JobDetails:
                     ),
                 )
 
-        if job_user_override is not None:
-            # If there is an override, we don't care about the job details jobRunAsUser
-            entity_data.pop("jobRunAsUser", None)
-        elif run_as_value := entity_data.get("jobRunAsUser", dict()).get("runAs", None):
-            # Validate jobRunAsUser -> runAs is one of ("QUEUE_CONFIGURED_USER" / "WORKER_AGENT_USER")
+        # Validate jobRunAsUser -> runAs is one of ("QUEUE_CONFIGURED_USER" / "WORKER_AGENT_USER")
+        if run_as_value := entity_data.get("jobRunAsUser", dict()).get("runAs", None):
             if run_as_value not in ("QUEUE_CONFIGURED_USER", "WORKER_AGENT_USER"):
                 raise ValueError(
                     f'Expected "jobRunAs" -> "runAs" to be one of "QUEUE_CONFIGURED_USER", "WORKER_AGENT_USER" but got "{run_as_value}"'

--- a/src/deadline_worker_agent/sessions/job_entities/job_entities.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_entities.py
@@ -35,7 +35,6 @@ from .job_details import JobDetails
 from .job_entity_type import JobEntityType
 from .step_details import StepDetails
 from .environment_details import EnvironmentDetails
-from ...startup.config import JobsRunAsUserOverride
 
 if TYPE_CHECKING:
     from ...api_models import (
@@ -110,7 +109,6 @@ class JobEntities:
         job_id: str,
         deadline_client: DeadlineClient,
         windows_credentials_resolver: Optional[WindowsCredentialsResolver],
-        job_run_as_user_override: Optional[JobsRunAsUserOverride],
     ) -> None:
         self._job_id = job_id
         self._farm_id = farm_id
@@ -119,7 +117,6 @@ class JobEntities:
         self._deadline_client = deadline_client
         self._windows_credentials_resolver = windows_credentials_resolver
         self._entity_record_map = {}
-        self._job_run_as_user_override = job_run_as_user_override
 
     def request(self, *, identifier: EntityIdentifier) -> dict[str, Any]:
         """Given an identifier, grab the associated data from the
@@ -325,7 +322,7 @@ class JobEntities:
         )
 
         result = self.request(identifier=identifier)
-        job_details_data = JobDetails.validate_entity_data(result, self._job_run_as_user_override)
+        job_details_data = JobDetails.validate_entity_data(result)
         job_details = JobDetails.from_boto(job_details_data)
 
         # if JobRunAsUser specifies a windows user resolve the credentials here

--- a/test/unit/sessions/job_entities/test_job_details.py
+++ b/test/unit/sessions/job_entities/test_job_details.py
@@ -230,7 +230,7 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
 )
 def test_input_validation_success(data: dict[str, Any]) -> None:
     """Test that validate_entity_data() can successfully handle valid input data."""
-    JobDetails.validate_entity_data(entity_data=data, job_user_override=None)
+    JobDetails.validate_entity_data(entity_data=data)
 
 
 @pytest.mark.parametrize(
@@ -665,4 +665,4 @@ def test_convert_job_user_from_boto(data: JobDetailsData, expected: JobDetails, 
 def test_input_validation_failure(data: dict[str, Any]) -> None:
     """Test that validate_entity_data() raises a ValueError when nonvalid input data is provided."""
     with pytest.raises(ValueError):
-        JobDetails.validate_entity_data(entity_data=data, job_user_override=None)
+        JobDetails.validate_entity_data(entity_data=data)

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -44,7 +44,6 @@ from deadline_worker_agent.api_models import (
     StepDetailsData,
     StepDetailsIdentifier,
 )
-from deadline_worker_agent.startup.config import JobsRunAsUserOverride
 from deadline_worker_agent.sessions.job_entities import (
     EnvironmentDetails,
     JobAttachmentDetails,
@@ -154,7 +153,6 @@ def job_entities(
         job_id=job_id,
         deadline_client=deadline_client,
         windows_credentials_resolver=windows_credentials_resolver,
-        job_run_as_user_override=None,
     )
 
     yield job_entities
@@ -227,7 +225,6 @@ class TestJobEntity:
             job_id=job_id,
             deadline_client=deadline_client,
             windows_credentials_resolver=windows_credentials_resolver,
-            job_run_as_user_override=None,
         )
 
         # WHEN
@@ -269,7 +266,7 @@ class TestJobEntity:
         }
 
         # WHEN
-        job_details_data = JobDetails.validate_entity_data(api_response, job_user_override=None)
+        job_details_data = JobDetails.validate_entity_data(api_response)
         entity_obj = JobDetails.from_boto(job_details_data)
 
         # THEN
@@ -282,57 +279,6 @@ class TestJobEntity:
             assert isinstance(entity_obj.job_run_as_user.windows_settings, JobRunAsWindowsUser)
             assert entity_obj.job_run_as_user.windows_settings.user == expected_user
             assert entity_obj.job_run_as_user.windows_settings.passwordArn == expected_password_arn
-
-    @pytest.mark.parametrize(
-        "job_run_as_user",
-        [
-            dict([key_val for key_val in (runAs, posix, windows) if key_val is not None])
-            for runAs in (("runAs", "QUEUE_CONFIGURED_USER"), ("runAs", "WORKER_AGENT_USER"))
-            for posix in (
-                (
-                    "posix",
-                    {
-                        "user": "job-user",
-                        "group": "job-group",
-                    },
-                ),
-                None,
-            )
-            for windows in (
-                (
-                    "windows",
-                    {
-                        "user": "job-user",
-                        "passwordArn": "job-password-arn",
-                    },
-                ),
-                None,
-            )
-        ],
-    )
-    def test_job_run_as_user_with_override(
-        self, job_run_as_user: dict, job_run_as_user_overrides: JobsRunAsUserOverride
-    ) -> None:
-        """Ensures that if we receive a job_run_as_user field in the response,
-        that the created entity has a SessionUser created with the
-        proper values"""
-        # GIVEN
-        api_response: dict = {
-            "jobId": "job-123",
-            "jobRunAsUser": job_run_as_user,
-            "logGroupName": "TEST",
-            "schemaVersion": TemplateSpecificationVersion.JOBTEMPLATE_v2023_09.value,
-        }
-
-        # WHEN
-        job_details_data = JobDetails.validate_entity_data(
-            api_response, job_user_override=job_run_as_user_overrides
-        )
-        entity_obj = JobDetails.from_boto(job_details_data)
-
-        # THEN
-        assert "jobRunAsUser" not in job_details_data
-        assert entity_obj.job_run_as_user is None
 
 
 class TestDetails:
@@ -387,7 +333,6 @@ class TestDetails:
             job_id=job_id,
             deadline_client=deadline_client,
             windows_credentials_resolver=windows_credentials_resolver,
-            job_run_as_user_override=None,
         )
 
         # WHEN
@@ -459,7 +404,6 @@ class TestDetails:
             job_id=job_id,
             deadline_client=deadline_client,
             windows_credentials_resolver=windows_credentials_resolver,
-            job_run_as_user_override=None,
         )
 
         # WHEN
@@ -493,7 +437,6 @@ class TestDetails:
             job_id=job_id,
             deadline_client=deadline_client,
             windows_credentials_resolver=windows_credentials_resolver,
-            job_run_as_user_override=None,
         )
 
         # WHEN
@@ -547,7 +490,6 @@ class TestDetails:
             job_id=job_id,
             deadline_client=deadline_client,
             windows_credentials_resolver=windows_credentials_resolver,
-            job_run_as_user_override=None,
         )
 
         # WHEN
@@ -601,7 +543,6 @@ class TestDetails:
             job_id=job_id,
             deadline_client=deadline_client,
             windows_credentials_resolver=windows_credentials_resolver,
-            job_run_as_user_override=None,
         )
 
         # WHEN


### PR DESCRIPTION
…a job user override  (#346)"

This reverts commit c0dd3b35db2faef3296277cbf66e3dc42adeb80f.

### What was the problem/requirement? (What/Why)

The E2E test on mainline is failing https://github.com/aws-deadline/deadline-cloud-worker-agent/actions/runs/9812743510/job/27097395094

### What was the solution? (How)

Revert for now, until we understand why the E2E test is failing

### What is the impact of this change?

Reverts #346 

### How was this change tested?

Not tested. 

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*