### PR TITLE
fix: prevent test s3 buckets not being able to be created in some regions

### DIFF
--- a/scripts/e2e_testing_infrastructure.yaml
+++ b/scripts/e2e_testing_infrastructure.yaml
@@ -197,7 +197,7 @@ Resources:
   FixturesBootstrapBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub deadline-cloud-agent-e2e-test-bootstrap-${AWS::AccountId}-${AWS::Region}
+      BucketName: !Sub deadline-cloud-wa-e2e-bootstrap-${AWS::AccountId}-${AWS::Region}
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -247,7 +247,7 @@ Resources:
   JobAttachmentsBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub deadline-cloud-agent-e2e-job-attachments-${AWS::AccountId}-${AWS::Region}
+      BucketName: !Sub deadline-cloud-wa-e2e-ja-${AWS::AccountId}-${AWS::Region}
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
Some regions with longer names (e.g. ap-southeast-1) cannot create test resources for E2E testing as the bucket names are too long.

### What was the solution? (How)
Reduce the s3 bucket names for the WA E2E tests.
### What is the impact of this change?
All regions should be able to deploy the E2E testing resources.

Better experience for development across all regions.
### How was this change tested?
Confirmed that the names will be under 63 characters for all regions
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*