### PR TITLE
feat: add deadline-cloud and openjd-session-for-python versions to boto3 useragent

### DIFF
--- a/src/deadline_worker_agent/boto/config.py
+++ b/src/deadline_worker_agent/boto/config.py
@@ -3,23 +3,34 @@
 from botocore.config import Config
 
 from .._version import __version__ as worker_agent_version
+from deadline.client import version as deadline_client_lib_version
+from openjd.sessions import version as openjd_sessions_version
+
+
+def construct_user_agent() -> str:
+    """
+    Compute the user agent string to send over boto requests.
+        - Contains the versions of Deadline Worker Agent, Deadline Client Library, OpenJD Sessions.
+    """
+    return f"deadline_worker_agent/{worker_agent_version} deadline_cloud/{deadline_client_lib_version} openjd_sessions/{openjd_sessions_version}"
 
 
 DEADLINE_BOTOCORE_CONFIG = Config(
     retries={
         "max_attempts": 1,
     },
-    user_agent_extra=f"deadline_worker_agent/{worker_agent_version}",
+    user_agent_extra=construct_user_agent(),
 )
+
 """
 Botocore client configuration for AWS Deadline Cloud. This overrides to:
     - botocore retries - the worker agent has its own retry logic for AWS Deadline Cloud
       API requests. See the `aws/deadline` sub-package for that retry logic.
-    - add deadline-worker-agent version to user User-Agent request header
+    - add deadline, deadline worker agent and openjd package versions to user User-Agent request header
 """
 
-OTHER_BOTOCORE_CONFIG = Config(user_agent_extra=f"deadline_worker_agent/{worker_agent_version}")
+OTHER_BOTOCORE_CONFIG = Config(user_agent_extra=construct_user_agent())
 """
 Botocore client configuration for other AWS services. This overrides to:
-    - add deadline-worker-agent version to user User-Agent request header
+    - add deadline, deadline worker agent and openjd package versions to user User-Agent request header
 """

--- a/test/unit/boto/test_config.py
+++ b/test/unit/boto/test_config.py
@@ -3,6 +3,8 @@
 from botocore.config import Config
 
 from deadline_worker_agent._version import __version__
+from deadline.client import version as deadline_client_lib_version
+from openjd.sessions import version as openjd_sessions_version
 import deadline_worker_agent.boto.config as boto_config_mod
 
 
@@ -20,7 +22,10 @@ class TestDeadlineBotocoreConfig:
 
         # THEN
         assert isinstance(DEADLINE_BOTOCORE_CONFIG, Config)
-        assert DEADLINE_BOTOCORE_CONFIG.user_agent_extra == f"deadline_worker_agent/{__version__}"
+        libraries: list[str] = DEADLINE_BOTOCORE_CONFIG.user_agent_extra.split(" ")
+        assert libraries[0] == f"deadline_worker_agent/{__version__}"
+        assert libraries[1] == f"deadline_cloud/{deadline_client_lib_version}"
+        assert libraries[2] == f"openjd_sessions/{openjd_sessions_version}"
 
     def test_does_not_retry(self) -> None:
         """Asserts that DEADLINE_BOTOCORE_CONFIG sets retries.max_attempts to 1.
@@ -60,4 +65,7 @@ class TestOtherBotocoreConfig:
 
         # THEN
         assert isinstance(OTHER_BOTOCORE_CONFIG, Config)
-        assert OTHER_BOTOCORE_CONFIG.user_agent_extra == f"deadline_worker_agent/{__version__}"
+        libraries: list[str] = OTHER_BOTOCORE_CONFIG.user_agent_extra.split(" ")
+        assert libraries[0] == f"deadline_worker_agent/{__version__}"
+        assert libraries[1] == f"deadline_cloud/{deadline_client_lib_version}"
+        assert libraries[2] == f"openjd_sessions/{openjd_sessions_version}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Users of Deadline Worker Agent may be pulling or building different dependencies when running in a Deadline Customer Managed Fleet. When an error occurs, it is not clear what combination of software was installed, making it hard to root cause.

### What was the solution? (How)
- Add deadline client lib and OpenJD Sessions to the boto request header string. This will allow backend providers to debug if any specific combinations of versions has errors.

### What is the impact of this change?
- Adding more traceability into the system. Regressions can be quickly determined and isolated.

### How was this change tested?
- hatch build
- hatch run fmt
- hatch run test
```
Required test coverage of 78.0% reached. Total coverage: 87.29%
============================================================================== slowest 5 durations ===============================================================================
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_asg_termination[job_run_as_user_overrides0]
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[job_run_as_user_overrides0-spot-shutdown-15-sec]
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[job_run_as_user_overrides0-spot-shutdown-1-min]
0.20s call     test/unit/sessions/test_log_config.py::TestLogConfiguration::test_from_boto_local_log_setup
0.10s call     test/unit/sessions/test_session.py::TestSessionInnerRun::test_locking_semantics
================================================================= 2518 passed, 17 skipped, 5 warnings in 18.42s ==================================================================
```
### Was this change documented?
- NA

### Is this a breaking change?
- No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*