### PR TITLE
test: enable windows e2e tests and enforce job host OS

### DIFF
--- a/test/e2e/cross_os/test_worker_status.py
+++ b/test/e2e/cross_os/test_worker_status.py
@@ -16,7 +16,6 @@ import pytest
 
 @pytest.mark.parametrize("operating_system", [os.environ["OPERATING_SYSTEM"]], indirect=True)
 class TestWorkerStatus:
-    @pytest.mark.usefixtures("function_worker")
     def test_worker_lifecycle_status_is_expected(
         self,
         deadline_resources,

--- a/test/e2e/linux/test_job_submissions.py
+++ b/test/e2e/linux/test_job_submissions.py
@@ -34,6 +34,9 @@ class TestJobSubmission:
                 "name": "Sleep Job",
                 "steps": [
                     {
+                        "hostRequirements": {
+                            "attributes": [{"name": "attr.worker.os.family", "allOf": ["linux"]}]
+                        },
                         "name": "Step0",
                         "script": {"actions": {"onRun": {"command": "/bin/sleep", "args": ["5"]}}},
                     },
@@ -66,6 +69,9 @@ class TestJobSubmission:
                 "steps": [
                     {
                         "name": "Step0",
+                        "hostRequirements": {
+                            "attributes": [{"name": "attr.worker.os.family", "allOf": ["linux"]}]
+                        },
                         "script": {
                             "embeddedFiles": [
                                 {

--- a/test/e2e/windows/test_job_submissions.py
+++ b/test/e2e/windows/test_job_submissions.py
@@ -38,6 +38,14 @@ class TestJobSubmission:
                 "name": "Sleep Job",
                 "steps": [
                     {
+                        "hostRequirements": {
+                            "attributes": [
+                                {
+                                    "name": "attr.worker.os.family",
+                                    "allOf": ["windows"],
+                                }
+                            ]
+                        },
                         "name": "Step0",
                         "script": {
                             "actions": {

--- a/test/e2e/windows/test_override_job_user.py
+++ b/test/e2e/windows/test_override_job_user.py
@@ -61,6 +61,14 @@ class TestJobUserOverride:
                 "name": f"whoami {test_name}",
                 "steps": [
                     {
+                        "hostRequirements": {
+                            "attributes": [
+                                {
+                                    "name": "attr.worker.os.family",
+                                    "allOf": ["windows"],
+                                }
+                            ]
+                        },
                         "name": "Step0",
                         "script": {
                             "actions": {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Some of the E2E tests for Worker Agent on Windows were disabled, because of bugs in the tests. We need to fix those bugs and re-enable them, to allow for better code coverage of the tests.

Furthermore, there is a rare possible race condition in some of the tests that submit jobs that would only run on a certain OS, that a worker of a different specified OS could be able to pick up the job and unsuccessfully run the test job.
### What was the solution? (How)
Fix the windows E2E tests, and re-enable. 

Also added a host capability requirement for the jobs, so that they run on a worker of the required OS.

### What is the impact of this change?
Better test coverage for the worker agent on windows, especially regarding job submissions.

Less chance of a race condition in which a worker of a non-desired OS runs a job that the tests submit.
### How was this change tested?
Using [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/DEVELOPMENT.md), ran all of the tests for both linux and windows, using 

```

source .e2e_linux_infra.sh
hatch run linux-e2e-test
hatch run cross-os-e2e-test
```

```
source .e2e_windows_infra.sh
hatch run windows-e2e-test
hatch run cross-os-e2e-test
```
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*