### PR TITLE
feat: configurable session root directory

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -163,15 +163,24 @@ IAM"][iam-security-best-practices] when handling worker AWS credentials files.
 
 [aws-config-credentials-path-override]: https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html#file-location-change
 
-## Session directories
+## Session Directories
 
-The worker agent creates a session directory for each worker session it runs. The session
-directories are created in a platform-specific path:
+The worker agent creates a unique session directory for each worker session it runs. The session
+directories are created under a configurable root directory. This can be configured by supplying a
+`--session-root-dir <SESSION_ROOT_DIR>` argument to `install-deadline-worker`. If not specified,
+the platform-specific defaults are:
 
-| Platform | Session directory path |
+| Platform | Default session root directory |
 | --- | --- |
-| POSIX | `/sessions/<SESSION_ID>` |
-| Windows | `C:\ProgramData\Amazon\OpenJD\<SESSION_ID>` |
+| POSIX | `/sessions` |
+| Windows | `C:\ProgramData\Amazon\OpenJD` |
+
+Session directories are created as children of the session root directory. The directories begin
+with the session ID, with trailing random characters:
+
+```
+<SESSION_ROOT_DIR>/<SESSION_ID>_a159c9
+```
 
 These directories are populated by the worker agent with files created to run the session. This
 includes:

--- a/src/deadline_worker_agent/config/__main__.py
+++ b/src/deadline_worker_agent/config/__main__.py
@@ -41,6 +41,9 @@ class ParsedArguments(argparse.Namespace):
     """A Windows username to override the queue jobRunAs configuration. If False, then no
     modification is made. If None, then the setting is unset."""
 
+    session_root_dir: str | None = None
+    """Path to the parent directory where the worker agent creates per-session subdirectories under"""
+
 
 def create_argument_parser() -> argparse.ArgumentParser:
     """Creates the argparse ArgumentParser for the deadline_worker_agent.config module"""
@@ -61,6 +64,12 @@ def create_argument_parser() -> argparse.ArgumentParser:
         "--fleet-id",
         help="The unique identifier for the Deadline Cloud fleet",
         required=False,
+    )
+    worker_group.add_argument(
+        "--session-root-dir",
+        help="The parent directory that worker agent creates per-session subdirectories under",
+        required=False,
+        type=str,
     )
 
     aws_group = parser.add_argument_group("AWS", "Settings related to AWS and EC2 hosts")
@@ -193,6 +202,13 @@ def args_to_setting_modifications(parsed_args: ParsedArguments) -> list[SettingM
             raise NotImplementedError(
                 f"Unexpected value for windows_job_user: {parsed_args.windows_job_user}"
             )
+    if parsed_args.session_root_dir is not None:
+        settings_to_modify.append(
+            SettingModification(
+                setting=ModifiableSetting.SESSION_ROOT_DIR,
+                value=parsed_args.session_root_dir,
+            )
+        )
 
     return settings_to_modify
 

--- a/src/deadline_worker_agent/config/cli_args.py
+++ b/src/deadline_worker_agent/config/cli_args.py
@@ -26,6 +26,7 @@ class ParsedCommandLineArguments(Namespace):
     host_metrics_logging: bool | None = None
     host_metrics_logging_interval_seconds: float | None = None
     structured_logs: bool | None = None
+    session_root_dir: Path | None = None
 
 
 def get_argument_parser() -> ArgumentParser:
@@ -151,5 +152,11 @@ def get_argument_parser() -> ArgumentParser:
         action="store_const",
         const=True,
         default=None,
+    )
+    parser.add_argument(
+        "--session-root-dir",
+        help="Path to the directory where session directories are created under.",
+        default=None,
+        type=Path,
     )
     return parser

--- a/src/deadline_worker_agent/config/config.py
+++ b/src/deadline_worker_agent/config/config.py
@@ -87,6 +87,8 @@ class Configuration:
     """Whether to retain the OpenJD's session directory on completion"""
     structured_logs: bool
     """Whether or not the Worker Agent logs are structured logs."""
+    session_root_dir: Path
+    """Path to the root directory where worker session directories are created under"""
 
     # Used to optimize the memory allocation and attribute lookup speed. Tells python to not create a dict
     # for the attributes.
@@ -109,6 +111,7 @@ class Configuration:
         "host_metrics_logging_interval_seconds",
         "retain_session_dir",
         "structured_logs",
+        "session_root_dir",
     )
 
     def __init__(
@@ -156,6 +159,8 @@ class Configuration:
             settings_kwargs["retain_session_dir"] = parsed_cli_args.retain_session_dir
         if parsed_cli_args.structured_logs is not None:
             settings_kwargs["structured_logs"] = parsed_cli_args.structured_logs
+        if parsed_cli_args.session_root_dir is not None:
+            settings_kwargs["session_root_dir"] = parsed_cli_args.session_root_dir.absolute()
 
         settings = WorkerSettings(**settings_kwargs)
 
@@ -207,6 +212,7 @@ class Configuration:
         self.host_metrics_logging_interval_seconds = settings.host_metrics_logging_interval_seconds
         self.retain_session_dir = settings.retain_session_dir
         self.structured_logs = settings.structured_logs
+        self.session_root_dir = settings.session_root_dir
 
         self._validate()
 

--- a/src/deadline_worker_agent/config/config_file.py
+++ b/src/deadline_worker_agent/config/config_file.py
@@ -113,6 +113,20 @@ To prevent the worker agent from shutting down the host when being told to stop,
 line below:
 """.lstrip(),
     )
+    SESSION_ROOT_DIR = ModifiableSettingData(
+        setting_name="session_root_dir",
+        table_name="worker",
+        preceding_comment="""
+The session root directory is a parent directory where worker agent creates per-session
+subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
+variable is set or the --session-root-dir command-line argument is specified.
+
+The default session root directory on POSIX systems is "/sessions" and on Windows systems is
+"C:\ProgramData\Amazon\OpenJD".
+
+Uncomment the line below and replace the value with your desired session root directory:
+""".lstrip(),
+    )
     WINDOWS_JOB_USER = ModifiableSettingData(
         setting_name="windows_job_user",
         table_name="os",

--- a/src/deadline_worker_agent/config/config_file.py
+++ b/src/deadline_worker_agent/config/config_file.py
@@ -149,6 +149,7 @@ class WorkerConfigSection(BaseModel):
     fleet_id: Optional[str] = Field(regex=r"^fleet-[a-z0-9]{32}$", default=None)
     cleanup_session_user_processes: bool = True
     worker_persistence_dir: Optional[Path] = None
+    session_root_dir: Optional[Path] = None
 
 
 class AwsConfigSection(BaseModel):
@@ -394,6 +395,8 @@ class ConfigFile(BaseModel):
             output_settings["fleet_id"] = self.worker.fleet_id
         if self.worker.worker_persistence_dir is not None:
             output_settings["worker_persistence_dir"] = self.worker.worker_persistence_dir
+        if self.worker.session_root_dir is not None:
+            output_settings["session_root_dir"] = self.worker.session_root_dir
         if self.aws.profile is not None:
             output_settings["profile"] = self.aws.profile
         if self.aws.allow_ec2_instance_profile is not None:

--- a/src/deadline_worker_agent/config/settings.py
+++ b/src/deadline_worker_agent/config/settings.py
@@ -26,6 +26,11 @@ DEFAULT_WINDOWS_WORKER_PERSISTENCE_DIR = Path(
     os.path.expandvars(r"%PROGRAMDATA%/Amazon/Deadline/Cache")
 )
 
+DEFAULT_POSIX_SESSION_ROOT_DIR = Path("/sessions")
+DEFAULT_WINDOWS_SESSION_ROOT_DIR: Path = (
+    Path(os.getenv("PROGRAMDATA", "C:\\ProgramData")) / "Amazon" / "OpenJD"
+)
+
 
 class WorkerSettings(BaseSettings):
     """Model class for the worker settings. This defines all of the fields and their validation as
@@ -116,6 +121,9 @@ class WorkerSettings(BaseSettings):
     host_metrics_logging_interval_seconds: float = 60
     retain_session_dir: bool = False
     structured_logs: bool = False
+    session_root_dir: Path = (
+        DEFAULT_WINDOWS_SESSION_ROOT_DIR if os.name == "nt" else DEFAULT_POSIX_SESSION_ROOT_DIR
+    )
 
     class Config:
         fields = {
@@ -144,6 +152,7 @@ class WorkerSettings(BaseSettings):
             },
             "retain_session_dir": {"env": "DEADLINE_WORKER_RETAIN_SESSION_DIR"},
             "structured_logs": {"env": "DEADLINE_WORKER_STRUCTURED_LOGS"},
+            "session_dir_root": {"env": "DEADLINE_WORKER_SESSION_ROOT_DIR"},
         }
 
         @classmethod

--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -10,6 +10,11 @@ import requests
 import sys
 import sysconfig
 
