### PR TITLE
test: increase MaxWorkerCount for test infrastructure fleets to 10

### DIFF
--- a/scripts/e2e_testing_infrastructure.yaml
+++ b/scripts/e2e_testing_infrastructure.yaml
@@ -653,7 +653,7 @@ Resources:
     Properties:
       DisplayName: NonScalingLinuxFleet_x86
       FarmId: !GetAtt DeadlineFarm.FarmId
-      MaxWorkerCount: 2
+      MaxWorkerCount: 10
       MinWorkerCount: 0
       RoleArn: !GetAtt LinuxFleetRole.Arn
       Configuration:
@@ -674,7 +674,7 @@ Resources:
     Properties:
       DisplayName: AutoScalingLinuxFleet_x86
       FarmId: !GetAtt DeadlineFarm.FarmId
-      MaxWorkerCount: 2
+      MaxWorkerCount: 10
       MinWorkerCount: 0
       RoleArn: !GetAtt LinuxFleetRole.Arn
       Configuration:
@@ -695,7 +695,7 @@ Resources:
     Properties:
       DisplayName: NonScalingWindowsFleet_x86
       FarmId: !GetAtt DeadlineFarm.FarmId
-      MaxWorkerCount: 2
+      MaxWorkerCount: 10
       MinWorkerCount: 0
       RoleArn: !GetAtt WindowsFleetRole.Arn
       Configuration:
@@ -716,7 +716,7 @@ Resources:
     Properties:
       DisplayName: AutoScalingWindowsFleet_x86
       FarmId: !GetAtt DeadlineFarm.FarmId
-      MaxWorkerCount: 2
+      MaxWorkerCount: 10
       MinWorkerCount: 0
       RoleArn: !GetAtt WindowsFleetRole.Arn
       Configuration:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In the future, we wish to parallelize the Worker Agent E2e tests by running the jobs against multiple workers at the same time. However, right now the test infrastructure fleets only allow a max of 2 workers each, meaning we can only parallelize with 2 workers max.
### What was the solution? (How)
Increase the MaxWorkerCount for each of the fleets created by the test infrastructure to 10. 
### What is the impact of this change?
Test infrastructure fleets are now able to accomodate up to 10 workers, allowing for parallelization of tests, which is being worked on as a priority to save time running the tests.
### How was this change tested?
Ran `scripts/deploy_e2e_testing_infrastructure.sh` again, confirmed the fleets were updated to have a max of 10 workers

### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*