### PR TITLE
ci: make Windows E2E tests a requirement before the bump job in the release bump workflow

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -56,7 +56,7 @@ jobs:
       environment: mainline
       os: linux
 
-  WindowsE2ETest:
+  WindowsE2ETests:
     needs: UnitTests
     name: Windows E2E Test
     permissions:
@@ -71,7 +71,7 @@ jobs:
       os: windows
 
   Bump:
-    needs: LinuxE2ETests
+    needs: [LinuxE2ETests, WindowsE2ETests, WindowsIntegrationTests]
     name: Version Bump
     uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
     secrets: inherit


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The "Release: Bump" workflow initiates an Windows E2E test run and Windows integration test run, but currently does not block the "Bump" job on these tests passing. It only blocks on the Linux E2E tests passing.

### What was the solution? (How)

Make the `Bump` job in the `release_bump` workflow require passing `WindowsE2ETests` and `WindowsIntegrationTests` jobs.

### What is the impact of this change?

There is less risk of operators accidentally approving the `Bump` step despite Windows E2E and/or integration tests not completing or succeeding.

### How was this change tested?

N/A

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*