### PR TITLE
chore: add maintenance label to maintenance GitHub template

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "tomli == 2.0.* ; python_version<'3.11'",
     "tomlkit == 0.13.*",
     "typing_extensions ~= 4.8",
-    "psutil >= 5.9,< 7.0",
+    "psutil >= 5.9,< 8.0",
     "pydantic ~= 1.10.0",
     "pywin32 == 308; platform_system == 'Windows'",
     "requests == 2.32.*",


### PR DESCRIPTION
To help us organize GitHub issues, we are adding a maintenance label on maintenance-related GitHub issues by default.