### PR TITLE
ci: add windows release canary

### DIFF
--- a/.github/workflows/release_e2e_canary.yml
+++ b/.github/workflows/release_e2e_canary.yml
@@ -36,3 +36,16 @@ jobs:
       branch: release
       environment: canary
       os: linux
+
+  ReleaseWindowsE2ECanary:
+    name: Release Windows Canary
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_canary.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: release
+      environment: canary
+      os: windows


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to add Canaries for Windows E2E tests

### What was the solution? (How)
Add the Windows E2E job to the release canary workflow

### What is the impact of this change?
Adds canaries that run against release branch

### How was this change tested?
Windows E2E tests are working [here.](https://github.com/aws-deadline/deadline-cloud-worker-agent/actions/runs/10014524395)

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*