### PR TITLE
test: add session_worker fixture to step step dependencies test

### DIFF
--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -1730,6 +1730,7 @@ class TestJobSubmission:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
+        session_worker: EC2InstanceWorker,
         tmp_path: pathlib.Path,
     ) -> None:
         # Test that submits a job that has step step dependencies and confirm that the final output is as we expect


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need the session worker fixture in every WA Job submission test now since otherwise the build will fail with `function uses no fixture operating_system
### What was the solution? (How)
Add the worker fixture to the step step dependencies test.

### What is the impact of this change?
The test will now pass
### How was this change tested?

```
# Linux
source .e2e_linux_infra.sh
hatch run e2e-test

# Windows
source .e2e_windows_infra.sh
hatch run e2e-test

```
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*