### PR TITLE
ci: prevent concurrent e2e canary runs

### DIFF
--- a/.github/workflows/mainline_e2e_canary.yml
+++ b/.github/workflows/mainline_e2e_canary.yml
@@ -36,6 +36,8 @@ jobs:
       branch: mainline
       environment: canary
       os: linux
+    concurrency:
+      group: mainlinelinuxe2ecanary
 
   MainlineWindowsE2ECanary:
     name: Mainline Windows Canary
@@ -49,3 +51,5 @@ jobs:
       branch: mainline
       environment: canary
       os: windows
+    concurrency:
+      group: mainlinewindowse2ecanary

--- a/.github/workflows/release_e2e_canary.yml
+++ b/.github/workflows/release_e2e_canary.yml
@@ -38,6 +38,8 @@ jobs:
       branch: release
       environment: canary
       os: linux
+    concurrency:
+      group: releaselinuxe2ecanary
 
   ReleaseWindowsE2ECanary:
     name: Release Windows Canary
@@ -51,3 +53,5 @@ jobs:
       branch: release
       environment: canary
       os: windows
+    concurrency:
+      group: releasewindowse2ecanary


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When manually re-running canaries, it is possible that they run together with the automated mainline/release canaries, causing race conditions in the tests.
### What was the solution? (How)
Add a canary group for each of the mainline/release canaries. So that they will not run together causing failures.
### What is the impact of this change?
Canaries will not run at the same time causing failures.
### How was this change tested?
Will be tested through github actions
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*