### PR TITLE
ci: add windows release canary

### DIFF
--- a/.github/workflows/release_e2e_canary.yml
+++ b/.github/workflows/release_e2e_canary.yml
@@ -36,3 +36,16 @@ jobs:
       branch: release
       environment: canary
       os: linux
+
+  ReleaseWindowsE2ECanary:
+    name: Release Windows Canary
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_canary.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: release
+      environment: canary
+      os: windows


### PR DESCRIPTION
# What was the problem/requirement? (What/Why)
We need to add Canaries for Windows E2E tests.

# What was the solution? (How)

Add the Windows E2E job to the release canary workflow

This change was reverted [here](https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/405) under the assumption that the change caused action failures [here](https://github.com/aws-deadline/deadline-cloud-worker-agent/actions/runs/10619325379). This was not the case, the failure was due to an increase of tests added to e2e testing which increased the runtime. CodeBuild timeout was the actual cause of the failure. The timeout of CodeBuild has since been increased which should resolve this issue.


# What is the impact of this change?
Adds canaries that run against release branch

# How was this change tested?
Windows E2E tests are working [here.](https://github.com/aws-deadline/deadline-cloud-worker-agent/actions/runs/10014524395)

# Was this change documented?
no

# Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*