### PR TITLE
docs: fix dealine-worker typo to deadline-worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,16 +151,16 @@ The following commands demonstrate how to manually control the operating system 
 
 ```sh
 # Start the worker agent
-systemctl start dealine-worker
+systemctl start deadline-worker
 
 # Stop the worker agent
-systemctl stop dealine-worker
+systemctl stop deadline-worker
 
 # Configure the worker agent to start on boot
-systemctl enable dealine-worker
+systemctl enable deadline-worker
 
 # Configure the worker agent to NOT start on boot
-systemctl disable dealine-worker
+systemctl disable deadline-worker
 ```
 
 **On Windows:**


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was a typo in the `README.md` that refers to the systemd service created by the worker agent installer on Linux. The typo was `dealine-worker` but should have been `deadline-worker`.

### What was the solution? (How)

Fix the typo from `dealine-worker` &rarr; `deadline-worker`.

### What is the impact of this change?

Readers of the documentation will not be misled by the typo and encounter errors when copy/pasting.

### How was this change tested?

Visually confirmed the service name matches the systemd service 

https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/e759cf25ab1b2a529f1c94a4bacb630ed0bc1b07/src/deadline_worker_agent/installer/install.sh#L433

### Was this change documented?

This change is fixing documentation

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*