### PR TITLE
feat: add job user override for windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ ignore = [
 # We need to use a platform assertion to short-circuit mypy type checking on non-Windows platforms
 # https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks
 # This causes imports to come after regular Python statements causing flake8 rule E402 to be flagged
-"src/deadline_worker_agent/**/*windows*.py" = ["E402"]
+"src/deadline_worker_agent/**/*win*.py" = ["E402"]
 "test/**/*windows*.py" = ["E402"]
 
 [tool.ruff.lint.isort]

--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -97,6 +97,8 @@ def install() -> None:
             installer_args.update(password=args.password)
         if args.telemetry_opt_out:
             installer_args.update(telemetry_opt_out=args.telemetry_opt_out)
+        if args.windows_job_user:
+            installer_args.update(windows_job_user=args.windows_job_user)
 
         start_windows_installer(**installer_args)
     else:
@@ -157,6 +159,7 @@ class ParsedCommandLineArguments(Namespace):
     vfs_install_path: str
     grant_required_access: bool
     disallow_instance_profile: bool
+    windows_job_user: Optional[str] = None
 
 
 def get_argument_parser() -> ArgumentParser:  # pragma: no cover
@@ -268,6 +271,14 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
             action="store_true",
             required=False,
             default=False,
+        )
+        parser.add_argument(
+            "--windows-job-user",
+            help=(
+                "The username of the Windows user that jobs run as. The password for this user account is reset during worker startup."
+            ),
+            required=False,
+            default=None,
         )
 
     return parser

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -179,7 +179,7 @@
 #
 # run_jobs_as_agent_user = true
 
-# AWS Deadline Cloud may specify an OS user to run a Job's session actions as. Setting
+# AWS Deadline Cloud may specify a Posix OS user to run a Job's session actions as. Setting
 # "posix_job_user" will override the OS user and the session actions will be run as
 # the user given in the value of "posix_job_user" instead. This setting is ignored
 # if "run_jobs_as_agent_user" is set to true.
@@ -200,6 +200,19 @@
 # environment variable or if the --posix-job-user command-line flag is specified.
 #
 # posix_job_user = "user:group"
+
+# AWS Deadline Cloud may specify a Windows OS user to run a Job's session actions as. Setting
+# "windows_job_user" will override the OS user and the session actions will be run as
+# the user given in the value of "windows_job_user" instead. It is important to note that by specifying 
+# this value, the password for the Windows OS user specified will be reset to a random, unstored value.
+# This setting also requires that the worker agent is run with administrator privileges. This setting is 
+# incompatible the setting "run_jobs_as_agent_user" set to true.
+#
+# To have a specific Windows OS user used when running jobs, uncomment the line below and
+# replace the username as desired. This value is overridden when the DEADLINE_WORKER_WINDOWS_JOB_USER
+# environment variable or if the --windows-job-user command-line flag is specified.
+#
+# windows_job_user = "job-user"
 
 # AWS Deadline Cloud may tell the worker to stop. If the "shutdown_on_stop" setting below is true, then the
 # Worker will attempt to shutdown the host system after the Worker has been stopped.

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -392,7 +392,7 @@ class JobDetails:
                 run_as_windows = entity_data["jobRunAsUser"].get("windows", None)
                 if os.name == "nt" and not run_as_windows:
                     raise ValueError(
-                        'Expected ""jobRunAs" -> "windows" to exist when "jobRunAs" -> "runAs" is "QUEUE_CONFIGURED_USER" but it was not present'
+                        'Expected "jobRunAs" -> "windows" to exist when "jobRunAs" -> "runAs" is "QUEUE_CONFIGURED_USER" but it was not present'
                     )
                 if os.name == "posix" and not run_as_posix:
                     raise ValueError(

--- a/src/deadline_worker_agent/startup/cli_args.py
+++ b/src/deadline_worker_agent/startup/cli_args.py
@@ -17,6 +17,7 @@ class ParsedCommandLineArguments(Namespace):
     no_shutdown: bool | None = None
     run_jobs_as_agent_user: bool | None = None
     posix_job_user: str | None = None
+    windows_job_user: str | None = None
     disallow_instance_profile: bool | None = None
     logs_dir: Path | None = None
     local_session_logs: bool | None = None
@@ -75,6 +76,13 @@ def get_argument_parser() -> ArgumentParser:
             "--posix-job-user",
             help="Overrides the posix user that the Worker Agent impersonates. Format: 'user:group'. "
             "If not set, defaults to what the service sets.",
+            default=None,
+        )
+    elif os.name == "nt":
+        parser.add_argument(
+            "--windows-job-user",
+            help="Overrides the windows user that the Worker Agent impersonates. In doing so, resets the specified user's password to a cryptographically random, unstored value during worker startup. "
+            "If not set, impersonation behavior defers to what the service sets.",
             default=None,
         )
 

--- a/src/deadline_worker_agent/startup/config_file.py
+++ b/src/deadline_worker_agent/startup/config_file.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 import sys
 import os
 
-from pydantic import BaseModel, BaseSettings, Field, ValidationError, root_validator
+from pydantic import BaseModel, BaseSettings, Field, ValidationError, root_validator, StrictStr
 
 try:
     from tomllib import load as load_toml, TOMLDecodeError
@@ -53,6 +53,7 @@ class OsConfigSection(BaseModel):
     )
     shutdown_on_stop: Optional[bool] = None
     retain_session_dir: Optional[bool] = None
+    windows_job_user: Optional[StrictStr] = Field(regex=r"^.{1,512}$")  # defer validation to OS.
 
     @root_validator(pre=True)
     def _disallow_impersonation(cls, values: dict[str, Any]) -> dict[str, Any]:
@@ -142,6 +143,8 @@ class ConfigFile(BaseModel):
             output_settings["run_jobs_as_agent_user"] = self.os.run_jobs_as_agent_user
         if self.os.posix_job_user is not None:
             output_settings["posix_job_user"] = self.os.posix_job_user
+        if self.os.windows_job_user is not None:
+            output_settings["windows_job_user"] = self.os.windows_job_user
         if self.os.retain_session_dir is not None:
             output_settings["retain_session_dir"] = self.os.retain_session_dir
         if self.capabilities is not None:

--- a/src/deadline_worker_agent/startup/settings.py
+++ b/src/deadline_worker_agent/startup/settings.py
@@ -54,6 +54,8 @@ class WorkerSettings(BaseSettings):
         If true, then all jobs run as the same user as the agent.
     posix_job_user : str
         Which 'user:group' to use instead of the Queue user when turned on.
+    windows_job_user : str
+        Which username to use instead of the Queue user when turned on.
     windows_job_user_password_arn : str
         The ARN of an AWS Secrets Manager secret containing the password of the job user for Windows.
     allow_instance_profile : bool
@@ -93,9 +95,7 @@ class WorkerSettings(BaseSettings):
     posix_job_user: Optional[str] = Field(
         regex=r"^[a-zA-Z0-9_.][^:]{0,31}:[a-zA-Z0-9_.][^:]{0,31}$"
     )
