### PR TITLE
chore(deps): bump deadline-cloud-test-fixtures from ==0.15.* to ==0.16.*

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,7 +1,7 @@
 backoff == 2.2.*
 coverage[toml] ~= 7.6
 coverage-conditional-plugin == 0.9.*
-deadline-cloud-test-fixtures == 0.15.*
+deadline-cloud-test-fixtures == 0.16.*
 flaky == 3.8.*
 pytest ~= 8.3
 pytest-cov == 5.0.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`deadline-cloud-test-fixtures` version `0.16.0` was just released with a bug fix (see aws-deadline/deadline-cloud-test-fixtures#160) that is impacting the end-to-end tests in the worker agent. The bug caused multiple worker agent processes to be launched on the same worker host and these processes were trying to manage the same worker resource and conflicting with eachother. This caused many false-positive test failures due to the test setup and not the worker agent itself.

### What was the solution? (How)

Bump the pinned version of `deadline-cloud-test-fixtures` from `== 0.15.*` &rarr; `== 0.16.*`

### What is the impact of this change?

The worker agent end-to-end tests will no longer be impacted by the multiple worker agent processes bug that was present in `deadline-cloud-test-fixtures==0.15.*`.

### How was this change tested?

During the development iterations on aws-deadline/deadline-cloud-test-fixtures#160, the bugfix was tested on the worker agent repository using the dev workflow in `DEVELOPMENT.md` of this repository. The tests passed successfully

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*