### PR TITLE
fix: Windows workers become NOT_RESPONDING on host shutdown

### DIFF
--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -246,6 +246,12 @@ class Worker:
                                 grace_time=worker_shutdown.grace_time,
                                 fail_message=worker_shutdown.fail_message,
                             )
+                        else:
+                            # If we are here, it's because self._stop.set() was set causing the monitor_ec2_shutdown thread to join.
+                            # The scheduler thread has a longer wait, so let's wake it up so it can join as well.
+                            self._scheduler.shutdown(
+                                fail_message="The Worker received a shutdown event locally from the host machine."
+                            )
                     elif future is scheduler_future:
                         logger.debug("scheduler future complete")
                         try:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When the Windows Service initiates the Worker shutdown procedure, the scheduler does not drain the remaining work, and the Worker status is never updated before the instance is Shutdown.

If we run the worker as a service on EC2 - and then terminate the instance from the EC2 console, we can observe the final output from the Worker:

```
{"level": "DEBUG", "message": "interval = 15"}
{"level": "INFO", "message": "Windows Service is being stopped"}
{"level": "DEBUG", "message": "EC2 shutdown monitoring thread exited"}
{"level": "DEBUG", "message": "monitor ec2 shutdown future complete"}
{"level": "DEBUG", "message": "Waiting for threads to join..."}
```

If we query the service after this, the workers status was never updated. Eventually it will be marked as STOPPED/UNHEALTHY by the heartbeat check. 

### What was the solution? (How)
The main worker event loop has 2 threads (futures). The first is the [thread which monitors for EC2 shutdown events](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/src/deadline_worker_agent/worker.py#L218), such as Auto-scaling scale in events, or Spot instance interruption events. The loop in this thread runs with a 1 second timeout. In the second [thread we have the scheduler](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/src/deadline_worker_agent/scheduler/scheduler.py#L279), this thread runs with a 15 second timeout. 

Since the `monitor_ec2_shutdown` thread completed because the `stop` event was set, [it returns `None`, and the main event loop never tells the scheduler to stop](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/src/deadline_worker_agent/worker.py#L243).

The solution is simply to wake up the scheduler thread in this case. Allowing it to detect that the `stop` event was set and perform it's own shutdown naturally. 

With this change we can see the scheduler shuts down and the status is updated from the worker logs:

```
{"level": "DEBUG", "message": "interval = 15"}
{"level": "INFO", "message": "Windows Service is being stopped"}
{"level": "DEBUG", "message": "EC2 shutdown monitoring thread exited"}
{"level": "DEBUG", "message": "monitor ec2 shutdown future complete"}
{"level": "DEBUG", "message": "Waiting for threads to join..."}
{"level": "INFO", "message": "Main event loop exited."}
{"level": "INFO", "message": "Draining any remaining Sessions."}
{"level": "INFO", "message": "Worker shutdown complete"}
{"level": "INFO", "message": "Setting Worker state to STOPPED."}
{"level": "INFO", "ti": "📤", "type": "API", "subtype": "Req", "operation": "deadline:UpdateWorker", "params": {"status": "STOPPED"}, "request_url": "redacted", "resource": {"farm-id": "redacted", "fleet-id": "redacted", "worker-id": "redacted"}}
{"level": "INFO", "ti": "📥", "type": "API", "subtype": "Resp", "operation": "deadline:UpdateWorker", "status_code": 200, "params": {}, "request_id": "redacted"}	
{"level": "INFO", "ti": "💻", "type": "Worker", "subtype": "Status", "message": "Status set to STOPPED.", "farm_id": "redacted", "fleet_id": "redacted", "worker_id": "redacted"}
```

### What is the impact of this change?
When running as a service on Windows and the instance is shutdown the worker will now complete it's shutdown behavior, marking itself as STOPPED with the service and draining it's scheduler, freeing up other workers to pick up tasks. 

### How was this change tested?
I built and deployed a worker instance with this change to a CMF, I scheduled a bunch of work and once the worker started picking up tasks I terminated the instance and observed the logs. 

### Was this change documented?
No.

### Is this a breaking change?
No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*