### PR TITLE
ci: create project env before setting whl path

### DIFF
--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -10,6 +10,7 @@ then
   if [ "$TEST_TYPE" = "WHEEL" ]
   then
     hatch build
+    hatch env create
     export WORKER_AGENT_WHL_PATH=dist/`hatch run metadata name | sed 's/-/_/g'`-`hatch run version`-py3-none-any.whl
     echo "Set WORKER_AGENT_WHL_PATH to $WORKER_AGENT_WHL_PATH"
   fi

--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -10,6 +10,7 @@ then
   if [ "$TEST_TYPE" = "WHEEL" ]
   then
     hatch build
+    hatch env create
     export WORKER_AGENT_WHL_PATH=dist/`hatch run metadata name | sed 's/-/_/g'`-`hatch run version`-py3-none-any.whl
     echo "Set WORKER_AGENT_WHL_PATH to $WORKER_AGENT_WHL_PATH"
   fi


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
WORKER_AGENT_WHL_PATH is not setting properly.

### What was the solution? (How)
Building the environment before setting the wheel environment variable

### What is the impact of this change?
allows wheel file env var to be set properly for tests

### How was this change tested?
```
hatch clean
hatch env prune
./pipelines/e2e.sh
```

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*