### PR TITLE
fix: Agent Logs to /var/log/messages when running as a service on Linux

### DIFF
--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -459,6 +459,8 @@ EOF
     cat >> /etc/systemd/system/deadline-worker.service <<EOF   
 ExecStart=$worker_agent_program
 Restart=on-failure
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When the worker agent is running as a `systemd` service on linux, we discovered that the agent logs are being sent to `/var/log/messages` when `systemd` is configured with `DefaultStandardOutput=journal`

This is redundant, and perhaps unexpected because the worker agent *already* logs to a file and cloudwatch as described in https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/docs/logging.md

### What was the solution? (How)

Set `StandardOutput=null` and `StandardError=null` in the `systemd` configuration. 

### What is the impact of this change?

Log messages when running as a `systemd` service no longer fill up `/var/log/messages`.

### How was this change tested?

Installed on a linux machine and confirmed that before the change logs were being sent to `/var/log/messages`, and after the change, logs were not being set to `/var/log/messages`

### Was this change documented?

Yes

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*