### PR TITLE
test: disable linux user override tests as they fail in Github

### DIFF
--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -22,7 +22,6 @@ from deadline_test_fixtures import (
     DeadlineClient,
     EC2InstanceWorker,
 )
-from flaky import flaky
 
 LOG = logging.getLogger(__name__)
 
@@ -319,9 +318,9 @@ class TestLinuxJobUserOverride:
 
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
-    @flaky(
-        max_runs=3, min_passes=1
-    )  # Flaky due to varying instance types causing race conditions with user reassignment
+    @pytest.mark.skip(
+        reason="Passes consistently on local but fails in Github. Will re-enable after investigation"
+    )
     def test_config_file_user_override(
         self,
         deadline_resources,
@@ -385,9 +384,9 @@ class TestLinuxJobUserOverride:
                 cmd_result.exit_code == 0
             ), f"Resetting the job user override via CLI failed: {cmd_result}"
 
-    @flaky(
-        max_runs=3, min_passes=1
-    )  # Flaky due to varying instance types causing race conditions with user reassignment
+    @pytest.mark.skip(
+        reason="Passes consistently on local but fails in Github. Will re-enable after investigation"
+    )
     def test_env_var_user_override(
         self,
         deadline_resources,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The new linux user override tests fail almost all the time on Github despite always passing with a local setup.

We should disable them to avoid more noise in the canaries.

We will be investigating the failed tests and enable when possible, it is suspected it may be an instance difference on local vs the github causing this.
### What was the solution? (How)
Disable the tests for now.
### What is the impact of this change?
No more noisy canaries for now.
### How was this change tested?
`hatch run fmt` hatch build
### Was this change documented?
no
### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*