### PR TITLE
test: include large files in syncInputJobAttachments cancelation tests to allow more time for cancelation

### DIFF
--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -735,10 +735,14 @@ class TestJobSubmission:
         # Create the input files to make sync inputs take a relatively long time
         files_path: str = os.path.join(tmp_path, "files")
         os.mkdir(files_path)
-        for i in range(2000):
+        for i in range(6000):
             file_name: str = os.path.join(files_path, f"input_file_{i+1}.txt")
             with open(file_name, "w+") as input_file:
-                input_file.write(f"{i}")
+                if i % 1000 == 0:
+                    # Create some big files (1GB each) so the syncInputAttachments don't fail due to low transfer rates
+                    input_file.write("A" * 1000000000)
+                else:
+                    input_file.write(f"{i}")
         config = configparser.ConfigParser()
 
         set_setting("defaults.farm_id", deadline_resources.farm.id, config)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`test_worker_reports_canceled_sync_input_actions_as_canceled` was failing flakily because sometimes the syncInputAttachments goes too fast so we don't have time to cancel it.
### What was the solution? (How)
Create bigger files in between the small files, so that  the syncInputJobAttachments is much slower (due to the addition of the big files), but it does not time out due to the perceived transfer rate being too slow (which happens when too many small files are attempted to be uploaded).

The small files are actually what's slowing down the syncInputJobAttachments action, so we still need them to be able to cancel the action.
### What is the impact of this change?
More robust `test_worker_reports_canceled_sync_input_actions_as_canceled` test
### How was this change tested?
```
# Linux
source .e2e_linux_infra.sh
hatch run e2e-test

# Windows
source .e2e_windows_infra.sh
hatch run e2e-test

```
Ran 5 times each, passed every time.
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*