### PR TITLE
fix: worker agent unable to start without EC2 metadata access

### DIFF
--- a/src/deadline_worker_agent/startup/bootstrap.py
+++ b/src/deadline_worker_agent/startup/bootstrap.py
@@ -650,8 +650,8 @@ def _get_metadata(metadata_type: str) -> requests.Response | None:
             f"http://169.254.169.254/latest/meta-data/{metadata_type}",
             headers={"X-aws-ec2-metadata-token": token},
         )
-    except (TimeoutError, ConnectionError):
-        _logger.info("Not running on Ec2, the metadata service was not found!")
+    except Exception:
+        _logger.info("Not running on EC2 or the metadata service was unable to be found!")
         return None
     else:
         return response


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
#571 caught that other exceptions could be thrown when trying to connect to the metadata service than what we were catching .
### What was the solution? (How)
Catch exceptions in general since we don't care exactly which exceptions are raised, just that the metadata service was not able to be reached.
### What is the impact of this change?
Next release of the worker agent should be able to run on non EC2 instances or those without access to the metadata service
### How was this change tested?
Ran the current release 0.28.1 locally on my laptop without access to the metadata service and got the following:
```
CRITICAL [2025-03-11 10:11:38,935][CRITICAL] HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url:              entrypoint.py:201
                             /latest/api/token (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x00000197415A0190>: Failed to
                             establish a new connection: [WinError 10051] A socket operation was attempted to an unreachable network'))
```

Ran the same test again with my change and the worker agent started successfully with the following in the logs:
```
 INFO     [2025-03-11 10:12:58,351][INFO    ] Not running on EC2 or the metadata service was unable to be found!                                bootstrap.py:654
 INFO     [2025-03-11 10:12:58,354][INFO    ] IMDS is not reachable. Worker host is not an EC2 instance or IMDs is turned off.  
```
### Was this change documented?
Will be documented in the changelog and in the open GitHub issue
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*