### PR TITLE
test: Increase maximum backoff time for session action cancelation

### DIFF
--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -903,7 +903,7 @@ class TestJobSubmission:
 
         @backoff.on_predicate(
             wait_gen=backoff.constant,
-            max_time=60,
+            max_time=70,
             interval=5,
         )
         def is_expected_session_action_canceled(sessions) -> bool:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We saw a test failure on `test_worker_reports_canceled_session_actions_as_canceled` because the test timed out shortly before the actual session action canceled.

### What was the solution? (How)
Increase the maximum backoff/retry time from 60 to 70 seconds.

### What is the impact of this change?
Tests will be more reliable.

### How was this change tested?
Ran existing tests to make sure nothing broke.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*