### PR TITLE
fix: WindowsPath is not JSON serializable during session cleanup

### DIFF
--- a/src/deadline_worker_agent/log_messages.py
+++ b/src/deadline_worker_agent/log_messages.py
@@ -1,4 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
 
 import sys
 from enum import Enum
@@ -208,9 +209,9 @@ class FilesystemLogEvent(BaseLogEvent):
     msg: str
     fmt = "%(message)s [%(filepath)s]"
 
-    def __init__(self, *, op: FilesystemLogEventOp, filepath: str, message: str) -> None:
+    def __init__(self, *, op: FilesystemLogEventOp, filepath: str | Path, message: str) -> None:
         self.subtype = op.value
-        self.filepath = filepath
+        self.filepath = str(filepath)
         self.msg = message
 
     def getMessage(self) -> str:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There is a bug: `Object of type WindowsPath is not JSON serializable` which can crash the worker agent when running on Windows. See https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/406

I was able to recreate this by changing the ACL of the queues cache directory (which stores queue credentials) to prevent deletion. 

### What was the solution? (How)
Convert `Path` types to `str` before logging. Doing this in the `FilesystemLogEvent` class since it will catch all present and future cases of logging a `Path` object.

### What is the impact of this change?

Fixes a worker agent crash: https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/406

### How was this change tested?

Reproduced https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/406, then added this change in and confirmed the worker agent instead logged the message properly and resumed 

```
2024/09/05 16:07:53-05:00 {"level": "WARNING", "ti": "💾", "type": "FileSystem", "subtype": "Delete", "message": "Failed to delete.", "filepath": "C:\\ProgramData\\Amazon\\Deadline\\Cache\\queues\\queue-2bb9d04f40da43f1b9bd204ef2684e64"}
```

### Was this change documented?

It is here!

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*