### PR TITLE
test: skip job attachment sync test with nonvalid queue role

### DIFF
--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -1402,7 +1402,8 @@ class TestJobSubmission:
 
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
-    def test_worker_fails_job_attachment_sync_when_no_queue_role(
+    @pytest.mark.skip(reason="Queue role permissions are failing the test during E2E test runs")
+    def test_worker_fails_job_attachment_sync_when_non_valid_queue_role(
         self,
         deadline_resources: DeadlineResources,
         session_worker: EC2InstanceWorker,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The E2E test that tests that job attachment sync during when a Nonvalid queue role is passed to the queue should fail is not working correctly due to lack of permissions in the queue role. We should investigate this more thoroughly after disabling the test first.

It is not a service code issue, but rather an issue with the test itself.
### What was the solution? (How)
Disable this test that's been failing.
### What is the impact of this change?
The test will not block releases and other workflows
### How was this change tested?
`hatch build`


```
# Linux
source .e2e_linux_infra.sh
hatch run e2e-test

# Windows
source .e2e_windows_infra.sh
hatch run e2e-test

```
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*