### PR TITLE
fix: add traversal and read permissions to session root dir for windows

### DIFF
--- a/src/deadline_worker_agent/file_system_operations.py
+++ b/src/deadline_worker_agent/file_system_operations.py
@@ -15,6 +15,7 @@ class FileSystemPermissionEnum(Enum):
     EXECUTE = "EXECUTE"
     READ_WRITE = "READ_WRITE"
     FULL_CONTROL = "FULL_CONTROL"
+    LIST_DIRECTORY_AND_READ = "LIST_DIRECTORY_AND_READ"
 
 
 def set_permissions(
@@ -82,6 +83,7 @@ def _set_windows_permissions(
     group: Optional[str] = None,
     group_permission: Optional[FileSystemPermissionEnum] = None,
     agent_user_permission: Optional[FileSystemPermissionEnum] = None,
+    users_group_permission: Optional[FileSystemPermissionEnum] = None,
 ):
     import win32security
     import ntsecuritycon
@@ -128,6 +130,16 @@ def _set_windows_permissions(
             _get_ntsecuritycon_mode(group_permission),
             group_sid,
         )
+    
+    # Add an ACE to the DACL giving the User group the required access and inheritance of the ACE
+    if users_group_permission is not None:
+        users_group_sid, _, _ = win32security.LookupAccountName(None, "Users")
+        dacl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION,
+            ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE,
+            _get_ntsecuritycon_mode(users_group_permission),
+            users_group_sid
+        )
 
     # Get the security descriptor of the object
     sd = win32security.GetFileSecurity(str(path.resolve()), win32security.DACL_SECURITY_INFORMATION)
@@ -157,5 +169,13 @@ def _get_ntsecuritycon_mode(mode: FileSystemPermissionEnum) -> int:
         FileSystemPermissionEnum.EXECUTE.value: ntsecuritycon.FILE_GENERIC_EXECUTE
         | ntsecuritycon.FILE_GENERIC_READ,
         FileSystemPermissionEnum.FULL_CONTROL.value: ntsecuritycon.GENERIC_ALL,
+        FileSystemPermissionEnum.LIST_DIRECTORY_AND_READ.value: ntsecuritycon.FILE_LIST_DIRECTORY
+        | ntsecuritycon.FILE_TRAVERSE
+        | ntsecuritycon.FILE_READ_ATTRIBUTES
+        | ntsecuritycon.FILE_READ_EA
+        | ntsecuritycon.SYNCHRONIZE
+        | ntsecuritycon.FILE_GENERIC_READ
+
+
     }
     return permission_mapping[mode.value]

--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -453,6 +453,7 @@ def provision_directories(
         group="Administrators",
         group_permission=FileSystemPermissionEnum.FULL_CONTROL,
         agent_user_permission=None,
+        users_group_permission=FileSystemPermissionEnum.LIST_DIRECTORY_AND_READ
     )
     logging.info(f"Done provisioning session root directory ({session_root_dir})")
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When trying to create folders with `mkdir` using bash on Windows in the session root directory, traversal permissions are required. We recently started creating the session root directory in the worker installer, the permissions are currently too restrictive to allow for this workflow.

### What was the solution? (How)

Add the `Users` group to the session root dir with the following permissions to allow Traversal and Read to support `mkdir ` on bash.
```
FILE_LIST_DIRECTORY
FILE_TRAVERSE
FILE_READ_ATTRIBUTES
FILE_READ_EA
SYNCHRONIZE
FILE_GENERIC_READ
```

### What is the impact of this change?
files can be created in the session rootdir using `mkdir` on bash

### How was this change tested?
1. Made the changes, built the package and installed it on a Windows host.
2. Installed the Worker Agent and confirmed the permissions were as inteded
3. Submitted a job with this template to confirm that `mkdir` now works.
4. Confirmed the permissions of the per-session directory to make sure that Users permissions were not being inherited.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*