### PR TITLE
test: disable failing windows e2e tests

### DIFF
--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -177,6 +177,10 @@ class TestJobSubmission:
             ),
         ],
     )
+    @pytest.mark.skipif(
+        os.environ["OPERATING_SYSTEM"] == "windows",
+        reason="Bug with test causing fail on windows. Re-enable when fixed.",
+    )
     def test_job_reports_canceled_session_action(
         self,
         deadline_resources: DeadlineResources,
@@ -328,6 +332,10 @@ class TestJobSubmission:
             ),
         ],
     )
+    @pytest.mark.skipif(
+        os.environ["OPERATING_SYSTEM"] == "windows",
+        reason="Bug with test causing fail on windows. Re-enable when fixed.",
+    )
     def test_worker_run_with_number_of_environments(
         self,
         deadline_resources: DeadlineResources,
@@ -383,6 +391,10 @@ class TestJobSubmission:
 
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
+    @pytest.mark.skipif(
+        os.environ["OPERATING_SYSTEM"] == "windows",
+        reason="Bug with test causing fail on windows. Re-enable when fixed.",
+    )
     def test_worker_streams_logs_to_cloudwatch(
         self,
         deadline_resources: DeadlineResources,
@@ -449,6 +461,10 @@ class TestJobSubmission:
                 else 'set /p input=<"{{Param.DataDir}}\\files\\test_input_file"\n echo|set /p="%%input%%{{Param.StringToAppend}}">{{Param.DataDir}}\\output_file.txt'
             )
         ],
+    )
+    @pytest.mark.skipif(
+        os.environ["OPERATING_SYSTEM"] == "windows",
+        reason="Bug with test causing fail on windows. Re-enable when fixed.",
     )
     def test_worker_uses_job_attachment_configuration(
         self,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Some e2e tests were failing on windows, due to bugs in the tests. We should disable them to minimize noise in the Github actions while investigating the issues.
### What was the solution? (How)
Disable the failing tests on windows.
### What is the impact of this change?
The E2E tests should all pass as expected.
### How was this change tested?
hatch run fmt, hatch run lint
`hatch run cross-os-e2e-test` with `OPERATING_SYSTEM` set to `windows` and confirmed the tests were not ran.
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*