### PR TITLE
ci: remove code coverage from e2e tests

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -11,7 +11,7 @@ test = "pytest test/unit --numprocesses=auto {args}"
 # See: https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers
 version = "hatch version"
 metadata = "hatch project metadata {args:}"
-linux-e2e-test = "pytest test/e2e/linux {args}"
+linux-e2e-test = "pytest --no-cov test/e2e/linux {args}"
 windows-e2e-test= "pytest --no-cov test/e2e/windows {args:}"
 windows-integ-test = "pytest --no-cov test/integ/installer {args:}"
 typing = "mypy {args:src test}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
E2E tests need code coverage removed to pass

### What was the solution? (How)
add `--no-cov` flag.

### What is the impact of this change?
Allow linux e2e tests to pass

### How was this change tested?
```
hatch run lint
hatch run test
```


### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*