### PR TITLE
fix: install-deadline-worker fails on posix if agent user does not pre-exist

### DIFF
--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -216,8 +216,15 @@ if [[ ! -z "${wa_user}" ]] && [[ ! "${wa_user}" =~ ^[a-z_]([a-z0-9_-]{0,31}|[a-z
     echo "ERROR: Not a valid value for --user: ${wa_user}"
     usage
 fi
+
 # Set wa_group as the primary group that the wa_user belongs to
-wa_group=$(id -gn "${wa_user}")
+if user_exists "${wa_user}"; then
+    wa_group=$(id -gn "${wa_user}")
+else
+    # We'll be creating a new user.
+    # The primary group of a newly created user has the same name as that user.
+    wa_group="${wa_user}"
+fi
 
 # Default the group to wa_user if it wasn't defined via the --group option.
 job_group=${job_group:-${default_job_group}}


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/371

### What was the problem/requirement? (What/Why)

If install-deadline-worker is run and the group with the same name as the desired agent user does not already exist, then the installer will crash with an error like:

```
id: ‘deadline-worker-agent’: no such user
```

### What was the solution? (How)

Check if the agent user exists before querying for the agent user's default group. If the agent user does not exist, then the default group will have the same name as the agent user.

### What is the impact of this change?

Users should be able to successfully install the agent on a clean system using the installer.

### How was this change tested?

via docker:

```
docker run -it --rm --name agent-test amazonlinux:2023 /bin/bash
docker container cp dist/deadline_cloud_worker_agent-*.whl agent-test:/root

# Inside the container:
yum install -y sudo pip which util-linux systemd
cd
python3 -m venv .venv
source .venv/bin/activate
pip install --force deadline_cloud_worker_agent-0.26.1*
install-deadline-worker --farm-id farm-00000000000000000000000000000000 --fleet-id fleet-00000000000000000000000000000000 --region us-west-2
```

Without the change in this PR:
```
(.venv) bash-5.2# install-deadline-worker --farm-id farm-00000000000000000000000000000000 --fleet-id fleet-00000000000000000000000000000000 --region us-west-2
id: ‘deadline-worker-agent’: no such user
```

With the change in this PR:
```
(.venv) bash-5.2# install-deadline-worker --farm-id farm-00000000000000000000000000000000 --fleet-id fleet-00000000000000000000000000000000 --region us-west-2
===========================================================
|      AWS Deadline Cloud Worker Agent Installer       |
===========================================================

Farm ID: farm-00000000000000000000000000000000
Fleet ID: fleet-00000000000000000000000000000000
Region: us-west-2
Worker agent user: deadline-worker-agent
Worker agent group: deadline-worker-agent
Worker job group: deadline-job-users
Scripts path: /root/.venv/bin
Worker agent program path: /root/.venv/bin/deadline-worker-agent
Deadline client program path: /root/.venv/bin/deadline
Allow worker agent shutdown: no
Start systemd service: no
Telemetry opt-out: no
VFS install path: unset
Disallow EC2 instance profile: no
Confirm install with the above settings (y/n):
...

(.venv) bash-5.2# groups deadline-worker-agent
deadline-worker-agent : deadline-worker-agent deadline-job-users
```

I am also going to try to update the https://github.com/aws-deadline/deadline-cloud-test-fixtures/ so that the agent user is no longer created before running the installer; this will let the installer create the user, and exercise this code path in an automated regression test.

i.e. [This line](https://github.com/aws-deadline/deadline-cloud-test-fixtures/blob/6d4023d244225a68d282839d60d342138a9e25d2/src/deadline_test_fixtures/deadline/worker.py#L679) will be deleted which will allow [this install](https://github.com/aws-deadline/deadline-cloud-test-fixtures/blob/6d4023d244225a68d282839d60d342138a9e25d2/src/deadline_test_fixtures/deadline/worker.py#L624) to create the user.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*