### PR TITLE
feat: include specific session runtime logs in the worker log

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -62,7 +62,7 @@ Log events may also contain a `type`, `subtype`, icon (`ti`), and additional fie
 | Session | Add/Remove | 🔷 | queue_id; job_id; session_id; action_ids; queued_actions | Adding or removing SessionActions in a Session. |
 | Session | Logs | 🔷 | queue_id; job_id; session_id; log_dest | Information regarding where the Session logs are located. |
 | Session | User | 🔷 | queue_id; job_id; session_id; user | The user that a Session is running Actions as. |
-| Session | Runtime | 🔷 | queue_id (optional); job_id (optional); session_id | Information related to the running Session. This includes information about the host, process control, and encountered Exceptions which could contain information like filepaths. |
+| Session | Runtime | 🔷 | queue_id; job_id; session_id | Information related to the running Session. This includes information about the host, process control, and encountered Exceptions which could contain information like filepaths. |
 | Worker | Create/Load/ID/Status/Delete | 💻 | farm_id; fleet_id; worker_id (optional); message | A notification related to a Worker resource within AWS Deadline Cloud. |
 
 If you prefer structured logs to be emited on your host, then you can configure your Worker Agent to emit structured logs instead. Please see the

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -62,6 +62,7 @@ Log events may also contain a `type`, `subtype`, icon (`ti`), and additional fie
 | Session | Add/Remove | 🔷 | queue_id; job_id; session_id; action_ids; queued_actions | Adding or removing SessionActions in a Session. |
 | Session | Logs | 🔷 | queue_id; job_id; session_id; log_dest | Information regarding where the Session logs are located. |
 | Session | User | 🔷 | queue_id; job_id; session_id; user | The user that a Session is running Actions as. |
+| Session | Runtime | 🔷 | queue_id (optional); job_id (optional); session_id | Information related to the running Session. This includes information about the host, process control, and encountered Exceptions which could contain information like filepaths. |
 | Worker | Create/Load/ID/Status/Delete | 💻 | farm_id; fleet_id; worker_id (optional); message | A notification related to a Worker resource within AWS Deadline Cloud. |
 
 If you prefer structured logs to be emited on your host, then you can configure your Worker Agent to emit structured logs instead. Please see the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.34.75",
     "deadline == 0.48.*",
-    "openjd-sessions >= 0.7,< 0.9",
+    "openjd-sessions >= 0.8.4,< 0.9",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "typing_extensions ~= 4.8",

--- a/src/deadline_worker_agent/log_messages.py
+++ b/src/deadline_worker_agent/log_messages.py
@@ -660,6 +660,8 @@ class LogRecordStringTranslationFilter(logging.Filter):
         if isinstance(record.msg, str):
             message = record.getMessage()
             record.msg = StringLogEvent(message)
+            # We must replace record.getMessage() so that a string is returned and not the LogEvent type.
+            # getMessageReplaced is used to indicate we already have done so, to avoid replacing twice.
             record.getMessageReplaced = True
             record.getMessage = MethodType(lambda self: self.msg.getMessage(), record)  # type: ignore
             record.args = None

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -128,12 +128,18 @@ class QueueAwsCredentials:
 
 class SessionMap(MappingWithCallbacks[str, SchedulerSession]):
     """
-    Map of session IDs to sessions.
+    Singleton mapping of session IDs to sessions.
 
     This class hooks into dict operations to register session with SessionCleanupManager
     """
 
+    __session_map_instance: SessionMap | None = None
     _session_cleanup_manager: SessionUserCleanupManager
