### PR TITLE
test: add test to verify worker enter stopping state while draining

### DIFF
--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -25,7 +25,7 @@ import uuid
 import os
 import configparser
 import tempfile
-from e2e.utils import wait_for_job_output, submit_sleep_job
+from e2e.utils import wait_for_job_output, submit_sleep_job, submit_custom_job
 
 LOG = logging.getLogger(__name__)
 
@@ -1600,54 +1600,12 @@ class TestJobSubmission:
             }}
             """
         )
-        job: Job = Job.submit(
-            client=deadline_client,
+        job: Job = submit_custom_job(
+            job_name="One Minute Sleep Job for Task Progress",
+            deadline_client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
-            max_retries_per_task=0,
-            priority=98,
-            template={
-                "specificationVersion": "jobtemplate-2023-09",
-                "name": "One Minute Sleep Job for Task Progress",
-                "steps": [
-                    {
-                        "name": "60 Second Sleep",
-                        "hostRequirements": {
-                            "attributes": [
-                                {
-                                    "name": "attr.worker.os.family",
-                                    "allOf": [os.environ["OPERATING_SYSTEM"]],
-                                }
-                            ]
-                        },
-                        "script": {
-                            "actions": {
-                                "onRun": (
-                                    {"command": "{{ Task.File.runScript }}"}
-                                    if os.environ["OPERATING_SYSTEM"] == "linux"
-                                    else {
-                                        "command": "powershell",
-                                        "args": ["{{ Task.File.runScript }}"],
-                                    }
-                                ),
-                            },
-                            "embeddedFiles": [
-                                {
-                                    "name": "runScript",
-                                    "type": "TEXT",
-                                    "runnable": True,
-                                    "data": sleep_script,
-                                    **(
-                                        {"filename": "SleepScript.ps1"}
-                                        if os.environ["OPERATING_SYSTEM"] == "windows"
-                                        else {}
-                                    ),
-                                }
-                            ],
-                        },
-                    },
-                ],
-            },
+            run_script=sleep_script,
         )
 
         @backoff.on_predicate(
@@ -1728,99 +1686,58 @@ class TestJobSubmission:
 
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
-def test_worker_enters_stopping_state_while_draining(
-    self,
-    deadline_resources: DeadlineResources,
-    deadline_client: DeadlineClient,
-    function_worker: EC2InstanceWorker,
-    sleep_script: str = (
-        """
-        #!/usr/bin/env bash
-        while true
-        do
-            sleep 1
-        done
-        """
-        if os.environ["OPERATING_SYSTEM"] == "linux"
-        else """
-        while ($true) {{
-            Start-Sleep -Seconds 1
-        }}
-        """
-    ),
-):
-    Job.submit(
-        client=deadline_client,
-        farm=deadline_resources.farm,
-        queue=deadline_resources.queue_a,
-        max_retries_per_task=0,
-        priority=98,
-        template={
-            "specificationVersion": "jobtemplate-2023-09",
-            "name": "Infinite Sleep Job",
-            "steps": [
-                {
-                    "name": "Sleep job",
-                    "hostRequirements": {
-                        "attributes": [
-                            {
-                                "name": "attr.worker.os.family",
-                                "allOf": [os.environ["OPERATING_SYSTEM"]],
-                            }
-                        ]
-                    },
-                    "script": {
-                        "actions": {
-                            "onRun": (
-                                {"command": "{{ Task.File.runScript }}"}
-                                if os.environ["OPERATING_SYSTEM"] == "linux"
-                                else {
-                                    "command": "powershell",
-                                    "args": ["{{ Task.File.runScript }}"],
-                                }
-                            ),
-                        },
-                        "embeddedFiles": [
-                            {
-                                "name": "runScript",
-                                "type": "TEXT",
-                                "runnable": True,
-                                "data": sleep_script,
-                                **(
-                                    {"filename": "SleepScript.ps1"}
-                                    if os.environ["OPERATING_SYSTEM"] == "windows"
-                                    else {}
-                                ),
-                            }
-                        ],
-                    },
-                },
-            ],
-        },
-    )
+    def test_worker_enters_stopping_state_while_draining(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        function_worker: EC2InstanceWorker,
+        sleep_script: str = (
+            """
+            #!/usr/bin/env bash
+            while true
+            do
+                sleep 1
+            done
+            """
+            if os.environ["OPERATING_SYSTEM"] == "linux"
+            else """
+            while ($true) {{
+                Start-Sleep -Seconds 1
+            }}
+            """
+        ),
+    ):
 
-    if os.environ["OPERATING_SYSTEM"] == "linux":
-        cmd_result = function_worker.send_command("sudo systemctl stop deadline-worker")
-    else:
-        cmd_result = function_worker.send_command("sc.exe stop DeadlineWorker")
-
-    assert cmd_result.exit_code == 0
-
-    @backoff.on_predicate(
-        wait_gen=backoff.constant,
-        max_time=120,
-        interval=10,
-    )
-    def worker_stop(worker: EC2InstanceWorker) -> bool:
-        response = function_worker.deadline_client.get_worker(
-            farmId=function_worker.configuration.farm_id,
-            fleetId=function_worker.configuration.fleet.id,
-            workerId=function_worker.worker_id,
-        )
-        LOG.info(
-            f"Waiting for {function_worker.worker_id} to transition to STOPPING/STOPPED status"
+        submit_custom_job(
+            job_name="Infinite Sleep Job",
+            deadline_client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            run_script=sleep_script,
         )
 
-        return response["status"] in ["STOPPED", "STOPPING"]
+        if os.environ["OPERATING_SYSTEM"] == "linux":
+            cmd_result = function_worker.send_command("sudo systemctl stop deadline-worker")
+        else:
+            cmd_result = function_worker.send_command("sc.exe stop DeadlineWorker")
 
-    assert worker_stop(function_worker)
+        assert cmd_result.exit_code == 0
+
+        @backoff.on_predicate(
+            wait_gen=backoff.constant,
+            max_time=120,
+            interval=10,
+        )
+        def worker_stop(worker: EC2InstanceWorker) -> bool:
+            response = function_worker.deadline_client.get_worker(
+                farmId=function_worker.configuration.farm_id,
+                fleetId=function_worker.configuration.fleet.id,
+                workerId=function_worker.worker_id,
+            )
+            LOG.info(
+                f"Waiting for {function_worker.worker_id} to transition to STOPPING/STOPPED status"
+            )
+
+            return response["status"] in ["STOPPED", "STOPPING"]
+
+        assert worker_stop(function_worker)

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -1694,16 +1694,11 @@ class TestJobSubmission:
         sleep_script: str = (
             """
             #!/usr/bin/env bash
