### PR TITLE
test: add IMDS query exception handling test

### DIFF
--- a/src/deadline_worker_agent/startup/bootstrap.py
+++ b/src/deadline_worker_agent/startup/bootstrap.py
@@ -650,8 +650,8 @@ def _get_metadata(metadata_type: str) -> requests.Response | None:
             f"http://169.254.169.254/latest/meta-data/{metadata_type}",
             headers={"X-aws-ec2-metadata-token": token},
         )
-    except (TimeoutError, ConnectionError):
-        _logger.info("Not running on Ec2, the metadata service was not found!")
+    except Exception:
+        _logger.info("Not running on EC2 or the metadata service was unable to be found!")
         return None
     else:
         return response

--- a/test/unit/startup/test_bootstrap.py
+++ b/test/unit/startup/test_bootstrap.py
@@ -7,7 +7,6 @@ import stat
 from tempfile import TemporaryDirectory
 from pathlib import Path
 import json
-
 from botocore.exceptions import ClientError
 from pytest import fixture, mark, param, raises
 
@@ -883,7 +882,6 @@ class TestStartWorker:
             )
 
 
-@mark.usefixtures("get_metadata_mock")
 class TestEnforceNoInstanceProfile:
     def test_success(
         self,
@@ -945,6 +943,27 @@ class TestEnforceNoInstanceProfile:
             "Unexpected HTTP status code (%d) from /iam/info IMDS response",
             unexpected_status_code,
         )
+
+    def test_imds_exception_handling(
+        self,
+        mod_logger_mock: MagicMock,
+    ) -> None:
+        # GIVEN
+        logger_info: MagicMock = mod_logger_mock.info
+        with patch.object(
+            bootstrap_mod.requests,
+            "put",
+            side_effect=bootstrap_mod.requests.ConnectionError("Testing"),
+        ) as requests_put_mock:
+            # WHEN
+            result = bootstrap_mod._get_metadata("iam/info")
+
+        # THEN
+        requests_put_mock.assert_called_once()
+        logger_info.assert_called_once_with(
+            "Not running on EC2 or the metadata service was unable to be found!",
+        )
+        assert result is None
 
 
 class TestEnforceNoInstanceProfileOrStopWorker:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
#572 fixed an issue where the worker agent failed to start when running on machines without IMDS accessible due to unhandled exceptions.
### What was the solution? (How)
This PR adds a unit test to prevent regressions and ensure we handle the exception gracefully.
### What is the impact of this change?
Better coverage to prevent regressions
### How was this change tested?
Ran the unit tests
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*