-    windows_job_user: Optional[str] = Field(
-        regex=r"^[a-zA-Z0-9_.][^:]{0,31}:[a-zA-Z0-9_.][^:]{0,31}$"
-    )
+    windows_job_user: Optional[str] = Field(regex=r"^.{1,512}$")
     windows_job_user_password_arn: Optional[str] = Field(
         regex=r"^arn:aws:secretsmanager:[a-z0-9\-]+:\d{12}:secret\/[a-zA-Z0-9/_+=.@-]+$"
     )

--- a/src/deadline_worker_agent/windows/win_logon.py
+++ b/src/deadline_worker_agent/windows/win_logon.py
@@ -1,0 +1,242 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# This assertion short-circuits mypy from type checking this module on platforms other than Windows
+# https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks
+import sys
+
+assert sys.platform == "win32"
+from ctypes.wintypes import HANDLE as cHANDLE
+from pywintypes import error as PyWinError
+from win32security import (
+    LogonUser,
+    LOGON32_LOGON_INTERACTIVE,
+    LOGON32_PROVIDER_DEFAULT,
+)
+import win32net
+import win32security
+from win32profile import LoadUserProfile, PI_NOUI, UnloadUserProfile
+from typing import Any, Optional, TYPE_CHECKING
+from logging import getLogger
+from datetime import datetime, timezone
+
+import secrets
+import string
+from . import win_service
+
+if TYPE_CHECKING:
+    from _win32typing import PyHKEY, PyHANDLE
+else:
+    PyHKEY = Any
+    PyHANDLE = Any
+
+from openjd.sessions import WindowsSessionUser, BadCredentialsException
+
+logger = getLogger(__name__)
+
+
+class PasswordResetException(Exception):
+    pass
+
+
+class _WindowsCredentialsCacheEntry:
+    def __init__(
+        self,
+        windows_session_user: Optional[WindowsSessionUser],
+        last_fetched_at: Optional[datetime] = None,
+        last_accessed: Optional[datetime] = None,
+        user_profile: Optional[PyHKEY] = None,
+        logon_token: Optional[PyHANDLE] = None,
+    ):
+        self.windows_session_user = windows_session_user
+        self.last_fetched_at = (
+            last_fetched_at if last_fetched_at is not None else datetime.now(tz=timezone.utc)
+        )
+        self.last_accessed = (
+            last_accessed if last_accessed is not None else datetime.now(tz=timezone.utc)
+        )
+        self.user_profile = user_profile
+        self.logon_token = logon_token
+
+
+def get_windows_credentials(username: str, password: str) -> _WindowsCredentialsCacheEntry:
+    """
+    Returns a WindowsSessionUser object for the given username and password.
+
+    When running in session zero this acquires a logon token and loads the user profile.
+    Otherwise, returns a bare WindowsSessionUser object
+
+    Raises:
+        BadCredentialsException: If the username and/or password are incorrect
+        OSError: If the UserProfile fails to load in session zero
+    """
+    if not win_service.is_windows_session_zero():
+        # raises: BadCredentialsException
+        return _WindowsCredentialsCacheEntry(
+            windows_session_user=WindowsSessionUser(user=username, password=password)
+        )
+    try:
+        # https://timgolden.me.uk/pywin32-docs/win32profile__LoadUserProfile_meth.html
+        logon_token = LogonUser(
+            Username=username,
+            LogonType=LOGON32_LOGON_INTERACTIVE,
+            LogonProvider=LOGON32_PROVIDER_DEFAULT,
+            Password=password,
+            Domain=None,
+        )
+    except OSError as e:
+        raise BadCredentialsException(f'Error logging on as "{username}": {e}')
+    else:
+        # https://timgolden.me.uk/pywin32-docs/win32profile__LoadUserProfile_meth.html
+        # raises: OSError
+        user_profile = LoadUserProfile(
+            logon_token,
+            {
+                "UserName": username,
+                "Flags": PI_NOUI,
+                "ProfilePath": None,
+            },
+        )
+        try:
+            windows_session_user = WindowsSessionUser(
+                user=username,
+                logon_token=cHANDLE(int(logon_token)),
+            )
+        except OSError as e:
+            raise BadCredentialsException(f'Error logging on as "{username}": {e}')
+        else:
+            return _WindowsCredentialsCacheEntry(
+                windows_session_user=windows_session_user,
+                user_profile=user_profile,
+                logon_token=logon_token,
+            )
+
+
+def reset_user_password(username: str) -> _WindowsCredentialsCacheEntry:
+    """
+    Change the password of a Windows OS user without requiring the old one.
+
+    :param username: The username of the account.
+    :param new_password: The new password for the account.
+
+    Raises:
+        PasswordResetException: If the password reset and logon was not successful.
+    """
+    try:
+        user_info = win32net.NetUserGetInfo(None, username, 1)
+        user_info["password"] = generate_password(username)
+        win32net.NetUserSetInfo(None, username, 1, user_info)
+    except PyWinError as e:
+        raise PasswordResetException(
+            f'Failed to reset password for "{username}". Error: {e.strerror}'
+        ) from e
+    except Exception as e:
+        raise PasswordResetException(
+            f'Failed to reset password for "{username}". Error: {e}'
+        ) from e
+    else:
+        logger.info(f'Password for user "{username}" successfully reset')
+
+    try:
+        return get_windows_credentials(username, user_info["password"])
+    except OSError as e:
+        raise PasswordResetException(
+            f'Failed to load the user profile for "{username}". Error: {e}'
+        ) from e
+    except BadCredentialsException as e:
+        raise PasswordResetException(f'Failed to logon as "{username}". Error: {e}') from e
+
+
+def unload_and_close(user_profile: Optional[PyHKEY], logon_token: PyHANDLE):
+    """Unloads the user profile and closes the logon token handle"""
+    # https://timgolden.me.uk/pywin32-docs/win32profile__UnloadUserProfile_meth.html
+    if user_profile is not None:
+        UnloadUserProfile(logon_token, user_profile)
+    logon_token.Close()
+
+
+def generate_password(username: str, length: int = 256):
+    """
+    Generate a password of the given length that:
+        - Does not contain any two consecutive characcters from the user's account or full name
+        - Contains characters from three of the following four categories:
+            - uppercase alphabet character
+            - lowercase alphabet characters
+            - digits 0-9
+            - punctuation characters
+    Returns
+        str: password
+    """
+    alphabet = string.ascii_letters + string.digits + string.punctuation
+    account_name = username
+    full_name = ""
+    try:
+        user_info = win32net.NetUserGetInfo(None, username, 2)
+        account_name = user_info["name"]
+        full_name = user_info.get("full_name", "")
+    except PyWinError:
+        # The user may not exist yet. Just use the username
+        pass
+
+    lower_name_pairs = (
+        set()
+    )  # contains pairs of consecutive characters which will fail windows password validation
+    for name in [account_name, full_name]:
+        for i in range(len(name) - 1):
+            lower_name_pairs.add(name[i : i + 2].lower())
+
+    for i in range(100):
+        password = secrets.choice(alphabet)
+        while len(password) < length:
+            # Use secrets.choice to ensure a secure random selection of characters
+            # https://docs.python.org/3/library/secrets.html#recipes-and-best-practices
+            choice = secrets.choice(alphabet)
+            if (password[-1] + choice).lower() in lower_name_pairs:
+                continue
+            password += choice
+        if _validate_password_chars(password):
+            return password
+    else:
+        raise PasswordResetException(
+            "Failed to generate a password which meets security requirements."
+        )
+
+
+def _validate_password_chars(password: str) -> bool:
+    """
+    Windows requires that three of the following four categories of characters be present in a password:
+        - uppercase alphabet character
+        - lowercase alphabet characters
+        - digits 0-9
+        - punctuation characters
+
+    This function returns a boolean indicating whether the given password contains at least three of
+    the four above categories of characters.
+    """
+    upper_in_password = any(char.isupper() for char in password)
+    lower_in_password = any(char.islower() for char in password)
+    digit_in_password = any(char.isdigit() for char in password)
+    special_in_password = any(not char.isalnum() for char in password)
+    return sum([upper_in_password, lower_in_password, digit_in_password, special_in_password]) >= 3
+
+
+def users_equal(user1: str, user2: str) -> bool:
+    """
+    Returns a boolean indicating whether the two users are the same.
+
+    If both accounts do not exist this falls back to a simple string comparison.
+    """
+    lookup_failed = False
+    try:
+        acc_sid1, _, _ = win32security.LookupAccountName(None, user1)
+    except PyWinError:
+        lookup_failed = True
+
+    try:
+        acc_sid2, _, _ = win32security.LookupAccountName(None, user2)
+    except PyWinError:
+        lookup_failed = True
+
+    if lookup_failed:
+        return user1 == user2  # one or both accounts do not exist, fall back to string comparison
+
+    return acc_sid1 == acc_sid2

