### PR TITLE
fix: install-deadline-worker doesn't create queues persistence dir on Windows

### DIFF
--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -429,6 +429,7 @@ def provision_directories(agent_username: str) -> WorkerAgentDirectories:
     - %PROGRAMDATA%/Amazon/Deadline
     - %PROGRAMDATA%/Amazon/Deadline/Logs
     - %PROGRAMDATA%/Amazon/Deadline/Cache
+    - %PROGRAMDATA%/Amazon/Deadline/Cache/queues
     - %PROGRAMDATA%/Amazon/Deadline/Config
 
     Parameters
@@ -461,6 +462,11 @@ def provision_directories(agent_username: str) -> WorkerAgentDirectories:
     logging.info(f"Provisioning persistence directory ({deadline_persistence_subdir})")
     os.makedirs(deadline_persistence_subdir, exist_ok=True)
     logging.info(f"Done provisioning persistence directory ({deadline_persistence_subdir})")
+
+    deadline_persistence_queues_subdir = os.path.join(deadline_persistence_subdir, "queues")
+    logging.info(f"Provisioning persistence directory ({deadline_persistence_queues_subdir})")
+    os.makedirs(deadline_persistence_queues_subdir, exist_ok=True)
+    logging.info(f"Done provisioning persistence directory ({deadline_persistence_queues_subdir})")
 
     deadline_config_subdir = os.path.join(deadline_dir, "Config")
     logging.info(f"Provisioning config directory ({deadline_config_subdir})")

--- a/test/unit/windows/test_win_logon.py
+++ b/test/unit/windows/test_win_logon.py
@@ -370,7 +370,7 @@ if sys.platform == "win32":
 
             # THEN
             assert secrets_choice.call_count >= 256
-            assert secrets_choice.has_calls(
+            secrets_choice.assert_has_calls(
                 [call(alphabet) for _ in range(secrets_choice.call_count)]
             )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

On Linux, the `install-deadline-worker` command creates the `<PERSISTENCE_DIR>/queues` directory if it does not pre-exist.

On Windows, the `install-deadline-worker` command does not create the `<PERSISTENCE_DIR>/queues` directory.

See https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/docs/state.md#persistence-directory for details on the persistence directory.

### What was the solution? (How)

Add logic to the Windows `install-deadline-worker` implementation to create the `<PERSISTENCE_DIR>/queues` directory if it does not exist.

When trying to run the linting (`hatch run lint`) and unit tests (`hatch run test`) on Windows, I encountered some failures that I've included in this PR to get the tests passing.

### What is the impact of this change?

The behavior of `install-deadline-worker` is consistent between Linux and Windows and creates the `<PERSISTENCE_DIR>/queues` directory if it does not exist.

### How was this change tested?

Ran the modified `install-deadline-worker` on a Windows host and confirmed that the `<PERSISTENCE_DIR>/queues` directory was created as expected.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*