### PR TITLE
fix: --run-jobs-as-agent-user crashes on windows

### DIFF
--- a/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
+++ b/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py
@@ -384,7 +384,6 @@ class QueueBoto3Session(BaseBoto3Session):
             else:
                 set_permissions(
                     file_path=credentials_file_path,
-                    permitted_user=self._os_user,
                     agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
                 )
             credentials_object = cast(SettableCredentials, self.get_credentials())
@@ -536,7 +535,7 @@ class QueueBoto3Session(BaseBoto3Session):
                 # not be used.
                 set_permissions(
                     file_path=self._credentials_process_script_path,
-                    user_permission=FileSystemPermissionEnum.EXECUTE,
+                    agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
                 )
 
             f.write(self._generate_credential_process_script())


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`--run-jobs-as-agent-user` crashes on windows when the job gets picked up, see
https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/298

This is because `_set_windows_permissions()` throws an exception if `user_permission` is provided without a `user`, or if `group_permission` is provided without a `group`. 

https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/src/deadline_worker_agent/file_system_operations.py#L92-L96

### What was the solution? (How)

When running as the agent user, `_os_user` resolves to None in [`_determine_user_for_session`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/1ce6746db102ab904d2b5146d071fb873b9f8055/src/deadline_worker_agent/scheduler/scheduler.py#L692)

This propagates down to this line: https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/1ce6746db102ab904d2b5146d071fb873b9f8055/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py#L537

and this line: https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/1ce6746db102ab904d2b5146d071fb873b9f8055/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py#L385

where `_set_windows_permissions` then throws an exception. Instead, forgo user permissions because there is no user to set permissions for

I also scanned for all transitive usages of `_set_windows_permissions()` to make sure these were the only two error cases

### What is the impact of this change?

`--run-jobs-as-agent-user` no longer crashes on windows

### How was this change tested?

Tested on a windows machine running with the `--run-jobs-as-agent-user` argument. Confirmed jobs ran successfully

### Was this change documented?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*