### PR TITLE
chore(deps): update mypy from ~= 1.13 to ~= 1.14, types-psutil from ~= 5.9 to ~= 6.1 and change version expression of deadline-cloud-test-fixtures

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -2,7 +2,7 @@ backoff == 2.2.*
 coverage[toml] ~= 7.6
 coverage-conditional-plugin == 0.9.*
 # The fixture code relies on a bugfix in 0.17.1
-deadline-cloud-test-fixtures >= 0.17.1, == 0.17.*
+deadline-cloud-test-fixtures >= 0.17.1, < 0.18
 flaky == 3.8.*
 pytest ~= 8.3
 pytest-cov == 6.0.*
@@ -11,9 +11,9 @@ pytest-xdist == 3.6.*
 black[jupyter] ~= 24.10
 rich == 13.9.*
 types-python-dateutil ~= 2.9
-mypy ~= 1.13
+mypy ~= 1.14
 types-requests ~= 2.31; python_version < "3.10"
 types-requests ~= 2.32; python_version >= "3.10"
 ruff ~= 0.9.2
 twine ~= 6.0
-types-psutil ~= 5.9
+types-psutil ~= 6.1

--- a/src/deadline_worker_agent/capabilities.py
+++ b/src/deadline_worker_agent/capabilities.py
@@ -39,7 +39,10 @@ def detect_system_capabilities() -> Capabilities:
 
     attributes[AttributeCapabilityName("attr.worker.cpu.arch")] = [_get_arch()]
 
-    amounts[AmountCapabilityName("amount.worker.vcpu")] = float(psutil.cpu_count())
+    cpu_count = psutil.cpu_count()
+    if cpu_count is None:
+        raise RuntimeError("Unable to determine cpu count")
+    amounts[AmountCapabilityName("amount.worker.vcpu")] = float(cpu_count)
     amounts[AmountCapabilityName("amount.worker.memory")] = float(psutil.virtual_memory().total) / (
         1024.0**2
     )


### PR DESCRIPTION
Dependabot is refusing to rebase changes, so we're going to manually update them:

1. Changed the way deadline-cloud-test-fixtures is pinned from `>= 0.17.1, == 0.17.*` to `>= 0.17.1, < 0.18` because `0.17.2` existing was causing dependabot to want to "upgrade" to `0.17.*`.
2. Updated mypy to 1.14. This caused an issue because we were previously converting an `Optional[int]` into `float` which mypy appears to be more strict about now. We now check to see if `psutil.cpu_count()` returns `None` and raise an exception if it is.
3. Updated types-psutil to 6.1