### PR TITLE
Revert "ci: add windows release canary (#362)"

### DIFF
--- a/.github/workflows/release_e2e_canary.yml
+++ b/.github/workflows/release_e2e_canary.yml
@@ -36,16 +36,3 @@ jobs:
       branch: release
       environment: canary
       os: linux
-
-  ReleaseWindowsE2ECanary:
-    name: Release Windows Canary
-    permissions:
-      id-token: write
-      contents: read
-    uses: aws-deadline/.github/.github/workflows/reusable_canary.yml@mainline
-    secrets: inherit
-    with:
-      repository: ${{ github.event.repository.name }}
-      branch: release
-      environment: canary
-      os: windows


### PR DESCRIPTION
This reverts commit bf992a2a8618b225e560a6bce0f85491e3596ccb.

### What was the problem/requirement? (What/Why)
I pre-emptively merged this PR Yesterday https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/362

### What was the solution? (How)
Reverting the commit for now. 

### What is the impact of this change?

### How was this change tested?

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*