### PR TITLE
fix: update log kind to differentiate sync input and sync output

### DIFF
--- a/src/deadline_worker_agent/log_messages.py
+++ b/src/deadline_worker_agent/log_messages.py
@@ -473,7 +473,8 @@ class SessionActionLogKind(str, Enum):
     ENV_ENTER = "EnvEnter"
     ENV_EXIT = "EnvExit"
     TASK_RUN = "TaskRun"
-    JA_SYNC = "JobAttachSyncInput"
+    JA_SYNC_INPUT = "JobAttachSyncInput"
+    JA_SYNC_OUTPUT = "JobAttachSyncOutput"
     JA_DEP_SYNC = "JobAttachSyncDeps"
 
 

--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -536,11 +536,11 @@ class SessionActionQueue:
                             job_attachment_details = self._job_entities.job_attachment_details()
                         except UnsupportedSchema as e:
                             raise JobEntityUnsupportedSchemaError(
-                                action_id, SessionActionLogKind.JA_SYNC, e._version
+                                action_id, SessionActionLogKind.JA_SYNC_INPUT, e._version
                             ) from e
                         except ValueError as e:
                             raise JobAttachmentDetailsError(
-                                action_id, SessionActionLogKind.JA_SYNC, str(e)
+                                action_id, SessionActionLogKind.JA_SYNC_INPUT, str(e)
                             ) from e
                         next_action = AttachmentDownloadAction(
                             id=action_id,
@@ -588,11 +588,11 @@ class SessionActionQueue:
                             job_attachment_details = self._job_entities.job_attachment_details()
                         except UnsupportedSchema as e:
                             raise JobEntityUnsupportedSchemaError(
-                                action_id, SessionActionLogKind.JA_SYNC, e._version
+                                action_id, SessionActionLogKind.JA_SYNC_INPUT, e._version
                             ) from e
                         except ValueError as e:
                             raise JobAttachmentDetailsError(
-                                action_id, SessionActionLogKind.JA_SYNC, str(e)
+                                action_id, SessionActionLogKind.JA_SYNC_INPUT, str(e)
                             ) from e
                         next_action = SyncInputJobAttachmentsAction(
                             id=action_id,

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -44,8 +44,6 @@ from openjd.model.v2023_09 import (
 from openjd.model import ParameterValue
 
 from ...log_messages import SessionActionLogKind
-
-
 from .openjd_action import OpenjdAction
 
 if TYPE_CHECKING:
@@ -77,7 +75,7 @@ class AttachmentDownloadAction(OpenjdAction):
         super(AttachmentDownloadAction, self).__init__(
             id=id,
             action_log_kind=(
-                SessionActionLogKind.JA_SYNC
+                SessionActionLogKind.JA_SYNC_INPUT
                 if step_details is None
                 else SessionActionLogKind.JA_DEP_SYNC
             ),

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
@@ -58,7 +58,7 @@ class AttachmentUploadAction(OpenjdAction):
     ) -> None:
         super(AttachmentUploadAction, self).__init__(
             id=id,
-            action_log_kind=(SessionActionLogKind.JA_SYNC),
+            action_log_kind=(SessionActionLogKind.JA_SYNC_OUTPUT),
         )
         self._step_id = step_id
         self._task_id = task_id

--- a/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
+++ b/src/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py
@@ -60,7 +60,7 @@ class SyncInputJobAttachmentsAction(SessionActionDefinition):
         super(SyncInputJobAttachmentsAction, self).__init__(
             id=id,
             action_log_kind=(
-                SessionActionLogKind.JA_SYNC
+                SessionActionLogKind.JA_SYNC_INPUT
                 if step_details is None
                 else SessionActionLogKind.JA_DEP_SYNC
             ),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Sync output as part of task run is still logged as `(Kind: JobAttachSyncInput)`, which is misleading.

### What was the solution? (How)
Create a log kind as `JobAttachSyncOutput` and pass that for attachment upload action.

### What is the impact of this change?
Customers can have a clear differentiation of sync input and output in worker agent logs.

### How was this change tested?
1. Build the code and install `.whl` file
2. Submit a sample test job
3. Inspect the logs


```
[2025-01-08 22:39:38,734][INFO    ] 🟢 Action.Start 🟢 [session-b5aa23074f9e4f0e95d917824373a05e](sessionaction-b5aa23074f9e4f0e95d917824373a05e-0) Action started. (Kind: JobAttachSyncInput) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:38,790][INFO    ] 🔷 Session.Runtime 🔷 [session-b5aa23074f9e4f0e95d917824373a05e] Command started as pid: 23849 [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:39,427][INFO    ] 🔷 Session.Runtime 🔷 [session-b5aa23074f9e4f0e95d917824373a05e] Process pid 23849 exited with code: 0 (unsigned) / 0x0 (hex) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:39,430][INFO    ] 🟣 Action.End 🟣 [session-b5aa23074f9e4f0e95d917824373a05e](sessionaction-b5aa23074f9e4f0e95d917824373a05e-0) Action complete. (Status: SUCCEEDED) (Kind: JobAttachSyncInput) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:39,491][INFO    ] 🟢 Action.Start 🟢 [session-b5aa23074f9e4f0e95d917824373a05e](sessionaction-b5aa23074f9e4f0e95d917824373a05e-1) Action started. (Kind: EnvEnter) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:39,496][INFO    ] 🔷 Session.Runtime 🔷 [session-b5aa23074f9e4f0e95d917824373a05e] Command started as pid: 23881 [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:39,499][INFO    ] 🔷 Session.Runtime 🔷 [session-b5aa23074f9e4f0e95d917824373a05e] Process pid 23881 exited with code: 0 (unsigned) / 0x0 (hex) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:39,501][INFO    ] 🟣 Action.End 🟣 [session-b5aa23074f9e4f0e95d917824373a05e](sessionaction-b5aa23074f9e4f0e95d917824373a05e-1) Action complete. (Status: SUCCEEDED) (Kind: EnvEnter) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:39,596][INFO    ] 🟢 Action.Start 🟢 [session-b5aa23074f9e4f0e95d917824373a05e](sessionaction-b5aa23074f9e4f0e95d917824373a05e-2) Action started. (Kind: TaskRun) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6/step-52b6ec982944418e98146fab30fc1551/task-52b6ec982944418e98146fab30fc1551-0]
[2025-01-08 22:39:39,602][INFO    ] 🔷 Session.Runtime 🔷 [session-b5aa23074f9e4f0e95d917824373a05e] Command started as pid: 23884 [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:39,621][INFO    ] 🔷 Session.Runtime 🔷 [session-b5aa23074f9e4f0e95d917824373a05e] Process pid 23884 exited with code: 0 (unsigned) / 0x0 (hex) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:39,702][INFO    ] 🟢 Action.Start 🟢 [session-b5aa23074f9e4f0e95d917824373a05e](sessionaction-b5aa23074f9e4f0e95d917824373a05e-2) Action started. (Kind: JobAttachSyncOutput) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6/step-52b6ec982944418e98146fab30fc1551]
[2025-01-08 22:39:39,708][INFO    ] 🔷 Session.Runtime 🔷 [session-b5aa23074f9e4f0e95d917824373a05e] Command started as pid: 23901 [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:40,358][INFO    ] 🔷 Session.Runtime 🔷 [session-b5aa23074f9e4f0e95d917824373a05e] Process pid 23901 exited with code: 1 (unsigned) / 0x1 (hex) [queue-6e0d65129f884c328f1b057604fb56af/job-bc6d5e74f0894908911e495f266248f6]
[2025-01-08 22:39:40,361][INFO    ] 🟣 Action.End 🟣 [session-b5aa23074f9e4f0e95d917824373a05e](sessionaction-b5aa23074f9e4f0e95d917824373a05e-2) Action complete. (Status: FAILED) (Kind: TaskRun)
```


### Was this change documented?
N/A

### Is this a breaking change?
No, this feature is still experimental and under a feature flag.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*