### PR TITLE
test: update service model and worker agent whl copy path

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -156,7 +156,8 @@ def worker_config(
             dest_path = posixpath.join("/tmp", os.path.basename(resolved_whl_path))
         else:
             dest_path = posixpath.join(
-                "%USERPROFILE%\\AppData\\Local\\Temp", os.path.basename(resolved_whl_path)
+                "C:\\Windows\\System32\\Config\\systemprofile\\AppData\\Local\\Temp",
+                os.path.basename(resolved_whl_path),
             )
         file_mappings = [(resolved_whl_path, dest_path)]
 
@@ -180,7 +181,9 @@ def worker_config(
         if operating_system.name == "AL2023":
             dst_path = posixpath.join("/tmp", src_path.name)
         else:
-            dst_path = posixpath.join("%USERPROFILE%\\AppData\\Local\\Temp", src_path.name)
+            dst_path = posixpath.join(
+                "C:\\Windows\\System32\\Config\\systemprofile\\AppData\\Local\\Temp", src_path.name
+            )
         LOG.info(f"The service model will be copied to {dst_path} on the Worker environment")
         file_mappings.append((str(src_path), dst_path))
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
SSM and UserData are used to setup/install the service model and worker agent whl file. Since different user (SYSTEM/Administrator) are used we cannit use `%USERPROFILE%` or `$env:USERPROFILE`.  

### What was the solution? (How)
Setup userdata to copy the files to the system profile location so that SSM commands (which run as SYSTEM) can find the files.

### What is the impact of this change?
model files are properly installed

### How was this change tested?
`hatch run e2e-test`

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*