### PR TITLE
fix: vague error message when no AWS region specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ REM stop the service
 sc.exe stop DeadlineWorker
 ```
 
+### Running Outside of an Operating System Service
+
+---
+**NOTE:**
+It is highly recommended to run the worker agent through an OS service in production environments. The OS service automatically handles:
+- Restarting the worker agent process if the agent process crashes.
+- Starting the worker agent when the host machine starts up.
+- Attempting graceful shutdown when the host machine is shutting down.
+----
+The worker agent can also be started outside of a service context if required. Run `deadline-worker-agent --help` to see a list of supported command line arguments.
+
+ **NOTE:** You must have an [AWS region](https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html) specified in order to run the worker agent from the command line. This can be configured through:
+  - The `AWS_DEFAULT_REGION` [environment variable](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list).
+  - The [AWS Configuration File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where)
+    - Configured [manually](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-format), or through the [command line](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-methods).
+
+
 ## Logging
 
 [See logging](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/docs/logging.md)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running the worker agent from a CLI, a frequently encountered issue is the worker agent failing with a message like:

```
[CRITICAL] You must specify a region.
[INFO    ] 🚪 Worker Agent exiting
```

This is a bit vague and is hard to debug if you aren't familiar with the reason for that error message.

### What was the solution? (How)

Catch `NoRegionError`s from boto, and log a warning with guidance to check the worker agent documentation on how to set the AWS region.

Also update the README with information for running the worker agent outside of a OS service context
 
### What is the impact of this change?

Hopefully more clear messaging on a common situation of starting the worker agent without a region specified, which often happens when running from the command line (since the WA service installation sets the region).

### How was this change tested?

Tested on a machine and removed the region configuration in the system installation. Then started the worker agent and observed the following lines:

```
[WARNING ] The Worker Agent was started with no AWS region specified. Refer to the Deadline Cloud Worker Agent documentation for guidance.
[CRITICAL] You must specify a region.
[INFO    ] 🚪 Worker Agent exiting
```

### Was this change documented?

Yes, through the commit message/changelog

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*