### PR TITLE
test: Add test to verify JA sync progress

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -12,15 +12,11 @@ import tempfile
 from dataclasses import dataclass, field, InitVar
 from typing import Generator, Type
 from contextlib import contextmanager
-from deadline.job_attachments._aws.deadline import get_queue
-from deadline.job_attachments import download
 
 from deadline_test_fixtures import (
     DeadlineWorker,
     DeadlineWorkerConfiguration,
     DockerContainerWorker,
-    DeadlineClient,
-    Job,
     Farm,
     Fleet,
     Queue,
@@ -373,29 +369,3 @@ def operating_system(request) -> OperatingSystem:
         return OperatingSystem(name="AL2023")
     else:
         return OperatingSystem(name="WIN2022")
-
-
-def get_job_output(
-    job: Job, deadline_client: DeadlineClient, deadline_resources: DeadlineResources
-) -> dict[str, list[str]]:
-    job.wait_until_complete(client=deadline_client, max_retries=20)
-
-    job_attachment_settings = get_queue(
-        farm_id=deadline_resources.farm.id,
-        queue_id=deadline_resources.queue_a.id,
-    ).jobAttachmentSettings
-
-    assert job_attachment_settings is not None
-
-    job_output_downloader = download.OutputDownloader(
-        s3_settings=job_attachment_settings,
-        farm_id=deadline_resources.farm.id,
-        queue_id=deadline_resources.queue_a.id,
-        job_id=job.id,
-        step_id=None,
-        task_id=None,
-    )
-    output_paths_by_root = job_output_downloader.get_output_paths_by_root()
-    job_output_downloader.download_job_output()
-
-    return output_paths_by_root

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -12,11 +12,15 @@ import tempfile
 from dataclasses import dataclass, field, InitVar
 from typing import Generator, Type
 from contextlib import contextmanager
+from deadline.job_attachments._aws.deadline import get_queue
+from deadline.job_attachments import download
 
 from deadline_test_fixtures import (
     DeadlineWorker,
     DeadlineWorkerConfiguration,
     DockerContainerWorker,
+    DeadlineClient,
+    Job,
     Farm,
     Fleet,
     Queue,
@@ -369,3 +373,29 @@ def operating_system(request) -> OperatingSystem:
         return OperatingSystem(name="AL2023")
     else:
         return OperatingSystem(name="WIN2022")
+
+
+def get_job_output(
+    job: Job, deadline_client: DeadlineClient, deadline_resources: DeadlineResources
+) -> dict[str, list[str]]:
+    job.wait_until_complete(client=deadline_client, max_retries=20)
+
+    job_attachment_settings = get_queue(
+        farm_id=deadline_resources.farm.id,
+        queue_id=deadline_resources.queue_a.id,
+    ).jobAttachmentSettings
+
+    assert job_attachment_settings is not None
+
+    job_output_downloader = download.OutputDownloader(
+        s3_settings=job_attachment_settings,
+        farm_id=deadline_resources.farm.id,
+        queue_id=deadline_resources.queue_a.id,
+        job_id=job.id,
+        step_id=None,
+        task_id=None,
+    )
+    output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+    job_output_downloader.download_job_output()
+
+    return output_paths_by_root

--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -3,7 +3,9 @@
 This test module contains tests that verify the Worker agent's behavior by submitting jobs to the
 Deadline Cloud service and checking that the result/output of the jobs is as we expect it.
 """
+import hashlib
 import json
+import shutil
 from typing import Any, Dict, List, Optional
 import pytest
 import logging
@@ -676,3 +678,195 @@ class TestJobSubmission:
 
                 # Verify that the output file content is the input file content plus the uuid we appended in the job
                 assert output_file_content == (input_file_content + test_run_uuid)
+
+    @pytest.mark.parametrize(
+        "hash_string_script",
+        [
+            (
+                '#!/usr/bin/env bash\n\nfolder_path={{Param.DataDir}}/files\ncombined_contents=""\nfor file in "$folder_path"/*; do\n   if [ -f "$file" ]; then\n      combined_contents+="$(cat "$file" | tr -d \'\\n\')"\n   fi\ndone\nsha256_hash=$(echo -n "$combined_contents" | sha256sum | awk \'{ print $1 }\')\necho -n "$sha256_hash" > {{Param.DataDir}}/output_file.txt'
+                if os.environ["OPERATING_SYSTEM"] == "linux"
+                else '$InputFolder = "{{Param.DataDir}}\\files"\n$OutputFile = "{{Param.DataDir}}\\output_file.txt"\n$combinedContent = ""\n$files = Get-ChildItem -Path $InputFolder -File\nforeach ($file in $files) {\n    $combinedContent += [IO.File]::ReadAllText($file.FullName)\n}\n$sha256 = [System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($combinedContent))\n$hashString = [System.BitConverter]::ToString($sha256).Replace("-", "").ToLower()\nSet-Content -Path $OutputFile -Value $hashString -NoNewLine'
+            )
+        ],
+    )
+    def test_worker_uses_job_attachment_sync(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        hash_string_script: str,
+    ) -> None:
+        # Verify that the worker sync job attachment correctly and report the progress correctly as well
+
+        job_bundle_path: str = os.path.join(
+            os.path.dirname(__file__),
+            "job_attachment_bundle_large",
+        )
+        file_path: str = os.path.join(job_bundle_path, "files")
+
+        os.mkdir(job_bundle_path)
+        os.mkdir(file_path)
+
+        # Create 2500 very small files to transfer
+        for i in range(2500):
+            file_name: str = os.path.join(job_bundle_path, "files", f"file_{i+1}.txt")
+            with open(file_name, "w") as file_to_write:
+                file_to_write.write(str(i))
+
+        # Calculate the hash of all the files content combine
+        combined_string: str = ""
+        for file_name in sorted(os.listdir(file_path)):
+            file: str = os.path.join(file_path, file_name)
+            # Open the file and read its contents
+            with open(file, "r") as file_string:
+                file_contents: str = file_string.read()
+
+            # Concatenate the file contents to the combined string
+            combined_string += file_contents
+
+        combined_hash: str = hashlib.sha256(combined_string.encode()).hexdigest()
+
+        # JA template to get all files and compute the hash
+        job_parameters: List[Dict[str, str]] = [
+            {"name": "DataDir", "value": job_bundle_path},
+        ]
+        with open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file:
+            template_file.write(
+                json.dumps(
+                    {
+                        "specificationVersion": "jobtemplate-2023-09",
+                        "name": "AssetsSync",
+                        "parameterDefinitions": [
+                            {
+                                "name": "DataDir",
+                                "type": "PATH",
+                                "dataFlow": "INOUT",
+                                "userInterface": {
+                                    "label": "Input/Output Directory",
+                                    "control": "CHOOSE_DIRECTORY",
+                                },
+                            },
+                        ],
+                        "steps": [
+                            {
+                                "name": "HashString",
+                                "hostRequirements": {
+                                    "attributes": [
+                                        {
+                                            "name": "attr.worker.os.family",
+                                            "allOf": [os.environ["OPERATING_SYSTEM"]],
+                                        }
+                                    ]
+                                },
+                                "script": {
+                                    "actions": {
+                                        "onRun": (
+                                            {"command": "{{ Task.File.runScript }}"}
+                                            if os.environ["OPERATING_SYSTEM"] == "linux"
+                                            else {
+                                                "command": "powershell",
+                                                "args": ["{{ Task.File.runScript }}"],
+                                            }
+                                        ),
+                                    },
+                                    "embeddedFiles": [
+                                        {
+                                            "name": "runScript",
+                                            "type": "TEXT",
+                                            "runnable": True,
+                                            "data": hash_string_script,
+                                            **(
+                                                {"filename": "hashscript.ps1"}
+                                                if os.environ["OPERATING_SYSTEM"] == "windows"
+                                                else {}
+                                            ),
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    }
+                )
+            )
+
+        config = configparser.ConfigParser()
+
+        set_setting("defaults.farm_id", deadline_resources.farm.id, config)
+        set_setting("defaults.queue_id", deadline_resources.queue_a.id, config)
+
+        job_id: Optional[str] = api.create_job_from_job_bundle(
+            job_bundle_path,
+            job_parameters,
+            priority=99,
+            max_retries_per_task=0,
+            config=config,
+            queue_parameter_definitions=[],
+        )
+        assert job_id is not None
+
+        job_details = Job.get_job_details(
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            job_id=job_id,
+        )
+        job = Job(
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            template={},
+            **job_details,
+        )
+
+        # Query the session to check for progress percentage
+        complete_percentage: float = 0
+        while complete_percentage < 100:
+            sessions = deadline_client.list_sessions(
+                farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
+            ).get("sessions")
+
+            if sessions:
+                session_actions = deadline_client.list_session_actions(
+                    farmId=job.farm.id,
+                    queueId=job.queue.id,
+                    jobId=job.id,
+                    sessionId=sessions[0]["sessionId"],
+                ).get("sessionActions")
+
+                for session_action in session_actions:
+                    if "syncInputJobAttachments" in session_action["definition"]:
+                        assert complete_percentage <= session_action["progressPercent"]
+                        complete_percentage = session_action["progressPercent"]
+
+        job.wait_until_complete(client=deadline_client, max_retries=20)
+
+        job_attachment_settings = get_queue(
+            farm_id=deadline_resources.farm.id,
+            queue_id=deadline_resources.queue_a.id,
+        ).jobAttachmentSettings
+
+        assert job_attachment_settings is not None
+
+        job_output_downloader = download.OutputDownloader(
+            s3_settings=job_attachment_settings,
+            farm_id=deadline_resources.farm.id,
+            queue_id=deadline_resources.queue_a.id,
+            job_id=job.id,
+            step_id=None,
+            task_id=None,
+        )
+
+        output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+
+            # Set root path output will be downloaded to to output_root_path. Assumes there is only one root path.
+            job_output_downloader.set_root_path(
+                list(output_paths_by_root.keys())[0],
+                tmp_dir_name,
+            )
+            job_output_downloader.download_job_output()
+
+            with (open(os.path.join(tmp_dir_name, "output_file.txt"), "r") as output_file,):
+                output_file_content = output_file.read()
+                # Verify that the hash is the same
+                assert output_file_content == combined_hash
+
+        shutil.rmtree(job_bundle_path)

--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 import pytest
 import logging
 from deadline_test_fixtures import Job, DeadlineClient, TaskStatus, EC2InstanceWorker
-from e2e.conftest import DeadlineResources, get_job_output
+from e2e.conftest import DeadlineResources
 import backoff
 import boto3
 import botocore.client
@@ -22,6 +22,8 @@ from deadline.client import api
 import uuid
 import os
 import configparser
+
+from e2e.utils import get_job_output
 
 LOG = logging.getLogger(__name__)
 

--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -833,6 +833,6 @@ class TestJobSubmission:
             output_file_content = output_file.read()
             # Verify that the hash is the same
             assert output_file_content == combined_hash
-            
+
         # Clean up the output file
         os.remove(os.path.join(list(output_path.keys())[0], "output_file.txt"))

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
 from deadline.job_attachments._aws.deadline import get_queue
 from deadline.job_attachments import download
 from deadline_test_fixtures import (

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -1,0 +1,34 @@
+from deadline.job_attachments._aws.deadline import get_queue
+from deadline.job_attachments import download
+from deadline_test_fixtures import (
+    DeadlineClient,
+    Job,
+)
+
+from e2e.conftest import DeadlineResources
+
+
+def get_job_output(
+    job: Job, deadline_client: DeadlineClient, deadline_resources: DeadlineResources
+) -> dict[str, list[str]]:
+    job.wait_until_complete(client=deadline_client, max_retries=20)
+
+    job_attachment_settings = get_queue(
+        farm_id=deadline_resources.farm.id,
+        queue_id=deadline_resources.queue_a.id,
+    ).jobAttachmentSettings
+
+    assert job_attachment_settings is not None
+
+    job_output_downloader = download.OutputDownloader(
+        s3_settings=job_attachment_settings,
+        farm_id=deadline_resources.farm.id,
+        queue_id=deadline_resources.queue_a.id,
+        job_id=job.id,
+        step_id=None,
+        task_id=None,
+    )
+    output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+    job_output_downloader.download_job_output()
+
+    return output_paths_by_root

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -10,7 +10,7 @@ from deadline_test_fixtures import (
 from e2e.conftest import DeadlineResources
 
 
-def get_job_output(
+def wait_for_job_output(
     job: Job, deadline_client: DeadlineClient, deadline_resources: DeadlineResources
 ) -> dict[str, list[str]]:
     job.wait_until_complete(client=deadline_client, max_retries=20)
@@ -31,6 +31,7 @@ def get_job_output(
         task_id=None,
     )
     output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+    # Download file and place it into the output_paths_by_root
     job_output_downloader.download_job_output()
 
     return output_paths_by_root


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We do not have e2e test to verify JA sync attachment progress to see whether the progress percentage is correct or not

### What was the solution? (How)
Add a e2e test that sync multiple file and assert the progress percentage to see if it's increase as expected
### What is the impact of this change?
More e2e coverage
### How was this change tested?
`hatch run cross-os-e2e-test`
### Was this change documented?
Yes
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*