### PR TITLE
fix: increase e2e test instance size

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -291,7 +291,7 @@ def create_worker(
         ami_id = os.getenv("AMI_ID")
         subnet_id = os.getenv("SUBNET_ID")
         security_group_id = os.getenv("SECURITY_GROUP_ID")
-        instance_type = os.getenv("WORKER_INSTANCE_TYPE", default="t3.medium")
+        instance_type = os.getenv("WORKER_INSTANCE_TYPE", default="t3.large")
         instance_shutdown_behavior = os.getenv("WORKER_INSTANCE_SHUTDOWN_BEHAVIOR", default="stop")
 
         assert subnet_id, "SUBNET_ID is required when deploying an EC2 worker"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We were occasionally running into instance check failures when running the E2E tests. One of the reasons this can arise is because of memory exhaustion.

### What was the solution? (How)
One of the things we want to try is increasing the test instance size slightly

### What is the impact of this change?
Hopefully the test instance doesn't run out of memory and passes instance checks.

### How was this change tested?
Ran the E2E tests and ensured that they passed.

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*