### PR TITLE
fix: skip attachment upload when outputs not modified

### DIFF
--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -1,0 +1,99 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest.mock import patch, Mock
+import pytest
+import tempfile
+import os
+
+from deadline_worker_agent.sessions.actions.scripts.attachment_upload import main, parse_args
+
+
+@pytest.fixture
+def path_mapping_file_path():
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        path_mapping_file_path: str = os.path.join(tmpdir_path, "mapping.json")
+        yield path_mapping_file_path
+
+
+@pytest.fixture
+def valid_args(path_mapping_file_path: str):
+    return [
+        "--path-mapping",
+        path_mapping_file_path,
+        "--s3-uri",
+        "s3://test-bucket/path",
+        "--manifest-map",
+        '{"root1": "/path/to/manifest1"}',
+    ]
+
+
+class TestAttachmentUpload:
+
+    def test_parse_args(self, path_mapping_file_path: str, valid_args: dict):
+        # Test valid arguments
+        args = parse_args(valid_args)
+        assert args.path_mapping == path_mapping_file_path
+        assert args.s3_uri == "s3://test-bucket/path"
+        assert args.manifest_map == {"root1": "/path/to/manifest1"}
+
+    def test_parse_args_missing_required(self, path_mapping_file_path: str):
+        # Test missing required argument
+        invalid_args = [
+            "--path-mapping",
+            path_mapping_file_path,
+            "--manifest-map",
+            '{"root1": "/path/to/manifest1"}',
+        ]
+        with pytest.raises(SystemExit):
+            parse_args(invalid_args)
+
+    def test_parse_args_invalid_json(self, path_mapping_file_path: str):
+        # Test invalid JSON in manifest-map
+        invalid_args = [
+            "--path-mapping",
+            path_mapping_file_path,
+            "--s3-uri",
+            "s3://test-bucket/path",
+            "--manifest-map",
+            "invalid-json",
+        ]
+        with pytest.raises(SystemExit):
+            parse_args(invalid_args)
+
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.snapshot")
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.upload")
+    def test_main_with_manifests(
+        self, mock_upload: Mock, mock_snapshot: Mock, path_mapping_file_path: str, valid_args: dict
+    ):
+        # Setup mock for snapshot to return some manifests
+        mock_snapshot.return_value = ["manifest1", "manifest2"]
+
+        # Run main with test arguments
+        main(valid_args)
+
+        # Verify snapshot was called with correct arguments
+        mock_snapshot.assert_called_once_with(
+            manifest_paths_by_root={"root1": "/path/to/manifest1"}
+        )
+
+        # Verify upload was called with correct arguments
+        mock_upload.assert_called_once_with(
+            manifests=["manifest1", "manifest2"],
+            s3_root_uri="s3://test-bucket/path",
+            path_mapping_rules=path_mapping_file_path,
+        )
+
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.snapshot")
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.upload")
+    def test_main_no_manifests(self, mock_upload: Mock, mock_snapshot: Mock, valid_args: dict):
+        # Setup mock for snapshot to return empty list
+        mock_snapshot.return_value = []
+
+        # Run main with test arguments
+        main(valid_args)
+
+        # Verify snapshot was called
+        mock_snapshot.assert_called_once()
+
+        # Verify upload was not called when no manifests
+        mock_upload.assert_not_called()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Attachment upload action runs `attachment_upload.py` script, which does not handle the case when there is no output correctly. As a result the empty path mapping file causes an error and the action fails

