### PR TITLE
test: put worker job attachment test template in test file and add OPERATING_SYSTEM env variable

### DIFF
--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -18,11 +18,13 @@ fi
 
 if [ "$OPERATING_SYSTEM" = "linux" ]
   then
+    export OPERATING_SYSTEM=linux
     hatch run linux-e2e-test 
 fi
 
 if [ "$OPERATING_SYSTEM" = "windows" ]
   then
+    export OPERATING_SYSTEM=windows
     hatch run windows-e2e-test
 fi
 

--- a/test/e2e/config-template.sh
+++ b/test/e2e/config-template.sh
@@ -130,6 +130,9 @@ export SUBNET_ID
 # Security group to deploy the EC2 instance into
 export SECURITY_GROUP_ID
 
+# Required - Worker operating system that we want the tests to be ran against. Currently supports "windows" and "linux" 
+export OPERATING_SYSTEM
+
 # --- OPTIONAL --- #
 
 # AMI ID to use for the EC2 instance

--- a/test/e2e/cross_os/test_worker_status.py
+++ b/test/e2e/cross_os/test_worker_status.py
@@ -3,6 +3,7 @@
 This test module contains tests that verify the Worker agent's behavior by starting/stopping the Worker,
 and making sure that the status of the Worker is that of what we expect.
 """
+import os
 import pytest
 from typing import Any, Dict
 from deadline_worker_agent.api_models import (
@@ -10,11 +11,10 @@ from deadline_worker_agent.api_models import (
 )
 import backoff
 from deadline_test_fixtures import DeadlineClient, EC2InstanceWorker
-from utils import get_operating_system_name
 import pytest
 
 
-@pytest.mark.parametrize("operating_system", [get_operating_system_name()], indirect=True)
+@pytest.mark.parametrize("operating_system", [os.environ["OPERATING_SYSTEM"]], indirect=True)
 class TestWorkerStatus:
     @pytest.mark.usefixtures("function_worker")
     def test_worker_lifecycle_status_is_expected(

--- a/test/e2e/cross_os/utils.py
+++ b/test/e2e/cross_os/utils.py
@@ -1,9 +1,0 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-import sys
-
-
-def get_operating_system_name() -> str:
-    if sys.platform == "win32":
-        return "windows"
-    else:
-        return "linux"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We should put the test template for the job attachment test in the test file itself, as there is no need for it to live inside a folder.

Furthermore, we need to run the test on windows, so we need to create a windows script so the test works properly on windows fleets. 


### What was the solution? (How)
Move the template to the test class that creates  the temporary template, based off whether the OS is Windows or Linux that we want to test.

Also added an operating system variable so we can easier specify the OS we want to run the tests on

### What is the impact of this change?

Better file readability in the package file structure.
 
Windows OS test for job attachments test should be running properly after. 

Easier to specify OS we want to run the tests on 
### How was this change tested?
`hatch run cross-os-e2e-test` 
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*