### PR TITLE
fix: remove unnecessary report to service team message

### DIFF
--- a/src/deadline_worker_agent/log_messages.py
+++ b/src/deadline_worker_agent/log_messages.py
@@ -639,8 +639,7 @@ class LogRecordStringTranslationFilter(logging.Filter):
                 user=None,  # User is only used for SessionLogEventSubtype.USER
             )
         else:
-            # This also should never happen. Fall back to a StringLogEvent.
-            record.msg += f" The Worker Agent could not locate the job and queue ID for this log originating from session {session_id}. Please report this to the service team."
+            # This can happen at the very beginning of a session. Fall back to a StringLogEvent.
             return
         record.getMessageReplaced = True
         record.getMessage = MethodType(lambda self: self.msg.getMessage(), record)  # type: ignore

--- a/test/unit/test_log_messages.py
+++ b/test/unit/test_log_messages.py
@@ -883,7 +883,7 @@ def test_openjd_logs_openjd_log_content_session_not_in_map() -> None:
     # GIVEN
     message = "Test OpenJD Message."
     session_id = "not exist"
-    expected_message = f"{message} The Worker Agent could not locate the job and queue ID for this log originating from session {session_id}. Please report this to the service team."
+    expected_message = f"{message}"  # Checking that we don't append a message
     record = logging.makeLogRecord(
         {
             "name": LOG.name,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There's a log line which appears in service logs saying:

> `The Worker Agent could not locate the job and queue ID for this log originating from session session-****. Please report this to the service team.`

This was added as part of #422 because [we suspected it wasn't possible to have a session running without it being in the session map](https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/422#discussion_r1803792032) (which is used to find the queue and job id for the session.) 

This ended up not being the case, there is a race when displaying the version info here: https://github.com/OpenJobDescription/openjd-sessions-for-python/blob/mainline/src/openjd/sessions/_session.py#L399C70-L410

because those lines are logged when initializing the Session object here: https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/src/deadline_worker_agent/scheduler/scheduler.py#L1107

but the Session isn't added to the session map until here: https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/src/deadline_worker_agent/scheduler/scheduler.py#L1153

For now, since this isn't a failure case, we should stop spooking customers by telling them to report it to the service team, now that we know about this.

### What was the solution? (How)

Remove the part of code where we add the log line. 

### What is the impact of this change?

Instances where the are no `job-id` or `queue-id` for specific session logs will not tell customers to report it to the service team, now that we are aware of the issue.

### How was this change tested?

Unit/integ tests pass. 

### Was this change documented?

Yes, through the changelog

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*