### PR TITLE
fix: install-deadline-worker on Windows creates session root directory without read and traversal permissions for Users

### DIFF
--- a/src/deadline_worker_agent/file_system_operations.py
+++ b/src/deadline_worker_agent/file_system_operations.py
@@ -15,6 +15,7 @@ class FileSystemPermissionEnum(Enum):
     EXECUTE = "EXECUTE"
     READ_WRITE = "READ_WRITE"
     FULL_CONTROL = "FULL_CONTROL"
+    LIST_DIRECTORY_AND_READ = "LIST_DIRECTORY_AND_READ"
 
 
 def set_permissions(
@@ -82,6 +83,7 @@ def _set_windows_permissions(
     group: Optional[str] = None,
     group_permission: Optional[FileSystemPermissionEnum] = None,
     agent_user_permission: Optional[FileSystemPermissionEnum] = None,
+    users_group_permission: Optional[FileSystemPermissionEnum] = None,
 ):
     import win32security
     import ntsecuritycon
@@ -129,6 +131,16 @@ def _set_windows_permissions(
             group_sid,
         )
 
+    # Add an ACE to the DACL giving the User group the required access and inheritance of the ACE
+    if users_group_permission is not None:
+        users_group_sid, _, _ = win32security.LookupAccountName(None, "Users")
+        dacl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION,
+            ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE,
+            _get_ntsecuritycon_mode(users_group_permission),
+            users_group_sid,
+        )
+
     # Get the security descriptor of the object
     sd = win32security.GetFileSecurity(str(path.resolve()), win32security.DACL_SECURITY_INFORMATION)
 
@@ -157,5 +169,8 @@ def _get_ntsecuritycon_mode(mode: FileSystemPermissionEnum) -> int:
         FileSystemPermissionEnum.EXECUTE.value: ntsecuritycon.FILE_GENERIC_EXECUTE
         | ntsecuritycon.FILE_GENERIC_READ,
         FileSystemPermissionEnum.FULL_CONTROL.value: ntsecuritycon.GENERIC_ALL,
+        FileSystemPermissionEnum.LIST_DIRECTORY_AND_READ.value: ntsecuritycon.FILE_LIST_DIRECTORY
+        | ntsecuritycon.FILE_TRAVERSE
+        | ntsecuritycon.FILE_GENERIC_READ,
     }
     return permission_mapping[mode.value]

--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -453,6 +453,7 @@ def provision_directories(
         group="Administrators",
         group_permission=FileSystemPermissionEnum.FULL_CONTROL,
         agent_user_permission=None,
+        users_group_permission=FileSystemPermissionEnum.LIST_DIRECTORY_AND_READ,
     )
     logging.info(f"Done provisioning session root directory ({session_root_dir})")
 

--- a/test/integ/windows/test_installer.py
+++ b/test/integ/windows/test_installer.py
@@ -243,13 +243,16 @@ def test_update_config_file_creates_backup(setup_example_config):
     assert os.path.isfile(backup_worker_config), "Backup of worker config file was not created"
 
 
-def verify_least_privilege(windows_user: str, path: Path):
+def verify_least_privilege(windows_user: str, path: Path, is_session_root: bool = False):
     builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, "Administrators")
     user_sid, _, _ = win32security.LookupAccountName(None, windows_user)
+    users_group_sid, _, _ = win32security.LookupAccountName(None, "Users")
+
     sd = win32security.GetFileSecurity(
         str(path),
         win32con.DACL_SECURITY_INFORMATION | win32con.OWNER_SECURITY_INFORMATION,
     )