+
+    def __new__(cls, *args, **kwargs) -> SessionMap:
+        if cls.__session_map_instance is None:
+            cls.__session_map_instance = super().__new__(cls)
+        return cls.__session_map_instance
 
     def __init__(
         self,
@@ -159,6 +165,10 @@ class SessionMap(MappingWithCallbacks[str, SchedulerSession]):
             # Nothing to do, base class will raise KeyError
             return
         self._session_cleanup_manager.deregister(scheduler_session.session)
+
+    @classmethod
+    def get_session_map(cls) -> SessionMap | None:
+        return cls.__session_map_instance
 
 
 class WorkerScheduler:

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -15,8 +15,6 @@ from threading import Event
 from typing import Optional
 from pathlib import Path
 
-from openjd.sessions import LOG as OPENJD_SESSION_LOG
-
 from ..api_models import WorkerStatus
 from ..boto import DEADLINE_BOTOCORE_CONFIG, OTHER_BOTOCORE_CONFIG, DeadlineClient
 from ..errors import ServiceShutdown
@@ -349,16 +347,8 @@ def _configure_base_logging(
     ):
         logging.getLogger(logger_name).setLevel(logging.WARNING)
 
-    # We don't want the Session logs to appear in the Worker Agent logs, so
-    # set the Open Job Description library's logger to not propagate.
-    # We do this because the Session log will contain job-specific customer
-    # sensitive data. The Worker's log is intended for IT admins that may
-    # have different/lesser permissions/access-rights/need-to-know than the
-    # folk submitting jobs, so keep the sensitive stuff out of the agent log.
-    OPENJD_SESSION_LOG.propagate = False
-
-    # Similarly, Job Attachments is a feature that only runs in the context of a
-    # Session. So, it's logs should not propagate to the root logger. Instead,
+    # Job Attachments is a feature that only runs in the context of a
+    # Session. So, its logs should not propagate to the root logger. Instead,
     # the Job Attachments logs will route to the Session Logs only.
     JOB_ATTACHMENTS_LOGGER = logging.getLogger("deadline.job_attachments")
     JOB_ATTACHMENTS_LOGGER.propagate = False


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Some information which would be useful in the worker logs, is not present in the worker logs. This information is logged by the OpenJD sessions module, but goes to the session log. 

This can make troubleshooting difficult in scenarios where:
  - The session log is noisy enough to make it difficult to find key session logs
  - The session log is completely unavailable.
 
Since some of the information in the session log is applicable to the operations of the worker agent, we would like for this information to be in the worker logs.

### What was the solution? (How)

[openjd-sessions 0.8.4](https://github.com/OpenJobDescription/openjd-sessions-for-python/releases/tag/0.8.4) made available  a `LogContent` flag which appears in most openjd logs. This flag gives consumers of `openjd.sessions` (like the worker agent) information about what each log from the module contains.

We remove the code where we [previously disabled log propagation from openjd](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/src/deadline_worker_agent/startup/entrypoint.py#L358) and instead add a filter which:

- Assert the LogRecord is a string (has not been processed) and originated from `openjd.sessions`.
- If so, confirm the `openjd_log_content` field exists and is the right type
- If so, confirm the content is that which belongs in the worker logs
- If so, create a `SessionLogEvent` Log message, to adhere to the worker agent structure logging approach.
   - In order to get queue and job info into the log event, I needed to make the `SessionMap` used by the scheduler a singleton which allows the `LogFilter` to query for information of the session which the log originated from.

### What is the impact of this change?

Worker logs contain more information, which should help with debugging some scenarios as described above.

### How was this change tested?
Installed this version of the worker agent on to a host and submitted a job:
```
specificationVersion: jobtemplate-2023-09
name: hang job
steps:
  - name: hang
    script:
      embeddedFiles:
        - name: Hang
          type: TEXT
          filename: hang.py
          data: |
            import subprocess
            import time
            import os
            import json

            PING_COMMAND = ["ping", "localhost"] + (["-t"] if os.name == "nt" else [])

            process = subprocess.Popen(
                [
                    "python",
                    "-c",
                    f'import subprocess; p=subprocess.Popen({json.dumps(PING_COMMAND)}, encoding=\"utf-8\")'
                ],
            )
            print("Exiting script.")

      actions:
        onRun:
          command: python
          args: ["{{Task.File.Hang}}"]
```

This job creates a detached process which logs output from the hosts `ping` executable. 

I confirmed the logs around process control appeared in the worker logs, while none of the command output from the session was present.


```
[2024-09-24 20:27:22,443][INFO    ] 🔷 Session.Starting 🔷 [session-2c2221bfba0e401fa596455139756e74] Starting new Session. [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:22,646][INFO    ] 🔷 Session.Add 🔷 [session-2c2221bfba0e401fa596455139756e74] Appended new SessionActions. (ActionIds: ['sessionaction-2c2221bfba0e401fa596455139756e74-0', 'sessionaction-2c2221bfba0e401fa596455139756e74-1']) (QueuedActionCount: 2) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:22,646][INFO    ] 🔷 Session.User 🔷 [session-2c2221bfba0e401fa596455139756e74] Running as host-configured override user. (User: job-user) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:22,658][INFO    ] 💾 FileSystem.Create 💾 Credentials directory. [/var/lib/deadline/queues/queue-9ebfa880f9e14e59b1dd63e5cd53743f]
[2024-09-24 20:27:22,659][INFO    ] 💾 FileSystem.Write 💾 Credential Process script. [/var/lib/deadline/queues/queue-9ebfa880f9e14e59b1dd63e5cd53743f/get_aws_credentials.sh]
[2024-09-24 20:27:22,659][INFO    ] 💾 FileSystem.Write 💾 Saving profile updates. [/var/lib/deadline/queues/queue-9ebfa880f9e14e59b1dd63e5cd53743f/config]
[2024-09-24 20:27:22,660][INFO    ] 💾 FileSystem.Write 💾 Saving profile updates. [/var/lib/deadline/queues/queue-9ebfa880f9e14e59b1dd63e5cd53743f/credentials]
[2024-09-24 20:27:23,034][INFO    ] 🔷 Session.AWSCreds 🔷 [session-2c2221bfba0e401fa596455139756e74] AWS Credentials are available. [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:23,132][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] openjd.model Library Version: 0.4.4
[2024-09-24 20:27:23,133][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] openjd.sessions Library Version: 0.8.4
[2024-09-24 20:27:23,133][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Installed at: /opt/deadline/worker/lib/python3.11/site-packages/openjd
[2024-09-24 20:27:23,133][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Python Interpreter: /opt/deadline/worker/bin/python
[2024-09-24 20:27:23,133][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Python Version: 3.11.6 (main, Apr 24 2024, 00:00:00) [GCC 11.4.1 20230605 (Red Hat 11.4.1-2)]
[2024-09-24 20:27:23,133][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Platform: linux
[2024-09-24 20:27:23,137][INFO    ] 🔷 Session.Logs 🔷 [session-2c2221bfba0e401fa596455139756e74] Logs streamed to: AWS CloudWatch Logs. (LogDestination: /aws/deadline/farm-332a8793644847a2b8e1298603ac39ef/queue-9ebfa880f9e14e59b1dd63e5cd53743f/session-2c2221bfba0e401fa596455139756e74) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:23,138][INFO    ] 🔷 Session.Info 🔷 [session-2c2221bfba0e401fa596455139756e74] Warming Job Entity Cache [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:23,395][INFO    ] 🔷 Session.Info 🔷 [session-2c2221bfba0e401fa596455139756e74] Fully warmed Job Entity Cache [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:23,496][INFO    ] 🟢 Action.Start 🟢 [session-2c2221bfba0e401fa596455139756e74](sessionaction-2c2221bfba0e401fa596455139756e74-0) Action started. (Kind: EnvEnter) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:23,498][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Command started as pid: 14087 [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:24,109][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Process pid 14087 exited with code: 0 (unsigned) / 0x0 (hex) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:24,109][INFO    ] 🟣 Action.End 🟣 [session-2c2221bfba0e401fa596455139756e74](sessionaction-2c2221bfba0e401fa596455139756e74-0) Action complete. (Status: SUCCEEDED) (Kind: EnvEnter) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:24,199][INFO    ] 🟢 Action.Start 🟢 [session-2c2221bfba0e401fa596455139756e74](sessionaction-2c2221bfba0e401fa596455139756e74-1) Action started. (Kind: TaskRun) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099/step-f761c5bc1c5c47cf991377792e9068a1/task-f761c5bc1c5c47cf991377792e9068a1-0]
[2024-09-24 20:27:24,202][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Command started as pid: 14137 [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:25,530][WARNING ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Command exited but STDOUT stream is still open. Waiting gracetime of 5 seconds for the STDOUT stream to close before ending action. [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:30,530][WARNING ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Gracetime of 5 seconds elapsed but the STDOUT stream is still open. Ending action. [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:30,531][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Process pid 14137 exited with code: 0 (unsigned) / 0x0 (hex) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:30,531][INFO    ] 🟣 Action.End 🟣 [session-2c2221bfba0e401fa596455139756e74](sessionaction-2c2221bfba0e401fa596455139756e74-1) Action complete. (Status: SUCCEEDED) (Kind: TaskRun) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099/step-f761c5bc1c5c47cf991377792e9068a1/task-f761c5bc1c5c47cf991377792e9068a1-0]
[2024-09-24 20:27:30,972][INFO    ] 🔷 Session.Add 🔷 [session-2c2221bfba0e401fa596455139756e74] Appended new SessionActions. (ActionIds: ['sessionaction-2c2221bfba0e401fa596455139756e74-2']) (QueuedActionCount: 1) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:31,008][INFO    ] 🟢 Action.Start 🟢 [session-2c2221bfba0e401fa596455139756e74](sessionaction-2c2221bfba0e401fa596455139756e74-2) Action started. (Kind: EnvExit) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:31,010][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Command started as pid: 14169 [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:31,376][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Process pid 14169 exited with code: 0 (unsigned) / 0x0 (hex) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:31,377][INFO    ] 🟣 Action.End 🟣 [session-2c2221bfba0e401fa596455139756e74](sessionaction-2c2221bfba0e401fa596455139756e74-2) Action complete. (Status: SUCCEEDED) (Kind: EnvExit) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:31,527][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Command started as pid: 14198 [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:31,817][INFO    ] 🔷 Session.Runtime 🔷 [session-2c2221bfba0e401fa596455139756e74] Process pid 14198 exited with code: 0 (unsigned) / 0x0 (hex) [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
[2024-09-24 20:27:31,818][INFO    ] Cleaning up remaining session user processes for 'job-user'
[2024-09-24 20:27:31,904][INFO    ] Stopped processes:
 killed (pid 14091)
 killed (pid 14093)
[2024-09-24 20:27:31,904][INFO    ] 🔷 Session.Complete 🔷 [session-2c2221bfba0e401fa596455139756e74] Session complete. [queue-9ebfa880f9e14e59b1dd63e5cd53743f/job-6f30c839dfe04a7bb775a4f6301d2099]
```

Also added unit tests which pass, and are designed to ensure future additions to `LogContent` are not logged by default.

### Was this change documented?

Yes, modified the `Logging` docs, as well as adding in-line comments

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*