### PR TITLE
docs: adds missed case in worker api protocol docs

### DIFF
--- a/docs/worker_api_protocol.md
+++ b/docs/worker_api_protocol.md
@@ -52,6 +52,7 @@ The steps to take are:
     and then retry indefinitely.
     * Response: ConflictException(409) ->
         * `reason` is `STATUS_CONFLICT`:
+            * `context["status"]` is `ASSOCIATED` -> Perform exponential backoff, and then retry.
             * `context["status"]` is `STOPPING` or `NOT_COMPATIBLE` -> Worker cannot transition to `STARTED` from its
             current status. Invoke `UpdateWorker` API with (farmId, fleetId, workerId, status=STOPPED)
             successfully, and then retry this call.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was a missed case in the API protocol documentation for this code path: https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/src/deadline_worker_agent/aws/deadline/__init__.py#L598

### What was the solution? (How)

Document it!

### What is the impact of this change?

More accurate docs

### How was this change tested?

I read over it and it looks correct ;)

### Was this change documented?

By definition yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*