+from deadline_worker_agent.config.settings import (
+    DEFAULT_POSIX_SESSION_ROOT_DIR,
+    DEFAULT_WINDOWS_SESSION_ROOT_DIR,
+)
+
 
 if sys.platform == "win32":
     from deadline_worker_agent.installer.win_installer import (
@@ -70,7 +75,7 @@ def install() -> None:
         sys.exit(1)
 
     arg_parser = get_argument_parser()
-    args = arg_parser.parse_args(namespace=ParsedCommandLineArguments)
+    args = arg_parser.parse_args(namespace=ParsedCommandLineArguments())
     scripts_path = Path(sysconfig.get_path("scripts"))
 
     if args.region is None:
@@ -91,6 +96,7 @@ def install() -> None:
             parser=arg_parser,
             grant_required_access=args.grant_required_access,
             allow_ec2_instance_profile=not args.disallow_instance_profile,
+            session_root_dir=args.session_root_dir,
         )
         if args.user:
             installer_args.update(user_name=args.user)
@@ -124,6 +130,8 @@ def install() -> None:
             str(scripts_path),
             "--python-interpreter-path",
             sys.executable,
+            "--session-root-dir",
+            str(args.session_root_dir),
         ]
         if args.vfs_install_path:
             cmd += ["--vfs-install-path", args.vfs_install_path]
@@ -169,6 +177,7 @@ class ParsedCommandLineArguments(Namespace):
     grant_required_access: bool
     disallow_instance_profile: bool
     windows_job_user: Optional[str] = None
+    session_root_dir: Path
 
 
 def get_argument_parser() -> ArgumentParser:  # pragma: no cover
@@ -258,6 +267,16 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
         ),
         action="store_true",
         default=False,
+    )
+    parser.add_argument(
+        "--session-root-dir",
+        help="The root directory under which the worker agent creates session directories",
+        type=Path,
+        default=(
+            str(DEFAULT_WINDOWS_SESSION_ROOT_DIR)
+            if sys.platform == "win32"
+            else str(DEFAULT_POSIX_SESSION_ROOT_DIR)
+        ),  # pragma: nocover
     )
 
     if sys.platform == "win32":

--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -48,6 +48,7 @@ telemetry_opt_out="no"
 warning_lines=()
 vfs_install_path="unset"
 python_interpreter_path="unset"
+session_root_dir="/sessions"
 
 usage()
 {
@@ -106,6 +107,8 @@ usage()
     echo "        agent makes requests to the EC2 instance meta-data service (IMDS) to check for an instance profile. "
     echo "        If an instance profile is detected, the worker agent will stop and exit. When this is not provided, "
     echo "        the worker agent no longer performs these checks, allowing it to run with an EC2 instance profile."
+    echo "    --session-root-dir SESSION_ROOT_DIR"
+    echo "        The root directory under which the worker agent will create session directories."
 
     exit 2
 }
@@ -131,7 +134,7 @@ validate_deadline_id() {
 }
 
 # Validate arguments
-PARSED_ARGUMENTS=$(getopt -n install.sh --longoptions farm-id:,fleet-id:,region:,user:,group:,scripts-path:,python-interpreter-path:,vfs-install-path:,start,allow-shutdown,no-install-service,telemetry-opt-out,disallow-instance-profile -- "y" "$@")
+PARSED_ARGUMENTS=$(getopt -n install.sh --longoptions farm-id:,fleet-id:,region:,user:,group:,scripts-path:,python-interpreter-path:,vfs-install-path:,session-root-dir:,start,allow-shutdown,no-install-service,telemetry-opt-out,disallow-instance-profile -- "y" "$@")
 VALID_ARGUMENTS=$?
 if [ "${VALID_ARGUMENTS}" != "0" ]; then
     usage
@@ -152,6 +155,7 @@ do
     --scripts-path)                 scripts_path="$2"               ; shift 2 ;;
     --python-interpreter-path)      python_interpreter_path="$2"    ; shift 2 ;;
     --vfs-install-path)             vfs_install_path="$2"           ; shift 2 ;;
+    --session-root-dir)             session_root_dir="$2"           ; shift 2 ;;
     --allow-shutdown)               allow_shutdown="yes"            ; shift   ;;
     --disallow-instance-profile)    disallow_instance_profile="yes" ; shift   ;;
     --no-install-service)           no_install_service="yes"        ; shift   ;;
@@ -276,6 +280,7 @@ echo "Worker agent user: ${wa_user}"
 echo "Worker agent group: ${wa_group}"
 echo "Worker job group: ${job_group}"
 echo "Scripts path: ${scripts_path}"
+echo "Session root directory: ${session_root_dir}"
 echo "Worker agent program path: ${worker_agent_program}"
 echo "Deadline client program path: ${client_library_program}"
 echo "Allow worker agent shutdown: ${allow_shutdown}"
@@ -382,10 +387,12 @@ if [ -f /var/lib/deadline/worker.json ]; then
 fi
 echo "Done provisioning persistence directory (/var/lib/deadline)"
 
-echo "Provisioning root directory for OpenJD Sessions (/sessions)"
-mkdir -p /sessions
-chown "${wa_user}:${job_group}" /sessions
-chmod 755 /sessions
+# Provision session directory
+echo "Provisioning root directory for OpenJD Sessions (${session_root_dir})"
+mkdir -p "${session_root_dir}"
+chown "${wa_user}:${job_group}" "${session_root_dir}"
+chmod 755 "${session_root_dir}"
+echo "Done provisioning root directory for OpenJD Sessions (${session_root_dir})"
 
 echo "Provisioning configuration directory (/etc/amazon/deadline)"
 mkdir -p /etc/amazon/deadline
@@ -420,7 +427,8 @@ fi
     --farm-id "${farm_id}"                  \
     --fleet-id "${fleet_id}"                \
     "${allow_ec2_instance_profile_flag}"    \
-    "${shutdown_on_stop_flag}"
+    "${shutdown_on_stop_flag}"              \
+    --session-root-dir "${session_root_dir}"
 
 if ! [[ "${no_install_service}" == "yes" ]]; then
     # Set up the service

--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -317,6 +317,7 @@ def update_config_file(
     allow_ec2_instance_profile: bool,
     shutdown_on_stop: Optional[bool] = None,
     windows_job_user: Optional[str] = None,
+    session_root_dir: Optional[Path] = None,
 ) -> None:
     """
     Updates the worker configuration file, creating it from the example if it does not exist.
@@ -367,6 +368,13 @@ def update_config_file(
                 value=shutdown_on_stop,
             )
         )
+    if session_root_dir is not None:
+        settings_to_modify.append(
+            SettingModification(
+                setting=ModifiableSetting.SESSION_ROOT_DIR,
+                value=str(session_root_dir),
+            )
+        )
 
     updated_keys = [sm.setting.value.setting_name for sm in settings_to_modify]
 
@@ -379,7 +387,11 @@ def update_config_file(
     logging.info(f"Done configuring {updated_keys} in {config_path}")
 
 
-def provision_directories(agent_username: str) -> WorkerAgentDirectories:
+def provision_directories(
+    *,
+    agent_username: str,
+    session_root_dir: Path,
+) -> WorkerAgentDirectories:
     """
     Creates all required directories for Deadline Worker Agent.
     This function creates the following directories:
@@ -391,6 +403,8 @@ def provision_directories(agent_username: str) -> WorkerAgentDirectories:
 
     Parameters
         agent_username(str): Worker Agent's username used for setting the permission for the directories
+        session_root_dir(Path): Path to the parent directory where the worker agent will create session directories
+            under
 
     Returns
         WorkerAgentDirectories: all directories created in the function
@@ -429,6 +443,18 @@ def provision_directories(agent_username: str) -> WorkerAgentDirectories:
     logging.info(f"Provisioning config directory ({deadline_config_subdir})")
     os.makedirs(deadline_config_subdir, exist_ok=True)
     logging.info(f"Done provisioning config directory ({deadline_config_subdir})")