+
     # Verify ownership
     owner_sid = sd.GetSecurityDescriptorOwner()
     assert builtin_admin_group_sid == owner_sid, (
@@ -258,22 +261,54 @@ def verify_least_privilege(windows_user: str, path: Path):
 
     # Verify all ACEs
     dacl = sd.GetSecurityDescriptorDacl()
-    assert dacl.GetAceCount() == 2, f"Number of aces for {path} was not as expected"
+    if is_session_root:
+        assert dacl.GetAceCount() == 3, f"Number of aces for {path} was not as expected"
+    else:
+        assert dacl.GetAceCount() == 2, f"Number of aces for {path} was not as expected"
+
+    users_group_permission_found = False
+    list_directory_and_read_mask = (
+        ntsecuritycon.FILE_LIST_DIRECTORY
+        | ntsecuritycon.FILE_TRAVERSE
+        | ntsecuritycon.FILE_GENERIC_READ
+    )
+
     for ace in [dacl.GetAce(i) for i in range(dacl.GetAceCount())]:
         _ace_info, mask, sid = ace
         ace_type, ace_flags = _ace_info
 
-        assert ace_type == ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE, (
-            f"Unexpected ace type found for {path}"
-        )
-        assert (
-            ace_flags == ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE
-        ), "Unexpected inheritance in ace for  {path}"
-        assert (
-            # we set ntsecuritycon.GENERIC_ALL but that gets converted to win32File.FILE_ALL_ACCESS
-            mask == win32file.FILE_ALL_ACCESS
-        ), f"Expected only FILE_FULL_ACCESS aces for {path} but found {mask}"
-        assert sid in [builtin_admin_group_sid, user_sid], f"Unexpected sid found in ace for {path}"
+        if sid in [builtin_admin_group_sid, user_sid]:
+            assert ace_type == ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE, (
+                f"Unexpected ace type found for {path}"
+            )
+            assert (
+                ace_flags == ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE
+            ), "Unexpected inheritance in ace for  {path}"
+            assert (
+                # we set ntsecuritycon.GENERIC_ALL but that gets converted to win32File.FILE_ALL_ACCESS
+                mask == win32file.FILE_ALL_ACCESS
+            ), f"Expected only FILE_FULL_ACCESS aces for {path} but found {mask}"
+            assert sid in [builtin_admin_group_sid, user_sid], (
+                f"Unexpected sid found in ace for {path}"
+            )
+        # Check for Users group ACE with LIST_DIRECTORY_AND_READ permissions
+        elif sid == users_group_sid:
+            assert ace_type == ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE, (
+                f"Unexpected ace type found for Users group ACE for {path}"
+            )
+            assert (
+                ace_flags == ntsecuritycon.OBJECT_INHERIT_ACE | ntsecuritycon.CONTAINER_INHERIT_ACE
+            ), f"Unexpected inheritance in Users group ace for {path}"
+
+            # Check if the mask includes all required permissions for LIST_DIRECTORY_AND_READ
+            assert (mask & list_directory_and_read_mask) == list_directory_and_read_mask, (
+                f"Users group does not have LIST_DIRECTORY_AND_READ permissions for {path}"
+            )
+
+            users_group_permission_found = True
+
+    if is_session_root:
+        assert users_group_permission_found, f"No ACE found for Users group for {path}"
 
 
 def test_provision_directories(
@@ -322,7 +357,7 @@ def test_provision_directories(
     assert actual_dirs.deadline_config_subdir.exists()
     verify_least_privilege(windows_user, actual_dirs.deadline_config_subdir)
     assert session_root_dir.exists()
-    verify_least_privilege(windows_user, session_root_dir)
+    verify_least_privilege(windows_user, session_root_dir, is_session_root=True)
 
 
 def test_update_deadline_client_config(tmp_path: Path) -> None:

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -994,4 +994,5 @@ class TestProvisionDirectories:
             group="Administrators",
             group_permission=FileSystemPermissionEnum.FULL_CONTROL,
             agent_user_permission=None,
+            users_group_permission=FileSystemPermissionEnum.LIST_DIRECTORY_AND_READ,
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When trying to create folders with `mkdir` using bash on Windows in the session root directory, traversal permissions are required. We recently started creating the session root directory in the worker installer, the permissions are currently too restrictive to allow for this workflow.

### What was the solution? (How)

Add the `Users` group to the session root dir with the following permissions to allow Traversal and Read to support `mkdir ` on bash.
```
FILE_LIST_DIRECTORY
FILE_TRAVERSE
FILE_GENERIC_READ
```

### What is the impact of this change?
files can be created in the session rootdir using `mkdir` on bash

### How was this change tested?
1. Made the changes, built the package and installed it on a Windows host.
2. Installed the Worker Agent and confirmed the permissions were as intended

![UsersPermissions](https://github.com/user-attachments/assets/7732eb95-1590-4470-8b36-08d25e1bbae8)

4. Submitted a job with this template to confirm that `mkdir` now works.
```
specificationVersion: 'jobtemplate-2023-09'
name: OutPutTest
parameterDefinitions:
- name: OutputDir
  type: PATH
  objectType: DIRECTORY
  dataFlow: OUT
  userInterface:
    control: CHOOSE_DIRECTORY
    label: Output Directory
  default: "./output"
steps:
- name: WelcomeToAWSDeadlineCloud
  script:
    actions:
      onRun:
        command: bash
        args: ['{{Task.File.Run}}']
    embeddedFiles:
      - name: Run
        type: TEXT
        data: |
          set -xeuo pipefail

          mkdir -p '{{Param.OutputDir}}'

          echo "Hello World" > '{{Param.OutputDir}}/test.txt'

          cat '{{Param.OutputDir}}/test.txt'
```
6. Confirmed the permissions of the per-session directory to make sure that Users permissions were not being inherited.
![ConfirmSessionDIrPermissions](https://github.com/user-attachments/assets/e08758bc-3835-46f0-bb1d-f75bdfd13314)


### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*