### PR TITLE
test: fix inconsistent test for SUCCEEDED session action logging

### DIFF
--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1593,6 +1593,10 @@ class TestSessionActionUpdatedImpl:
             action_status=success_action_status,
             now=action_complete_time,
         )
+        # This because the _action_update_impl submits a future to this thread pool executor
+        # The test assertion depends on this future completing and so there's a race condition
+        # if we do not wait for the thread pool to shutdown and all futures to complete.
+        session._executor.shutdown()
 
         # THEN
         mock_mod_logger.info.assert_called_once()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The tests in `test/unit/session/test_session.py` were failing inconsistently with:

```
>           raise AssertionError(msg)
E           AssertionError: Expected 'info' to have been called once. Called 0 times.

msg        = "Expected 'info' to have been called once. Called 0 times."
self       = <MagicMock name='logger.info' id='140565391024288'>

/usr/lib64/python3.9/unittest/mock.py:886: AssertionError
```

### What was the solution? (How)

The test was asserting that a log message was emitted when a session action completed successfully. In a code branch where the session action was a task run and there were job output attachments to upload, the implementation code submitted a future to a `concurrent.futures.ThreadPoolExecutor`. That future emitted the logging statement, but because the test did no block on this concurrently running future, the test could fail under the race condition.

Modified the test to call the `ThreadPoolExecutor.shutdown()` method which blocks until all active futures complete.

### What is the impact of this change?

The unit tests will only fail if the code running in the concurrent future does not emit a log. This more accurately 

### How was this change tested?

Ran the modified unit tests repeatedly without any failures.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*