### PR TITLE
test: add skipif linux marker to failed session action test

### DIFF
--- a/test/e2e/cross_os/test_job_submissions.py
+++ b/test/e2e/cross_os/test_job_submissions.py
@@ -79,6 +79,10 @@ class TestJobSubmission:
             ),
         ],
     )
+    @pytest.mark.skipif(
+        os.environ["OPERATING_SYSTEM"] == "linux",
+        reason="Linux test is flaky. Disabling until further investigation.",
+    )
     def test_job_reports_failed_session_action(
         self,
         deadline_resources: DeadlineResources,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The failed session action wa e2e test sometimes fails in the Mainline Linux E2E tests. More investigation is needed.
### What was the solution? (How)
Add skipif linux marker to this test
### What is the impact of this change?
The test should pass and not block the release cycle.
### How was this change tested?
`hatch run fmt` `hatch build`
### Was this change documented?
no
### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*