### PR TITLE
docs: fix minor file name typo in README

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -23,8 +23,8 @@ def test_windows_behaviour() -> None:
 ```
 
 # Test Scoping
-**Session** - Tests that do not need to perform host or worker configuration, or will not impact the outcome of another test within session scope. It is beneficial to use session scope to keep test time low as it will not require another instance startup and configuration. Use the `session_worker` fixture (defined in `conftesy.py`) to specify this scope.
+**Session** - Tests that do not need to perform host or worker configuration, or will not impact the outcome of another test within session scope. It is beneficial to use session scope to keep test time low as it will not require another instance startup and configuration. Use the `session_worker` fixture (defined in `conftest.py`) to specify this scope.
 
-**Class** - Tests defined as methods of a class that require modification(s) to the host or worker configuration. These modifications would impact tests using the session scoped worker fixture so instead we use a separate worker. Use the `class_worker` fixture (defined in `conftesy.py`) to specify this scope.
+**Class** - Tests defined as methods of a class that require modification(s) to the host or worker configuration. These modifications would impact tests using the session scoped worker fixture so instead we use a separate worker. Use the `class_worker` fixture (defined in `conftest.py`) to specify this scope.
 
-**Function** - Tests that modify the host or worker configuration in a way that cannot be grouped with other tests. The worker and its associated EC2 instance are not shared with other tests. Use the `function_worker` fixture (defined in `conftesy.py`) to specify this scope.
+**Function** - Tests that modify the host or worker configuration in a way that cannot be grouped with other tests. The worker and its associated EC2 instance are not shared with other tests. Use the `function_worker` fixture (defined in `conftest.py`) to specify this scope.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Minor typo in README
### What was the solution? (How)
Fix the minor typo.
### What is the impact of this change?
Easier to read README
### How was this change tested?
NA
### Was this change documented?
NA
### Is this a breaking change?
NA
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*