### PR TITLE
test: add debug logs for failed session action test

### DIFF
--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -132,13 +132,18 @@ class TestJobSubmission:
                 sessionId=session["sessionId"],
             ).get("sessionActions")
 
+            logging.info(f"Session actions: {session_actions}")
             for session_action in session_actions:
                 # Session action should be failed IFF it's the expected action to fail
                 if expected_failed_action in session_action["definition"]:
                     found_failed_session_action = True
-                    assert session_action["status"] == "FAILED"
+                    assert (
+                        session_action["status"] == "FAILED"
+                    ), f"Session action that should have failed is not in FAILED status. {session_action}"
                 else:
-                    assert session_action["status"] != "FAILED"
+                    assert (
+                        session_action["status"] != "FAILED"
+                    ), f"Session action that should not have failed is in FAILED status. {session_action}"
         assert found_failed_session_action
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We should add debug logs to the failed session action test to make sure that if it fails, we have the relevant information to debug it.
### What was the solution? (How)
Add these debug logs.
### What is the impact of this change?
We will have the relevant debug logs if the test does fail in the future
### How was this change tested?
`hatch run fmt`, `hatch build`. The test does not fail on local.
### Was this change documented?
no
### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*