### PR TITLE
fix: High memory usage when running job attachment test cases.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -151,13 +151,16 @@ The worker agent has end-to-end tests that run the agent on ec2 instances with t
 are located under `test/e2e` in this repository. To run these tests:
 
 1. Configure your AWS credentials profile & region to test within. (e.g. Set the env vars `AWS_PROFILE` and `AWS_DEFAULT_REGION`)
-2. Deploy the testing infrastructure: Run `scripts/deploy_e2e_testing_infrastructure.sh`
-3. Gather the environment variable exports that you will need for each OS:
+2. Deploy https://github.com/aws-cloudformation/community-registry-extensions/blob/main/resources/S3_DeleteBucketContents/resource-role-prod.yaml to your account. Note down the output role ARN.
+3. Goto `AWS Console -> CloudFormation -> Public Extensions -> Search for Third Party Resource: 'AwsCommunity::S3::DeleteBucketContents' -> Activate`. Use the role ARN from step 2.
+4. Before deploying the test farm, make sure your account has sufficient Farm quota. Each account has a limit of 2.
+5. Deploy the testing infrastructure: Run `scripts/deploy_e2e_testing_infrastructure.sh`
+6. Gather the environment variable exports that you will need for each OS:
 ```bash
 ./scripts/get_e2e_test_ids_from_cfn.sh --os Linux > .e2e_linux_infra.sh
 ./scripts/get_e2e_test_ids_from_cfn.sh --os Windows > .e2e_windows_infra.sh
 ```
-4. Run the tests:
+7. Run the tests:
 ```
 rm -f dist/*
 hatch build

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -1012,6 +1012,10 @@ class TestJobSubmission:
                     }
                 )
             )
+
+        # 100 meg file.    10,000,000
+        large_file = "A" * 100000000
+
         # Create the input files to make sync inputs take a relatively long time
         files_path: str = os.path.join(tmp_path, "files")
         os.mkdir(files_path)
@@ -1020,7 +1024,9 @@ class TestJobSubmission:
             with open(file_name, "w+") as input_file:
                 if i % 1000 == 0:
                     # Create some big files (1GB each) so the syncInputAttachments don't fail due to low transfer rates
-                    input_file.write("A" * 1000000000)
+                    # Write 10 100 meg buffers to reduce memory usage.
+                    for _ in range(10):
+                        input_file.write(large_file)
                 else:
                     input_file.write(f"{i}")
         config = configparser.ConfigParser()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Flaky test report
```
The test test_worker_reports_canceled_sync_input_actions_as_canceled can sometimes experience a MemoryError and cause the canary to fail.

This error indicates we are running out of memory on the test runner.
```

### What was the solution? (How)
- Instead of writing A* 1000000000 (1GB) files every time we have 1000 files, we can use a statically allocated buffer of 100 megs and write the 100 megs 10 times. This should reduce the memory usage while Python is running.

### What is the impact of this change?
- More stable tests.

### How was this change tested?
- hatch run fmt
- hatch run test.  (all pass)
- hatch run integ-test (all pass)
- hatch run e2e-test (still running)

```
=================================================================================== slowest 5 durations ===================================================================================
651.26s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
313.12s call     test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_reports_canceled_sync_input_actions_as_canceled
265.71s setup    test/e2e/test_cap_kill.py::test_cap_kill_not_inherited_by_running_jobs
238.10s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_local_session_logs_can_be_turned_off
229.84s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
================================================================= 39 passed, 6 skipped, 40 warnings in 4325.02s (1:12:05) =================================================================
```
### Was this change documented?
- Not applicable, this is a test case.
 
### Is this a breaking change?
- Not applicable. 
- 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*