### PR TITLE
chore(deps): update to deadline cloud 0.49, openjd-sessions 0.9, pywin32 308

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,14 @@ license = "Apache-2.0"
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.34.75",
-    "deadline == 0.48.*",
-    "openjd-sessions >= 0.8.4,< 0.9",
+    "deadline == 0.49.*",
+    "openjd-sessions >= 0.9.0,< 0.10",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "typing_extensions ~= 4.8",
     "psutil >= 5.9,< 7.0",
     "pydantic ~= 1.10.0",
-    "pywin32 == 306; platform_system == 'Windows'",
+    "pywin32 == 308; platform_system == 'Windows'",
     "requests == 2.32.*",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

New `deadline` library was released.

### What was the solution? (How)

Update `deadline` dependency to `0.49.*`
Also updated `pywin32` to `308` and `openjd-sessions` to `>=0.9.0, < 10` to match the `pywin32` update in `deadline`.

### What is the impact of this change?

Get new changes and keep up to date.

### How was this change tested?

Ran `hatch build`. Installed Worker Agent. Made sure it ran, was the correct version and the correct job_attachments versions.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*