### PR TITLE
test: increase job length when testing session action cancellation

### DIFF
--- a/src/deadline_worker_agent/startup/bootstrap.py
+++ b/src/deadline_worker_agent/startup/bootstrap.py
@@ -650,8 +650,8 @@ def _get_metadata(metadata_type: str) -> requests.Response | None:
             f"http://169.254.169.254/latest/meta-data/{metadata_type}",
             headers={"X-aws-ec2-metadata-token": token},
         )
-    except (TimeoutError, ConnectionError):
-        _logger.info("Not running on Ec2, the metadata service was not found!")
+    except Exception:
+        _logger.info("Not running on EC2 or the metadata service was unable to be found!")
         return None
     else:
         return response

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -95,7 +95,7 @@ class TestJobSubmission:
             )
             def is_job_started(current_job: Job) -> bool:
                 current_job.refresh_job_info(client=deadline_client)
-                LOG.info(f"Waiting for job {current_job.id} to be created")
+                LOG.info(f"Waiting for job {current_job.id} to be created and running")
 
                 assert current_job.task_run_status not in [
                     TaskStatus.INTERRUPTING,
@@ -183,7 +183,7 @@ class TestJobSubmission:
             )
             def is_job_started(current_job: Job) -> bool:
                 current_job.refresh_job_info(client=deadline_client)
-                LOG.info(f"Waiting for job {current_job.id} to be created")
+                LOG.info(f"Waiting for job {current_job.id} to be created and running")
 
                 assert current_job.task_run_status not in [
                     TaskStatus.INTERRUPTING,
@@ -558,9 +558,9 @@ class TestJobSubmission:
                             else "powershell"
                         ),
                         "args": (
-                            ["40"]
+                            ["300"]
                             if os.environ["OPERATING_SYSTEM"] == "linux"
-                            else ["ping", "localhost", "-n", "40"]
+                            else ["ping", "localhost", "-n", "300"]
                         ),
                         "cancelation": {
                             "mode": "NOTIFY_THEN_TERMINATE",
@@ -589,9 +589,9 @@ class TestJobSubmission:
                             else "powershell"
                         ),
                         "args": (
-                            ["40"]
+                            ["300"]
                             if os.environ["OPERATING_SYSTEM"] == "linux"
-                            else ["ping", "localhost", "-n", "40"]
+                            else ["ping", "localhost", "-n", "300"]
                         ),
                         "cancelation": {
                             "mode": "NOTIFY_THEN_TERMINATE",
@@ -652,12 +652,12 @@ class TestJobSubmission:
             max_time=120,
             interval=10,
         )
-        def is_job_started(current_job: Job) -> bool:
+        def is_job_created(current_job: Job) -> bool:
             current_job.refresh_job_info(client=deadline_client)
             LOG.info(f"Waiting for job {current_job.id} to be created")
             return current_job.lifecycle_status != "CREATE_IN_PROGRESS"
 
-        assert is_job_started(job)
+        assert is_job_created(job)
 
         @backoff.on_predicate(
             wait_gen=backoff.constant,
@@ -859,12 +859,12 @@ class TestJobSubmission:
             max_time=120,
             interval=10,
         )
-        def is_job_started(current_job: Job) -> bool:
+        def is_job_created(current_job: Job) -> bool:
             current_job.refresh_job_info(client=deadline_client)
             logging.info(f"Waiting for job {current_job.id} to be created")
             return current_job.lifecycle_status != "CREATE_IN_PROGRESS"
 
-        assert is_job_started(job)
+        assert is_job_created(job)
 
         @backoff.on_predicate(
             wait_gen=backoff.constant,
@@ -1241,7 +1241,7 @@ class TestJobSubmission:
         )
         def is_job_started_with_sessions(current_job: Job) -> bool:
             current_job.refresh_job_info(client=deadline_client)
-            LOG.info(f"Waiting for job {current_job.id} to be created")
+            LOG.info(f"Waiting for job {current_job.id} to be created and running")
             if current_job.lifecycle_status == "CREATE_IN_PROGRESS":
                 return False
             sessions: list[dict[str, Any]] = deadline_client.list_sessions(
@@ -2434,12 +2434,12 @@ class TestJobSubmission:
             max_time=120,
             interval=2,
         )
-        def is_job_started() -> bool:
+        def is_job_created() -> bool:
             job.refresh_job_info(client=deadline_client)
             LOG.info(f"Waiting for job {job.id} to be created")
             return job.lifecycle_status != "CREATE_IN_PROGRESS"
 
-        assert is_job_started()
+        assert is_job_created()
 
         @backoff.on_predicate(
             wait_gen=backoff.constant,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
It looks like there's a race condition in one of the canary tests that failed in the latest run because a session action that the test expected to be cancelled managed to finish running before it was actually cancelled.
```
if expected_canceled_action == "envEnter":
                        # If we canceled the envEnter, everything else should have been NEVER_ATTEMPTED
>                       assert session_action["status"] == "NEVER_ATTEMPTED"
E                       AssertionError: assert 'SUCCEEDED' == 'NEVER_ATTEMPTED'
E                         
E                         - NEVER_ATTEMPTED
E                         + SUCCEEDED
```
### What was the solution? (How)
Increase the runtime from 40 seconds to 5 minutes(300 seconds) to give additional time for the tests to check that the job has been created, sessions exist and then cancel the job which should cancel the running session action all before the action is able to complete

Also cleaned up the naming and logging of some functions since it was unclear if we were waiting for the job to just be created or actually running
### What is the impact of this change?
Less flaky tests hopefully
### How was this change tested?
It wasn't
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*