### PR TITLE
fix: increase default instance size

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -291,7 +291,7 @@ def create_worker(
         ami_id = os.getenv("AMI_ID")
         subnet_id = os.getenv("SUBNET_ID")
         security_group_id = os.getenv("SECURITY_GROUP_ID")
-        instance_type = os.getenv("WORKER_INSTANCE_TYPE", default="t3.medium")
+        instance_type = os.getenv("WORKER_INSTANCE_TYPE", default="c5.xlarge")
         instance_shutdown_behavior = os.getenv("WORKER_INSTANCE_SHUTDOWN_BEHAVIOR", default="stop")
 
         assert subnet_id, "SUBNET_ID is required when deploying an EC2 worker"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have some flaky worker agent tests in the past week, in which Windows workers took too long to start, causing multiple tests to fail 

We should fix these flakiness so the tests are trustworthy.
### What was the solution? (How)

Increase default EC2 size so the workers boot up faster.
### What is the impact of this change?
Less flakiness in tests lead to better reliability and consistency of the code
### How was this change tested?
```
# Linux
source .e2e_linux_infra.sh
hatch run e2e-test

# Windows
source .e2e_windows_infra.sh
hatch run e2e-test

```
All the tests passed, and the worker did boot up faster. (Around 5-6 minutes for windows as opposed to around 7 minutes before)
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*