### PR TITLE
test: change test with disallow instance profile to create worker in right fleet

### DIFF
--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -318,9 +318,6 @@ class TestLinuxJobUserOverride:
 
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
-    @pytest.mark.skip(
-        reason="Passes consistently on local but fails in Github. Will re-enable after investigation"
-    )
     def test_config_file_user_override(
         self,
         deadline_resources,
@@ -384,9 +381,6 @@ class TestLinuxJobUserOverride:
                 cmd_result.exit_code == 0
             ), f"Resetting the job user override via CLI failed: {cmd_result}"
 
-    @pytest.mark.skip(
-        reason="Passes consistently on local but fails in Github. Will re-enable after investigation"
-    )
     def test_env_var_user_override(
         self,
         deadline_resources,

--- a/test/e2e/test_worker_config.py
+++ b/test/e2e/test_worker_config.py
@@ -36,7 +36,6 @@ class TestWorkerConfiguration:
             dataclasses.replace(
                 worker_config,
                 disallow_instance_profile="True",
-                fleet=deadline_resources.scaling_fleet,
             )
         )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Test for disallowing instance profile in worker was not creating the worker in the right fleet, causing unexpected behaviour.
### What was the solution? (How)
Create the worker in the default fleet.
### What is the impact of this change?
More robust tests
### How was this change tested?
```
# Linux
source .e2e_linux_infra.sh
hatch run e2e-test

# Windows
source .e2e_windows_infra.sh
hatch run e2e-test

```
### Was this change documented?
No
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*