### PR TITLE
chore(deps): update to python-semantic-release 9.12

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -8,16 +8,16 @@
         {% endfor %}
     {% endif %}
 
-    {% if "feature" in release["elements"] %}
+    {% if "features" in release["elements"] %}
 ### Features
-        {% for commit in release["elements"]["feature"] %}
+        {% for commit in release["elements"]["features"] %}
 * {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(": ")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
         {% endfor %}
     {% endif %}
 
-    {% if "fix" in release["elements"] %}
+    {% if "bug fixes" in release["elements"] %}
 ### Bug Fixes
-        {% for commit in release["elements"]["fix"] %}
+        {% for commit in release["elements"]["bug fixes"] %}
 * {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
         {% endfor %}
     {% endif %}

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,1 @@
-python-semantic-release == 9.8.*
+python-semantic-release == 9.12.*


### PR DESCRIPTION
Fixes: None

### What was the problem/requirement? (What/Why)

Updates to the latest python-semantic-release.

### What was the solution? (How)

There's a difference between 9.8 and 9.12 in the specific keys used for bugs & features in the parsed data that we use to generate the CHANGELOG.md file, so the changelog template file needed to be updated as well.

### What is the impact of this change?

Dependencies are updated.

### How was this change tested?

Tested by running the `hatch run release:bump` command and comparing the generated changelog.

### Was this change documented?

N/A

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*