### PR TITLE
test: do not retry test jobs that are expected to fail in test_job_reports_failed_session_action

### DIFF
--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -117,6 +117,7 @@ class TestJobSubmission:
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             priority=98,
+            max_retries_per_task=0,
             template={
                 "specificationVersion": "jobtemplate-2023-09",
                 "name": f"jobactionfail-{expected_failed_action}",


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)
`test_job_reports_failed_session_action` submits jobs that are expected to fail. However previously we are retrying the jobs despite them expected to fail. To save time and make the test behaviour more consistent, we should no retry them.
### What was the solution? (How)
Give these test jobs that are expected to fail 0 retries.
### What is the impact of this change?
Resources saved during testing, more consistent test behaviour.
### How was this change tested?
```
# Linux
source .e2e_linux_infra.sh
hatch run e2e-test

# Windows
source .e2e_windows_infra.sh
hatch run e2e-test

```

The tests passed.
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*