-            while true
-            do
-                sleep 1
-            done
+            sleep 600
             """
             if os.environ["OPERATING_SYSTEM"] == "linux"
             else """
-            while ($true) {{
-                Start-Sleep -Seconds 1
-            }}
+            Start-Sleep -Seconds 600
             """
         ),
     ):

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -1727,3 +1727,100 @@ class TestJobSubmission:
         job.wait_until_complete(client=deadline_client)
 
         assert job.task_run_status == TaskStatus.SUCCEEDED
+
+def test_worker_enters_stopping_state_while_draining(
+    self,
+    deadline_resources: DeadlineResources,
+    deadline_client: DeadlineClient,
+    function_worker: EC2InstanceWorker,
+    sleep_script: str = (
+        """
+        #!/usr/bin/env bash
+        while true
+        do
+            sleep 1
+        done
+        """
+        if os.environ["OPERATING_SYSTEM"] == "linux"
+        else """
+        while ($true) {{
+            Start-Sleep -Seconds 1
+        }}
+        """
+    ),
+):
+    Job.submit(
+        client=deadline_client,
+        farm=deadline_resources.farm,
+        queue=deadline_resources.queue_a,
+        max_retries_per_task=0,
+        priority=98,
+        template={
+            "specificationVersion": "jobtemplate-2023-09",
+            "name": "Infinite Sleep Job",
+            "steps": [
+                {
+                    "name": "Sleep job",
+                    "hostRequirements": {
+                        "attributes": [
+                            {
+                                "name": "attr.worker.os.family",
+                                "allOf": [os.environ["OPERATING_SYSTEM"]],
+                            }
+                        ]
+                    },
+                    "script": {
+                        "actions": {
+                            "onRun": (
+                                {"command": "{{ Task.File.runScript }}"}
+                                if os.environ["OPERATING_SYSTEM"] == "linux"
+                                else {
+                                    "command": "powershell",
+                                    "args": ["{{ Task.File.runScript }}"],
+                                }
+                            ),
+                        },
+                        "embeddedFiles": [
+                            {
+                                "name": "runScript",
+                                "type": "TEXT",
+                                "runnable": True,
+                                "data": sleep_script,
+                                **(
+                                    {"filename": "SleepScript.ps1"}
+                                    if os.environ["OPERATING_SYSTEM"] == "windows"
+                                    else {}
+                                ),
+                            }
+                        ],
+                    },
+                },
+            ],
+        },
+    )
+
+    if os.environ["OPERATING_SYSTEM"] == "linux":
+        cmd_result = function_worker.send_command("sudo systemctl stop deadline-worker")
+    else:
+        cmd_result = function_worker.send_command("sc.exe stop DeadlineWorker")
+
+    assert cmd_result.exit_code == 0
+
+    @backoff.on_predicate(
+        wait_gen=backoff.constant,
+        max_time=120,
+        interval=10,
+    )
+    def worker_stop(worker: EC2InstanceWorker) -> bool:
+        response = function_worker.deadline_client.get_worker(
+            farmId=function_worker.configuration.farm_id,
+            fleetId=function_worker.configuration.fleet.id,
+            workerId=function_worker.worker_id,
+        )
+        LOG.info(
+            f"Waiting for {function_worker.worker_id} to transition to STOPPING/STOPPED status"
+        )
+
+        return response["status"] in ["STOPPED", "STOPPING"]
+
+    assert worker_stop(function_worker)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We having a gap in e2e test to make sure worker report stopping/stopped when we kill worker
### What was the solution? (How)
Implement a test to make sure when we submit a command to shutdown worker, it will report correctly as stopping/stopped

### What is the impact of this change?
Increase test coverage and improve confident when release worker agent
### How was this change tested?
`hatch run e2e-test`
Both on Windows and Linux
### Was this change documented?
Yes
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*