### PR TITLE
ci: add mainline canary and change release canary schedule

### DIFF
--- a/.github/workflows/mainline_e2e_canary.yml
+++ b/.github/workflows/mainline_e2e_canary.yml
@@ -1,10 +1,8 @@
-name: Release Canary
+name: Mainline Canary
 
 on:
   schedule:
-    - cron: '0 13 * * *'
-    - cron: '0 19 * * *'
-    - cron: '0 1 * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch:
 
 jobs:
@@ -26,8 +24,8 @@ jobs:
     - name: Run Windows Integration Tests
       run: hatch run windows-integ-test
       
-  ReleaseLinuxE2ECanary:
-    name: Release Linux Canary
+  MainlineLinuxE2ECanary:
+    name: Mainline Linux Canary
     permissions:
       id-token: write
       contents: read
@@ -35,12 +33,12 @@ jobs:
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      branch: release
+      branch: mainline
       environment: canary
       os: linux
 
-  ReleaseWindowsE2ECanary:
-    name: Release Windows Canary
+  MainlineWindowsE2ECanary:
+    name: Mainline Windows Canary
     permissions:
       id-token: write
       contents: read
@@ -48,6 +46,6 @@ jobs:
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      branch: release
+      branch: mainline
       environment: canary
       os: windows


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to add a Canary to mainline, to check on a regular interval that there are no issues in the mainline branch. Update release canary to run three times a day.

### What was the solution? (How)
Add a workflow for a mainline canary to run ever 2 hours. Updated release canary to run a 8:00, 14:00, 20:00 CDT ( 13:00, 19,:00, 1:00 UTC)

### What is the impact of this change?
Helps keep the mainline branch healthy by regularly checking for possible issues.

### How was this change tested?
n/a - will be tested in CI

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*