### PR TITLE
test: add e2e tests for worker agent cancel action and environment exit

### DIFF
--- a/.github/workflows/mainline_e2e_test.yml
+++ b/.github/workflows/mainline_e2e_test.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - 'mainline'
 
+  
+
 jobs:
   WindowsIntegrationTests:
     name: Windows Integration Tests
@@ -37,6 +39,8 @@ jobs:
       branch: mainline
       environment: mainline
       os: linux
+    concurrency:
+      group: linuxe2e
 
   MainlineWindowsE2ETest:
     name: Windows E2E Test
@@ -50,3 +54,5 @@ jobs:
       branch: mainline
       environment: mainline
       os: windows
+    concurrency:
+      group: windowse2e

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -2,6 +2,7 @@ backoff == 2.2.*
 coverage[toml] ~= 7.6
 coverage-conditional-plugin == 0.9.*
 deadline-cloud-test-fixtures == 0.12.*
+flaky == 3.8.*
 pytest ~= 8.2
 pytest-cov == 5.0.*
 pytest-timeout == 2.3.*

--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -4,6 +4,7 @@ This test module contains tests that verify the Worker agent's behavior by submi
 Deadline Cloud service and checking that the result/output of the jobs is as we expect it.
 """
 import hashlib
+from flaky import flaky
 import json
 import pathlib
 from typing import Any, Dict, List, Optional
@@ -211,7 +212,6 @@ class TestJobSubmission:
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             priority=98,
-            max_retries_per_task=0,
             template={
                 "specificationVersion": "jobtemplate-2023-09",
                 "name": f"jobactioncancel-{expected_canceled_action}",
@@ -311,6 +311,498 @@ class TestJobSubmission:
             farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
         ).get("sessions")
         assert is_expected_session_action_canceled(sessions)
+
+    @pytest.mark.parametrize("expected_canceled_action", ["envEnter", "taskRun"])
+    def test_worker_reports_canceled_session_actions_as_canceled(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        expected_canceled_action: str,
+    ) -> None:
+        # Tests that when running a job session action with a trap for SIGINT, the corresponding session action is canceled almost immediately.
+        action_script = (
+            "#!/usr/bin/env bash\n trap 'exit 0' SIGINT\n bash\n\n sleep 300\n "
+            if os.environ["OPERATING_SYSTEM"] == "linux"
+            else """try
+                {
+                    Start-Sleep -Seconds 300 
+                }
+                finally
+                {
+                    Exit
+                }"""
+        )
+
+        environment_exit_id = str(uuid.uuid4())
+        # Submit a job that either sleeps a long time during envEnter, or taskRun, depending on the test setting
+        job = Job.submit(
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            priority=98,
+            template={
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": f"jobactioncanceltrap-{expected_canceled_action}",
+                "steps": [
+                    {
+                        "name": "Step0",
+                        "hostRequirements": {
+                            "attributes": [
+                                {
+                                    "name": "attr.worker.os.family",
+                                    "allOf": [os.environ["OPERATING_SYSTEM"]],
+                                }
+                            ]
+                        },
+                        "script": {
+                            "actions": {
+                                "onRun": (
+                                    {"command": "{{ Task.File.runScript }}"}
+                                    if os.environ["OPERATING_SYSTEM"] == "linux"
+                                    else {
+                                        "command": "powershell",
+                                        "args": ["{{ Task.File.runScript }}"],
+                                    }
+                                ),
+                            },
+                            "embeddedFiles": [
+                                {
+                                    "name": "runScript",
+                                    "type": "TEXT",
+                                    "runnable": True,
+                                    "data": (
+                                        action_script
+                                        if expected_canceled_action == "taskRun"
+                                        else "whoami"
+                                    ),
+                                    **(
+                                        {"filename": "sleepscript.ps1"}
+                                        if os.environ["OPERATING_SYSTEM"] == "windows"
+                                        else {}
+                                    ),
+                                }
+                            ],
+                        },
+                    },
+                ],
+                "jobEnvironments": [
+                    {
+                        "name": "environment",
+                        "script": {
+                            "actions": {
+                                "onEnter": (
+                                    (
+                                        {"command": "{{ Env.File.runScript }}"}
+                                        if os.environ["OPERATING_SYSTEM"] == "linux"
+                                        else {
+                                            "command": "powershell",
+                                            "args": ["{{ Env.File.runScript }}"],
+                                        }
+                                    )
+                                    if expected_canceled_action == "envEnter"
+                                    else {"command": "whoami"}
+                                ),
+                                "onExit": (
+                                    (
+                                        {
+                                            "command": "echo",
+                                            "args": ["Environment exit " + environment_exit_id],
+                                        }
+                                        if os.environ["OPERATING_SYSTEM"] == "linux"
+                                        else {
+                                            "command": "powershell",
+                                            "args": [
+                                                '"Environment"',
+                                                "+",
+                                                '" exit "',
+                                                "+",
+                                                f'"{environment_exit_id}"',
+                                            ],
+                                        }
+                                    )
+                                ),
+                            },
+                            "embeddedFiles": [
+                                {
+                                    "name": "runScript",
+                                    "type": "TEXT",
+                                    "runnable": True,
+                                    "data": (
+                                        action_script
+                                        if expected_canceled_action == "envEnter"
+                                        else "whoami"
+                                    ),
+                                    **(
+                                        {"filename": "sleepscript.ps1"}
+                                        if os.environ["OPERATING_SYSTEM"] == "windows"
+                                        else {}
+                                    ),
+                                }
+                            ],
+                        },
+                    }
+                ],
+            },
+        )
+
+        @backoff.on_predicate(
+            wait_gen=backoff.constant,
+            max_time=120,
+            interval=10,
+        )
+        def is_job_started(current_job: Job) -> bool:
+            current_job.refresh_job_info(client=deadline_client)
+            logging.info(f"Waiting for job {current_job.id} to be created")
+            return current_job.lifecycle_status != "CREATE_IN_PROGRESS"
+
+        assert is_job_started(job)
+
+        @backoff.on_predicate(
+            wait_gen=backoff.constant,
+            max_time=120,
+            interval=10,
+        )
+        def action_to_cancel_has_started(current_job: Job) -> bool:
+            sessions = deadline_client.list_sessions(
+                farmId=current_job.farm.id, queueId=current_job.queue.id, jobId=current_job.id
+            ).get("sessions")
+
+            if len(sessions) == 0:
+                return False
+            for session in sessions:
+                session_actions = deadline_client.list_session_actions(
+                    farmId=job.farm.id,
+                    queueId=job.queue.id,
+                    jobId=job.id,
+                    sessionId=session["sessionId"],
+                ).get("sessionActions")
+
+                logging.info(f"Session Actions: {session_actions}")
+                for session_action in session_actions:
+
+                    # Session action should be canceled if it's the action we expect to be canceled
+                    if expected_canceled_action in session_action["definition"]:
+                        if session_action["status"] == "RUNNING":
+                            return True
+            return False
+
+        # Wait for the sleep action that we want to cancel to start, before canceling it
+        assert action_to_cancel_has_started(job)
+
+        deadline_client.update_job(
+            farmId=job.farm.id, queueId=job.queue.id, jobId=job.id, targetTaskRunStatus="CANCELED"
+        )
+
+        # Check that the expected actions should be canceled way before the sleep ends.
+
+        @backoff.on_predicate(
+            wait_gen=backoff.constant,
+            max_time=60,
+            interval=5,
+        )
+        def is_expected_session_action_canceled(sessions) -> bool:
+            found_canceled_session_action: bool = False
+            for session in sessions:
+                session_actions = deadline_client.list_session_actions(
+                    farmId=job.farm.id,
+                    queueId=job.queue.id,
+                    jobId=job.id,
+                    sessionId=session["sessionId"],
+                ).get("sessionActions")
+
+                logging.info(f"Session Actions: {session_actions}")
+                for session_action in session_actions:
+
+                    # Session action should be canceled if it's the action we expect to be canceled
+                    if expected_canceled_action in session_action["definition"]:
+                        if session_action["status"] == "CANCELED":
+                            found_canceled_session_action = True
+                    else:
+                        assert (
+                            session_action["status"] != "CANCELED"
+                        )  # This should not happen at all, so we fast exit
+            return found_canceled_session_action
+
+        sessions = deadline_client.list_sessions(
+            farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
+        ).get("sessions")
+        assert is_expected_session_action_canceled(sessions)
+
+        # Wait until the job is completed
+
+        job.wait_until_complete(client=deadline_client)
+
+        # Verify that envExit was ran
+        @backoff.on_predicate(
+            wait_gen=backoff.constant,
+            max_time=120,
+            interval=5,
+        )
+        def verify_env_exit_ran() -> bool:
+            job_logs = job.get_logs(
+                deadline_client=deadline_client,
+                logs_client=boto3.client(
+                    "logs",
+                    config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+                ),
+            )
+            full_log: str = "\n".join(
+                [le.message for _, log_events in job_logs.logs.items() for le in log_events]
+            )
+            return ("Environment exit " + environment_exit_id) in full_log
+
+        if expected_canceled_action == "taskRun":
+            # Verify that envExit was ran, if the action being canceled in question is the taskRun, not the envEnter
+            assert verify_env_exit_ran()
+
+    @flaky(max_runs=3, min_passes=1)  # Flaky as sync input sometimes completes before expected.
+    def test_worker_reports_canceled_sync_input_actions_as_canceled(
+        self, deadline_resources: DeadlineResources, deadline_client: DeadlineClient, tmp_path
+    ) -> None:
+        # Test that when syncing input job attachments and the user cancels the job, the syncInputJobAttachments session actions are canceled
+        # Create the template file, the job won't actually do anything substantial
+        job_parameters: List[Dict[str, str]] = [
+            {"name": "DataDir", "value": tmp_path},
+        ]
+        with open(os.path.join(tmp_path, "template.json"), "w+") as template_file:
+            template_file.write(
+                json.dumps(
+                    {
+                        "specificationVersion": "jobtemplate-2023-09",
+                        "name": "SyncInputsJob",
+                        "parameterDefinitions": [
+                            {
+                                "name": "DataDir",
+                                "type": "PATH",
+                                "dataFlow": "INOUT",
+                            },
+                        ],
+                        "steps": [
+                            {
+                                "name": "WhoamiStep",
+                                "hostRequirements": {
+                                    "attributes": [
+                                        {
+                                            "name": "attr.worker.os.family",
+                                            "allOf": [os.environ["OPERATING_SYSTEM"]],
+                                        }
+                                    ]
+                                },
+                                "script": {
+                                    "actions": {"onRun": {"command": "whoami"}},
+                                },
+                            }
+                        ],
+                    }
+                )
+            )
+        # Create the input files to make sync inputs take a relatively long time
+        files_path = os.path.join(tmp_path, "files")
+        os.mkdir(files_path)
+        for i in range(2000):
+            file_name: str = os.path.join(files_path, f"input_file_{i+1}.txt")
+            with open(file_name, "w+") as input_file:
+                input_file.write(f"{i}")
+        config = configparser.ConfigParser()
+
+        set_setting("defaults.farm_id", deadline_resources.farm.id, config)
+        set_setting("defaults.queue_id", deadline_resources.queue_a.id, config)
+
+        job_id: Optional[str] = api.create_job_from_job_bundle(
+            tmp_path,
+            job_parameters,
+            priority=99,
+            config=config,
+            max_retries_per_task=0,
+            queue_parameter_definitions=[],
+        )
+
+        assert job_id is not None
+        job_details = Job.get_job_details(
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            job_id=job_id,
+        )
+        job = Job(
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            template={},
+            **job_details,
+        )
+
+        @backoff.on_predicate(
+            wait_gen=backoff.constant,
+            max_time=60,
+            interval=2,
+        )
+        def sync_input_action_started(current_job: Job) -> bool:
+            sessions = deadline_client.list_sessions(
+                farmId=current_job.farm.id, queueId=current_job.queue.id, jobId=current_job.id
+            ).get("sessions")
+            if len(sessions) == 0:
+                return False
+            for session in sessions:
+                session_actions = deadline_client.list_session_actions(
+                    farmId=job.farm.id,
+                    queueId=job.queue.id,
+                    jobId=job.id,
+                    sessionId=session["sessionId"],
+                ).get("sessionActions")
+                logging.info(f"Session actions: {session_actions}")
+                for session_action in session_actions:
+                    if "syncInputJobAttachments" in session_action["definition"]:
+                        if session_action["status"] in ["ASSIGNED", "RUNNING"]:
+                            return True
+            return False
+
+        # Wait until the sync input action has started
+        assert sync_input_action_started(job)
+
+        deadline_client.update_job(
+            farmId=job.farm.id,
+            queueId=job.queue.id,
+            jobId=job.id,
+            targetTaskRunStatus="CANCELED",
+        )
+
+        # Wait until the job is completed
+        job.wait_until_complete(client=deadline_client)
+
+        @backoff.on_predicate(
+            wait_gen=backoff.constant,
+            max_time=120,
+            interval=10,
+        )
+        def sync_input_actions_are_canceled(sessions: List[Dict[str, Any]]) -> bool:
+            found_canceled_sync_input_action = False
+            for session in sessions:
+                session_actions = deadline_client.list_session_actions(
+                    farmId=job.farm.id,
+                    queueId=job.queue.id,
+                    jobId=job.id,
+                    sessionId=session["sessionId"],
+                ).get("sessionActions")
+                logging.info(f"Session actions: {session_actions}")
+                for session_action in session_actions:
+                    # Session action should be canceled if it's the action we expect to be canceled
+                    if "syncInputJobAttachments" in session_action["definition"]:
+                        if session_action["status"] == "CANCELED":
+                            found_canceled_sync_input_action = True
+                    else:
+                        assert (
+                            session_action["status"] == "SUCCEEDED"
+                            or session_action["status"] == "NEVER_ATTEMPTED"
+                        )
+            return found_canceled_sync_input_action
+
+        sessions = deadline_client.list_sessions(
+            farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
+        ).get("sessions")
+
+        assert sync_input_actions_are_canceled(sessions)
+
+    def test_worker_always_runs_env_exit_despite_failure(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+    ) -> None:
+        # Tests that whenever a envEnter on a job is attempted, the corresponding envExit is also ran despite session action failures
+
+        successful_environment_name = "SuccessfulEnvironment"
+        unsuccessful_environment_name = "UnsuccessfulEnvironment"
+        job = Job.submit(
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            priority=98,
+            max_retries_per_task=0,
+            template={
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": "TestEnvJobFail",
+                "jobEnvironments": [
+                    {
+                        "name": successful_environment_name,
+                        "script": {
+                            "actions": {
+                                "onEnter": ({"command": "whoami"}),
+                                "onExit": ({"command": "whoami"}),
+                            },
+                        },
+                    },
+                    {
+                        "name": unsuccessful_environment_name,
+                        "script": {
+                            "actions": {
+                                "onEnter": ({"command": "nonexistentcommand"}),
+                                "onExit": ({"command": "nonexistentcommand"}),
+                            },
+                        },
+                    },
+                ],
+                "steps": [
+                    {
+                        "name": "Step0",
+                        "hostRequirements": {
+                            "attributes": [
+                                {
+                                    "name": "attr.worker.os.family",
+                                    "allOf": [os.environ["OPERATING_SYSTEM"]],
+                                }
+                            ]
+                        },
+                        "script": {
+                            "actions": {
+                                "onRun": ({"command": "whoami"}),
+                            }
+                        },
+                    },
+                ],
+            },
+        )
+        # THEN
+
+        # Wait until the job is completed
+        job.wait_until_complete(client=deadline_client)
+
+        sessions = deadline_client.list_sessions(
+            farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
+        ).get("sessions")
+
+        found_successful_env_enter = False
+        found_unsuccessful_env_enter = False
+        found_unsuccessful_env_exit = False
+        found_successful_env_exit = False
+
+        # Find that the both the unsuccessful and successful environment ran, with envExit and envEnter for each.
+        for session in sessions:
+
+            session_actions = deadline_client.list_session_actions(
+                farmId=job.farm.id,
+                queueId=job.queue.id,
+                jobId=job.id,
+                sessionId=session["sessionId"],
+            ).get("sessionActions")
+            logging.info(f"Session actions: {session_actions}")
+            for session_action in session_actions:
+                definition = session_action["definition"]
+                if "envEnter" in definition:
+                    if successful_environment_name in definition["envEnter"]["environmentId"]:
+                        found_successful_env_enter = session_action["status"] == "SUCCEEDED"
+                    elif unsuccessful_environment_name in definition["envEnter"]["environmentId"]:
+                        found_unsuccessful_env_enter = session_action["status"] == "FAILED"
+                elif "envExit" in definition:
+                    if successful_environment_name in definition["envExit"]["environmentId"]:
+                        found_successful_env_exit = session_action["status"] == "SUCCEEDED"
+                    elif unsuccessful_environment_name in definition["envExit"]["environmentId"]:
+                        found_unsuccessful_env_exit = session_action["status"] == "FAILED"
+
+        assert (
+            found_successful_env_enter
+            and found_unsuccessful_env_enter
+            and found_unsuccessful_env_exit
+            and found_successful_env_exit
+        )
 
     @pytest.mark.parametrize(
         "job_environments",
@@ -563,10 +1055,6 @@ class TestJobSubmission:
                                     "name": "DataDir",
                                     "type": "PATH",
                                     "dataFlow": "INOUT",
-                                    "userInterface": {
-                                        "label": "Input/Output Directory",
-                                        "control": "CHOOSE_DIRECTORY",
-                                    },
                                 },
                                 {"name": "StringToAppend", "type": "STRING"},
                             ],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Worker agent is the core functionality of processing and interacting with a job, including canceling job actions while they are underway, as well as running job environments.

We should make sure that these components of worker agent are thoroughly tested, to ensure high code quality standards in this package.
### What was the solution? (How)
Add tests that test these functionalities, including
* Test that environment exit on an environment that has been entered, is always ran, regardless of the result of the job, and whether it's been canceled or failed
* Test that canceled session actions, which have a trap to intercept INT signals, are almost immediately canceled and move to `CANCELED` status
* Test that when syncing job attachment inputs, if the job is canceled, then the job attachment input sync is canceled accordingly
### What is the impact of this change?

Better test coverage of the worker agent code, to ensure better Worker Agent code quality, especially regarding canceling jobs while they are running, as well as relating to environment exiting properly.
### How was this change tested?
```
source .e2e_linux_infra.sh
hatch run linux-e2e-test
hatch run cross-os-e2e-test


source .e2e_windows_infra.sh
hatch run windows-e2e-test
hatch run cross-os-e2e-test

```

All the tests passed
### Was this change documented?
no
### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*