### PR TITLE
test: refactor test for worker status to use ssm command

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -196,6 +196,7 @@ def worker_config(
             service_model_path=dst_path,
             file_mappings=file_mappings or None,
             windows_job_users=windows_job_users,
+            start_service=True,
         )
 
 

--- a/test/e2e/cross_os/test_worker_status.py
+++ b/test/e2e/cross_os/test_worker_status.py
@@ -3,15 +3,15 @@
 This test module contains tests that verify the Worker agent's behavior by starting/stopping the Worker,
 and making sure that the status of the Worker is that of what we expect.
 """
+import logging
 import os
 import pytest
 from typing import Any, Dict
-from deadline_worker_agent.api_models import (
-    WorkerStatus,
-)
 import backoff
 from deadline_test_fixtures import DeadlineClient, EC2InstanceWorker
 import pytest
+
+LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("operating_system", [os.environ["OPERATING_SYSTEM"]], indirect=True)
@@ -47,19 +47,15 @@ class TestWorkerStatus:
 
         assert is_worker_started()
 
-        deadline_client.update_worker(
-            farmId=deadline_resources.farm.id,
-            fleetId=deadline_resources.fleet.id,
-            workerId=function_worker.worker_id,
-            status=WorkerStatus.STOPPED,
-        )
+        function_worker.stop_worker_service()
 
         @backoff.on_predicate(
             wait_gen=backoff.constant,
-            max_time=60,
+            max_time=180,
             interval=10,
         )
         def is_worker_stopped() -> bool:
+            LOG.info(f"Checking whether {function_worker.worker_id} is stopped")
             get_worker_response: Dict[str, Any] = deadline_client.get_worker(
                 farmId=deadline_resources.farm.id,
                 fleetId=deadline_resources.fleet.id,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The existing test to test that worker status is correctly updated uses the deadline API, and not directly interacting with the worker.

We want to make sure that when the worker is STOPPED correctly when the worker service is shut down.

### What was the solution? (How)
Change the test to shut down the worker using an SSM command to shut down the service.

Also fixed an issue with the default deadline worker configuration not automatically starting the worker service. 
### What is the impact of this change?
Better testing for the worker service in regards to the worker status presented to users.
### How was this change tested?
Using `DEVELOPMENT.md`

# Linux
source .e2e_linux_infra.sh
hatch run linux-e2e-test

hatch run cross-os-e2e-test

# Windows
source .e2e_windows_infra.sh
hatch run windows-e2e-test

hatch run cross-os-e2e-test
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*