### PR TITLE
chore: use pytest automatic color output detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,6 @@ line-length = 100
 xfail_strict = true
 addopts = [
     "--durations=5",
-    "--color=yes",
     "--cov=src/deadline_worker_agent",
     "--cov-report=html:build/coverage",
     "--cov-report=xml:build/coverage/coverage.xml",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `deadline-cloud-worker-agent` repository had a configuration setting to force use console color output. This was done to ensure pytest output is colorized in GitHub actions (see pytest-dev/pytest#7462 and actions/runner#241 for background on this issue).

Forcing color output negatively impacts legibility in CodeBuild where we run our integration and e2e tests.

### What was the solution? (How)

Remove the configuration in `pyproject.toml` to force colorized pytest output. Legibility is more important than colorized output.

### What is the impact of this change?

Test output is more legible in CodeBuild and GitHub actions will no longer have colorized output. There is no change for running tests in a terminal. Pytest correctly detects the terminal and colorizes output.

### How was this change tested?

Ran the tests with:

```
hatch run test
```

The tests succeed and are colorized locally

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*