### PR TITLE
fix: Assume 0 MiB of memory is available on a disabled NVIDIA GPU

### DIFF
--- a/src/deadline_worker_agent/capabilities.py
+++ b/src/deadline_worker_agent/capabilities.py
@@ -106,6 +106,7 @@ def _get_gpu_count(*, verbose: bool = True) -> int:
 def _get_gpu_memory(*, verbose: bool = True) -> int:
     """
     Get the total GPU memory available on the machine.
+    Disabled GPUs will appear to have 0 MiB memory if they have no memory currently allocated for use.
 
     Returns
     -------
@@ -138,7 +139,15 @@ def _get_gpu_memory(*, verbose: bool = True) -> int:
 
     mem_per_gpu: list[int] = []
     for line in output.splitlines():
-        mem_mib = int(line.replace("MiB", ""))
+        try:
+            # Active GPU: nvidia-smi returns an integer followed by "MiB"
+            # Disabled GPU with no memory currently allocated: nvidia-smi returns "[N/A]"
+            mem_mib = int(line.replace("MiB", ""))
+        except ValueError:
+            if verbose:
+                _logger.warning(f"Could not detect GPU memory, non-numeric result returned by nvidia-smi: {line}")
+            mem_mib = 0
+        
         mem_per_gpu.append(mem_mib)
 
     min_memory = min(mem_per_gpu)

--- a/src/deadline_worker_agent/capabilities.py
+++ b/src/deadline_worker_agent/capabilities.py
@@ -164,7 +164,7 @@ def _get_gpu_memory(*, verbose: bool = True) -> int:
         return 0
     output = output_bytes.decode().strip()
 
-    mem_per_gpu = _parse_gpu_memory(output)
+    mem_per_gpu = _parse_gpu_memory(output, verbose)
 
     min_memory = min(mem_per_gpu)
 

--- a/src/deadline_worker_agent/capabilities.py
+++ b/src/deadline_worker_agent/capabilities.py
@@ -103,6 +103,33 @@ def _get_gpu_count(*, verbose: bool = True) -> int:
         return int(output.decode().strip())
 
 
+def _parse_gpu_memory(lines: List, verbose: bool = True) -> List:
+
+    """
+    Parses the output of nvidia-smi to determine GPU memory.
+    Disabled GPUs will be assigned 0 MiB memory if they have no memory currently allocated for use.
+
+    Returns
+    -------
+    List
+        The memory available for each GPU.
+    """
+
+    mem_per_gpu: list[int] = []
+    for line in lines.splitlines():
+        try:
+            # Active GPU: nvidia-smi returns an integer followed by "MiB"
+            # Disabled GPU with no memory currently allocated: nvidia-smi returns "[N/A]"
+            mem_mib = int(line.replace("MiB", ""))
+        except ValueError:
+            if verbose:
+                _logger.warning(f"Could not detect GPU memory, non-numeric result returned by nvidia-smi: {line}")
+            mem_mib = 0
+
+        mem_per_gpu.append(mem_mib)
+    return mem_per_gpu
+
+
 def _get_gpu_memory(*, verbose: bool = True) -> int:
     """
     Get the total GPU memory available on the machine.
@@ -137,18 +164,7 @@ def _get_gpu_memory(*, verbose: bool = True) -> int:
         return 0
     output = output_bytes.decode().strip()
 
-    mem_per_gpu: list[int] = []
-    for line in output.splitlines():
-        try:
-            # Active GPU: nvidia-smi returns an integer followed by "MiB"
-            # Disabled GPU with no memory currently allocated: nvidia-smi returns "[N/A]"
-            mem_mib = int(line.replace("MiB", ""))
-        except ValueError:
-            if verbose:
-                _logger.warning(f"Could not detect GPU memory, non-numeric result returned by nvidia-smi: {line}")
-            mem_mib = 0
-        
-        mem_per_gpu.append(mem_mib)
+    mem_per_gpu = _parse_gpu_memory(output)
 
     min_memory = min(mem_per_gpu)
 


### PR DESCRIPTION
…

### What was the problem/requirement? (What/Why)
As described in https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/536:

On a system with a disabled NVIDIA GPU that has no memory allocated to the GPU, the worker agent exits in its initialization phase due to a critical error from `_get_gpu_memory()` trying to parse a string as an integer.

### What was the solution? (How)
`nvidia-smi --query-gpu=memory.total` returns a memory value that can be parsed by `int()` if the GPU is active, or the string "`[N/A]`" if the GPU is disabled. There are no other mode flags (e.g. `display_active`, `display_mode`) that can be used to determine whether a GPU has no memory allocated to it.

Catching the `ValueError` raised when trying to parse the "`[N/A]`" string output from `nvidia-smi --query-gpu=memory.total` instead of letting it propagate upward allows the worker agent to finish initializing. A GPU that's present in a system but not active contributes zero memory towards that system's total GPU memory, and therefore `_get_gpu_memory()` is made to return 0 for a GPU if that GPU's memory size cannot be queried.

### What is the impact of this change?
GPUs without allocated memory will be part of the total number of GPUs available on the machine, but they contribute 0 MiB to the total amount of GPU memory available on the machine. The worker agent emits a warning in its log that a non-numeric result was received from `nvidia-smi`.

### How was this change tested?
The change was tested on an affected machine and the worker agent starts up successfully.

### Was this change documented?
The docstring is updated and the code block has comments.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*