### PR TITLE
test: Adding GetLog permissions to the queue role for newly deployed test resources

### DIFF
--- a/scripts/e2e_testing_infrastructure.yaml
+++ b/scripts/e2e_testing_infrastructure.yaml
@@ -560,6 +560,15 @@ Resources:
                     - ''
                     - - !GetAtt JobAttachmentsBucket.Arn
                       - /*
+              - Effect: Allow
+                Action:
+                  - logs:GetLogEvents
+                Resource:
+                  - !Join
+                    - ''
+                    - - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/deadline/
+                      - !GetAtt DeadlineFarm.FarmId
+                      - /*
       Tags:
         - Key: Origin
           Value: DeadlineCloudAgentE2ETest

--- a/scripts/e2e_testing_infrastructure.yaml
+++ b/scripts/e2e_testing_infrastructure.yaml
@@ -560,6 +560,10 @@ Resources:
                     - ''
                     - - !GetAtt JobAttachmentsBucket.Arn
                       - /*
+        - PolicyName: LogPermissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
               - Effect: Allow
                 Action:
                   - logs:GetLogEvents


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- The queue role for the deployed test resources was missing the `GetLogEvents` permission.

### What was the solution? (How)
- I added the `logs:GetLogEvents` permission to the deployed queue role in the `e2e_testing_infrastructure.yaml`

### What is the impact of this change?
- Adding this permission to the queue role means that newly created test resources will have the required permissions to view the job logs in the Deadline Cloud Monitor to help with debugging tests.

### How was this change tested?
- I deployed the new resources, confirmed the policy was built correctly, and confirmed that job logs could be viewed from the Monitor. Other E2E tests and integration tests are passing. Nothing changed here will impact them.

### Was this change documented?
- N/A

### Is this a breaking change?
- No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*