### PR TITLE
test: update to support ec2_worker_type

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,6 +1,6 @@
 coverage[toml] ~= 7.5
 coverage-conditional-plugin == 0.9.*
-deadline-cloud-test-fixtures == 0.10.*
+deadline-cloud-test-fixtures == 0.12.*
 pytest ~= 8.2
 pytest-cov == 5.0.*
 pytest-timeout == 2.3.*

--- a/src/deadline_worker_agent/sessions/actions/enter_env.py
+++ b/src/deadline_worker_agent/sessions/actions/enter_env.py
@@ -48,7 +48,7 @@ class EnterEnvironmentAction(OpenjdAction):
 
     def __eq__(self, other: Any) -> bool:
         return (
-            type(self) == type(other)
+            type(self) is type(other)
             and self._id == other._id
             and self._job_env_id == other._job_env_id
             and self._session_env_id == other._session_env_id

--- a/src/deadline_worker_agent/sessions/actions/exit_env.py
+++ b/src/deadline_worker_agent/sessions/actions/exit_env.py
@@ -37,7 +37,7 @@ class ExitEnvironmentAction(OpenjdAction):
 
     def __eq__(self, other: Any) -> bool:
         return (
-            type(self) == type(other)
+            type(self) is type(other)
             and self._id == other._id
             and self._environment_id == other._environment_id
         )

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -52,7 +52,7 @@ class RunStepTaskAction(OpenjdAction):
 
     def __eq__(self, other: Any) -> bool:
         return (
-            type(self) == type(other)
+            type(self) is type(other)
             and self._id == other._id
             and self.step_id == other.step_id
             and self.task_id == other.task_id

--- a/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
+++ b/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
@@ -73,7 +73,7 @@ class SyncInputJobAttachmentsAction(SessionActionDefinition):
 
     def __eq__(self, other: Any) -> bool:
         return (
-            type(self) == type(other)
+            type(self) is type(other)
             and self._id == other._id
             and self._job_attachment_details == other._job_attachment_details
             and self._step_details == other._step_details

--- a/test/e2e/linux/test_credential_handling.py
+++ b/test/e2e/linux/test_credential_handling.py
@@ -29,7 +29,7 @@ def test_access_worker_credential_file_from_job(
     ########################################################################################
     # WHEN
     result = worker.send_command(
-        f'sudo -u "{worker_config.user}" cat /var/lib/deadline/credentials/{worker.worker_id}.json > /dev/null'
+        f'sudo -u "{worker_config.agent_user}" cat /var/lib/deadline/credentials/{worker.worker_id}.json > /dev/null'
     )
 
     # THEN

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -218,7 +218,7 @@ class TestSessionActionQueueDequeue:
         result = session_queue.dequeue()
 
         # THEN
-        assert type(result) == type(expected)
+        assert type(result) is type(expected)
         assert result.id == expected.id  # type: ignore
         assert len(session_queue._actions) == 0
         assert len(session_queue._actions_by_id) == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Tests need to be updated to support changes in https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/125

### What was the solution? (How)
Update conftest.py to support ec2_worker_type

### What is the impact of this change?
Support latest deadline-cloud-test-fixtures version

### How was this change tested?
```
hatch run fmt
hatch run lint
hatch run linux-e2e-test
hatch run windows-e2e-test
```

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*