### PR TITLE
test: all 0 retries for test that purposely failed/canceled

### DIFF
--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -92,6 +92,7 @@ class TestJobSubmission:
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             priority=98,
+            max_retries_per_task=0,
             template={
                 "specificationVersion": "jobtemplate-2023-09",
                 "name": f"jobactionfail-{expected_failed_action}",
@@ -210,6 +211,7 @@ class TestJobSubmission:
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             priority=98,
+            max_retries_per_task=0,
             template={
                 "specificationVersion": "jobtemplate-2023-09",
                 "name": f"jobactioncancel-{expected_canceled_action}",
@@ -612,6 +614,7 @@ class TestJobSubmission:
                 job_bundle_path,
                 job_parameters,
                 priority=99,
+                max_retries_per_task=0,
                 config=config,
                 queue_parameter_definitions=[],
             )

--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -614,7 +614,6 @@ class TestJobSubmission:
                 job_bundle_path,
                 job_parameters,
                 priority=99,
-                max_retries_per_task=0,
                 config=config,
                 queue_parameter_definitions=[],
             )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Test that purposely failed/canceled job will be retries up to 5 times per the default config
### What was the solution? (How)
Make sure when submitting job, `max_retries` is set at 0
### What is the impact of this change?
Job that purposely failed will not retries to save resource
### How was this change tested?
`hatch run cross-os-e2e-test`
### Was this change documented?
No
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*