+
+    logging.info(f"Porvisioning session root directory ({session_root_dir})")
+    os.makedirs(session_root_dir, exist_ok=True)
+    _set_windows_permissions(
+        path=session_root_dir,
+        user=agent_username,
+        user_permission=FileSystemPermissionEnum.FULL_CONTROL,
+        group="Administrators",
+        group_permission=FileSystemPermissionEnum.FULL_CONTROL,
+        agent_user_permission=None,
+    )
+    logging.info(f"Done provisioning session root directory ({session_root_dir})")
 
     return WorkerAgentDirectories(
         deadline_dir=Path(deadline_dir),
@@ -772,6 +798,7 @@ def start_windows_installer(
     region: str,
     allow_shutdown: bool,
     parser: ArgumentParser,
+    session_root_dir: Path,
     user_name: str = DEFAULT_WA_USER,
     password: Optional[str] = None,
     group_name: str = DEFAULT_JOB_GROUP,
@@ -851,6 +878,7 @@ def start_windows_installer(
         f"Region: {region}\n"
         f"Worker agent user: {user_name}\n"
         f"Worker job group: {group_name}\n"
+        f"Session root directory: {session_root_dir}\n"
         f"Allow worker agent shutdown: {allow_shutdown}\n"
         f"Install Windows service: {install_service}\n"
         f"Start service: {start_service}\n"
@@ -946,7 +974,7 @@ def start_windows_installer(
         add_user_to_group(group_name, user_name)
 
     # Create directories and configure their permissions
-    agent_dirs = provision_directories(user_name)
+    agent_dirs = provision_directories(agent_username=user_name, session_root_dir=session_root_dir)
     update_config_file(
         deadline_config_sub_directory=str(agent_dirs.deadline_config_subdir),
         farm_id=farm_id,
@@ -956,6 +984,7 @@ def start_windows_installer(
         shutdown_on_stop=allow_shutdown,
         allow_ec2_instance_profile=allow_ec2_instance_profile,
         windows_job_user=windows_job_user,
+        session_root_dir=session_root_dir,
     )
 
     if telemetry_opt_out:

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -35,6 +35,18 @@
 # The following is the default worker persistence dir on POSIX systems.
 # worker_persistence_dir = "/var/lib/deadline"
 
+
+# The session root directory is a parent directory where worker agent creates per-session
+# subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
+# variable is set or the --session-root-dir command-line argument is specified.
+#
+# The default session root directory on POSIX systems is "/sessions" and on Windows systems is
+# "C:\ProgramData\Amazon\OpenJD".
+#
+# Uncomment the line below and replace the value with your desired session root directory:
+#
+# session_root_dir = "/sessions"
+
 [aws]
 
 # The worker agent requires initial AWS credentials in order to bootstrap the worker. Bootstrapping

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -193,6 +193,7 @@ class WorkerScheduler:
     _worker_persistence_dir: Path
     _worker_logs_dir: Path | None
     _retain_session_dir: bool
+    _session_root_dir: Path
 
     # Map from queueId -> QueueAwsCredentials.
     _queue_aws_credentials: dict[str, QueueAwsCredentials]
@@ -212,6 +213,7 @@ class WorkerScheduler:
         cleanup_session_user_processes: bool,
         worker_persistence_dir: Path,
         worker_logs_dir: Path | None,
+        session_root_dir: Path,
         retain_session_dir: bool = False,
         stop: Event | None = None,
     ) -> None:
@@ -249,6 +251,7 @@ class WorkerScheduler:
         self._worker_logs_dir = worker_logs_dir
         self._retain_session_dir = retain_session_dir
         self._windows_credentials_resolver: Optional[WindowsCredentialsResolver]
+        self._session_root_dir = session_root_dir
 
         if os.name == "nt" and not (
             self._job_run_as_user_override.job_user or self._job_run_as_user_override.run_as_agent
@@ -1116,6 +1119,7 @@ class WorkerScheduler:
                 retain_session_dir=self._retain_session_dir,
                 action_update_callback=self._handle_session_action_update,
                 action_update_lock=self._action_update_lock,
+                session_root_dir=self._session_root_dir,
             )
 
             def run_session(

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -97,7 +97,6 @@ OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS: dict[
     ActionState.SUCCESS: "SUCCEEDED",
     ActionState.TIMEOUT: "FAILED",
 }
-DEFAULT_POSIX_OPENJD_SESSION_DIR = Path("/sessions")
 TIME_DELTA_ZERO = timedelta()
 
 # During a SYNC_INPUT_JOB_ATTACHMENTS session action, the transfer rate is periodically reported through
@@ -192,6 +191,7 @@ class Session:
         job_details: JobDetails,
         action_update_callback: Callable[[SessionActionStatus], None],
         action_update_lock: RLock,
+        session_root_dir: Path,
     ) -> None:
         self._id = id
         self._action_update_lock = action_update_lock
@@ -210,10 +210,6 @@ class Session:
         def openjd_session_action_callback(session_id: str, action_status: ActionStatus) -> None:
             self.update_action(action_status)
 
-        session_root_directory: Optional[Path] = None
-        if os.name == "posix":
-            session_root_directory = DEFAULT_POSIX_OPENJD_SESSION_DIR
-
         self._session = OPENJDSession(
             session_id=self._id,
             job_parameter_values=self._job_details.parameters,
@@ -222,7 +218,7 @@ class Session:
             user=self._os_user,
             callback=openjd_session_action_callback,
             os_env_vars=self._env,
-            session_root_directory=session_root_directory,
+            session_root_directory=session_root_dir,
         )
 
         self._queue = queue

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -179,6 +179,7 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
                 host_metrics_logging_interval_seconds=config.host_metrics_logging_interval_seconds,
                 retain_session_dir=config.retain_session_dir,
                 stop=stop,
+                session_root_dir=config.session_root_dir,
             )
             try:
                 worker_sessions.run()

--- a/src/deadline_worker_agent/windows/win_service.py
+++ b/src/deadline_worker_agent/windows/win_service.py
@@ -8,7 +8,7 @@ import win32serviceutil
 import win32service
 import servicemanager
 
-from deadline_worker_agent.startup.entrypoint import entrypoint
+from ..startup.entrypoint import entrypoint
 
 
 logger = logging.getLogger(__name__)

--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -89,6 +89,7 @@ class Worker:
         cleanup_session_user_processes: bool,
         worker_persistence_dir: Path,
         worker_logs_dir: Path | None,
+        session_root_dir: Path,
         host_metrics_logging: bool,
         host_metrics_logging_interval_seconds: float | None = None,
         retain_session_dir: bool = False,
@@ -113,6 +114,7 @@ class Worker:
             worker_logs_dir=worker_logs_dir,
             retain_session_dir=retain_session_dir,
             stop=stop,
+            session_root_dir=session_root_dir,
         )
         self._stop = stop or Event()
         self._boto_session = boto_session

--- a/test/e2e/test_worker_config.py
+++ b/test/e2e/test_worker_config.py
@@ -3,14 +3,24 @@
 This test module contains tests that verify the Worker agent's behavior by creating the Worker with non-default configuration settings,
 and making sure that the behavior and outputs of the Worker is that of what we expect.
 """
-import logging
-import os
+
 from time import sleep
 from typing import Any, Callable, Optional
 import backoff
 import boto3
-from deadline_test_fixtures import DeadlineClient, EC2InstanceWorker, DeadlineWorkerConfiguration
+import botocore
 import dataclasses
+import logging
+import os
+import re
+
+from deadline_test_fixtures import (
+    DeadlineClient,
+    DeadlineWorkerConfiguration,
+    EC2InstanceWorker,
+    OperatingSystem,
+)
+
 from e2e.utils import submit_custom_job, submit_sleep_job
 from e2e.conftest import DeadlineResources
 
@@ -184,3 +194,66 @@ class TestWorkerConfiguration:
             assert instance_status["Name"] in ["stopped", "stopping"]
 
         check_instance_stopping()
+
+    def test_session_root_dir(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        worker_config: DeadlineWorkerConfiguration,
+        function_worker_factory: Callable[[DeadlineWorkerConfiguration], EC2InstanceWorker],
+        operating_system: OperatingSystem,
+    ) -> None:
+        """Tests that when a session root directory is configured, that session directories
+        are created under this root directory."""
+
+        # GIVEN
+        logs_client = boto3.client(
+            "logs",
+            config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+        )
+        session_root_dir: str
+        run_script: str
+
+        if operating_system.is_amazon_linux():
+            run_script = """
+#!/usr/bin/bash
+
+set -euo pipefail
+
+pwd
+""".lstrip()
+            session_root_dir = "/mysessionroot"
+        elif operating_system.is_windows():
+            run_script = """
+$ErrorActionPreference = 'Stop'
+
+(Get-Item .).FullName
+"""
+            session_root_dir = "C:\\Sessions"
+        else:
+            raise NotImplementedError(f"Test not implemented for {operating_system}")
+
+        function_worker_factory(
+            dataclasses.replace(worker_config, session_root_dir=session_root_dir)
+        )
+
+        # WHEN
+        job = submit_custom_job(
+            "Test Job with worker local session logs off",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+            run_script=run_script,
+        )
+
+        # THEN
+        job.wait_until_complete(client=deadline_client)
+        assert job.task_run_status == "SUCCEEDED"
+        job.assert_single_task_log_contains(
+            deadline_client=deadline_client,
+            logs_client=logs_client,
+            expected_pattern=re.compile(
+                f"^{re.escape(session_root_dir)}[\\\\/]session-[a-f0-9]{{32}}.*$", re.MULTILINE
+            ),
+            assert_fail_msg=f"Session root directory ({session_root_dir}) not applied",
+        )

--- a/test/integ/config/data/commented/session_root_dir/input.toml
+++ b/test/integ/config/data/commented/session_root_dir/input.toml
@@ -1,0 +1,12 @@
+[worker]
+
+# The session root directory is a parent directory where worker agent creates per-session
+# subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
+# variable is set or the --session-root-dir command-line argument is specified.
+#
+# The default session root directory on POSIX systems is "/sessions" and on Windows systems is
+# "C:\ProgramData\Amazon\OpenJD".
+#
+# Uncomment the line below and replace the value with your desired session root directory:
+#
+# session_root_dir = "/sessions"

--- a/test/integ/config/data/commented/session_root_dir/output.toml
+++ b/test/integ/config/data/commented/session_root_dir/output.toml
@@ -1,0 +1,12 @@
+[worker]
+
+# The session root directory is a parent directory where worker agent creates per-session
+# subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
+# variable is set or the --session-root-dir command-line argument is specified.
+#
+# The default session root directory on POSIX systems is "/sessions" and on Windows systems is
+# "C:\ProgramData\Amazon\OpenJD".
+#
+# Uncomment the line below and replace the value with your desired session root directory:
+#
+session_root_dir = "/custom-session-root"

--- a/test/integ/config/data/existing/session_root_dir/input.toml
+++ b/test/integ/config/data/existing/session_root_dir/input.toml
@@ -1,0 +1,12 @@
+[worker]
+
+# The session root directory is a parent directory where worker agent creates per-session
+# subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
+# variable is set or the --session-root-dir command-line argument is specified.
+#
+# The default session root directory on POSIX systems is "/sessions" and on Windows systems is
+# "C:\ProgramData\Amazon\OpenJD".
+#
+# Uncomment the line below and replace the value with your desired session root directory:
+#
+session_root_dir = "/sessions"

--- a/test/integ/config/data/existing/session_root_dir/output.toml
+++ b/test/integ/config/data/existing/session_root_dir/output.toml
@@ -1,0 +1,12 @@
+[worker]
+
+# The session root directory is a parent directory where worker agent creates per-session
+# subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
+# variable is set or the --session-root-dir command-line argument is specified.
+#
+# The default session root directory on POSIX systems is "/sessions" and on Windows systems is
+# "C:\ProgramData\Amazon\OpenJD".
+#
+# Uncomment the line below and replace the value with your desired session root directory:
+#
+session_root_dir = "/custom-session-root"

--- a/test/integ/config/data/missing/session_root_dir/input.toml
+++ b/test/integ/config/data/missing/session_root_dir/input.toml
@@ -1,0 +1,7 @@
+[worker]
+
+# Some prior content that should be preserved
+prior_setting_1 = 1
+
+# More content to preserve
+prior_setting_2 = "abc"  # and here's an inline comment

--- a/test/integ/config/data/missing/session_root_dir/output.toml
+++ b/test/integ/config/data/missing/session_root_dir/output.toml
@@ -1,0 +1,18 @@
+[worker]
+
+# Some prior content that should be preserved
+prior_setting_1 = 1
+
+# More content to preserve
+prior_setting_2 = "abc"  # and here's an inline comment
+
+
+# The session root directory is a parent directory where worker agent creates per-session
+# subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
+# variable is set or the --session-root-dir command-line argument is specified.
+#
+# The default session root directory on POSIX systems is "/sessions" and on Windows systems is
+# "C:\ProgramData\Amazon\OpenJD".
+#
+# Uncomment the line below and replace the value with your desired session root directory:
+session_root_dir = "/custom-session-root"

--- a/test/integ/config/data/unset/session_root_dir/input.toml
+++ b/test/integ/config/data/unset/session_root_dir/input.toml
@@ -1,0 +1,12 @@
+[worker]
+
+# The session root directory is a parent directory where worker agent creates per-session
+# subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
+# variable is set or the --session-root-dir command-line argument is specified.
+#
+# The default session root directory on POSIX systems is "/sessions" and on Windows systems is
+# "C:\ProgramData\Amazon\OpenJD".
+#
+# Uncomment the line below and replace the value with your desired session root directory:
+#
+session_root_dir = "/custom-session-root"

--- a/test/integ/config/data/unset/session_root_dir/output.toml
+++ b/test/integ/config/data/unset/session_root_dir/output.toml
@@ -1,0 +1,12 @@
+[worker]
+
+# The session root directory is a parent directory where worker agent creates per-session
+# subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
+# variable is set or the --session-root-dir command-line argument is specified.
+#
+# The default session root directory on POSIX systems is "/sessions" and on Windows systems is
+# "C:\ProgramData\Amazon\OpenJD".
+#
+# Uncomment the line below and replace the value with your desired session root directory:
+#
+# session_root_dir = "/custom-session-root"

--- a/test/integ/config/test_config_cli.py
+++ b/test/integ/config/test_config_cli.py
@@ -63,6 +63,15 @@ def cli_args_for_shutdown_on_stop(value: str | bool | None) -> list[str]:
         raise NotImplementedError(f"Unexpected value: {value}")
 
 
+def cli_args_for_session_root_dir(value: str | bool | None) -> list[str]:
+    if value is None:
+        return []
+    elif isinstance(value, str):
+        return ["--session-root-dir", value]
+    else:
+        raise NotImplementedError(f"Unexpected value: {value}")
+
+
 SETTING_TO_CLI_ARGS: dict[
     config_file.ModifiableSetting, Callable[[str | bool | None], list[str]]
 ] = {
@@ -71,6 +80,7 @@ SETTING_TO_CLI_ARGS: dict[
     config_file.ModifiableSetting.FLEET_ID: cli_args_for_fleet_id,
     config_file.ModifiableSetting.WINDOWS_JOB_USER: cli_args_for_windows_job_user,
     config_file.ModifiableSetting.SHUTDOWN_ON_STOP: cli_args_for_shutdown_on_stop,
+    config_file.ModifiableSetting.SESSION_ROOT_DIR: cli_args_for_session_root_dir,
 }
 
 

--- a/test/integ/windows/test_installer.py
+++ b/test/integ/windows/test_installer.py
@@ -5,14 +5,15 @@ import sys
 
 assert sys.platform == "win32"
 
-import pathlib
 import os
 import sys
 import typing
 import uuid
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from _pytest.tmpdir import TempPathFactory
 
 import win32api
 import win32con
@@ -116,7 +117,7 @@ def test_ensure_user_profile_exists(windows_user, windows_user_password):
 
     # THEN
     # Verify user profile was created by checking that the home directory exists
-    assert pathlib.Path(f"~{windows_user}").expanduser().exists()
+    assert Path(f"~{windows_user}").expanduser().exists()
 
 
 def delete_group(group_name: str) -> None:
@@ -242,7 +243,7 @@ def test_update_config_file_creates_backup(setup_example_config):
     assert os.path.isfile(backup_worker_config), "Backup of worker config file was not created"
 
 
-def verify_least_privilege(windows_user: str, path: pathlib.Path):
+def verify_least_privilege(windows_user: str, path: Path):
     builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, "Administrators")
     user_sid, _, _ = win32security.LookupAccountName(None, windows_user)
     sd = win32security.GetFileSecurity(
@@ -278,11 +279,13 @@ def verify_least_privilege(windows_user: str, path: pathlib.Path):
 
 def test_provision_directories(
     windows_user: str,
-    tmp_path: pathlib.Path,
+    tmp_path: Path,
+    tmp_path_factory: TempPathFactory,
 ):
     # GIVEN
     root_dir = tmp_path / "ProgramDataTest"
     root_dir.mkdir()
+    session_root_dir: Path = tmp_path_factory.mktemp("session_root")
     expected_dirs = WorkerAgentDirectories(
         deadline_dir=root_dir / "Amazon" / "Deadline",
         deadline_log_subdir=root_dir / "Amazon" / "Deadline" / "Logs",
@@ -304,7 +307,10 @@ def test_provision_directories(
 
     # WHEN
     with patch.dict(win_installer.os.environ, {"PROGRAMDATA": str(root_dir)}):
-        actual_dirs = provision_directories(windows_user)
+        actual_dirs = provision_directories(
+            agent_username=windows_user,
+            session_root_dir=session_root_dir,
+        )
 
     # THEN
     assert actual_dirs == expected_dirs
@@ -316,9 +322,11 @@ def test_provision_directories(
     verify_least_privilege(windows_user, actual_dirs.deadline_persistence_subdir)
     assert actual_dirs.deadline_config_subdir.exists()
     verify_least_privilege(windows_user, actual_dirs.deadline_config_subdir)
+    assert session_root_dir.exists()
+    verify_least_privilege(windows_user, session_root_dir)
 
 
-def test_update_deadline_client_config(tmp_path: pathlib.Path) -> None:
+def test_update_deadline_client_config(tmp_path: Path) -> None:
     # GIVEN
     deadline_client_config_path = tmp_path / "deadline_client_config"
     deadline_client_config_path.touch(mode=0o644, exist_ok=False)

--- a/test/unit/config/conftest.py
+++ b/test/unit/config/conftest.py
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+
+import pytest
+
+
+@pytest.fixture(
+    params=(
+        pytest.param("/foo", marks=pytest.mark.skipif(os.name == "nt", reason="POSIX-only test")),
+        pytest.param("/bar", marks=pytest.mark.skipif(os.name == "nt", reason="POSIX-only test")),
+        pytest.param(
+            "C:\\SessionDir1",
+            marks=pytest.mark.skipif(os.name != "nt", reason="Windows-only test"),
+        ),
+        pytest.param(
+            "C:\\SessionDir2",
+            marks=pytest.mark.skipif(os.name != "nt", reason="Windows-only test"),
+        ),
+    ),
+)
+def session_root_dir(request: pytest.FixtureRequest) -> str:
+    return request.param

--- a/test/unit/config/test_cli_args.py
+++ b/test/unit/config/test_cli_args.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 from argparse import ArgumentParser
+from pathlib import Path
 
 import pytest
 import os
@@ -43,6 +44,7 @@ class TestArgumentParser:
         assert result.verbose is None
         assert result.posix_job_user is None
         assert result.windows_job_user is None
+        assert result.session_root_dir is None
 
     @pytest.mark.parametrize(
         ["farm_id"],
@@ -175,3 +177,18 @@ class TestArgumentParser:
 
         # THEN
         assert result.windows_job_user == windows_job_user
+
+    def test_session_root_dir(
+        self,
+        arg_parser: ArgumentParser,
+        # defined in conftest.py in this dir
+        session_root_dir: str,
+    ) -> None:
+        # GIVEN
+        args = ["--session-root-dir", session_root_dir]
+
+        # WHEN
+        result = arg_parser.parse_args(args, namespace=cli_args_mod.ParsedCommandLineArguments())
+
+        # THEN
+        assert result.session_root_dir == Path(session_root_dir)

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -5,8 +5,8 @@
 from __future__ import annotations
 from contextlib import nullcontext
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-from typing import Any, Generator, List, Optional, cast
+from unittest.mock import ANY, MagicMock, patch
+from typing import Generator, List, Optional, cast
 import logging
 import pytest
 import os
@@ -42,6 +42,7 @@ def mock_worker_settings_cls() -> Generator[MagicMock, None, None]:
         "host_metrics_logging": True,
         "host_metrics_logging_interval_seconds": 10,
         "retain_session_dir": False,
+        "session_root_dir": Path("/sessions"),
     }
 
     class FakeWorkerSettings:
@@ -70,7 +71,7 @@ def parsed_args(
 
 @pytest.fixture(autouse=True)
 def arg_parser(
-    parsed_args: config_mod.ParsedCommandLineArguments,
+    parsed_args: ParsedCommandLineArguments,
 ) -> Generator[MagicMock, None, None]:
     """Fixture containing the mocked argument parser"""
     with patch.object(config_mod, "get_argument_parser") as get_argument_parser:
@@ -133,17 +134,13 @@ class TestLoad:
         config_mod.Configuration.load(args)
 
         # THEN
-        class IsEmptyParsedCommandLineArguments:
-            def __eq__(self, other: Any) -> bool:
-                return (
-                    isinstance(other, config_mod.ParsedCommandLineArguments)
-                    and other.profile is None
-                    and other.farm_id is None
-                    and other.fleet_id is None
-                    and other.verbose is None
-                )
-
-        parse_args.assert_called_with(args, namespace=IsEmptyParsedCommandLineArguments())
+        parse_args.assert_called_once_with(args, namespace=ANY)
+        namespace_arg = parse_args.call_args.kwargs["namespace"]
+        assert isinstance(namespace_arg, config_mod.ParsedCommandLineArguments)
+        assert namespace_arg.profile is None
+        assert namespace_arg.farm_id is None
+        assert namespace_arg.fleet_id is None
+        assert namespace_arg.verbose is None
 
     def test_uses_parsed_farm_id(self, parsed_args: config_mod.ParsedCommandLineArguments) -> None:
         """Tests that the farm ID is parsed from command-line arguments"""
@@ -399,6 +396,43 @@ class TestLoad:
         # THEN
         assert config.retain_session_dir == retain_session_dir
 
+    @pytest.mark.parametrize(
+        argnames="session_root_dir",
+        argvalues=(
+            pytest.param(
+                Path("/foo"),
+                marks=pytest.mark.skipif(os.name == "nt", reason="POSIX-speicifc test"),
+            ),
+            pytest.param(
+                Path("/bar"),
+                marks=pytest.mark.skipif(os.name == "nt", reason="POSIX-speicifc test"),
+            ),
+            pytest.param(
+                Path("C:\\foo"),
+                marks=pytest.mark.skipif(os.name != "nt", reason="POSIX-speicifc test"),
+            ),
+            pytest.param(
+                Path("C:\\bar"),
+                marks=pytest.mark.skipif(os.name != "nt", reason="POSIX-speicifc test"),
+            ),
+        ),
+    )
+    def test_uses_session_root_dir(
+        self,
+        parsed_args: config_mod.ParsedCommandLineArguments,
+        session_root_dir: Path,
+    ) -> None:
+        # GIVEN
+        parsed_args.session_root_dir = session_root_dir
+        parsed_args.farm_id = "farm_id"
+        parsed_args.fleet_id = "fleet_id"
+
+        # WHEN
+        config = config_mod.Configuration.load()
+
+        # THEN
+        assert config.session_root_dir == session_root_dir
+
 
 class TestInit:
     """Tests for Configuration.__init__"""
@@ -435,13 +469,15 @@ class TestInit:
         assert config.verbose == verbose
 
     def test_correct_default_paths(self) -> None:
-        """Tests that the Configuration has worker_persistence_dir and worker_credentials_dir
-        Path attributes that point to the correct default path:
+        """Tests that the Configuration has worker_persistence_dir, worker_credentials_dir,
+        worker_state_file, and session_root_dir Path attributes that point to the correct default
+        path:
 
         POSIX:
             worker_persistence_dir = /var/lib/deadline
             worker_credentials_dir = /var/lib/deadline/credentials
             worker_state_file = /var/lib/deadline/worker.json
+            session_root_dir = /sessions
         """
         # GIVEN
         cli_args = ParsedCommandLineArguments()
@@ -457,6 +493,7 @@ class TestInit:
         assert config.worker_persistence_dir == Path("/var/lib/deadline")
         assert config.worker_credentials_dir == Path("/var/lib/deadline/credentials")
         assert config.worker_state_file == Path("/var/lib/deadline/worker.json")
+        assert config.session_root_dir == Path("/sessions")
 
     def test_empty_fleet_id(self) -> None:
         """Tests when no `fleet_id` is supplied a `ConfigurationError` is raised"""
@@ -926,6 +963,35 @@ class TestInit:
             assert "retain_session_dir" not in call.kwargs
 
     @pytest.mark.parametrize(
+        argnames="session_root_dir",
+        argvalues=(
+            Path("/foo"),
+            Path("/bar"),
+            None,
+        ),
+    )
+    def test_session_root_dir_passed_to_settings_initializer(
+        self,
+        session_root_dir: Path | None,
+        parsed_args: ParsedCommandLineArguments,
+        mock_worker_settings_cls: MagicMock,
+    ) -> None:
+        # GIVEN
+        parsed_args.session_root_dir = session_root_dir
+
+        # WHEN
+        config_mod.Configuration(parsed_cli_args=parsed_args)
+
+        # THEN
+        mock_worker_settings_cls.assert_called_once()
+        call = mock_worker_settings_cls.call_args_list[0]
+
+        if session_root_dir is not None:
+            assert call.kwargs.get("session_root_dir") == session_root_dir.absolute()
+        else:
+            assert "session_root_dir" not in call.kwargs
+
+    @pytest.mark.parametrize(
         argnames=("posix_job_user_setting", "windows_job_user_setting"),
         argvalues=(
             pytest.param(
@@ -1102,11 +1168,7 @@ class TestLog:
         config.log(logger=logger)
 
         # THEN
-        class Any:
-            def __eq__(self, other: object) -> bool:
-                return True
-
-        logger_log_mock.assert_called_with(logging.DEBUG, Any())
+        logger_log_mock.assert_called_with(logging.DEBUG, ANY)
 
     def test_supplied_level(self) -> None:
         # GIVEN

--- a/test/unit/config/test_config_file.py
+++ b/test/unit/config/test_config_file.py
@@ -239,6 +239,22 @@ class TestWorkerConfigSection:
         # THEN
         WorkerConfigSection.parse_obj(worker_config_section_data)
 
+    def test_session_root_dir_valid(
+        self,
+        worker_config_section_data: dict[str, Any],
+        # defined in conftest.py in this dir
+        session_root_dir: str,
+    ) -> None:
+        """Asserts that a valid path to a session root directory is parsed as expected"""
+        # GIVEN
+        worker_config_section_data["session_root_dir"] = session_root_dir
+
+        # WHEN
+        parsed = WorkerConfigSection.parse_obj(worker_config_section_data)
+
+        # THEN
+        assert parsed.session_root_dir == Path(session_root_dir)
+
 
 class TestAwsConfigSection:
     def test_valid_inputs(

--- a/test/unit/config/test_settings.py
+++ b/test/unit/config/test_settings.py
@@ -172,6 +172,17 @@ FIELD_TEST_CASES: list[FieldTestCaseParams] = [
         expected_default=False,
         expected_default_factory_return_value=None,
     ),
+    FieldTestCaseParams(
+        field_name="session_root_dir",
+        expected_type=Path,
+        expected_required=False,
+        expected_default=(
+            Path("/sessions")
+            if os.name == "posix"
+            else Path(os.getenv("PROGRAMDATA", "C:\\ProgramData")) / "Amazon" / "OpenJD"
+        ),
+        expected_default_factory_return_value=None,
+    ),
 ]
 
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 import os
 import secrets
@@ -112,6 +113,14 @@ def disallow_instance_profile() -> bool:
 @pytest.fixture
 def windows_job_user() -> str:
     return "job-user"
+
+
+@pytest.fixture
+def session_root_dir() -> Path:
+    if os.name == "nt":
+        return Path("C:\\Sessions\\Root")
+    else:
+        return Path("/my/session/root")
 
 
 @pytest.fixture

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -140,6 +140,7 @@ def parsed_args(
     grant_required_access: bool,
     disallow_instance_profile: bool,
     windows_job_user: str,
+    session_root_dir: Path,
 ) -> ParsedCommandLineArguments:
     parsed_args = ParsedCommandLineArguments()
     parsed_args.farm_id = farm_id
@@ -157,6 +158,7 @@ def parsed_args(
     parsed_args.grant_required_access = grant_required_access
     parsed_args.disallow_instance_profile = disallow_instance_profile
     parsed_args.windows_job_user = windows_job_user
+    parsed_args.session_root_dir = session_root_dir
     return parsed_args
 
 

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 import sys
 import sysconfig
 import typing
@@ -67,6 +67,8 @@ def expected_cmd(
         sysconfig.get_path("scripts"),
         "--python-interpreter-path",
         sys.executable,
+        "--session-root-dir",
+        str(parsed_args.session_root_dir),
         "--vfs-install-path",
         parsed_args.vfs_install_path,
     ]
@@ -142,6 +144,7 @@ class TestInstallRunsCommand:
                 grant_required_access=True,
                 disallow_instance_profile=True,
                 windows_job_user="job-user",
+                session_root_dir="/sessions/root",
             ),
             ParsedCommandLineArguments(
                 farm_id="farm-2",
@@ -159,6 +162,7 @@ class TestInstallRunsCommand:
                 grant_required_access=False,
                 disallow_instance_profile=False,
                 windows_job_user="another-job-user",
+                session_root_dir="/different/root",
             ),
         )
     )
@@ -183,7 +187,8 @@ class TestInstallRunsCommand:
         # THEN
         mock_subprocess_run.assert_called_once_with(expected_cmd, check=True)
         mock_get_arg_parser.assert_called_once_with()
-        mock_parse_args.assert_called_once_with(namespace=ParsedCommandLineArguments)
+        mock_parse_args.assert_called_once_with(namespace=ANY)
+        assert isinstance(mock_parse_args.call_args.kwargs["namespace"], ParsedCommandLineArguments)
 
 
 @pytest.mark.parametrize(

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -6,6 +6,8 @@ import typing
 from typing import Generator
 from unittest.mock import Mock, call, patch, MagicMock, ANY
 
+from deadline_worker_agent.file_system_operations import FileSystemPermissionEnum
+
 import pytest
 
 if sys.platform != "win32":
@@ -48,6 +50,7 @@ def parsed_kwargs(parsed_args: ParsedCommandLineArguments) -> Generator[dict, No
             "grant_required_access": parsed_args.grant_required_access,
             "allow_ec2_instance_profile": not parsed_args.disallow_instance_profile,
             "windows_job_user": parsed_args.windows_job_user,
+            "session_root_dir": parsed_args.session_root_dir,
         }
 
 
@@ -950,12 +953,45 @@ class TestProvisionDirectories:
         agent_username: str,
     ) -> None:
         """Tests that provision_directories creates the queue persistence directory"""
+        # GIVEN
+        session_root_dir = MagicMock()
 
         # WHEN
-        win_installer.provision_directories(agent_username)
+        win_installer.provision_directories(
+            agent_username=agent_username, session_root_dir=session_root_dir
+        )
 
         # THEN
         mock_os_makedirs.assert_any_call(
             os.path.join(os.environ["PROGRAMDATA"], "Amazon", "Deadline", "Cache", "queues"),
             exist_ok=True,
+        )
+
+    def test_creates_session_root_dir(
+        self,
+        mock_os_makedirs: MagicMock,
+        mock_set_windows_permissions: MagicMock,
+        agent_username: str,
+    ) -> None:
+        """Tests that provision_directories creates the session root directory"""
+        # GIVEN
+        session_root_dir = MagicMock()
+
+        # WHEN
+        win_installer.provision_directories(
+            agent_username=agent_username, session_root_dir=session_root_dir
+        )
+
+        # THEN
+        mock_os_makedirs.assert_any_call(
+            session_root_dir,
+            exist_ok=True,
+        )
+        mock_set_windows_permissions.assert_called_with(
+            path=session_root_dir,
+            user=agent_username,
+            user_permission=FileSystemPermissionEnum.FULL_CONTROL,
+            group="Administrators",
+            group_permission=FileSystemPermissionEnum.FULL_CONTROL,
+            agent_user_permission=None,
         )

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -6,8 +6,15 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Generator, Optional
 from unittest.mock import ANY, MagicMock, Mock, call, patch
+import logging
 
-from openjd.sessions import ActionState, ActionStatus, SessionUser, PosixSessionUser
+from openjd.sessions import (
+    ActionState,
+    ActionStatus,
+    SessionUser,
+    PosixSessionUser,
+    WindowsSessionUser,
+)
 from botocore.exceptions import ClientError
 import pytest
 import os
@@ -32,6 +39,7 @@ from deadline_worker_agent.sessions.job_entities.job_details import (
 )
 from deadline_worker_agent.config import JobsRunAsUserOverride
 from deadline_worker_agent.errors import ServiceShutdown
+from deadline_worker_agent.log_messages import LogRecordStringTranslationFilter
 import deadline_worker_agent.scheduler.scheduler as scheduler_mod
 from deadline_worker_agent.aws.deadline import (
     DeadlineRequestError,
@@ -41,6 +49,14 @@ from deadline_worker_agent.aws.deadline import (
 )
 from deadline_worker_agent.file_system_operations import FileSystemPermissionEnum
 from openjd.model import SpecificationRevision
+
+
+@pytest.fixture(autouse=True)
+def log_translation_filter() -> Generator[None, None, None]:
+    string_translation_filter = LogRecordStringTranslationFilter()
+    logging.root.addFilter(string_translation_filter)
+    yield None
+    logging.root.removeFilter(string_translation_filter)
 
 
 @pytest.fixture
@@ -63,6 +79,9 @@ def scheduler(
     job_run_as_user_overrides: JobsRunAsUserOverride,
     boto_session: Mock,
     worker_logs_dir: Path,
+    session_root_dir: Path,
+    # Ensure the log filter is setup
+    log_translation_filter: None,
 ) -> WorkerScheduler:
     """Fixture for a WorkerScheduler instance"""
     return WorkerScheduler(
@@ -75,6 +94,7 @@ def scheduler(
         cleanup_session_user_processes=True,
         worker_persistence_dir=Path("/var/lib/deadline"),
         worker_logs_dir=worker_logs_dir,
+        session_root_dir=session_root_dir,
     )
 
 
@@ -107,9 +127,9 @@ class MockSession(MagicMock):
 
 
 @pytest.fixture()
-def mock_session() -> Generator[None, None, None]:
-    with patch.object(scheduler_mod, "Session", new=MockSession):
-        yield
+def mock_session() -> Generator[MagicMock, None, None]:
+    with patch.object(scheduler_mod, "Session") as mock_session:
+        yield mock_session
 
 
 class TestSchedulerRun:
@@ -689,23 +709,21 @@ class TestSchedulerSync:
 class TestCreateNewSessions:
     """Tests for WorkerScheduler._create_new_sessions"""
 
-    def test_local_logging(
-        self,
-        scheduler: WorkerScheduler,
-        worker_logs_dir: Path,
-    ) -> None:
-        """Tests that when creating a new session, that the WorkerScheduler:
+    @pytest.fixture
+    def queue_id(self) -> str:
+        return "queue-abcdef0123456789abcdef0123456789"
 
-        1.  Provisions a directory for the queue with 700 permissions (read/write/traversal for
-            owner/agent OS user only)
-        2.  Provisions a log file for the session with 600 permissions (read/write permissions for
-            owner/agent OS user only)
-        3.  Forwards the session log file path to the LogConfiguration.from_boto() class method
-        """
-        # GIVEN
-        queue_id = "queue-abcdef0123456789abcdef0123456789"
-        session_id = "session-abcdef0123456789abcdef0123456789"
-        assigned_sessions: dict[str, AssignedSession] = {
+    @pytest.fixture
+    def session_id(self) -> str:
+        return "session-abcdef0123456789abcdef0123456789"
+
+    @pytest.fixture
+    def assigned_sessions(
+        self,
+        queue_id: str,
+        session_id: str,
+    ) -> dict[str, AssignedSession]:
+        return {
             session_id: AssignedSession(
                 queueId=queue_id,
                 jobId="job-abcdef0123456789abcdef0123456789",
@@ -735,6 +753,39 @@ class TestCreateNewSessions:
                 ],
             ),
         }
+
+    @pytest.fixture
+    def mock_datetime(self) -> Generator[MagicMock, None, None]:
+        with patch.object(scheduler_mod, "datetime") as mock_datetime:
+            yield mock_datetime
+
+    @pytest.fixture
+    def mock_datetime_now(self, mock_datetime: MagicMock) -> Generator[MagicMock, None, None]:
+        datetime_now_mock: MagicMock = mock_datetime.now
+        yield datetime_now_mock
+
+    @pytest.fixture
+    def mock_job_entities(self) -> Generator[MagicMock, None, None]:
+        with patch.object(scheduler_mod, "JobEntities") as job_entities_mock:
+            yield job_entities_mock
+
+    def test_local_logging(
+        self,
+        scheduler: WorkerScheduler,
+        worker_logs_dir: Path,
+        queue_id: str,
+        session_id: str,
+        assigned_sessions: dict[str, AssignedSession],
+    ) -> None:
+        """Tests that when creating a new session, that the WorkerScheduler:
+
+        1.  Provisions a directory for the queue with 700 permissions (read/write/traversal for
+            owner/agent OS user only)
+        2.  Provisions a log file for the session with 600 permissions (read/write permissions for
+            owner/agent OS user only)
+        3.  Forwards the session log file path to the LogConfiguration.from_boto() class method
+        """
+        # GIVEN
         queue_log_dir_path = MagicMock()
         session_log_file_path = MagicMock()
 
@@ -882,6 +933,7 @@ class TestCreateNewSessions:
     def test_log_provision_error(
         self,
         scheduler: WorkerScheduler,
+        mock_datetime_now: MagicMock,
     ) -> None:
         """Tests that when a session is assigned with a log provisioning error, that the assigned
         action is marked as FAILED, the rest are marked as NEVER_ATTEMPTED,
@@ -920,11 +972,9 @@ class TestCreateNewSessions:
                 ],
             ),
         }
-        with patch.object(scheduler_mod, "datetime") as datetime_mock:
-            datetime_now_mock: MagicMock = datetime_mock.now
 
-            # WHEN
-            scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
+        # WHEN
+        scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
 
         # THEN
         for action_num in (1, 2):
@@ -942,8 +992,8 @@ class TestCreateNewSessions:
             if action_num == 1:
                 assert action_update.completed_status == "FAILED"
 
-                assert action_update.start_time == datetime_now_mock.return_value
-                assert action_update.end_time == datetime_now_mock.return_value
+                assert action_update.start_time == mock_datetime_now.return_value
+                assert action_update.end_time == mock_datetime_now.return_value
             else:
                 assert action_update.completed_status == "NEVER_ATTEMPTED"
                 assert action_update.start_time is None
@@ -961,6 +1011,9 @@ class TestCreateNewSessions:
         self,
         scheduler: WorkerScheduler,
         job_details_error: Exception,
+        assigned_sessions: dict[str, AssignedSession],
+        mock_datetime_now: MagicMock,
+        mock_job_entities: MagicMock,
     ) -> None:
         """Tests that when a session encounters a job details error, that the first assigned
         action is marked as FAILED, the rest are marked as NEVER_ATTEPTED,
@@ -968,46 +1021,12 @@ class TestCreateNewSessions:
         immediate follow-up UpdateWorkerSchedule request to signal the failure.
         """
         # GIVEN
-        queue_id = "queue-abcdef0123456789abcdef0123456789"
-        session_id = "session-abcdef0123456789abcdef0123456789"
-        assigned_sessions: dict[str, AssignedSession] = {
-            session_id: AssignedSession(
-                queueId=queue_id,
-                jobId="job-abcdef0123456789abcdef0123456789",
-                logConfiguration=LogConfiguration(
-                    logDriver="awslogs",
-                    options={},
-                    parameters={"interval": "15"},
-                ),
-                sessionActions=[
-                    EnvironmentAction(
-                        actionType="ENV_ENTER",
-                        environmentId="env-1",
-                        sessionActionId="action-1",
-                    ),
-                    TaskRunAction(
-                        actionType="TASK_RUN",
-                        parameters={},
-                        sessionActionId="action-2",
-                        stepId="step-1",
-                        taskId="task-1",
-                    ),
-                ],
-            ),
-        }
-
         job_entity_mock = MagicMock()
         job_entity_mock.job_details.side_effect = job_details_error
+        mock_job_entities.return_value = job_entity_mock
 
-        with (
-            patch.object(scheduler_mod, "datetime") as datetime_mock,
-            patch.object(scheduler_mod, "JobEntities") as job_entities_mock,
-        ):
-            job_entities_mock.return_value = job_entity_mock
-            datetime_now_mock: MagicMock = datetime_mock.now
-
-            # WHEN
-            scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
+        # WHEN
+        scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
 
         # THEN
         for action_num in (1, 2):
@@ -1022,8 +1041,8 @@ class TestCreateNewSessions:
             if action_num == 1:
                 assert action_update.completed_status == "FAILED"
 
-                assert action_update.start_time == datetime_now_mock.return_value
-                assert action_update.end_time == datetime_now_mock.return_value
+                assert action_update.start_time == mock_datetime_now.return_value
+                assert action_update.end_time == mock_datetime_now.return_value
             else:
                 assert action_update.completed_status == "NEVER_ATTEMPTED"
                 assert action_update.start_time is None
@@ -1033,6 +1052,8 @@ class TestCreateNewSessions:
     def test_job_details_run_as_worker_agent_user_windows(
         self,
         scheduler: WorkerScheduler,
+        mock_datetime_now: MagicMock,
+        mock_job_entities: MagicMock,
     ) -> None:
         """Tests that when a session encounters a runAs: WORKER_AGENT_USER for Windows os,
         the first assigned action is marked as FAILED, the rest are marked as NEVER_ATTEPTED,
@@ -1077,15 +1098,10 @@ class TestCreateNewSessions:
             job_run_as_user=JobRunAsUser(is_worker_agent_user=True),
         )
 
-        with (
-            patch.object(scheduler_mod, "datetime") as datetime_mock,
-            patch.object(scheduler_mod, "JobEntities") as job_entities_mock,
-        ):
-            job_entities_mock.return_value = job_entity_mock
-            datetime_now_mock: MagicMock = datetime_mock.now
+        mock_job_entities.return_value = job_entity_mock
 
-            # WHEN
-            scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
+        # WHEN
+        scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
 
         # THEN
         for action_num in (1, 2):
@@ -1099,8 +1115,8 @@ class TestCreateNewSessions:
             assert action_update.status.fail_message == expected_err_msg
             if action_num == 1:
                 assert action_update.completed_status == "FAILED"
-                assert action_update.start_time == datetime_now_mock.return_value
-                assert action_update.end_time == datetime_now_mock.return_value
+                assert action_update.start_time == mock_datetime_now.return_value
+                assert action_update.end_time == mock_datetime_now.return_value
             else:
                 assert action_update.completed_status == "NEVER_ATTEMPTED"
                 assert action_update.start_time is None
@@ -1135,34 +1151,68 @@ class TestCreateNewSessions:
         job_details_run_as: JobRunAsUser,
         scheduler_run_as_agent: bool,
         job_user: SessionUser,
-        mock_session: MockSession,
+        mock_session: MagicMock,
+        assigned_sessions: dict[str, AssignedSession],
+        mock_job_entities: MagicMock,
     ) -> None:
         """Tests that when a session encounters a runAs: WORKER_AGENT_USER,
         and the agent is configured with a JobsRunAsUserOverride, that the session is not
         marked as FAILED
         """
         # GIVEN
-        queue_id = "queue-abcdef0123456789abcdef0123456789"
-        session_id = "session-abcdef0123456789abcdef0123456789"
         if scheduler_run_as_agent:
             scheduler._job_run_as_user_override = JobsRunAsUserOverride(run_as_agent=True)
         else:
             scheduler._job_run_as_user_override = JobsRunAsUserOverride(
                 run_as_agent=False, job_user=job_user
             )
+
+        job_entity_mock = MagicMock()
+        job_entity_mock.job_details.return_value = JobDetails(
+            log_group_name="/aws/deadline/queue-0000",
+            schema_version=SpecificationRevision.v2023_09,
+            job_run_as_user=job_details_run_as,
+        )
+        mock_job_entities.return_value = job_entity_mock
+
+        # WHEN
+        scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
+
+        # THEN
+        mock_session.assert_called_once()
+        if scheduler_run_as_agent:
+            mock_session.call_args.kwargs["os_user"] is None
+        else:
+            mock_session.call_args.kwargs["os_user"] is job_user
+
+    @pytest.mark.parametrize(
+        argnames="session_root_dir",
+        argvalues=(
+            pytest.param(Path("/foo"), id="1"),
+            pytest.param(Path("/bar"), id="1"),
+        ),
+    )
+    def test_passes_session_root_dir(
+        self,
+        scheduler: WorkerScheduler,
+        mock_session: MagicMock,
+        session_root_dir: Path,
+        mock_job_entities: MagicMock,
+    ) -> None:
+        """Tests that the session_root_dir argument passed when creating the WorkerScheduler is
+        also passed when creating Session objects"""
+        # GIVEN
+        queue_id = "queue-abcdef0123456789abcdef0123456789"
+        session_id = "session-abcdef0123456789abcdef0123456789"
+        scheduler._job_run_as_user_override = JobsRunAsUserOverride(run_as_agent=False)
         assigned_sessions: dict[str, AssignedSession] = {
             session_id: AssignedSession(
                 queueId=queue_id,
                 jobId="job-abcdef0123456789abcdef0123456789",
                 logConfiguration=LogConfiguration(
                     logDriver="awslogs",
-                    options={
-                        "logGroupName": "logGroup",
-                        "logStreamName": "logStreamName",
-                    },
-                    parameters={
-                        "interval": "15",
-                    },
+                    options={},
+                    parameters={"interval": "15"},
                 ),
                 sessionActions=[
                     EnvironmentAction(
@@ -1180,28 +1230,31 @@ class TestCreateNewSessions:
                 ],
             ),
         }
-
         job_entity_mock = MagicMock()
         job_entity_mock.job_details.return_value = JobDetails(
             log_group_name="/aws/deadline/queue-0000",
             schema_version=SpecificationRevision.v2023_09,
-            job_run_as_user=job_details_run_as,
+            job_run_as_user=JobRunAsUser(
+                posix=(
+                    PosixSessionUser(user="username", group="group") if os.name == "posix" else None
+                ),
+                windows=(
+                    WindowsSessionUser(user="username", password="password")
+                    if os.name == "nt"
+                    else None
+                ),
+                windows_settings=None,
+            ),
         )
+        mock_job_entities.return_value = job_entity_mock
 
-        # WHEN
-        with (patch.object(scheduler_mod, "JobEntities") as job_entities_mock,):
-            job_entities_mock.return_value = job_entity_mock
+        with (patch.object(scheduler, "_executor"),):
+            # WHEN
             scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
 
         # THEN
-        if session_id not in scheduler._sessions:
-            assert session_id in list(scheduler._sessions.keys())
-        assert session_id in scheduler._sessions
-
-        if scheduler_run_as_agent:
-            assert scheduler._sessions[session_id].session.os_user is None
-        else:
-            assert scheduler._sessions[session_id].session.os_user is job_user
+        mock_session.assert_called_once()
+        assert mock_session.call_args.kwargs["session_root_dir"] == session_root_dir
 
     class MockSessionUser(SessionUser):
         user: str

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from concurrent.futures import wait
 from datetime import datetime, timedelta
-from pathlib import PurePosixPath, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from threading import Event, RLock
 from types import TracebackType
 from typing import Generator, Iterable, Literal, Optional
@@ -172,6 +172,7 @@ def session(
     session_id: str,
     action_update_callback: MagicMock,
     action_update_lock: MagicMock,
+    session_root_dir: Path,
 ) -> Session:
     """A fixture that creates and returns the Worker Session"""
     return Session(
@@ -185,6 +186,7 @@ def session(
         job_id="job-1234",
         action_update_callback=action_update_callback,
         action_update_lock=action_update_lock,
+        session_root_dir=session_root_dir,
     )
 
 
@@ -482,6 +484,26 @@ class TestSessionInit:
             assert env == mock_openjd_session_cls.call_args.kwargs["os_env_vars"]
         else:
             assert not mock_openjd_session_cls.call_args.kwargs.get("os_env_vars", False)
+
+    @pytest.mark.parametrize(
+        argnames="session_root_dir",
+        argvalues=(
+            pytest.param(Path("/foo"), id="1"),
+            pytest.param(Path("/bar"), id="1"),
+        ),
+    )
+    def test_has_session_root_dir(
+        self,
+        session: Session,
+        mock_openjd_session_cls: MagicMock,
+        session_root_dir: Path,
+    ) -> None:
+        """Ensure that Session passes session_root_dir when creating the Open Job Description session"""
+        # THEN
+        mock_openjd_session_cls.assert_called_once()
+        assert (
+            mock_openjd_session_cls.call_args.kwargs["session_root_directory"] == session_root_dir
+        )
 
 
 class TestSessionOuterRun:

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -648,23 +648,24 @@ def test_passes_worker_logs_dir(
         entrypoint()
 
     # THEN
-    worker_mock.assert_called_once_with(
-        farm_id=ANY,
-        fleet_id=ANY,
-        worker_id=ANY,
-        deadline_client=ANY,
-        s3_client=ANY,
-        logs_client=ANY,
-        boto_session=ANY,
-        job_run_as_user_override=ANY,
-        cleanup_session_user_processes=ANY,
-        worker_persistence_dir=ANY,
-        worker_logs_dir=tmp_path,
-        host_metrics_logging=ANY,
-        host_metrics_logging_interval_seconds=ANY,
-        retain_session_dir=ANY,
-        stop=ANY,
-    )
+    worker_mock.assert_called_once()
+    assert worker_mock.call_args.kwargs["worker_logs_dir"] == tmp_path
+
+
+def test_passes_session_root_dir(
+    configuration: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Assert that the Worker is passed the session_root_dir from the configuration"""
+    # GIVEN
+    configuration.session_root_dir = tmp_path
+    with patch.object(entrypoint_mod, "Worker") as worker_mock:
+        # WHEN
+        entrypoint()
+
+    # THEN
+    worker_mock.assert_called_once()
+    assert worker_mock.call_args.kwargs["session_root_dir"] == tmp_path
 
 
 @patch.object(entrypoint_mod, "_logger")

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from threading import Event
 from typing import Generator
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import MagicMock, call, patch
 from pathlib import Path
 
 import pytest
@@ -53,6 +53,7 @@ def worker(
     s3_client: MagicMock,
     worker_id: str,
     worker_logs_dir: Path,
+    session_root_dir: Path,
     # This is unused, but declaring it as a dependency fixture ensures we mock the scheduler class
     # before we instantiate the Worker instance within this fixture body
     mock_scheduler_cls: MagicMock,
@@ -71,6 +72,7 @@ def worker(
             worker_persistence_dir=Path("/var/lib/deadline"),
             worker_logs_dir=worker_logs_dir,
             host_metrics_logging=False,
+            session_root_dir=session_root_dir,
         )
 
 
@@ -134,6 +136,13 @@ class TestInit:
         assert isinstance(worker._stop, Event)
         assert not worker._stop.is_set()
 
+    @pytest.mark.parametrize(
+        argnames="worker_logs_dir",
+        argvalues=(
+            pytest.param(Path("/foo"), id="1"),
+            pytest.param(Path("/bar"), id="2"),
+        ),
+    )
     def test_passes_worker_logs_dir(
         self,
         # Not used, but declared in order to have the Worker.__init__() called
@@ -144,19 +153,28 @@ class TestInit:
         """Asserts that when a Worker instance is created, the worker_logs_dir keyword argument is
         passed when creating the WorkerScheduler instance"""
         # THEN
-        mock_scheduler_cls.assert_called_once_with(
-            deadline=ANY,
-            farm_id=ANY,
-            fleet_id=ANY,
-            worker_id=ANY,
-            job_run_as_user_override=ANY,
-            boto_session=ANY,
-            cleanup_session_user_processes=ANY,
-            worker_persistence_dir=ANY,
-            worker_logs_dir=worker_logs_dir,
-            retain_session_dir=ANY,
-            stop=ANY,
-        )
+        mock_scheduler_cls.assert_called_once()
+        assert mock_scheduler_cls.call_args.kwargs["worker_logs_dir"] == worker_logs_dir
+
+    @pytest.mark.parametrize(
+        argnames="session_root_dir",
+        argvalues=(
+            pytest.param(Path("/foo"), id="1"),
+            pytest.param(Path("/bar"), id="2"),
+        ),
+    )
+    def test_passes_session_root_dir(
+        self,
+        # Not used, but declared in order to have the Worker.__init__() called
+        worker: Worker,
+        mock_scheduler_cls: MagicMock,
+        session_root_dir: Path,
+    ) -> None:
+        """Asserts that when a Worker instance is created, the session_root_dir keyword argument is
+        passed when creating the WorkerScheduler instance"""
+        # THEN
+        mock_scheduler_cls.assert_called_once()
+        assert mock_scheduler_cls.call_args.kwargs["session_root_dir"] == session_root_dir
 
 
 class TestRun:

--- a/test/unit/windows/test_win_logon.py
+++ b/test/unit/windows/test_win_logon.py
@@ -43,8 +43,7 @@ if sys.platform == "win32":
 
         @fixture(autouse=True)
         def outside_session_0(self) -> Generator[MagicMock, None, None]:
-            with patch.object(win_logon_mod, "is_windows_session_zero") as mock:
-                mock.return_value = False
+            with patch.object(win_logon_mod, "is_windows_session_zero", return_value=False) as mock:
                 yield mock
 
         def test_logon_outside_session_0(
@@ -109,8 +108,7 @@ if sys.platform == "win32":
 
         @fixture(autouse=True)
         def is_session_0(self) -> Generator[MagicMock, None, None]:
-            with patch.object(win_logon_mod, "is_windows_session_zero") as mock:
-                mock.return_value = True
+            with patch.object(win_logon_mod, "is_windows_session_zero", return_value=True) as mock:
                 yield mock
 
         def test_logon_in_session_0(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Currently the Worker Agent has a hard-coded root directory under which session directories are created.

| Operating System | Session Root Directory |
| --- | --- |
| Linux | `/sessions` |
| Windows | `%PROGRAMDATA%\Amazon\OpenJD` |

Those using the worker agent may want to customize the directory where the sessions are created.

### What was the solution? (How)

Added a new session root directory setting to the worker agent configuration. As with other worker agent settings, this can be set using multiple sources in the following order of precedence (first is higher priority):

1.  Command-line argument: `--session-root-dir`
2. Environment variable: `DEADLINE_WORKER_SESSION_ROOT_DIR`
3. Configuration file: `[worker]` &rarr; `session_root_dir`
4. Defaults:
    *   `/sessions` on Linux
    *   `%PROGRAMDATA%\Amazon\OpenJD` on Windows

The setting is supplied in the `install-deadline-worker` command using the `--session-root-dir` CLI argument which will create (if needed) the worker agent configuration file and modify the `session_root_dir` setting. The installer will also provision the directory as needed and ensure it has the correct file-system ACLs.

The setting is now loaded on launch and passed down through the call stack and supplied to `session_root_directory` kwarg of the `Session` class in `openjd-sessions` ([code ref](https://github.com/OpenJobDescription/openjd-sessions-for-python/blob/b9be7a477921e384337cff009444cdf80679eb46/src/openjd/sessions/_session.py#L320)).

### What is the impact of this change?

Those using the worker agent can configure where session directories will be created on the worker host.

### How was this change tested?

*  Integration test cases were added for the worker agent configuration file modification for the session root directory
*  End-to-end test was added that verifies the configured session root directory is applied. This test succeeded

### Was this change documented?

The new `session_root_dir` was added to the `worker.toml.example` file with documentation comments

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*