```
--------------------------------------------------------------------------------------------------------------------------------------------------------------
|   timestamp   |                                                                  message                                                                   |
|---------------|--------------------------------------------------------------------------------------------------------------------------------------------|
| 1736878702936 | Running Session Actions as user: job-user                                                                                                  |
| 1736878703344 |                                                                                                                                            |
| 1736878703344 | ==============================================                                                                                             |
| 1736878703344 | --------- Running Task                                                                                                                     |
| 1736878703344 | ==============================================                                                                                             |
| 1736878703345 | ----------------------------------------------                                                                                             |
| 1736878703345 | Phase: Setup                                                                                                                               |
| 1736878703345 | ----------------------------------------------                                                                                             |
| 1736878703346 | ----------------------------------------------                                                                                             |
| 1736878703346 | Phase: Running action                                                                                                                      |
| 1736878703346 | ----------------------------------------------                                                                                             |
| 1736878703349 | Running command sudo -u job-user -i setsid -w /sessions/session-f2d1a69a5d594ccb951bafc06af98fadxi3od7xe/tmpn1fufpbp.sh                    |
| 1736878703463 | Command started as pid: 25971                                                                                                              |
| 1736878703464 | Output:                                                                                                                                    |
| 1736878708803 | Process pid 25971 exited with code: 0 (unsigned) / 0x0 (hex)                                                                               |
| 1736878708870 | ==============================================                                                                                             |
| 1736878708870 | --------- AttachmentUploadAction ---------                                                                                                 |
| 1736878708870 | ==============================================                                                                                             |
| 1736878708871 |                                                                                                                                            |
| 1736878708871 | ==============================================                                                                                             |
| 1736878708872 | --------- Running Task                                                                                                                     |
| 1736878708872 | ==============================================                                                                                             |
| 1736878708873 | ----------------------------------------------                                                                                             |
| 1736878708873 | Phase: Setup                                                                                                                               |
| 1736878708873 | ----------------------------------------------                                                                                             |
| 1736878708873 | Writing embedded files for Task to disk.                                                                                                   |
| 1736878708873 | Mapping: Task.File.AttachmentUpload -> /sessions/session-f2d1a69a5d594ccb951bafc06af98fadxi3od7xe/embedded_files68gchdm5/upload.py         |
| 1736878708873 | Wrote: AttachmentUpload -> /sessions/session-f2d1a69a5d594ccb951bafc06af98fadxi3od7xe/embedded_files68gchdm5/upload.py                     |
| 1736878708874 | ----------------------------------------------                                                                                             |
| 1736878708874 | Phase: Running action                                                                                                                      |
| 1736878708874 | ----------------------------------------------                                                                                             |
| 1736878708875 | Running command sudo -u job-user -i setsid -w /sessions/session-f2d1a69a5d594ccb951bafc06af98fadxi3od7xe/tmp89ys43yv.sh                    |
| 1736878708991 | Command started as pid: 26003                                                                                                              |
| 1736878708995 | Output:                                                                                                                                    |
| 1736878709525 |                                                                                                                                            |
| 1736878709525 | Starting upload...                                                                                                                         |
| 1736878709525 | Traceback (most recent call last):                                                                                                         |
| 1736878709525 |   File "/sessions/session-f2d1a69a5d594ccb951bafc06af98fadxi3od7xe/embedded_files68gchdm5/upload.py", line 80, in <module>                 |
| 1736878709525 |     upload(manifests=manifests, s3_root_uri=s3_uri, path_mapping_rules=path_mapping)                                                       |
| 1736878709525 |   File "/sessions/session-f2d1a69a5d594ccb951bafc06af98fadxi3od7xe/embedded_files68gchdm5/upload.py", line 33, in upload                   |
| 1736878709525 |     api.attachment_upload(                                                                                                                 |
| 1736878709526 |   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline/job_attachments/api/attachment.py", line 119, in attachment_upload     |
| 1736878709526 |     path_mapping_rule_list: List[PathMappingRule] = _process_path_mapping(                                                                 |
| 1736878709526 |   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline/job_attachments/api/attachment.py", line 203, in _process_path_mapping |
| 1736878709526 |     assert isinstance(data, list), "Path mapping rules have to be a list of dict."                                                         |
| 1736878709526 | AssertionError: Path mapping rules have to be a list of dict.                                                                              |
| 1736878709584 | Process pid 26003 exited with code: 1 (unsigned) / 0x1 (hex)                                                                               |
--------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### What was the solution? (How)
Check the manifest diff after `manifest_snapshot` to only call `attachment_upload` when there are manifests generated.

### What is the impact of this change?
Customer submitted jobs with no session output will be correctly processed.

### How was this change tested?
1. Added unit tests and ran `hatch run test`
2. Build worker agent locally and submit jobs to verify

#### Session with No Output
```
2025-01-14 22:27:17,032 INFO ==============================================
2025-01-14 22:27:17,032 INFO --------- AttachmentUploadAction ---------
2025-01-14 22:27:17,032 INFO ==============================================
2025-01-14 22:27:17,033 INFO 
2025-01-14 22:27:17,034 INFO ==============================================
2025-01-14 22:27:17,034 INFO --------- Running Task
2025-01-14 22:27:17,034 INFO ==============================================
2025-01-14 22:27:17,034 INFO ----------------------------------------------
2025-01-14 22:27:17,035 INFO Phase: Setup
2025-01-14 22:27:17,035 INFO ----------------------------------------------
2025-01-14 22:27:17,035 INFO Writing embedded files for Task to disk.
2025-01-14 22:27:17,035 INFO Mapping: Task.File.AttachmentUpload -> /sessions/session-aa87d3e871964e64b3c0ccccd7b72a9ddn822vpi/embedded_filest544h757/upload.py
2025-01-14 22:27:17,035 INFO Wrote: AttachmentUpload -> /sessions/session-aa87d3e871964e64b3c0ccccd7b72a9ddn822vpi/embedded_filest544h757/upload.py
2025-01-14 22:27:17,036 INFO ----------------------------------------------
2025-01-14 22:27:17,036 INFO Phase: Running action
2025-01-14 22:27:17,036 INFO ----------------------------------------------
2025-01-14 22:27:17,036 INFO Running command /sessions/session-aa87d3e871964e64b3c0ccccd7b72a9ddn822vpi/tmpe05mlfr9.sh
2025-01-14 22:27:17,037 INFO Command started as pid: 21373
2025-01-14 22:27:17,041 INFO Output:
2025-01-14 22:27:17,390 INFO No manifests to upload
2025-01-14 22:27:17,431 INFO Process pid 21373 exited with code: 0 (unsigned) / 0x0 (hex)
```

#### Session with Output
```
2025-01-15 00:19:01,746 INFO ==============================================
2025-01-15 00:19:01,746 INFO --------- Running Task
2025-01-15 00:19:01,746 INFO ==============================================
2025-01-15 00:19:01,746 INFO ----------------------------------------------
2025-01-15 00:19:01,746 INFO Phase: Setup
2025-01-15 00:19:01,746 INFO ----------------------------------------------
2025-01-15 00:19:01,746 INFO Writing embedded files for Task to disk.
2025-01-15 00:19:01,747 INFO Mapping: Task.File.AttachmentUpload -> /sessions/session-9535971c1cef4a9cb0a34a6acfb1e3aa829jhi3h/embedded_filesszhnyppl/upload.py
2025-01-15 00:19:01,747 INFO Wrote: AttachmentUpload -> /sessions/session-9535971c1cef4a9cb0a34a6acfb1e3aa829jhi3h/embedded_filesszhnyppl/upload.py
2025-01-15 00:19:01,747 INFO ----------------------------------------------
2025-01-15 00:19:01,747 INFO Phase: Running action
2025-01-15 00:19:01,747 INFO ----------------------------------------------
2025-01-15 00:19:01,748 INFO Running command /sessions/session-9535971c1cef4a9cb0a34a6acfb1e3aa829jhi3h/tmppj4z2r8d.sh
2025-01-15 00:19:01,748 INFO Command started as pid: 15708
2025-01-15 00:19:01,751 INFO Output:
2025-01-15 00:19:02,113 INFO Found difference at: computed_hashes.txt, Status: FileStatus.NEW
2025-01-15 00:19:02,210 INFO Hashing Attachments
2025-01-15 00:19:02,304 INFO Hashing Summary:
2025-01-15 00:19:02,305 INFO     Processed 1 file totaling 876.0 B.
2025-01-15 00:19:02,305 INFO     Skipped re-processing 0 files totaling 0.0 B.
2025-01-15 00:19:02,305 INFO     Total processing time of 0.01278 seconds at 68.53 KB/s.
2025-01-15 00:19:02,305 INFO 
2025-01-15 00:19:02,306 INFO Manifest Generated at /sessions/session-9535971c1cef4a9cb0a34a6acfb1e3aa829jhi3h/diff/output-7bb58db7970d258345820e08f186f96d_manifest-b07ead6893bf44c9315394f42d81bbc6-2025-01-15T00-19-02.manifest
2025-01-15 00:19:02,306 INFO 
2025-01-15 00:19:02,715 INFO 
2025-01-15 00:19:02,715 INFO Starting upload...
2025-01-15 00:19:02,715 INFO Uploaded assets from /sessions/session-9535971c1cef4a9cb0a34a6acfb1e3aa829jhi3h/assetroot-c505a77d076c00137a3b, to XXX, hashed data 07662f4c9f1ebae2412c901547c227a1
2025-01-15 00:19:02,715 INFO Finished uploading after 0.6097216731868684 seconds
2025-01-15 00:19:02,828 INFO Process pid 15708 exited with code: 0 (unsigned) / 0x0 (hex)
```

### Was this change documented?
N/A

### Is this a breaking change?
No, this is an experimental feature and still under feature flag.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*