### PR TITLE
fix: unexpected GPU memory configurations crash worker agent

### DIFF
--- a/src/deadline_worker_agent/capabilities.py
+++ b/src/deadline_worker_agent/capabilities.py
@@ -120,10 +120,15 @@ def _get_gpu_memory(*, verbose: bool = True) -> int:
 
         mem_per_gpu: list[int] = []
         for line in output.splitlines():
-            mem_mib = int(line.replace("MiB", ""))
-            mem_per_gpu.append(mem_mib)
+            try:
+                mem_mib = int(line.replace("MiB", ""))
+                mem_per_gpu.append(mem_mib)
+            except:
+                # If there's a parsing error on a line, skip it
+                pass
 
-        min_memory = min(mem_per_gpu)
+        # If no line had a valid memory amount, default to 0
+        min_memory = min(mem_per_gpu, default=0)
 
         if verbose:
             _logger.info("Minimum total memory of all GPUs: %s", min_memory)

--- a/src/deadline_worker_agent/capabilities.py
+++ b/src/deadline_worker_agent/capabilities.py
@@ -116,6 +116,18 @@ def _get_gpu_memory(*, verbose: bool = True) -> int:
         output_bytes = subprocess.check_output(
             ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader"]
         )
+        output = output_bytes.decode().strip()
+
+        mem_per_gpu: list[int] = []
+        for line in output.splitlines():
+            mem_mib = int(line.replace("MiB", ""))
+            mem_per_gpu.append(mem_mib)
+
+        min_memory = min(mem_per_gpu)
+
+        if verbose:
+            _logger.info("Minimum total memory of all GPUs: %s", min_memory)
+        return min_memory
     except FileNotFoundError:
         if verbose:
             _logger.warning("Could not detect GPU memory, nvidia-smi not found")
@@ -134,18 +146,6 @@ def _get_gpu_memory(*, verbose: bool = True) -> int:
         if verbose:
             _logger.warning("Could not detect GPU memory, unexpected error running nvidia-smi")
         return 0
-    output = output_bytes.decode().strip()
-
-    mem_per_gpu: list[int] = []
-    for line in output.splitlines():
-        mem_mib = int(line.replace("MiB", ""))
-        mem_per_gpu.append(mem_mib)
-
-    min_memory = min(mem_per_gpu)
-
-    if verbose:
-        _logger.info("Minimum total memory of all GPUs: %s", min_memory)
-    return min_memory
 
 
 def capability_type(capability_name_str: str) -> Literal["amount", "attr"]:

--- a/test/unit/test_capabilities.py
+++ b/test/unit/test_capabilities.py
@@ -354,16 +354,25 @@ class TestGetGPUMemory:
 
         assert result == expected_result
 
+    @pytest.mark.parametrize(
+        ("output", "expected_value"),
+        (
+            pytest.param("[N/A]", 0),
+            pytest.param("[N/A]\n[N/A]", 0),
+            pytest.param("\n\n\n", 0),
+            pytest.param("1000 MiB\n\n\n", 1000),
+            pytest.param("1000 MiB\n[N/A]\n\n", 1000),
+        ),
+    )
     @patch.object(capabilities_mod.subprocess, "check_output")
     def test_unexpected_output_does_not_raise_exception(
-        self,
-        check_output_mock: MagicMock,
+        self, check_output_mock: MagicMock, output: str, expected_value: int
     ) -> None:
         # GIVEN
-        check_output_mock.return_value = b"[N/A]"
+        check_output_mock.return_value = bytes(output, encoding="utf-8")
 
         # WHEN
         result = capabilities_mod._get_gpu_memory()
 
         # THEN
-        assert result == 0
+        assert result == expected_value

--- a/test/unit/test_capabilities.py
+++ b/test/unit/test_capabilities.py
@@ -353,3 +353,17 @@ class TestGetGPUMemory:
         )
 
         assert result == expected_result
+
+    @patch.object(capabilities_mod.subprocess, "check_output")
+    def test_unexpected_output_does_not_raise_exception(
+        self,
+        check_output_mock: MagicMock,
+    ) -> None:
+        # GIVEN
+        check_output_mock.return_value = b"[N/A]"
+
+        # WHEN
+        result = capabilities_mod._get_gpu_memory()
+
+        # THEN
+        assert result == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Some GPU configurations cause `nvidia-smi` to return an output that we didn't expect. The unexpected output raises an exception which is uncaught and crashes the worker agent.

Fixes: https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/536
Related: https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/537

### What was the solution? (How)
Catch exceptions for GPU memory parsing errors.

### What is the impact of this change?
Fixes a worker agent crash with some GPU configurations.

### How was this change tested?
Unit tests.

### Was this change documented?
n/a

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*