### PR TITLE
chore(deps): update requests and types-requests to 2.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "psutil >= 5.9,< 7.0",
     "pydantic ~= 1.10.0",
     "pywin32 == 306; platform_system == 'Windows'",
-    "requests == 2.31.*",
+    "requests == 2.32.*",
 ]
 requires-python = ">=3.9"
 description = "The AWS Deadline Cloud worker agent can be used to run a worker in an AWS Deadline Cloud fleet"

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -11,7 +11,8 @@ black[jupyter] ~= 24.10
 rich == 13.7.*
 types-python-dateutil ~= 2.9
 mypy ~= 1.13
-types-requests ~= 2.31
+types-requests ~= 2.31; python_version < "3.10"
+types-requests ~= 2.32; python_version >= "3.10"
 ruff ~= 0.5.1
 twine ~= 5.1
 types-psutil ~= 5.9


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There are new versions of requests & types-requests, but the dependabot updates for these aren't passing CI.

### What was the solution? (How)

Update them together. `types-requests` on python 3.10 and lower requires urllib3>2 for some reason, despite requests not requiring that, so I made the types-requests update conditional.

### What is the impact of this change?

Updated dep

### How was this change tested?

Running tests & linting.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*