### PR TITLE
test: Add test to verify that worker and session logs are streamed to CloudWatch

### DIFF
--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -6,7 +6,8 @@ Deadline Cloud service and checking that the result/output of the jobs is as we 
 from typing import Any, Dict, List
 import pytest
 import logging
-from deadline_test_fixtures import Job, DeadlineClient, TaskStatus
+from deadline_test_fixtures import Job, DeadlineClient, TaskStatus, EC2InstanceWorker
+from e2e.conftest import DeadlineResources
 from utils import get_operating_system_name
 import backoff
 import boto3
@@ -14,66 +15,369 @@ import botocore.client
 import botocore.config
 import botocore.exceptions
 
+
 LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures("worker")
 @pytest.mark.parametrize("operating_system", [get_operating_system_name()], indirect=True)
 class TestJobSubmission:
-    @pytest.mark.parametrize(
-        "run_actions,environment_actions, expected_failed_action",
-        [
-            (
-                {
-                    "onRun": {
-                        "command": "noneexistentcommand",  # This will fail
-                    },
-                },
-                {
-                    "onEnter": {
-                        "command": "whoami",
-                    },
-                },
-                "taskRun",
-            ),
-            (
-                {
-                    "onRun": {
-                        "command": "whoami",
-                    },
-                },
-                {
-                    "onEnter": {
-                        "command": "noneexistentcommand",  # This will fail
-                    },
-                },
-                "envEnter",
-            ),
-            (
-                {
-                    "onRun": {
-                        "command": "whoami",
-                    },
-                },
-                {
-                    "onEnter": {
-                        "command": "whoami",
-                    },
-                    "onExit": {
-                        "command": "noneexistentcommand",  # This will fail
-                    },
-                },
-                "envExit",
-            ),
-        ],
-    )
-    def test_job_reports_failed_session_action(
+    # @pytest.mark.parametrize(
+    #     "run_actions,environment_actions, expected_failed_action",
+    #     [
+    #         (
+    #             {
+    #                 "onRun": {
+    #                     "command": "noneexistentcommand",  # This will fail
+    #                 },
+    #             },
+    #             {
+    #                 "onEnter": {
+    #                     "command": "whoami",
+    #                 },
+    #             },
+    #             "taskRun",
+    #         ),
+    #         (
+    #             {
+    #                 "onRun": {
+    #                     "command": "whoami",
+    #                 },
+    #             },
+    #             {
+    #                 "onEnter": {
+    #                     "command": "noneexistentcommand",  # This will fail
+    #                 },
+    #             },
+    #             "envEnter",
+    #         ),
+    #         (
+    #             {
+    #                 "onRun": {
+    #                     "command": "whoami",
+    #                 },
+    #             },
+    #             {
+    #                 "onEnter": {
+    #                     "command": "whoami",
+    #                 },
+    #                 "onExit": {
+    #                     "command": "noneexistentcommand",  # This will fail
+    #                 },
+    #             },
+    #             "envExit",
+    #         ),
+    #     ],
+    # )
+    # def test_job_reports_failed_session_action(
+    #     self,
+    #     deadline_resources: DeadlineResources,
+    #     deadline_client: DeadlineClient,
+    #     run_actions: Dict[str, Any],
+    #     environment_actions: Dict[str, Any],
+    #     expected_failed_action: str,
+    # ) -> None:
+
+    #     job = Job.submit(
+    #         client=deadline_client,
+    #         farm=deadline_resources.farm,
+    #         queue=deadline_resources.queue_a,
+    #         priority=98,
+    #         template={
+    #             "specificationVersion": "jobtemplate-2023-09",
+    #             "name": f"jobactionfail-{expected_failed_action}",
+    #             "steps": [
+    #                 {
+    #                     "name": "Step0",
+    #                     "script": {"actions": run_actions},
+    #                 },
+    #             ],
+    #             "jobEnvironments": [
+    #                 {"name": "badenvironment", "script": {"actions": environment_actions}}
+    #             ],
+    #         },
+    #     )
+    #     # THEN
+    #     job.wait_until_complete(client=deadline_client)
+
+    #     # Retrieve job output and verify that the expected session action has failed
+
+    #     sessions = deadline_client.list_sessions(
+    #         farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
+    #     ).get("sessions")
+    #     found_failed_session_action: bool = False
+    #     for session in sessions:
+    #         session_actions = deadline_client.list_session_actions(
+    #             farmId=job.farm.id,
+    #             queueId=job.queue.id,
+    #             jobId=job.id,
+    #             sessionId=session["sessionId"],
+    #         ).get("sessionActions")
+
+    #         for session_action in session_actions:
+    #             # Session action should be failed IFF it's the expected action to fail
+    #             if expected_failed_action in session_action["definition"]:
+    #                 found_failed_session_action = True
+    #                 assert session_action["status"] == "FAILED"
+    #             else:
+    #                 assert session_action["status"] != "FAILED"
+    #     assert found_failed_session_action
+
+    # @pytest.mark.parametrize(
+    #     "run_actions,environment_actions,expected_canceled_action",
+    #     [
+    #         (
+    #             {
+    #                 "onRun": {
+    #                     "command": (
+    #                         "/bin/sleep" if get_operating_system_name() == "linux" else "timeout"
+    #                     ),
+    #                     "args": ["40"],
+    #                     "cancelation": {
+    #                         "mode": "NOTIFY_THEN_TERMINATE",
+    #                         "notifyPeriodInSeconds": 1,
+    #                     },
+    #                 },
+    #             },
+    #             {
+    #                 "onEnter": {
+    #                     "command": "whoami",
+    #                 },
+    #             },
+    #             "taskRun",
+    #         ),
+    #         (
+    #             {
+    #                 "onRun": {
+    #                     "command": "whoami",
+    #                 },
+    #             },
+    #             {
+    #                 "onEnter": {
+    #                     "command": (
+    #                         "/bin/sleep" if get_operating_system_name() == "linux" else "timeout"
+    #                     ),
+    #                     "args": ["40"],
+    #                     "cancelation": {
+    #                         "mode": "NOTIFY_THEN_TERMINATE",
+    #                         "notifyPeriodInSeconds": 1,
+    #                     },
+    #                 },
+    #             },
+    #             "envEnter",
+    #         ),
+    #     ],
+    # )
+    # def test_job_reports_canceled_session_action(
+    #     self,
+    #     deadline_resources: DeadlineResources,
+    #     deadline_client: DeadlineClient,
+    #     run_actions: Dict[str, Any],
+    #     environment_actions: Dict[str, Any],
+    #     expected_canceled_action: str,
+    # ) -> None:
+    #     job = Job.submit(
+    #         client=deadline_client,
+    #         farm=deadline_resources.farm,
+    #         queue=deadline_resources.queue_a,
+    #         priority=98,
+    #         template={
+    #             "specificationVersion": "jobtemplate-2023-09",
+    #             "name": f"jobactioncancel-{expected_canceled_action}",
+    #             "steps": [
+    #                 {
+    #                     "name": "Step0",
+    #                     "script": {
+    #                         "actions": run_actions,
+    #                     },
+    #                 },
+    #             ],
+    #             "jobEnvironments": [
+    #                 {
+    #                     "name": "environment",
+    #                     "script": {
+    #                         "actions": environment_actions,
+    #                     },
+    #                 }
+    #             ],
+    #         },
+    #     )
+
+    #     @backoff.on_predicate(
+    #         wait_gen=backoff.constant,
+    #         max_time=120,
+    #         interval=10,
+    #     )
+    #     def is_job_started(current_job: Job) -> bool:
+    #         current_job.refresh_job_info(client=deadline_client)
+    #         LOG.info(f"Waiting for job {current_job.id} to be created")
+    #         return current_job.lifecycle_status != "CREATE_IN_PROGRESS"
+
+    #     assert is_job_started(job)
+
+    #     @backoff.on_predicate(
+    #         wait_gen=backoff.constant,
+    #         max_time=120,
+    #         interval=10,
+    #     )
+    #     def sessions_exist(current_job: Job) -> bool:
+    #         sessions = deadline_client.list_sessions(
+    #             farmId=current_job.farm.id, queueId=current_job.queue.id, jobId=current_job.id
+    #         ).get("sessions")
+
+    #         return len(sessions) > 0
+
+    #     assert sessions_exist(job)
+
+    #     deadline_client.update_job(
+    #         farmId=job.farm.id, queueId=job.queue.id, jobId=job.id, targetTaskRunStatus="CANCELED"
+    #     )
+
+    #     # THEN
+
+    #     # Wait until the job is canceled or completed
+    #     job.wait_until_complete(client=deadline_client)
+
+    #     LOG.info(f"Job result: {job}")
+
+    #     @backoff.on_predicate(
+    #         wait_gen=backoff.constant,
+    #         max_time=120,
+    #         interval=10,
+    #     )
+    #     def is_expected_session_action_canceled(sessions: List[Dict[str, Any]]) -> bool:
+    #         found_canceled_session_action: bool = False
+    #         for session in sessions:
+    #             session_actions = deadline_client.list_session_actions(
+    #                 farmId=job.farm.id,
+    #                 queueId=job.queue.id,
+    #                 jobId=job.id,
+    #                 sessionId=session["sessionId"],
+    #             ).get("sessionActions")
+
+    #             LOG.info(f"Session Actions: {session_actions}")
+    #             for session_action in session_actions:
+
+    #                 # Session action should be canceled if it's the action we expect to be canceled
+    #                 if expected_canceled_action in session_action["definition"]:
+    #                     if session_action["status"] == "CANCELED":
+    #                         found_canceled_session_action = True
+    #                 else:
+    #                     assert (
+    #                         session_action["status"] != "CANCELED"
+    #                     )  # This should not happen at all, so we fast exit
+    #         return found_canceled_session_action
+
+    #     sessions = deadline_client.list_sessions(
+    #         farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
+    #     ).get("sessions")
+    #     assert is_expected_session_action_canceled(sessions)
+
+    # @pytest.mark.parametrize(
+    #     "job_environments",
+    #     [
+    #         ([]),
+    #         (
+    #             [
+    #                 {
+    #                     "name": "environment_1",
+    #                     "script": {
+    #                         "actions": {
+    #                             "onEnter": {"command": "echo", "args": ["Hello!"]},
+    #                         },
+    #                     },
+    #                 },
+    #             ]
+    #         ),
+    #         (
+    #             [
+    #                 {
+    #                     "name": "environment_1",
+    #                     "script": {
+    #                         "actions": {
+    #                             "onEnter": {"command": "echo", "args": ["Hello!"]},
+    #                         }
+    #                     },
+    #                 },
+    #                 {
+    #                     "name": "environment_2",
+    #                     "script": {
+    #                         "actions": {
+    #                             "onEnter": {"command": "echo", "args": ["Hello!"]},
+    #                         }
+    #                     },
+    #                 },
+    #                 {
+    #                     "name": "environment_3",
+    #                     "script": {
+    #                         "actions": {
+    #                             "onEnter": {"command": "echo", "args": ["Hello!"]},
+    #                         }
+    #                     },
+    #                 },
+    #             ]
+    #         ),
+    #     ],
+    # )
+    # def test_worker_run_with_number_of_environments(
+    #     self,
+    #     deadline_resources: DeadlineResources,
+    #     deadline_client: DeadlineClient,
+    #     job_environments: List[Dict[str, Any]],
+    # ) -> None:
+    #     job_template = {
+    #         "specificationVersion": "jobtemplate-2023-09",
+    #         "name": f"jobWithNumberOfEnvironments-{len(job_environments)}",
+    #         "steps": [
+    #             {
+    #                 "name": "Step0",
+    #                 "script": {
+    #                     "actions": {
+    #                         "onRun": {
+    #                             "command": "whoami",
+    #                         },
+    #                     },
+    #                 },
+    #             },
+    #         ],
+    #     }
+
+    #     if len(job_environments) > 0:
+    #         job_template["jobEnvironments"] = job_environments
+    #     job = Job.submit(
+    #         client=deadline_client,
+    #         farm=deadline_resources.farm,
+    #         queue=deadline_resources.queue_a,
+    #         priority=98,
+    #         template=job_template,
+    #     )
+
+    #     job.wait_until_complete(client=deadline_client)
+
+    #     # Retrieve job output and verify whoami printed the queue's jobsRunAsUser
+    #     job_logs = job.get_logs(
+    #         deadline_client=deadline_client,
+    #         logs_client=boto3.client(
+    #             "logs",
+    #             config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+    #         ),
+    #     )
+
+    #     full_log = "\n".join(
+    #         [le.message for _, log_events in job_logs.logs.items() for le in log_events]
+    #     )
+
+    #     assert full_log.count("Hello!") == len(
+    #         job_environments
+    #     ), "Expected number of Hello statements not found in job logs."
+
+    #     assert job.task_run_status == TaskStatus.SUCCEEDED
+
+    def test_worker_streams_logs_to_cloudwatch(
         self,
-        deadline_resources,
+        deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        run_actions: Dict[str, Any],
-        environment_actions: Dict[str, Any],
-        expected_failed_action: str,
+        worker: EC2InstanceWorker,
     ) -> None:
 
         job = Job.submit(
@@ -83,290 +387,42 @@ class TestJobSubmission:
             priority=98,
             template={
                 "specificationVersion": "jobtemplate-2023-09",
-                "name": f"jobactionfail-{expected_failed_action}",
-                "steps": [
-                    {
-                        "name": "Step0",
-                        "script": {"actions": run_actions},
-                    },
-                ],
-                "jobEnvironments": [
-                    {"name": "badenvironment", "script": {"actions": environment_actions}}
-                ],
-            },
-        )
-        # THEN
-        job.wait_until_complete(client=deadline_client)
-
-        # Retrieve job output and verify that the expected session action has failed
-
-        sessions = deadline_client.list_sessions(
-            farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
-        ).get("sessions")
-        found_failed_session_action: bool = False
-        for session in sessions:
-            session_actions = deadline_client.list_session_actions(
-                farmId=job.farm.id,
-                queueId=job.queue.id,
-                jobId=job.id,
-                sessionId=session["sessionId"],
-            ).get("sessionActions")
-
-            for session_action in session_actions:
-                # Session action should be failed IFF it's the expected action to fail
-                if expected_failed_action in session_action["definition"]:
-                    found_failed_session_action = True
-                    assert session_action["status"] == "FAILED"
-                else:
-                    assert session_action["status"] != "FAILED"
-        assert found_failed_session_action
-
-    @pytest.mark.parametrize(
-        "run_actions,environment_actions,expected_canceled_action",
-        [
-            (
-                {
-                    "onRun": {
-                        "command": (
-                            "/bin/sleep" if get_operating_system_name() == "linux" else "timeout"
-                        ),
-                        "args": ["40"],
-                        "cancelation": {
-                            "mode": "NOTIFY_THEN_TERMINATE",
-                            "notifyPeriodInSeconds": 1,
-                        },
-                    },
-                },
-                {
-                    "onEnter": {
-                        "command": "whoami",
-                    },
-                },
-                "taskRun",
-            ),
-            (
-                {
-                    "onRun": {
-                        "command": "whoami",
-                    },
-                },
-                {
-                    "onEnter": {
-                        "command": (
-                            "/bin/sleep" if get_operating_system_name() == "linux" else "timeout"
-                        ),
-                        "args": ["40"],
-                        "cancelation": {
-                            "mode": "NOTIFY_THEN_TERMINATE",
-                            "notifyPeriodInSeconds": 1,
-                        },
-                    },
-                },
-                "envEnter",
-            ),
-        ],
-    )
-    def test_job_reports_canceled_session_action(
-        self,
-        deadline_resources,
-        deadline_client: DeadlineClient,
-        run_actions: Dict[str, Any],
-        environment_actions: Dict[str, Any],
-        expected_canceled_action: str,
-    ) -> None:
-        job = Job.submit(
-            client=deadline_client,
-            farm=deadline_resources.farm,
-            queue=deadline_resources.queue_a,
-            priority=98,
-            template={
-                "specificationVersion": "jobtemplate-2023-09",
-                "name": f"jobactioncancel-{expected_canceled_action}",
+                "name": "Hello World Job",
                 "steps": [
                     {
                         "name": "Step0",
                         "script": {
-                            "actions": run_actions,
+                            "actions": {"onRun": {"command": "echo", "args": ["HelloWorld"]}}
                         },
                     },
-                ],
-                "jobEnvironments": [
-                    {
-                        "name": "environment",
-                        "script": {
-                            "actions": environment_actions,
-                        },
-                    }
                 ],
             },
         )
 
-        @backoff.on_predicate(
-            wait_gen=backoff.constant,
-            max_time=120,
-            interval=10,
-        )
-        def is_job_started(current_job: Job) -> bool:
-            current_job.refresh_job_info(client=deadline_client)
-            LOG.info(f"Waiting for job {current_job.id} to be created")
-            return current_job.lifecycle_status != "CREATE_IN_PROGRESS"
-
-        assert is_job_started(job)
-
-        @backoff.on_predicate(
-            wait_gen=backoff.constant,
-            max_time=120,
-            interval=10,
-        )
-        def sessions_exist(current_job: Job) -> bool:
-            sessions = deadline_client.list_sessions(
-                farmId=current_job.farm.id, queueId=current_job.queue.id, jobId=current_job.id
-            ).get("sessions")
-
-            return len(sessions) > 0
-
-        assert sessions_exist(job)
-
-        deadline_client.update_job(
-            farmId=job.farm.id, queueId=job.queue.id, jobId=job.id, targetTaskRunStatus="CANCELED"
-        )
-
-        # THEN
-
-        # Wait until the job is canceled or completed
         job.wait_until_complete(client=deadline_client)
-
-        LOG.info(f"Job result: {job}")
-
-        @backoff.on_predicate(
-            wait_gen=backoff.constant,
-            max_time=120,
-            interval=10,
-        )
-        def is_expected_session_action_canceled(sessions: List[Dict[str, Any]]) -> bool:
-            found_canceled_session_action: bool = False
-            for session in sessions:
-                session_actions = deadline_client.list_session_actions(
-                    farmId=job.farm.id,
-                    queueId=job.queue.id,
-                    jobId=job.id,
-                    sessionId=session["sessionId"],
-                ).get("sessionActions")
-
-                LOG.info(f"Session Actions: {session_actions}")
-                for session_action in session_actions:
-
-                    # Session action should be canceled if it's the action we expect to be canceled
-                    if expected_canceled_action in session_action["definition"]:
-                        if session_action["status"] == "CANCELED":
-                            found_canceled_session_action = True
-                    else:
-                        assert (
-                            session_action["status"] != "CANCELED"
-                        )  # This should not happen at all, so we fast exit
-            return found_canceled_session_action
-
-        sessions = deadline_client.list_sessions(
-            farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
-        ).get("sessions")
-        assert is_expected_session_action_canceled(sessions)
-
-    @pytest.mark.parametrize(
-        "job_environments",
-        [
-            ([]),
-            (
-                [
-                    {
-                        "name": "environment_1",
-                        "script": {
-                            "actions": {
-                                "onEnter": {"command": "echo", "args": ["Hello!"]},
-                            },
-                        },
-                    },
-                ]
-            ),
-            (
-                [
-                    {
-                        "name": "environment_1",
-                        "script": {
-                            "actions": {
-                                "onEnter": {"command": "echo", "args": ["Hello!"]},
-                            }
-                        },
-                    },
-                    {
-                        "name": "environment_2",
-                        "script": {
-                            "actions": {
-                                "onEnter": {"command": "echo", "args": ["Hello!"]},
-                            }
-                        },
-                    },
-                    {
-                        "name": "environment_3",
-                        "script": {
-                            "actions": {
-                                "onEnter": {"command": "echo", "args": ["Hello!"]},
-                            }
-                        },
-                    },
-                ]
-            ),
-        ],
-    )
-    def test_worker_run_with_number_of_environments(
-        self,
-        deadline_resources,
-        deadline_client: DeadlineClient,
-        job_environments: List[Dict[str, Any]],
-    ) -> None:
-        job_template = {
-            "specificationVersion": "jobtemplate-2023-09",
-            "name": f"jobWithNumberOfEnvironments-{len(job_environments)}",
-            "steps": [
-                {
-                    "name": "Step0",
-                    "script": {
-                        "actions": {
-                            "onRun": {
-                                "command": "whoami",
-                            },
-                        },
-                    },
-                },
-            ],
-        }
-
-        if len(job_environments) > 0:
-            job_template["jobEnvironments"] = job_environments
-        job = Job.submit(
-            client=deadline_client,
-            farm=deadline_resources.farm,
-            queue=deadline_resources.queue_a,
-            priority=98,
-            template=job_template,
+        logs_client: boto3.client = boto3.client(
+            "logs",
+            config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
         )
 
-        job.wait_until_complete(client=deadline_client)
-
-        # Retrieve job output and verify whoami printed the queue's jobsRunAsUser
-        job_logs = job.get_logs(
-            deadline_client=deadline_client,
-            logs_client=boto3.client(
-                "logs",
-                config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
-            ),
-        )
-
-        full_log = "\n".join(
+        # Retrieve job output and verify the echo is printed
+        job_logs = job.get_logs(deadline_client=deadline_client, logs_client=logs_client)
+        full_log: str = "\n".join(
             [le.message for _, log_events in job_logs.logs.items() for le in log_events]
         )
 
-        assert full_log.count("Hello!") == len(
-            job_environments
-        ), "Expected number of Hello statements not found in job logs."
+        assert (
+            full_log.count("HelloWorld") == 1
+        ), "Expected number of HelloWorld statements not found in job logs."
 
-        assert job.task_run_status == TaskStatus.SUCCEEDED
+        # Retrieve worker logs and verify that it's not empty
+        worker_log_group_name: str = (
+            f"/aws/deadline/{deadline_resources.farm.id}/{deadline_resources.fleet.id}"
+        )
+        worker_id = worker.worker_id
+
+        worker_logs = logs_client.get_log_events(
+            logGroupName=worker_log_group_name, logStreamName=worker_id
+        )
+
+        assert len(worker_logs["events"]) > 0


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)
When jobs are ran, worker agent streams the worker and session logs to Cloudwatch logs, so that users can debug any issues or logs with the worker and/or session.

We should make sure that there are no regressions regarding this part of the worker functionality, as it is essential for user to be able to debug their jobs.
### What was the solution? (How)
Add an E2E test that submits a job, and confirms that the corresponding worker and session logs exist in CloudWatch.
### What is the impact of this change?
Upholding high quality code for the worker code that streams logs to cloudwatch.
### How was this change tested?
`hatch run cross-os-test`
### Was this change documented?
no
### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*