### PR TITLE
chore(deps)!: update to openjd-sessions 0.10.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,13 @@ dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.34.75",
     "deadline == 0.49.*",
-    "openjd-sessions >= 0.9.0,< 0.10",
+    "openjd-sessions == 0.10.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "tomlkit == 0.13.*",
     "typing_extensions ~= 4.8",
     "psutil >= 5.9,< 8.0",
-    "pydantic ~= 1.10.0",
+    "pydantic >= 2.10, < 3",
     "pywin32 == 308; platform_system == 'Windows'",
     "requests == 2.32.*",
 ]
@@ -100,7 +100,8 @@ pretty = true
 
 # Declare mypy plugins
 plugins = [
-    "pydantic.mypy",
+  "pydantic.mypy",
+  "pydantic.v1.mypy"
 ]
 
 files = [ "src/**/*.py" ]
@@ -111,7 +112,6 @@ ignore_missing_imports = true
 # Ignore missing type annotations for the following packages
 # See https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml-file
 [[tool.mypy.overrides]]
-
 module = [
     "requests",
     "requests.exceptions",

--- a/src/deadline_worker_agent/capabilities.py
+++ b/src/deadline_worker_agent/capabilities.py
@@ -11,13 +11,13 @@ import platform
 import shutil
 import subprocess
 
-from pydantic import BaseModel, NonNegativeFloat, PositiveFloat
+from pydantic.v1 import BaseModel, NonNegativeFloat, PositiveFloat
 import psutil
 
 from .config.errors import ConfigurationError
 
 if TYPE_CHECKING:
-    from pydantic.typing import CallableGenerator
+    from pydantic.v1.typing import CallableGenerator
 
 
 _logger = logging.getLogger(__name__)

--- a/src/deadline_worker_agent/config/config.py
+++ b/src/deadline_worker_agent/config/config.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Sequence, Tuple, cast, TYPE_CHECKING
 
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.sessions import PosixSessionUser, SessionUser
 

--- a/src/deadline_worker_agent/config/config_file.py
+++ b/src/deadline_worker_agent/config/config_file.py
@@ -10,7 +10,7 @@ import sys
 import os
 
 import tomlkit
-from pydantic import BaseModel, BaseSettings, Field, ValidationError, root_validator, StrictStr
+from pydantic.v1 import BaseModel, BaseSettings, Field, ValidationError, root_validator, StrictStr
 from tomlkit.container import Container
 from tomlkit.items import Bool, Comment, SingleKey, String, Table, Trivia, Whitespace
 

--- a/src/deadline_worker_agent/config/settings.py
+++ b/src/deadline_worker_agent/config/settings.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Optional, Tuple
 from pathlib import Path
 
-from pydantic import BaseSettings, Field
-from pydantic.env_settings import SettingsSourceCallable
+from pydantic.v1 import BaseSettings, Field
+from pydantic.v1.env_settings import SettingsSourceCallable
 
 from ..capabilities import Capabilities
 from .config_file import ConfigFile

--- a/test/unit/config/test_config_file.py
+++ b/test/unit/config/test_config_file.py
@@ -7,7 +7,7 @@ import tempfile
 from pathlib import Path
 from deadline_worker_agent.capabilities import Capabilities
 
-from pydantic import ValidationError, BaseSettings
+from pydantic.v1 import ValidationError, BaseSettings
 import pytest
 
 try:

--- a/test/unit/config/test_settings.py
+++ b/test/unit/config/test_settings.py
@@ -9,7 +9,7 @@ import pytest
 import os
 from pathlib import Path
 
-from pydantic import ConstrainedStr
+from pydantic.v1 import ConstrainedStr
 
 import deadline_worker_agent.config.settings as settings_mod
 from deadline_worker_agent.capabilities import Capabilities

--- a/test/unit/test_capabilities.py
+++ b/test/unit/test_capabilities.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import subprocess
 
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from deadline_worker_agent.capabilities import Capabilities
 from deadline_worker_agent import capabilities as capabilities_mod


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Update to openjd-sessions `0.10.*`, we also need to updated the pydantic dependency to V2 since the latest version openjd-model now requires it.

[openjd-sessions-for-python release notes](https://github.com/OpenJobDescription/openjd-sessions-for-python/releases/tag/0.10.0)

### What was the solution? (How)
Update the openjd-session and pydantic dependencies. The Worker agent has not been updated for pydantic V2 usage yet. Update the imports to utilize `pydantic.v1` and update the mypy pydantic plugin to support v1 and v2 

### What is the impact of this change?
Updates openjd-session dependency

### How was this change tested?
`hatch run lint && hatch run test`

### Was this change documented?
No

### Is this a breaking change?
Yes. There was a breaking change in the openjd-sessions-for-python dependency. This results in a behaviour change for the Worker Agent where environment exit now has a default timeout of 5 minutes. To have long-running environment exit actions, job templates can specify a large timeout value when defining the action in a job or environment template.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*