--- a/test/e2e/config-template.sh
+++ b/test/e2e/config-template.sh
@@ -86,10 +86,13 @@ export KEEP_WORKER_AFTER_FAILURE
 export BYO_DEADLINE
 # Required - The ID of the farm to use
 export FARM_ID
-# Required - The ID of the queue to use
-export QUEUE_ID
-# Required - The ID of the fleet to use
+# Required - The ID of the queues to use
+export QUEUE_A_ID
+export QUEUE_B_ID
+export SCALING_QUEUE_ID
+# Required - The ID of the fleets to use
 export FLEET_ID
+export SCALING_FLEET_ID
 # Optional - The ID of the KMS key association with your farm
 # If you use this option, then you must BYO_BOOTSTRAP because the default IAM role created for
 # the Worker will not have sufficient permissions to access this key

--- a/test/e2e/linux/test_credential_handling.py
+++ b/test/e2e/linux/test_credential_handling.py
@@ -14,7 +14,7 @@ from deadline_test_fixtures import CommandResult, DeadlineWorkerConfiguration, E
 
 @pytest.mark.parametrize("operating_system", ["linux"], indirect=True)
 def test_access_worker_credential_file_from_job(
-    worker: EC2InstanceWorker,
+    session_worker: EC2InstanceWorker,
     worker_config: DeadlineWorkerConfiguration,
 ) -> None:
     """Tests that the worker agent credentials file cannot be read by a job user"""
