### PR TITLE
ci: add windows integ tests to hatch.toml

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -12,6 +12,7 @@ test = "pytest test/unit --numprocesses=auto {args}"
 version = "hatch version"
 metadata = "hatch project metadata {args:}"
 e2e-test= "pytest --no-cov test/e2e {args:}"
+windows-integ-test = "pytest --no-cov test/integ/installer {args:}"
 typing = "mypy {args:src test}"
 style = [
   "ruff check {args:.}",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`windows-integ-test` script was accidentally removed from `hatch.toml` in https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/411

### What was the solution? (How)
Add the script back.

### What is the impact of this change?
ci can run integ tests again

### How was this change tested?
`hatch run windows-integ-test`

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*