### PR TITLE
test:Add test to verify install give shutdown permission to WA user

### DIFF
--- a/test/e2e/cross_os/test_installer.py
+++ b/test/e2e/cross_os/test_installer.py
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+This test module contains tests that verify the Installer's behavior by submitting commands to the
+Deadline Cloud worker and checking that the result/output of the worker agent is as we expect it.
+"""
+import pytest
+import logging
+from deadline_test_fixtures import EC2InstanceWorker
+from utils import get_operating_system_name
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("operating_system", [get_operating_system_name()], indirect=True)
+class TestInstaller:
+    def test_installer_shutdown_permission(
+        self,
+        session_worker: EC2InstanceWorker,
+    ) -> None:
+
+        cmd_result = session_worker.send_command(
+            "egrep \
+                '^deadline-worker ALL=\(root\) NOPASSWD: /usr/sbin/shutdown now$' \
+                /etc/sudoers.d/deadline-worker-shutdown"
+        )
+
+        assert cmd_result.exit_code == 0, f"Shutdown WA permission do not exist: {cmd_result}"

--- a/test/e2e/linux/test_installer.py
+++ b/test/e2e/linux/test_installer.py
@@ -6,12 +6,11 @@ Deadline Cloud worker and checking that the result/output of the worker agent is
 import pytest
 import logging
 from deadline_test_fixtures import EC2InstanceWorker
-from utils import get_operating_system_name
 
 LOG = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize("operating_system", [get_operating_system_name()], indirect=True)
+@pytest.mark.parametrize("operating_system", ["linux"], indirect=True)
 class TestInstaller:
     def test_installer_shutdown_permission(
         self,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
WA missing some tests to verify its functionality.

In this case, we missing test to verify if the installer give shutdown permission to WA user
### What was the solution? (How)
Add test case to verify if the installer give shutdown permission to WA user
### What is the impact of this change?
We cover more test cases and reduce test gap

### How was this change tested?
`hatch run cross-os-e2e-test`

### Was this change documented?
Yes

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*