### PR TITLE
test: re-enable linux job user override tests

### DIFF
--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -318,9 +318,6 @@ class TestLinuxJobUserOverride:
 
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
-    @pytest.mark.skip(
-        reason="Passes consistently on local but fails in Github. Will re-enable after investigation"
-    )
     def test_config_file_user_override(
         self,
         deadline_resources,
@@ -384,9 +381,6 @@ class TestLinuxJobUserOverride:
                 cmd_result.exit_code == 0
             ), f"Resetting the job user override via CLI failed: {cmd_result}"
 
-    @pytest.mark.skip(
-        reason="Passes consistently on local but fails in Github. Will re-enable after investigation"
-    )
     def test_env_var_user_override(
         self,
         deadline_resources,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The linux job user override tests were failing in the mainline canaries as the canaries had separate workers that were not cleaned up properly in the fleet. This caused the job user override tests to fail as the jobs were submitted to workers that did not have the override.

These tests were disabled for the meanwhile to investigate. We can re-enable them after the leftover worker instances have been terminated.
### What was the solution? (How)

Re-enable these tests
### What is the impact of this change?
The tests should be re-enabled and work properly.
### How was this change tested?
```

source .e2e_linux_infra.sh
hatch run e2e-test

```
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*