### PR TITLE
feat: add Deadline Client Lib to telemetry and add a success/fail decorator…

### DIFF
--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -68,6 +68,7 @@ from deadline.job_attachments.os_file_permission import (
 from deadline.job_attachments.progress_tracker import ProgressReportMetadata, SummaryStatistics
 
 from ..aws.deadline import (
+    record_success_fail_telemetry_event,
     record_sync_inputs_fail_telemetry_event,
     record_sync_inputs_telemetry_event,
     record_sync_outputs_telemetry_event,
@@ -816,6 +817,7 @@ class Session:
         progress and status message are passed in by Job Attachments."""
         return True
 
+    @record_success_fail_telemetry_event()  # type: ignore
     def sync_asset_inputs(
         self,
         *,
@@ -1084,7 +1086,7 @@ class Session:
             self.logger.info("----------------------------------------------")
             self.logger.info("Uploading output files to Job Attachments")
             self.logger.info("----------------------------------------------")
-            future = self._executor.submit(
+            future: Future = self._executor.submit(
                 self._sync_asset_outputs,
                 current_action=current_action,
             )
@@ -1203,6 +1205,7 @@ class Session:
             )
         )
 
+    @record_success_fail_telemetry_event(metric_name="sync_asset_outputs")  # type: ignore
     def _sync_asset_outputs(
         self,
         *,

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -649,7 +649,7 @@ class TestSessionSyncAssetInputs:
         cancel = Event()
 
         # WHEN
-        session.sync_asset_inputs(
+        session.sync_asset_inputs(  # type: ignore
             cancel=cancel,
             job_attachment_details=job_attachment_details,
         )
@@ -712,7 +712,7 @@ class TestSessionSyncAssetInputs:
             )
 
         # WHEN
-        session.sync_asset_inputs(
+        session.sync_asset_inputs(  # type: ignore
             cancel=cancel,
             job_attachment_details=job_attachment_details,
         )
@@ -792,7 +792,7 @@ class TestSessionSyncAssetInputs:
             # WHEN
             with pytest.raises(RuntimeError) as raise_ctx:
                 for args in sync_asset_inputs_args_sequence:
-                    session.sync_asset_inputs(cancel=cancel, **args)  # type: ignore[arg-type]
+                    session.sync_asset_inputs(cancel=cancel, **args)  # type: ignore
             # THEN
             assert (
                 raise_ctx.value.args[0]
@@ -801,7 +801,7 @@ class TestSessionSyncAssetInputs:
         else:
             # WHEN
             for args in sync_asset_inputs_args_sequence:
-                session.sync_asset_inputs(cancel=cancel, **args)  # type: ignore[arg-type]
+                session.sync_asset_inputs(cancel=cancel, **args)  # type: ignore
             # THEN
             for call in mock_telemetry_event_for_sync_inputs.call_args_list:
                 assert call[0] == (
@@ -843,7 +843,7 @@ class TestSessionSyncAssetInputs:
                 session_mod, "record_sync_inputs_fail_telemetry_event"
             ) as mock_record_sync_inputs_fail_telemetry_event,
         ):
-            session.sync_asset_inputs(
+            session.sync_asset_inputs(  # type: ignore
                 cancel=mock_cancel,
                 job_attachment_details=JobAttachmentDetails(
                     manifests=[],
@@ -937,7 +937,7 @@ class TestSessionSyncAssetOutputs:
         session._job_attachment_details = job_attachment_details
 
         # WHEN
-        session._sync_asset_outputs(current_action=current_action)
+        session._sync_asset_outputs(current_action=current_action)  # type: ignore
 
         # THEN
         mock_ja_sync_outputs.assert_called_once_with(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Currently we lack telemetry when Job Attachments is downloaded or output is uploaded from S3. There is insufficient metrics to know if a particular release (or dependency release) has regressions.

### What was the solution? (How)
- Add success / fail telemetry metrics to Job Attachments download and upload functions. This is a generic try-catch metric that is useful as a canary. This will provide traceability to detect any regression.

### What is the impact of this change?
- More traceability into Worker Agent and Job Attachments execution.

### How was this change tested?
- hatch build
- hatch run fmt
- hatch run test
```
------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                         4808    672   2110    204    84%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml

Required test coverage of 80.0% reached. Total coverage: 84.42%
========================================================================================================== slowest 5 durations ==========================================================================================================
```

### Was this change documented?
- Not Applicable.

### Is this a breaking change?
- No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*