### PR TITLE
fix: jobRunAsUser always removed in BatchGetJobEntity JobDetails

### DIFF
--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -376,7 +376,9 @@ class JobDetails:
                     ),
                 )
 
-        if job_user_override is not None:
+        if job_user_override is not None and (
+            job_user_override.run_as_agent or job_user_override.job_user
+        ):
             # If there is an override, we don't care about the job details jobRunAsUser
             entity_data.pop("jobRunAsUser", None)
         elif run_as_value := entity_data.get("jobRunAsUser", dict()).get("runAs", None):

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -269,7 +269,9 @@ class TestJobEntity:
         }
 
         # WHEN
-        job_details_data = JobDetails.validate_entity_data(api_response, job_user_override=None)
+        job_details_data = JobDetails.validate_entity_data(
+            api_response, job_user_override=JobsRunAsUserOverride(run_as_agent=False, job_user=None)
+        )
         entity_obj = JobDetails.from_boto(job_details_data)
 
         # THEN


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The check here https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/c0dd3b35db2faef3296277cbf66e3dc42adeb80f/src/deadline_worker_agent/sessions/job_entities/job_details.py#L379
was not quite correct because just having an override object doesn't mean that the worker agent is actually overriding the queue user.

### What was the solution? (How)

Based on https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/c0dd3b35db2faef3296277cbf66e3dc42adeb80f/src/deadline_worker_agent/startup/config.py#L24

Now we:
  - Check that `JobsRunAsUserOverride` is not None
  - Check that it is either:
    - Using the worker agent user
    - Using an overriden job-user

### What is the impact of this change?

Fixes a bug which was introduced by #346 

### How was this change tested?

Unit tests pass

Modified `test_job_run_as_user` and confirmed that it passed, whereas it failed with the `JobsRunAsUserOverride(run_as_agent=False, job_user=None)` change without the fix in this PR

@moorec-aws confirmed the E2E tests pass with this change

### Was this change documented?

no

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*