### PR TITLE
ci: prevent concurrent E2E runs for PR merges and release bumps

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -55,6 +55,8 @@ jobs:
       branch: mainline
       environment: mainline
       os: linux
+    concurrency:
+      group: linuxe2e
 
   WindowsE2ETests:
     needs: UnitTests
@@ -69,6 +71,8 @@ jobs:
       branch: mainline
       environment: mainline
       os: windows
+    concurrency:
+      group: windowse2e
 
   Bump:
     needs: [LinuxE2ETests, WindowsE2ETests, WindowsIntegrationTests]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Concurrent runs of the Github actions E2E tests when merging PRs and running the release bump can collide and interfere with eachother

### What was the solution? (How)

Use Github actions concurrency groups ([docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs)).

This concurrency group configuration was already put in place in the `mainline` merge workflow:

https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/7d7d74f0a01943e89845fda76ec73f2fe433d7c9/.github/workflows/mainline_e2e_test.yml#L42-L43

and

https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/7d7d74f0a01943e89845fda76ec73f2fe433d7c9/.github/workflows/mainline_e2e_test.yml#L57-L58

but still needed to be instrumented in the release bump workflow which was done in this PR.

### What is the impact of this change?

Concurrent E2E test runs for worker agent pull requests and release bumps will not interfere with eachother.

### How was this change tested?

N/A

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*