### PR TITLE
test: simplify test fixtures

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,7 +1,8 @@
 backoff == 2.2.*
 coverage[toml] ~= 7.6
 coverage-conditional-plugin == 0.9.*
-deadline-cloud-test-fixtures == 0.17.*
+# The fixture code relies on a bugfix in 0.17.1
+deadline-cloud-test-fixtures >= 0.17.1, == 0.17.*
 flaky == 3.8.*
 pytest ~= 8.3
 pytest-cov == 5.0.*

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,23 +1,26 @@
 # Cross OS E2E Tests
 
-Tests designed to work with both Linux and Windows workers should use the `operating_system` parameter to differentiate differences between operating systems.
+Tests designed to cover Linux and Windows workers should use the `operating_system` fixture to for conditional testing logic between operating systems. The fixture uses the value of the `OPERATING_SYSTEM` environment variable and its value should be either `linux` or `windows`.
 
-Export the `OPERATING_SYSTEM` environment variable to either "linux" or "windows", depending on the OS of the worker that you would like to test.
+The `OPERATING_SYSTEM` environment variable is setup both in CI configuration and developer scripting (see [Running Worker Agent E2E Tests](../../DEVELOPMENT.md#running-worker-agent-e2e-tests)).
 
 # OS Specific Tests
-Use the `mark.skipif` parameter to differentiate between operating systems for os specific tests.
-```
+Use the `mark.skipif` parameter to differentiate between operating systems for os specific tests. Decorators are evaluated at import time and cannot use fixtures for their conditions.Instead, use the `OPERATING_SYSTEM` environment variable:
+
+```py
+# Linux-specific test
 @pytest.mark.skipif(
-        os.environ["OPERATING_SYSTEM"] == "windows",
-        reason="Linux specific test",
-    )
+    os.environ["OPERATING_SYSTEM"] != "linux",
+    reason="Linux specific test",
+)
 def test_linux_behaviour() -> None:
     ...
 
+# Windows-specific test
 @pytest.mark.skipif(
-        os.environ["OPERATING_SYSTEM"] == "linux",
-        reason="Windows specific test",
-    )
+    os.environ["OPERATING_SYSTEM"] != "windows",
+    reason="Windows specific test",
+)
 def test_windows_behaviour() -> None:
     ...
 ```

--- a/test/e2e/test_credential_handling.py
+++ b/test/e2e/test_credential_handling.py
@@ -17,7 +17,6 @@ from deadline_test_fixtures import CommandResult, DeadlineWorkerConfiguration, E
     os.environ["OPERATING_SYSTEM"] == "windows",
     reason="Linux specific test",
 )
-@pytest.mark.parametrize("operating_system", ["linux"], indirect=True)
 def test_access_worker_credential_file_from_job(
     session_worker: EC2InstanceWorker,
     worker_config: DeadlineWorkerConfiguration,

--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -17,7 +17,6 @@ LOG = logging.getLogger(__name__)
     os.environ["OPERATING_SYSTEM"] == "windows",
     reason="Linux specific test",
 )
-@pytest.mark.parametrize("operating_system", ["linux"], indirect=True)
 class TestInstaller:
     def test_installer_shutdown_permission(
         self,

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -37,7 +37,6 @@ from e2e.utils import wait_for_job_output, submit_sleep_job, submit_custom_job
 LOG = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize("operating_system", [os.environ["OPERATING_SYSTEM"]], indirect=True)
 class TestJobSubmission:
     def test_success(
         self,

--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -30,7 +30,6 @@ LOG = logging.getLogger(__name__)
     os.environ["OPERATING_SYSTEM"] == "linux",
     reason="Windows Specific Job User Override Tests.",
 )
-@pytest.mark.parametrize("operating_system", ["windows"], indirect=True)
 class TestWindowsJobUserOverride:
     @staticmethod
     def submit_whoami_job(
@@ -238,12 +237,10 @@ class TestWindowsJobUserOverride:
         ), f"Failed to unset DEADLINE_WORKER_WINDOWS_JOB_USER: {cmd_result}"
 
 
-@pytest.mark.usefixtures("operating_system")
 @pytest.mark.skipif(
     os.environ["OPERATING_SYSTEM"] == "windows",
     reason="Linux specific Job User Override tests",
 )
-@pytest.mark.parametrize("operating_system", ["linux"], indirect=True)
 class TestLinuxJobUserOverride:
     @staticmethod
     def submit_whoami_job(

--- a/test/e2e/test_worker_config.py
+++ b/test/e2e/test_worker_config.py
@@ -9,9 +9,7 @@ from time import sleep
 from typing import Any, Callable, Optional
 import backoff
 import boto3
-import pytest
 from deadline_test_fixtures import DeadlineClient, EC2InstanceWorker, DeadlineWorkerConfiguration
-import pytest
 import dataclasses
 from e2e.utils import submit_custom_job, submit_sleep_job
 from e2e.conftest import DeadlineResources
@@ -19,7 +17,6 @@ from e2e.conftest import DeadlineResources
 LOG = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize("operating_system", [os.environ["OPERATING_SYSTEM"]], indirect=True)
 class TestWorkerConfiguration:
 
     def test_worker_requires_no_instance_profile(

--- a/test/e2e/test_worker_status.py
+++ b/test/e2e/test_worker_status.py
@@ -16,7 +16,6 @@ import backoff
 LOG = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize("operating_system", [os.environ["OPERATING_SYSTEM"]], indirect=True)
 class TestWorkerStatus:
 
     @pytest.mark.skipif(


### PR DESCRIPTION
Depends on release of aws-deadline/deadline-cloud-test-fixtures#164

### What was the problem/requirement? (What/Why)

1.  The worker agent end-to-end tests had overridden the `worker_config` fixture from `deadline-cloud-test-fixtures` to work around bugs and enhance its functionality. This bug has been fixed upstream (see aws-deadline/deadline-cloud-test-fixtures#164)

2.  The worker agent end-to-end tests had used a combination of:

    ```py
    pytest.mark.parametrize("operating_system", ["linux"], indirect=True)
    pytest.mark.skipif(os.environ["OPERATING_SYSTEM"] == "windows")
    ```

    These are redundant. We should not need to use both of the above for each test case.
    
### What was the solution? (How)

1. Modify the `worker_config` fixture override to inherit the value from `deadline-cloud-test-fixture` but modify only the parts necessary
2. Modify the `operating_system` fixture to take its value from the `OPERATING_SYSTEM` environment variable

### What is the impact of this change?

1.  There is less duplication of the `worker_config` fixture from the upstream `deadline-cloud-test-fixtures` package and we do not have to maintain synchronization of their logic
2.  Tests are simpler to write and do not need a combination of pytest parametrization and conditional skipping. Test authors only need to use test skipping

### How was this change tested?

1.  Setup the environment with `hatch env create`
2. Installed the `mainline` version of `deadline-cloud-test-fixtures` (includes aws-deadline/deadline-cloud-test-fixtures#164) into the hatch env:

    ```sh
    $ hatch shell
    (deadline-cloud-worker-agent) $ pip install git+https://github.com/aws-deadline/deadline-cloud-test-fixtures.git
    ```
4.  Ran the end-to-end tests.
    *   Results pending...

### Was this change documented?

Yes, updated `test/e2e/README.md` with updated documentation for writing os-specific tests.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*