### PR TITLE
test: add tests relating to job attachment failures and empty output

### DIFF
--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -24,7 +24,7 @@ from deadline.client import api
 import uuid
 import os
 import configparser
-
+import tempfile
 from e2e.utils import wait_for_job_output
 
 LOG = logging.getLogger(__name__)
@@ -146,7 +146,7 @@ class TestJobSubmission:
         expected_failed_action: str,
     ) -> None:
 
-        job = Job.submit(
+        job: Job = Job.submit(
             client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
@@ -178,12 +178,12 @@ class TestJobSubmission:
 
         # Retrieve job output and verify that the expected session action has failed
 
-        sessions = deadline_client.list_sessions(
+        sessions: list[dict[str, Any]] = deadline_client.list_sessions(
             farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
         ).get("sessions")
         found_failed_session_action: bool = False
         for session in sessions:
-            session_actions = deadline_client.list_session_actions(
+            session_actions: list[dict[str, Any]] = deadline_client.list_session_actions(
                 farmId=job.farm.id,
                 queueId=job.queue.id,
                 jobId=job.id,
@@ -210,7 +210,7 @@ class TestJobSubmission:
         deadline_client: DeadlineClient,
     ) -> None:
         # Test that if a task takes longer than the timeout defined, the session action goes to FAILED status
-        job = Job.submit(
+        job: Job = Job.submit(
             client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
@@ -360,7 +360,7 @@ class TestJobSubmission:
         environment_actions: Dict[str, Any],
         expected_canceled_action: str,
     ) -> None:
-        job = Job.submit(
+        job: Job = Job.submit(
             client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
@@ -413,7 +413,7 @@ class TestJobSubmission:
             interval=10,
         )
         def sessions_exist(current_job: Job) -> bool:
-            sessions = deadline_client.list_sessions(
+            sessions: list[dict[str, Any]] = deadline_client.list_sessions(
                 farmId=current_job.farm.id, queueId=current_job.queue.id, jobId=current_job.id
             ).get("sessions")
 
@@ -440,7 +440,7 @@ class TestJobSubmission:
         def is_expected_session_action_canceled(sessions: List[Dict[str, Any]]) -> bool:
             found_canceled_session_action: bool = False
             for session in sessions:
-                session_actions = deadline_client.list_session_actions(
+                session_actions: list[dict[str, Any]] = deadline_client.list_session_actions(
                     farmId=job.farm.id,
                     queueId=job.queue.id,
                     jobId=job.id,
@@ -460,7 +460,7 @@ class TestJobSubmission:
                         )  # This should not happen at all, so we fast exit
             return found_canceled_session_action
 
-        sessions = deadline_client.list_sessions(
+        sessions: list[dict[str, Any]] = deadline_client.list_sessions(
             farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
         ).get("sessions")
         assert is_expected_session_action_canceled(sessions)
@@ -473,7 +473,7 @@ class TestJobSubmission:
         expected_canceled_action: str,
     ) -> None:
         # Tests that when running a job session action with a trap for SIGINT, the corresponding session action is canceled almost immediately.
-        action_script = (
+        action_script: str = (
             "#!/usr/bin/env bash\n trap 'exit 0' SIGINT\n bash\n\n sleep 300\n "
             if os.environ["OPERATING_SYSTEM"] == "linux"
             else """try
@@ -488,7 +488,7 @@ class TestJobSubmission:
 
         environment_exit_id = str(uuid.uuid4())
         # Submit a job that either sleeps a long time during envEnter, or taskRun, depending on the test setting
-        job = Job.submit(
+        job: Job = Job.submit(
             client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
@@ -616,14 +616,14 @@ class TestJobSubmission:
             interval=10,
         )
         def action_to_cancel_has_started(current_job: Job) -> bool:
-            sessions = deadline_client.list_sessions(
+            sessions: list[dict[str, Any]] = deadline_client.list_sessions(
                 farmId=current_job.farm.id, queueId=current_job.queue.id, jobId=current_job.id
             ).get("sessions")
 
             if len(sessions) == 0:
                 return False
             for session in sessions:
-                session_actions = deadline_client.list_session_actions(
+                session_actions: list[dict[str, Any]] = deadline_client.list_session_actions(
                     farmId=job.farm.id,
                     queueId=job.queue.id,
                     jobId=job.id,
@@ -656,7 +656,7 @@ class TestJobSubmission:
         def is_expected_session_action_canceled(sessions) -> bool:
             found_canceled_session_action: bool = False
             for session in sessions:
-                session_actions = deadline_client.list_session_actions(
+                session_actions: list[dict[str, Any]] = deadline_client.list_session_actions(
                     farmId=job.farm.id,
                     queueId=job.queue.id,
                     jobId=job.id,
@@ -676,7 +676,7 @@ class TestJobSubmission:
                         )  # This should not happen at all, so we fast exit
             return found_canceled_session_action
 
-        sessions = deadline_client.list_sessions(
+        sessions: list[dict[str, Any]] = deadline_client.list_sessions(
             farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
         ).get("sessions")
         assert is_expected_session_action_canceled(sessions)
@@ -738,7 +738,7 @@ class TestJobSubmission:
                 )
             )
         # Create the input files to make sync inputs take a relatively long time
-        files_path = os.path.join(tmp_path, "files")
+        files_path: str = os.path.join(tmp_path, "files")
         os.mkdir(files_path)
         for i in range(2000):
             file_name: str = os.path.join(files_path, f"input_file_{i+1}.txt")
@@ -758,13 +758,13 @@ class TestJobSubmission:
         )
 
         assert job_id is not None
-        job_details = Job.get_job_details(
+        job_details: dict[str, Any] = Job.get_job_details(
             client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             job_id=job_id,
         )
-        job = Job(
+        job: Job = Job(
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             template={},
@@ -777,13 +777,13 @@ class TestJobSubmission:
             interval=2,
         )
         def sync_input_action_started(current_job: Job) -> bool:
-            sessions = deadline_client.list_sessions(
+            sessions: list[dict[str, Any]] = deadline_client.list_sessions(
                 farmId=current_job.farm.id, queueId=current_job.queue.id, jobId=current_job.id
             ).get("sessions")
             if len(sessions) == 0:
                 return False
             for session in sessions:
-                session_actions = deadline_client.list_session_actions(
+                session_actions: list[dict[str, Any]] = deadline_client.list_session_actions(
                     farmId=job.farm.id,
                     queueId=job.queue.id,
                     jobId=job.id,
@@ -815,7 +815,7 @@ class TestJobSubmission:
             interval=10,
         )
         def sync_input_actions_are_canceled(sessions: List[Dict[str, Any]]) -> bool:
-            found_canceled_sync_input_action = False
+            found_canceled_sync_input_action: bool = False
             for session in sessions:
                 session_actions = deadline_client.list_session_actions(
                     farmId=job.farm.id,
@@ -836,7 +836,7 @@ class TestJobSubmission:
                         )
             return found_canceled_sync_input_action
 
-        sessions = deadline_client.list_sessions(
+        sessions: list[dict[str, Any]] = deadline_client.list_sessions(
             farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
         ).get("sessions")
 
@@ -849,9 +849,9 @@ class TestJobSubmission:
     ) -> None:
         # Tests that whenever a envEnter on a job is attempted, the corresponding envExit is also ran despite session action failures
 
-        successful_environment_name = "SuccessfulEnvironment"
-        unsuccessful_environment_name = "UnsuccessfulEnvironment"
-        job = Job.submit(
+        successful_environment_name: str = "SuccessfulEnvironment"
+        unsuccessful_environment_name: str = "UnsuccessfulEnvironment"
+        job: Job = Job.submit(
             client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
@@ -904,19 +904,19 @@ class TestJobSubmission:
         # Wait until the job is completed
         job.wait_until_complete(client=deadline_client)
 
-        sessions = deadline_client.list_sessions(
+        sessions: list[dict[str, Any]] = deadline_client.list_sessions(
             farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
         ).get("sessions")
 
-        found_successful_env_enter = False
-        found_unsuccessful_env_enter = False
-        found_unsuccessful_env_exit = False
-        found_successful_env_exit = False
+        found_successful_env_enter: bool = False
+        found_unsuccessful_env_enter: bool = False
+        found_unsuccessful_env_exit: bool = False
+        found_successful_env_exit: bool = False
 
         # Find that the both the unsuccessful and successful environment ran, with envExit and envEnter for each.
         for session in sessions:
 
-            session_actions = deadline_client.list_session_actions(
+            session_actions: list[dict[str, Any]] = deadline_client.list_session_actions(
                 farmId=job.farm.id,
                 queueId=job.queue.id,
                 jobId=job.id,
@@ -1022,7 +1022,7 @@ class TestJobSubmission:
         deadline_client: DeadlineClient,
         job_environments: List[Dict[str, Any]],
     ) -> None:
-        job_template = {
+        job_template: dict[str, Any] = {
             "specificationVersion": "jobtemplate-2023-09",
             "name": f"jobWithNumberOfEnvironments-{len(job_environments)}",
             "steps": [
@@ -1050,7 +1050,7 @@ class TestJobSubmission:
         if len(job_environments) > 0:
             job_template["jobEnvironments"] = job_environments
 
-        job = Job.submit(
+        job: Job = Job.submit(
             client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
@@ -1092,7 +1092,7 @@ class TestJobSubmission:
     ) -> None:
 
         job_start_time_seconds: float = time.time()
-        job = Job.submit(
+        job: Job = Job.submit(
             client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
@@ -1147,7 +1147,8 @@ class TestJobSubmission:
         worker_log_group_name: str = (
             f"/aws/deadline/{deadline_resources.farm.id}/{deadline_resources.fleet.id}"
         )
-        worker_id = session_worker.worker_id
+        worker_id: Optional[str] = session_worker.worker_id
+        assert worker_id is not None
 
         worker_logs = logs_client.get_log_events(
             logGroupName=worker_log_group_name,
@@ -1252,13 +1253,13 @@ class TestJobSubmission:
             # Clean up the template file
             os.remove(os.path.join(job_bundle_path, "template.json"))
 
-        job_details = Job.get_job_details(
+        job_details: dict[str, Any] = Job.get_job_details(
             client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             job_id=job_id,
         )
-        job = Job(
+        job: Job = Job(
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             template={},
@@ -1288,6 +1289,94 @@ class TestJobSubmission:
                 assert output_file_content == (input_file_content + test_run_uuid)
         finally:
             os.remove(os.path.join(list(output_path.keys())[0], "output_file"))
+
+    def test_worker_job_attachments_no_outputs_does_not_fail_job(
+        self, deadline_resources: DeadlineResources, deadline_client: DeadlineClient
+    ) -> None:
+        # Tests that if a job has no job output files in the output directory, the job does not fail. This tests prevents regressions in the output code
+
+        job_bundle_path: str = os.path.join(
+            os.path.dirname(__file__),
+            "job_attachment_bundle",
+        )
+
+        try:
+            with (
+                open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file,
+                tempfile.TemporaryDirectory() as temporary_output_directory,
+            ):
+
+                job_parameters: List[Dict[str, str]] = [
+                    {
+                        "name": "OutputFilePath",
+                        "value": temporary_output_directory,
+                    },
+                ]
+
+                template_file.write(
+                    json.dumps(
+                        {
+                            "specificationVersion": "jobtemplate-2023-09",
+                            "name": "NoOutputJob",
+                            "parameterDefinitions": [
+                                {
+                                    "name": "OutputFilePath",
+                                    "type": "PATH",
+                                    "objectType": "DIRECTORY",
+                                    "dataFlow": "OUT",
+                                },
+                            ],
+                            "steps": [
+                                {
+                                    "name": "MainStep",
+                                    "hostRequirements": {
+                                        "attributes": [
+                                            {
+                                                "name": "attr.worker.os.family",
+                                                "allOf": [os.environ["OPERATING_SYSTEM"]],
+                                            }
+                                        ]
+                                    },
+                                    "script": {
+                                        "actions": {"onRun": {"command": "whoami"}},
+                                    },
+                                }
+                            ],
+                        }
+                    )
+                )
+                config = configparser.ConfigParser()
+
+            set_setting("defaults.farm_id", deadline_resources.farm.id, config)
+            set_setting("defaults.queue_id", deadline_resources.queue_a.id, config)
+            job_id: Optional[str] = api.create_job_from_job_bundle(
+                job_bundle_path,
+                job_parameters,
+                priority=99,
+                config=config,
+                queue_parameter_definitions=[],
+                require_paths_exist=True,
+            )
+            assert job_id is not None
+        finally:
+            # Clean up the template file
+            os.remove(os.path.join(job_bundle_path, "template.json"))
+
+        job_details = Job.get_job_details(
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            job_id=job_id,
+        )
+        job = Job(
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            template={},
+            **job_details,
+        )
+        job.wait_until_complete(client=deadline_client)
+
+        assert job.task_run_status == TaskStatus.SUCCEEDED
 
     @pytest.mark.parametrize(
         "hash_string_script",
@@ -1497,8 +1586,8 @@ class TestJobSubmission:
             f"""
             #!/usr/bin/env bash
             percent=0
-            
-            while [ $percent -le 100 ] 
+
+            while [ $percent -le 100 ]
             do
                 echo "openjd_progress: $percent"
                 echo "openjd_status: {test_run_status_message}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
For when the customer is syncing their job attachments, either while syncing the inputs, or the outputs, we need to make sure that the sync works as expected.

In particular, the functionalities that:
* If an input file is not found, but the customer specified that all input paths should exist, we should fail the job submission, as this indicates that the customer likely forgot to save an input file 
* If there are no output files found in the output directory, the job should still pass.  This path should not have any regressions in the line
### What was the solution? (How)
* Add two tests that test these functionalities
* Also added a lot more typing to the tests file
### What is the impact of this change?
Better code coverage of the current features in worker-agent.
### How was this change tested?
```
# Linux
source .e2e_linux_infra.sh
hatch run linux-e2e-test
hatch run cross-os-e2e-test

# Windows
source .e2e_windows_infra.sh
hatch run windows-e2e-test
hatch run cross-os-e2e-test
```
### Was this change documented?
No
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*