### PR TITLE
fix: allow retries to tests

### DIFF
--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -93,7 +93,6 @@ class TestJobSubmission:
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             priority=98,
-            max_retries_per_task=0,
             template={
                 "specificationVersion": "jobtemplate-2023-09",
                 "name": f"jobactionfail-{expected_failed_action}",
@@ -613,7 +612,6 @@ class TestJobSubmission:
             job_parameters,
             priority=99,
             config=config,
-            max_retries_per_task=0,
             queue_parameter_definitions=[],
         )
 
@@ -716,7 +714,6 @@ class TestJobSubmission:
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             priority=98,
-            max_retries_per_task=0,
             template={
                 "specificationVersion": "jobtemplate-2023-09",
                 "name": "TestEnvJobFail",
@@ -1227,10 +1224,6 @@ class TestJobSubmission:
                                 "name": "DataDir",
                                 "type": "PATH",
                                 "dataFlow": "INOUT",
-                                "userInterface": {
-                                    "label": "Input/Output Directory",
-                                    "control": "CHOOSE_DIRECTORY",
-                                },
                             },
                         ],
                         "steps": [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Test start to fail after strictly do not allow retries. Need to enable it back to work
### What was the solution? (How)
Remove `max_retries_per_task` when create job
### What is the impact of this change?
Tests will now have more retries to pass
### How was this change tested?
`hatch run windows-e2e-test` 
`hatch run linux-e2e-test`
`hatch run cross-os-e2e-test`
### Was this change documented?
No
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*