@@ -28,8 +28,8 @@ def test_access_worker_credential_file_from_job(
     # to ensure that the file exists and our test is valid
     ########################################################################################
     # WHEN
-    result = worker.send_command(
-        f'sudo -u "{worker_config.agent_user}" cat /var/lib/deadline/credentials/{worker.worker_id}.json > /dev/null'
+    result = session_worker.send_command(
+        f'sudo -u "{worker_config.agent_user}" cat /var/lib/deadline/credentials/{session_worker.worker_id}.json > /dev/null'
     )
 
     # THEN
@@ -43,8 +43,8 @@ def test_access_worker_credential_file_from_job(
     # command fails.
     ########################################################################################
     # WHEN
-    result = worker.send_command(
-        f'sudo -u "{job_user.user}" cat /var/lib/deadline/credentials/{worker.worker_id}.json > /dev/null'
+    result = session_worker.send_command(
+        f'sudo -u "{job_user.user}" cat /var/lib/deadline/credentials/{session_worker.worker_id}.json > /dev/null'
     )
 
     # THEN

--- a/test/e2e/linux/test_job_submissions.py
+++ b/test/e2e/linux/test_job_submissions.py
@@ -15,7 +15,7 @@ from deadline_test_fixtures import Job, TaskStatus, PosixSessionUser, DeadlineCl
 LOG = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures("worker")
+@pytest.mark.usefixtures("session_worker")
 @pytest.mark.parametrize("operating_system", ["linux"], indirect=True)
 class TestJobSubmission:
     def test_success(

--- a/test/e2e/windows/test_job_submissions.py
+++ b/test/e2e/windows/test_job_submissions.py
@@ -8,17 +8,23 @@ import pytest
 
 import logging
 
-from deadline_test_fixtures import Job, TaskStatus, DeadlineClient
+from deadline_test_fixtures import (
+    Job,
+    TaskStatus,
+    DeadlineClient,
+    EC2InstanceWorker,
+)
+
 
 LOG = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures("worker")
 @pytest.mark.parametrize("operating_system", ["windows"], indirect=True)
 class TestJobSubmission:
     def test_success(
         self,
         deadline_resources,
+        class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
     ) -> None:
         # WHEN

--- a/test/e2e/windows/test_override_job_user.py
+++ b/test/e2e/windows/test_override_job_user.py
@@ -1,0 +1,250 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+This test module contains tests that verify the Worker agent's behavior by submitting jobs to the
+Deadline Cloud service and checking that the result/output of the jobs is as we expect it.
+"""
+
+import boto3
+import botocore
+import pytest
+
+import logging
+
+from deadline_test_fixtures import (
+    Job,
+    Farm,
+    Queue,
+    TaskStatus,
+    DeadlineClient,
+    EC2InstanceWorker,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("operating_system", ["windows"], indirect=True)
+class TestJobUserOverride:
+    @staticmethod
+    def submit_whoami_job(
+        test_name: str, deadline_client: DeadlineClient, farm: Farm, queue: Queue
+    ) -> Job:
+        job = Job.submit(
+            client=deadline_client,
+            farm=farm,
+            queue=queue,
+            priority=98,
+            template={
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": f"whoami {test_name}",
+                "steps": [
+                    {
+                        "name": "Step0",
+                        "script": {
+                            "actions": {
+                                "onRun": {
+                                    "command": "powershell",
+                                    "args": ["echo", '"I am: $((whoami).split("\\")[1])"'],
+                                }
+                            }
+                        },
+                    },
+                ],
+            },
+        )
+        return job
+
+    def test_no_user_override(
+        self,
+        deadline_resources,
+        class_worker: EC2InstanceWorker,
+        deadline_client: DeadlineClient,
+    ) -> None:
+
+        job = self.submit_whoami_job(
+            "no user override", deadline_client, deadline_resources.farm, deadline_resources.queue_a
+        )
+
+        LOG.info(f"Waiting for job {job.id} to complete")
+        job.wait_until_complete(client=deadline_client)
+        LOG.info(f"Job result: {job}")
+
+        # Retrieve job output and verify whoami printed the queue's jobsRunAsUser
+        job_logs = job.get_logs(
+            deadline_client=deadline_client,
+            logs_client=boto3.client(
+                "logs",
+                config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+            ),
+        )
+        full_log = "\n".join(
+            [le.message for _, log_events in job_logs.logs.items() for le in log_events]
+        )
+        assert (
+            "I am: job-user" in full_log
+        ), f"Expected message not found in Job logs. Logs are in CloudWatch log group: {job_logs.log_group_name}"
+        assert job.task_run_status == TaskStatus.SUCCEEDED
+
+    def test_config_file_user_override(
+        self,
+        deadline_resources,
+        class_worker: EC2InstanceWorker,
+        deadline_client: DeadlineClient,
+    ) -> None:
+
+        class_worker.stop_worker_service()
+
+        cmd_result = class_worker.send_command(
+            "(Get-Content -Path C:\ProgramData\Amazon\Deadline\Config\worker.toml -Raw) -replace '# windows_job_user = \"job-user\"', 'windows_job_user = \"config-override\"' | Set-Content -Path C:\ProgramData\Amazon\Deadline\Config\worker.toml"
+        )
+
+        class_worker.start_worker_service()
+
+        assert (
+            cmd_result.exit_code == 0
+        ), f"Setting the job user override via CLI failed: {cmd_result}"
+
+        job = self.submit_whoami_job(
+            "config user override",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+        )
+
+        LOG.info(f"Waiting for job {job.id} to complete")
+        job.wait_until_complete(client=deadline_client)
+        LOG.info(f"Job result: {job}")
+
+        # Retrieve job output and verify whoami printed the queue's jobsRunAsUser
+        job_logs = job.get_logs(
+            deadline_client=deadline_client,
+            logs_client=boto3.client(
+                "logs",
+                config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+            ),
+        )
+        full_log = "\n".join(
+            [le.message for _, log_events in job_logs.logs.items() for le in log_events]
+        )
+        assert (
+            "I am: config-override" in full_log
+        ), f"Expected message not found in Job logs. Logs are in CloudWatch log group: {job_logs.log_group_name}"
+        assert job.task_run_status == TaskStatus.SUCCEEDED
+
+        # reset config file
+        cmd_result = class_worker.send_command(
+            "(Get-Content -Path C:\ProgramData\Amazon\Deadline\Config\worker.toml -Raw) -replace 'windows_job_user = \"config-override\"', '# windows_job_user = \"job-user\"' | Set-Content -Path C:\ProgramData\Amazon\Deadline\Config\worker.toml"
+        )
+
+        assert cmd_result.exit_code == 0, f"Failed to reset config file: {cmd_result}"
+
+    def test_installer_user_override(
+        self,
+        deadline_resources,
+        class_worker: EC2InstanceWorker,
+        deadline_client: DeadlineClient,
+    ) -> None:
+
+        class_worker.stop_worker_service()
+
+        cmd_result = class_worker.send_command(
+            "install-deadline-worker "
+            + "-y "
+            + f"--farm-id {deadline_resources.farm.id} "
+            + f"--fleet-id {deadline_resources.fleet.id} "
+            + "--user ssm-user "
+            + "--windows-job-user install-override"
+        )
+
+        assert (
+            cmd_result.exit_code == 0
+        ), f"Failed to install worker with job user override: {cmd_result}"
+
+        class_worker.start_worker_service()
+
+        job = self.submit_whoami_job(
+            "installer user override",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+        )
+
+        LOG.info(f"Waiting for job {job.id} to complete")
+        job.wait_until_complete(client=deadline_client)
+        LOG.info(f"Job result: {job}")
+
+        # Retrieve job output and verify whoami printed the queue's jobsRunAsUser
+        job_logs = job.get_logs(
+            deadline_client=deadline_client,
+            logs_client=boto3.client(
+                "logs",
+                config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+            ),
+        )
+        full_log = "\n".join(
+            [le.message for _, log_events in job_logs.logs.items() for le in log_events]
+        )
+        assert (
+            "I am: install-override" in full_log
+        ), f"Expected message not found in Job logs. Logs are in CloudWatch log group: {job_logs.log_group_name}"
+        assert job.task_run_status == TaskStatus.SUCCEEDED
+
+        # reset config file
+        cmd_result = class_worker.send_command(
+            "(Get-Content -Path C:\ProgramData\Amazon\Deadline\Config\worker.toml -Raw) -replace 'windows_job_user = \"installer-override\"', '# windows_job_user = \"job-user\"' | Set-Content -Path C:\ProgramData\Amazon\Deadline\Config\worker.toml"
+        )
+
+        assert cmd_result.exit_code == 0, f"Failed to reset config file: {cmd_result}"
+
+    def test_env_var_user_override(
+        self,
+        deadline_resources,
+        class_worker: EC2InstanceWorker,
+        deadline_client: DeadlineClient,
+    ) -> None:
+
+        class_worker.stop_worker_service()
+
+        cmd_result = class_worker.send_command(
+            "[System.Environment]::SetEnvironmentVariable('DEADLINE_WORKER_WINDOWS_JOB_USER', 'env-override', [System.EnvironmentVariableTarget]::Machine)",
+        )
+
+        assert (
+            cmd_result.exit_code == 0
+        ), f"Failed to set DEADLINE_WORKER_WINDOWS_JOB_USER: {cmd_result}"
+
+        class_worker.start_worker_service()
+
+        job = self.submit_whoami_job(
+            "environment override",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+        )
+
+        LOG.info(f"Waiting for job {job.id} to complete")
+        job.wait_until_complete(client=deadline_client)
+        LOG.info(f"Job result: {job}")
+
+        # Retrieve job output and verify whoami printed the queue's jobsRunAsUser
+        job_logs = job.get_logs(
+            deadline_client=deadline_client,
+            logs_client=boto3.client(
+                "logs",
+                config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+            ),
+        )
+        full_log = "\n".join(
+            [le.message for _, log_events in job_logs.logs.items() for le in log_events]
+        )
+        assert (
+            "I am: env-override" in full_log
+        ), f"Expected message not found in Job logs. Logs are in CloudWatch log group: {job_logs.log_group_name}"
+        assert job.task_run_status == TaskStatus.SUCCEEDED
+
+        cmd_result = class_worker.send_command(
+            "[System.Environment]::SetEnvironmentVariable('DEADLINE_WORKER_WINDOWS_JOB_USER', '', [System.EnvironmentVariableTarget]::Machine)",
+        )
+
+        assert (
+            cmd_result.exit_code == 0
+        ), f"Failed to unset DEADLINE_WORKER_WINDOWS_JOB_USER: {cmd_result}"

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -79,6 +79,8 @@ def expected_cmd(
         expected_cmd.append("--telemetry-opt-out")
     if parsed_args.disallow_instance_profile:
         expected_cmd.append("--disallow-instance-profile")
+    if not parsed_args.install_service:
+        expected_cmd.append("--no-install-service")
     return expected_cmd
 
 
@@ -120,58 +122,44 @@ class TestInstallRunsCommand:
     """Test cases for install()"""
 
     @pytest.fixture(
-        params=("farm-1", "farm-2"),
-    )
-    def farm_id(self, request: pytest.FixtureRequest) -> str:
-        return request.param
-
-    @pytest.fixture(
-        params=("fleet-1", "fleet-2"),
-    )
-    def fleet_id(self, request: pytest.FixtureRequest) -> str:
-        return request.param
-
-    @pytest.fixture(
-        params=("us-west-2", "us-west-1"),
-    )
-    def region(self, request: pytest.FixtureRequest) -> str:
-        return request.param
-
-    @pytest.fixture(
-        params=(True, False),
-    )
-    def service_start(self, request: pytest.FixtureRequest) -> bool:
-        return request.param
-
-    @pytest.fixture(
-        params=("wa_user", "another_wa_user"),
-    )
-    def user(self, request: pytest.FixtureRequest) -> str:
-        return request.param
-
-    @pytest.fixture(
-        params=(True, False),
-    )
-    def allow_shutdown(self, request: pytest.FixtureRequest) -> bool:
-        return request.param
-
-    @pytest.fixture(
-        params=(True, False),
-    )
-    def telemetry_opt_out(self, request: pytest.FixtureRequest) -> bool:
-        return request.param
-
-    @pytest.fixture(
         params=(
-            True,
-            False,
-        ),
-        ids=(
-            "confirmed-true",
-            "confirmed-false",
-        ),
+            ParsedCommandLineArguments(
+                farm_id="farm-1",
+                fleet_id="fleet-1",
+                region="us-west-2",
+                user="wa-user",
+                password="wa-password",
+                group="group1",
+                service_start=True,
+                confirmed=True,
+                allow_shutdown=True,
+                install_service=True,
+                telemetry_opt_out=True,
+                vfs_install_path="/install/path",
+                grant_required_access=True,
+                disallow_instance_profile=True,
+                windows_job_user="job-user",
+            ),
+            ParsedCommandLineArguments(
+                farm_id="farm-2",
+                fleet_id="fleet-2",
+                region="us-east-2",
+                user="another-wa-user",
+                password="another-wa-password",
+                group="group2",
+                service_start=False,
+                confirmed=False,
+                allow_shutdown=False,
+                install_service=False,
+                telemetry_opt_out=False,
+                vfs_install_path="/another/install/path",
+                grant_required_access=False,
+                disallow_instance_profile=False,
+                windows_job_user="another-job-user",
+            ),
+        )
     )
-    def confirmed(self, request: pytest.FixtureRequest) -> bool:
+    def parsed_args(self, request: pytest.FixtureRequest) -> ParsedCommandLineArguments:
         return request.param
 
     def test_runs_expected_subprocess(

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -2,6 +2,7 @@
 
 import sys
 import typing
+from typing import Generator
 from unittest.mock import Mock, call, patch, MagicMock, ANY
 
 import pytest
@@ -24,65 +25,55 @@ from win32service import error as win_service_error
 from win32serviceutil import GetServiceClassString
 
 
-def test_start_windows_installer(
-    parsed_args: ParsedCommandLineArguments,
-) -> None:
-    # GIVEN
+@pytest.fixture
+def parsed_kwargs(parsed_args: ParsedCommandLineArguments) -> Generator[dict, None, None]:
+    assert parsed_args.region is not None, "Region is required"
     with patch.object(installer_mod, "get_argument_parser") as mock_get_arg_parser:
-        with patch.object(installer_mod, "start_windows_installer") as mock_start_windows_installer:
-            arg_parser: MagicMock = mock_get_arg_parser.return_value
-            arg_parser.parse_args.return_value = parsed_args
+        arg_parser: MagicMock = mock_get_arg_parser.return_value
+        arg_parser.parse_args.return_value = parsed_args
+        yield {
+            "farm_id": parsed_args.farm_id,
+            "fleet_id": parsed_args.fleet_id,
+            "region": parsed_args.region,
+            "install_service": parsed_args.install_service,
+            "start_service": parsed_args.service_start,
+            "confirm": parsed_args.confirmed,
+            "parser": mock_get_arg_parser(),
+            "user_name": parsed_args.user,
+            "group_name": str(parsed_args.group),
+            "password": parsed_args.password,
+            "allow_shutdown": parsed_args.allow_shutdown,
+            "telemetry_opt_out": parsed_args.telemetry_opt_out,
+            "grant_required_access": parsed_args.grant_required_access,
+            "allow_ec2_instance_profile": not parsed_args.disallow_instance_profile,
+            "windows_job_user": parsed_args.windows_job_user,
+        }
 
-            # WHEN
-            install()
 
-            # Then
-            mock_start_windows_installer.assert_called_once_with(
-                farm_id=parsed_args.farm_id,
-                fleet_id=parsed_args.fleet_id,
-                region=parsed_args.region,
-                install_service=parsed_args.install_service,
-                start_service=parsed_args.service_start,
-                confirm=parsed_args.confirmed,
-                parser=mock_get_arg_parser(),
-                user_name=parsed_args.user,
-                group_name=parsed_args.group,
-                password=parsed_args.password,
-                allow_shutdown=parsed_args.allow_shutdown,
-                telemetry_opt_out=parsed_args.telemetry_opt_out,
-                grant_required_access=parsed_args.grant_required_access,
-                allow_ec2_instance_profile=not parsed_args.disallow_instance_profile,
-                windows_job_user=parsed_args.windows_job_user,
-            )
+def test_start_windows_installer(parsed_kwargs: dict) -> None:
+    # GIVEN
+    with patch.object(installer_mod, "start_windows_installer") as mock_start_windows_installer:
+        # WHEN
+        install()
+
+        # Then
+        mock_start_windows_installer.assert_called_once_with(
+            **parsed_kwargs,
+        )
 
 
 @patch.object(shell, "IsUserAnAdmin")
 def test_start_windows_installer_fails_when_run_as_non_admin_user(
-    is_user_an_admin, parsed_args: ParsedCommandLineArguments
+    is_user_an_admin, parsed_kwargs: dict
 ) -> None:
     # GIVEN
     is_user_an_admin.return_value = False
-    assert parsed_args.region is not None, "Region is required"
+    with pytest.raises(SystemExit):
+        # WHEN
+        win_installer.start_windows_installer(**parsed_kwargs)
 
-    with (patch.object(installer_mod, "get_argument_parser") as mock_get_arg_parser,):
-        with pytest.raises(SystemExit):
-            # WHEN
-            win_installer.start_windows_installer(
-                farm_id=parsed_args.farm_id,
-                fleet_id=parsed_args.fleet_id,
-                region=parsed_args.region,
-                install_service=parsed_args.install_service,
-                start_service=parsed_args.service_start,
-                confirm=parsed_args.confirmed,
-                parser=mock_get_arg_parser(),
-                user_name=parsed_args.user,
-                group_name=str(parsed_args.group),
-                password=parsed_args.password,
-                allow_shutdown=parsed_args.allow_shutdown,
-            )
-
-            # THEN
-            is_user_an_admin.assert_called_once()
+        # THEN
+        is_user_an_admin.assert_called_once()
 
 
 @patch("deadline_worker_agent.installer.win_installer.check_account_existence", return_value=False)
@@ -90,35 +81,19 @@ def test_start_windows_installer_fails_when_run_as_non_admin_user(
 def test_start_windows_installer_fails_when_windows_job_user_not_exists(
     is_user_and_admin: MagicMock,
     check_account_existence: MagicMock,
-    parsed_args: ParsedCommandLineArguments,
+    parsed_kwargs: dict,
 ) -> None:
     # GIVEN
-    assert parsed_args.region is not None, "Region is required"  # this is mostly for mypy
+    with pytest.raises(win_installer.InstallerFailedException) as exc_info:
+        # WHEN
+        win_installer.start_windows_installer(**parsed_kwargs)
 
-    with (patch.object(installer_mod, "get_argument_parser") as mock_get_arg_parser,):
-        with pytest.raises(win_installer.InstallerFailedException) as exc_info:
-            # WHEN
-            win_installer.start_windows_installer(
-                farm_id=parsed_args.farm_id,
-                fleet_id=parsed_args.fleet_id,
-                region=parsed_args.region,
-                install_service=parsed_args.install_service,
-                start_service=parsed_args.service_start,
-                confirm=parsed_args.confirmed,
-                parser=mock_get_arg_parser(),
-                user_name=parsed_args.user,
-                group_name=str(parsed_args.group),
-                password=parsed_args.password,
-                allow_shutdown=parsed_args.allow_shutdown,
-                windows_job_user=parsed_args.windows_job_user,
-            )
-
-        # THEN
-        assert (
-            str(exc_info.value)
-            == f"Account {parsed_args.windows_job_user} provided for argument windows-job-user does not exist. "
-            "Please create the account before proceeding."
-        )
+    # THEN
+    assert (
+        str(exc_info.value)
+        == f"Account {parsed_kwargs['windows_job_user']} provided for argument windows-job-user does not exist. "
+        "Please create the account before proceeding."
+    )
 
 
 @patch("deadline_worker_agent.installer.win_installer.users_equal", return_value=True)
@@ -128,36 +103,22 @@ def test_start_windows_installer_fails_when_windows_job_user_is_agent_user(
     users_equal: MagicMock,
     is_user_and_admin: MagicMock,
     check_account_existence: MagicMock,
-    parsed_args: ParsedCommandLineArguments,
+    parsed_kwargs: dict,
 ) -> None:
     # GIVEN
-    assert parsed_args.region is not None, "Region is required"  # this is mostly for mypy
+    with pytest.raises(win_installer.InstallerFailedException) as exc_info:
+        # WHEN
+        win_installer.start_windows_installer(**parsed_kwargs)
 
-    with (patch.object(installer_mod, "get_argument_parser") as mock_get_arg_parser,):
-        with pytest.raises(win_installer.InstallerFailedException) as exc_info:
-            # WHEN
-            win_installer.start_windows_installer(
-                farm_id=parsed_args.farm_id,
-                fleet_id=parsed_args.fleet_id,
-                region=parsed_args.region,
-                install_service=parsed_args.install_service,
-                start_service=parsed_args.service_start,
-                confirm=parsed_args.confirmed,
-                parser=mock_get_arg_parser(),
-                user_name=parsed_args.user,
-                group_name=str(parsed_args.group),
-                password=parsed_args.password,
-                allow_shutdown=parsed_args.allow_shutdown,
-                windows_job_user=parsed_args.windows_job_user,
-            )
-
-        # THEN
-        assert (
-            str(exc_info.value)
-            == f"Argument for windows-job-user cannot be the same as the worker agent user: {parsed_args.user}. "
-            "If you wish to run jobs as the agent user, set run_jobs_as_agent_user = true in the agent configuration file."
-        )
-        assert users_equal.called_once_with(parsed_args.user, parsed_args.windows_job_user)
+    # THEN
+    assert (
+        str(exc_info.value)
+        == f"Argument for windows-job-user cannot be the same as the worker agent user: {parsed_kwargs['user_name']}. "
+        "If you wish to run jobs as the agent user, set run_jobs_as_agent_user = true in the agent configuration file."
+    )
+    assert users_equal.called_once_with(
+        parsed_kwargs["user_name"], parsed_kwargs["windows_job_user"]
+    )
 
 
 class TestCreateLocalQueueUserGroup:

--- a/test/unit/startup/test_cli_args.py
+++ b/test/unit/startup/test_cli_args.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from argparse import ArgumentParser
 
 import pytest
+import os
 
 from deadline_worker_agent.startup import cli_args as cli_args_mod
 
@@ -40,6 +41,8 @@ class TestArgumentParser:
         assert result.retain_session_dir is None
         assert result.structured_logs is None
         assert result.verbose is None
+        assert result.posix_job_user is None
+        assert result.windows_job_user is None
 
     @pytest.mark.parametrize(
         ["farm_id"],
@@ -153,3 +156,22 @@ class TestArgumentParser:
 
         # THEN
         assert result.cleanup_session_user_processes == expected_cleanup_session_user_processes
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
+    @pytest.mark.parametrize(
+        ["windows_job_user"],
+        (
+            ("job user a",),
+            ("job user b",),
+        ),
+    )
+    def test_windows_job_user(self, arg_parser: ArgumentParser, windows_job_user: str) -> None:
+        """Asserts that the --windows-job-user command-line argument is parsed"""
+        # GIVEN
+        args = ["--windows-job-user", windows_job_user]
+
+        # WHEN
+        result = arg_parser.parse_args(args, namespace=cli_args_mod.ParsedCommandLineArguments())
+
+        # THEN
+        assert result.windows_job_user == windows_job_user

--- a/test/unit/windows/test_win_credentials_resolver.py
+++ b/test/unit/windows/test_win_credentials_resolver.py
@@ -159,7 +159,7 @@ if sys.platform == "win32":
             password_arn = "new_password_arn"
 
             with patch(
-                "deadline_worker_agent.windows.win_credentials_resolver.WindowsSessionUser",
+                "deadline_worker_agent.windows.win_logon.WindowsSessionUser",
                 side_effect=BadCredentialsException("Invalid credentials"),
             ):
                 # WHEN

--- a/test/unit/windows/test_win_logon.py
+++ b/test/unit/windows/test_win_logon.py
@@ -1,0 +1,461 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock, call
+from typing import Generator
+import string
+import sys
+
+from openjd.sessions import BadCredentialsException
+from pytest import fixture, param
+import pytest
+
+# This if is required for two purposes:
+# 1.  It short-circuits mypy from type checking this module on platforms other than Windows
+#     https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks
+# 2.  It causes the tests to not be discovered/ran on non-Windows platforms
+if sys.platform == "win32":
+    import deadline_worker_agent.windows.win_logon as win_logon_mod
+    from deadline_worker_agent.windows.win_logon import (
+        get_windows_credentials,
+        reset_user_password,
+        unload_and_close,
+        generate_password,
+        PI_NOUI,
+        LOGON32_LOGON_INTERACTIVE,
+        LOGON32_PROVIDER_DEFAULT,
+        PasswordResetException,
+        PyWinError,
+        users_equal,
+    )
+
+    class TestGetWindowsCredentialsOutsideSession0:
+        @pytest.fixture(
+            params=[("some-user", "some-password"), ("another-user", "another-password")]
+        )
+        def username_password(self, request: pytest.FixtureRequest) -> str:
+            return request.param
+
+        @fixture(autouse=True)
+        def windows_session_user(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod, "WindowsSessionUser") as mock:
+                yield mock
+
+        @fixture(autouse=True)
+        def outside_session_0(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod.win_service, "is_windows_session_zero") as mock:
+                mock.return_value = False
+                yield mock
+
+        def test_logon_outside_session_0(
+            self,
+            windows_session_user: MagicMock,
+            username_password: tuple[str, str],
+        ):
+            # GIVEN
+            username, password = username_password
+
+            # WHEN
+            cache_entry = get_windows_credentials(username, password)
+
+            # THEN
+            windows_session_user.assert_called_once_with(user=username, password=password)
+            assert cache_entry.windows_session_user is windows_session_user.return_value
+
+        def test_wrong_password_raises_outside_session_0(
+            self,
+            windows_session_user: MagicMock,
+            username_password: tuple[str, str],
+        ):
+            # GIVEN
+            username, password = username_password
+            windows_session_user.side_effect = BadCredentialsException("password bad!")
+
+            # THEN
+            with pytest.raises(BadCredentialsException) as exc_info:
+                # WHEN
+                get_windows_credentials(username, password)
+
+            # THEN
+            assert exc_info.value is windows_session_user.side_effect
+
+    class TestGetWindowsCredentialsInSession0:
+        @pytest.fixture(
+            params=[("some-user", "some-password"), ("another-user", "another-password")]
+        )
+        def username_password(self, request: pytest.FixtureRequest) -> str:
+            return request.param
+
+        @fixture(autouse=True)
+        def logon_user(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod, "LogonUser") as mock:
+                mock.return_value.__int__.return_value = 12983791  # default is 1, mix it up a bit
+                yield mock
+
+        @fixture(autouse=True)
+        def load_user_profile(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod, "LoadUserProfile") as mock:
+                yield mock
+
+        @fixture(autouse=True)
+        def windows_session_user(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod, "WindowsSessionUser") as mock:
+                yield mock
+
+        @fixture(autouse=True)
+        def chandle(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod, "cHANDLE") as mock:
+                yield mock
+
+        @fixture(autouse=True)
+        def is_session_0(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod.win_service, "is_windows_session_zero") as mock:
+                mock.return_value = True
+                yield mock
+
+        def test_logon_in_session_0(
+            self,
+            windows_session_user: MagicMock,
+            logon_user: MagicMock,
+            load_user_profile: MagicMock,
+            chandle: MagicMock,
+            username_password: tuple[str, str],
+        ):
+            # GIVEN
+            username, password = username_password
+
+            # WHEN
+            cache_entry = get_windows_credentials(username, password)
+
+            # THEN
+
+            logon_user.assert_called_once_with(
+                Username=username,
+                LogonType=LOGON32_LOGON_INTERACTIVE,
+                LogonProvider=LOGON32_PROVIDER_DEFAULT,
+                Password=password,
+                Domain=None,
+            )
+            load_user_profile.assert_called_once_with(
+                logon_user.return_value,
+                {
+                    "UserName": username,
+                    "Flags": PI_NOUI,
+                    "ProfilePath": None,
+                },
+            )
+            chandle.assert_called_once_with(logon_user.return_value.__int__.return_value)
+            windows_session_user.assert_called_once_with(
+                user=username, logon_token=chandle.return_value
+            )
+
+            assert cache_entry.windows_session_user is windows_session_user.return_value
+            assert cache_entry.logon_token is logon_user.return_value
+            assert cache_entry.user_profile is load_user_profile.return_value
+
+        def test_wrong_password_raises_in_session_0(
+            self,
+            logon_user: MagicMock,
+            username_password: tuple[str, str],
+        ):
+            # GIVEN
+            username, password = username_password
+            message = "Password bad!"
+            logon_user.side_effect = OSError(message)
+
+            # THEN
+            with pytest.raises(BadCredentialsException) as exc_info:
+                # WHEN
+                get_windows_credentials(username, password)
+
+            # THEN
+            assert str(exc_info.value) == f'Error logging on as "{username}": {message}'
+
+        def test_user_profile_load_fail_raises_in_session_0(
+            self,
+            load_user_profile: MagicMock,
+            username_password: tuple[str, str],
+        ):
+            # GIVEN
+            username, password = username_password
+            load_user_profile.side_effect = OSError("Profile bad!")
+
+            # THEN
+            with pytest.raises(OSError) as exc_info:
+                # WHEN
+                get_windows_credentials(username, password)
+
+            assert exc_info.value is load_user_profile.side_effect
+
+        def test_logon_token_is_bad(
+            self,
+            windows_session_user: MagicMock,
+            username_password: tuple[str, str],
+        ):
+            # GIVEN
+            username, password = username_password
+            message = "Token bad!"
+            windows_session_user.side_effect = OSError(message)
+
+            # THEN
+            with pytest.raises(BadCredentialsException) as exc_info:
+                # WHEN
+                get_windows_credentials(username, password)
+
+            # THEN
+            assert str(exc_info.value) == f'Error logging on as "{username}": {message}'
+
+    class TestResetUserPassword:
+        @fixture
+        def username(self) -> str:
+            return "some-user"
+
+        @fixture(autouse=True)
+        def get_windows_credentials(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod, "get_windows_credentials") as mock:
+                yield mock
+
+        @fixture(autouse=True)
+        def win32net(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod, "win32net") as mock:
+                yield mock
+
+        @fixture(autouse=True)
+        def generate_password(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod, "generate_password") as mock:
+                mock.return_value = "new-password"
+                yield mock
+
+        def test_get_user_info_fails(
+            self,
+            username: str,
+            win32net: MagicMock,
+        ):
+            # GIVEN
+            win32net.NetUserGetInfo.side_effect = PyWinError(
+                2221, "NetUserGetInfo", "The user name could not be found."
+            )
+
+            # WHEN
+            with pytest.raises(PasswordResetException) as exc_info:
+                reset_user_password(username)
+
+            # THEN
+            assert (
+                str(exc_info.value)
+                == f'Failed to reset password for "{username}". Error: {win32net.NetUserGetInfo.side_effect.strerror}'
+            )
+
+        def test_set_user_info_fails(
+            self,
+            username: str,
+            win32net: MagicMock,
+        ):
+            # GIVEN
+            win32net.NetUserSetInfo.side_effect = PyWinError(
+                2246, "NetUserGetInfo", "The password of this user is too recent to change"
+            )
+
+            # WHEN
+            with pytest.raises(PasswordResetException) as exc_info:
+                reset_user_password(username)
+
+            # THEN
+            assert (
+                str(exc_info.value)
+                == f'Failed to reset password for "{username}". Error: {win32net.NetUserSetInfo.side_effect.strerror}'
+            )
+
+        @pytest.mark.parametrize(
+            "error",
+            [
+                OSError("User Profile does not exist"),
+                BadCredentialsException("Password is not correct"),
+            ],
+        )
+        def test_get_windows_credentials_fails(
+            self,
+            username: str,
+            get_windows_credentials: MagicMock,
+            error: Exception,
+        ):
+            # GIVEN
+            get_windows_credentials.side_effect = error
+
+            # WHEN
+            with pytest.raises(PasswordResetException) as exc_info:
+                reset_user_password(username)
+
+            # THEN
+            if isinstance(error, OSError):
+                assert (
+                    str(exc_info.value)
+                    == f'Failed to load the user profile for "{username}". Error: {str(error)}'
+                )
+            else:
+                assert (
+                    str(exc_info.value) == f'Failed to logon as "{username}". Error: {str(error)}'
+                )
+
+        def test_reset_user_password(
+            self,
+            username: str,
+            get_windows_credentials: MagicMock,
+            generate_password: MagicMock,
+        ):
+            cache_entry = reset_user_password(username)
+
+            # THEN
+            generate_password.assert_called_once()
+            assert cache_entry is get_windows_credentials.return_value
+
+    class TestUnloadAndClose:
+        @fixture
+        def unload_user_profile(self) -> Generator[MagicMock, None, None]:
+            with patch.object(win_logon_mod, "UnloadUserProfile") as mock:
+                yield mock
+
+        @pytest.mark.parametrize(
+            "logon_token,user_profile",
+            [
+                (MagicMock(), MagicMock()),
+                (MagicMock(), None),
+            ],
+        )
+        def test_unload_and_close(
+            self,
+            unload_user_profile: MagicMock,
+            logon_token: MagicMock,
+            user_profile: MagicMock | None,
+        ):
+            # WHEN
+            unload_and_close(user_profile, logon_token)
+
+            # THEN
+            if user_profile is not None:
+                unload_user_profile.assert_called_once_with(logon_token, user_profile)
+            logon_token.Close.assert_called_once()
+
+    class TestGeneratePassword:
+        @fixture
+        def secrets_choice(self) -> Generator[MagicMock, None, None]:
+            with patch.object(
+                win_logon_mod.secrets, "choice", side_effect=["a", "A", "1", "*"] * 100
+            ) as mock:
+                yield mock
+
+        @fixture(autouse=True)
+        def net_user_get_info(self):
+            with patch.object(
+                win_logon_mod.win32net,
+                "NetUserGetInfo",
+                return_value={"name": "test-user", "full_name": "Test User"},
+            ) as mock:
+                yield mock
+
+        @fixture
+        def alphabet(self) -> str:
+            return string.ascii_letters + string.digits + string.punctuation
+
+        def test_password_is_not_reused(self, net_user_get_info: MagicMock):
+            # WHEN
+            password = generate_password("username")
+
+            # THEN
+            assert generate_password("username") != password
+
+        def test_password_uses_secrets(self, secrets_choice: MagicMock, alphabet: str):
+            # WHEN
+            generate_password("username")
+
+            # THEN
+            assert secrets_choice.call_count >= 256
+            assert secrets_choice.has_calls(
+                [call(alphabet) for _ in range(secrets_choice.call_count)]
+            )
+
+        def test_password_composition(self, net_user_get_info: MagicMock, alphabet: str):
+            # WHEN
+            password = generate_password("username")
+
+            # THEN
+            assert len(password) == 256
+            assert any(char.isupper() for char in password)
+            assert any(char.islower() for char in password)
+            assert any(char.isdigit() for char in password)
+            assert any(not char.isalnum() for char in password)
+
+        def test_cannot_generate_valid_password(self):
+            # GIVEN
+            with pytest.raises(PasswordResetException) as exc_info:
+                # WHEN
+                generate_password("username", length=1)
+
+            assert (
+                str(exc_info.value)
+                == "Failed to generate a password which meets security requirements."
+            )
+
+    class TestUsersEqual:
+        @pytest.mark.parametrize(
+            "side_effect, should_be_equal, usernames",
+            [
+                param(
+                    [(1, None, None), (1, None, None)],
+                    True,
+                    ("user", "domain\\user"),
+                    id="same sid",
+                ),
+                param(
+                    [(1, None, None), (2, None, None)],
+                    False,
+                    ("user", "domain\\user"),
+                    id="diff sid",
+                ),
+                param(
+                    [
+                        (1, None, None),
+                        PyWinError(2221, "NetUserGetInfo", "The user name could not be found."),
+                    ],
+                    False,
+                    ("user", "domain\\user"),
+                    id="one doesn't exist",
+                ),
+                param(
+                    [
+                        PyWinError(2221, "NetUserGetInfo", "The user name could not be found."),
+                        PyWinError(2221, "NetUserGetInfo", "The user name could not be found."),
+                    ],
+                    True,
+                    ("user", "user"),
+                    id="both don't exist string comparison success",
+                ),
+                param(
+                    [
+                        PyWinError(2221, "NetUserGetInfo", "The user name could not be found."),
+                        PyWinError(2221, "NetUserGetInfo", "The user name could not be found."),
+                    ],
+                    False,
+                    ("user", "domain\\user"),
+                    id="both don't exist string comparison failure",
+                ),
+            ],
+        )
+        @patch.object(win_logon_mod.win32security, "LookupAccountName")
+        def test_users_equal(
+            self,
+            lookup_account_name: MagicMock,
+            side_effect: list,
+            should_be_equal: bool,
+            usernames: tuple[str, str],
+        ):
+            # GIVEN
+            lookup_account_name.side_effect = side_effect
+            user_1, user_2 = usernames
+
+            # WHEN
+            is_equal = users_equal(user_1, user_2)
+
+            # THEN
+            lookup_account_name.assert_has_calls([call(None, user_1), call(None, user_2)])
+            assert is_equal == should_be_equal


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Windows was lacking the job user override which was available for POSIX systems.

### What was the solution? (How)

Add it! The solution is as follows:

1. Add a worker agent configuration option: `windows_job_user`
    -  This is a string field available through:
        - Environment Variable: `DEADLINE_WORKER_WINDOWS_JOB_USER=<the user>`
        - Worker Agent configuration File: `windows_job_user = "<the user>"`
        - Command Line Argument: `--windows-job-user <the user>`

This configuration will change the worker agent startup flow as follows:

1. On startup, the worker checks its configuration
2. If `windows_job_user` is set:
    1. change the `windows_job_user` password to a random value kept in memory
        1. A 256 character, cryptographically secure password will be generated using the python module secrets 
    2. The worker agent uses that password to:
       - Obtain a `logon_token` from the `LogonUserW Windows API if running under session 0
       -  Create a `WindowsSessionUser` if not running under session 0
    3. If running under session 0, then the Job User’s password is then dereferenced in Python and marked for garbage collection, and the logon_token is cached for use when assigned a session
  
 Also added some logic to fail in the installer and startup if the `windows_job_user` == the `agent user`, since then the `run_jobs_as_agent_user` setting should be used instead.

### What is the impact of this change?

The worker agent can ignore queue-level `JobRunAs` configuration and always run as the override user on windows systems as well (feature parity with linux).

### How was this change tested?

Unit tests created and pass

Integ tests:
```
============================================================= slowest 5 durations =============================================================
459.71s setup    test/e2e/windows/test_job_submissions.py::TestJobSubmission::test_success[windows]
456.52s setup    test/e2e/windows/test_override_job_user.py::TestJobUserOverride::test_no_user_override[windows]
128.29s teardown test/e2e/windows/test_job_submissions.py::TestJobSubmission::test_success[windows]
90.17s call     test/e2e/windows/test_override_job_user.py::TestJobUserOverride::test_installer_user_override[windows]
87.53s call     test/e2e/windows/test_override_job_user.py::TestJobUserOverride::test_config_file_user_override[windows]
================================================== 5 passed, 1 warning in 1367.90s (0:22:47) ==================================================
```

Manual tests on a windows instance connected to the service.

### Was this change documented?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

Signed-off-by: Samuel Anderson <119458760+AWS-Samuel@users.noreply.github.com>