### PR TITLE
test: Verify default Windows worker agent user and permissions

### DIFF
--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -8,7 +8,12 @@ import pytest
 import logging
 import os
 
-from deadline_test_fixtures import EC2InstanceWorker
+from e2e.utils import submit_custom_job
+from deadline_test_fixtures import (
+    DeadlineClient,
+    DeadlineResources,
+    EC2InstanceWorker,
+)
 
 
 LOG = logging.getLogger(__name__)
@@ -30,3 +35,114 @@ class TestInstaller:
         )
 
         assert cmd_result.exit_code == 0, f"Shutdown WA permission do not exist: {cmd_result}"
+
+
+@pytest.mark.skipif(os.environ["OPERATING_SYSTEM"] == "linux", reason="Windows specific tests")
+class TestWindowsInstaller:
+    def test_windows_installer_default_agent_user(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        session_worker: EC2InstanceWorker,
+    ) -> None:
+        # Length of time for the job to run
+        job_time = 5
+        # Default Windows Worker Agent username
+        defaultName = "deadline-worker"
+
+        def countdown_script(seconds: int = 1):
+            return f"""
+for ($i = {seconds}; $i -gt 0; $i--) {{
+  Write-Output "Seconds remaining $i"
+  Start-Sleep -Seconds 1
+}}
+Write-Output "Done!"
+"""
+
+        def check_admin_permissions(
+            session: EC2InstanceWorker,
+            username: str,
+        ) -> None:
+            test_command = "net localgroup administrators"
+            cmd_result = session.send_command(command=test_command)
+            assert cmd_result.exit_code == 0, "Failed to execute {test_command} command"
+            assert username in cmd_result.stdout, (
+                f"User {username} should exist when using command {test_command}"
+            )
+
+        def check_security_permissions(
+            session: EC2InstanceWorker,
+            username: str,
+            permissions: list[str],
+            should_exist: bool = True,
+        ) -> None:
+            permissions_str = '", "'.join(permissions)
+            cmd_result = session.send_command(
+                command=f"""
+secedit /export /cfg "$env:TEMP\security.cfg" | Out-Null
+Get-Content "$env:TEMP\security.cfg" | Select-String "{permissions_str}"
+"""
+            )
+            assert cmd_result.exit_code == 0, (
+                f"Failed to execute 'Get-Content' for permissions: {permissions}"
+            )
+            if should_exist:
+                assert username in cmd_result.stdout, (
+                    f"{username} does not have required permissions: {permissions}"
+                )
+            else:
+                assert username not in cmd_result.stdout, (
+                    f"{username} has unexpected permissions: {permissions}"
+                )
+
+        # Job to ensure the instance is fully running
+        submit_custom_job(
+            job_name="Test Job to start the instance",
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            run_script=countdown_script(),
+        ).wait_until_complete(client=deadline_client)
+
+        retain_instance_job = submit_custom_job(
+            job_name="Test Job to retain the instance",
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            run_script=countdown_script(job_time),
+        )
+
+        try:
+            # Check administrator membership
+            check_admin_permissions(session_worker, defaultName)
+
+            # Check for verified permissions
+            check_security_permissions(
+                session=session_worker,
+                username=defaultName,
+                permissions=["SeServiceLogonRight"],
+                should_exist=True,
+            )
+
+            check_security_permissions(
+                session=session_worker,
+                username=defaultName,
+                permissions=["SeAssignPrimary"],
+                should_exist=True,
+            )
+
+            # Check permissions that should not be assigned
+            check_security_permissions(
+                session=session_worker,
+                username=defaultName,
+                permissions=["SeShutdown", "SeIncreaseQuota"],
+                should_exist=False,
+            )
+        finally:
+            # Cleanup the temp directory
+            cmd_result = session_worker.send_command(
+                command='Remove-Item "$env:TEMP\security.cfg" -Force'
+            )
+            assert cmd_result.exit_code == 0, "Failed to cleanup security configuration file"
+
+        retain_instance_job.wait_until_complete(client=deadline_client)

--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -9,9 +9,9 @@ import logging
 import os
 
 from e2e.utils import submit_custom_job
+from e2e.conftest import DeadlineResources
 from deadline_test_fixtures import (
     DeadlineClient,
-    DeadlineResources,
     EC2InstanceWorker,
 )
 

--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -48,7 +48,7 @@ class TestWindowsInstaller:
         # Length of time for the job to run
         job_time = 5
         # Default Windows Worker Agent username
-        defaultName = "deadline-worker"
+        default_name = "deadline-worker"
 
         def countdown_script(seconds: int = 1):
             return f"""
@@ -98,35 +98,37 @@ Get-Content "$env:TEMP\security.cfg" | Select-String "{permissions_str}"
         # Job to ensure the instance is fully running
         submit_custom_job(
             job_name="Test Job to start the instance",
-            client=deadline_client,
+            deadline_client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             run_script=countdown_script(),
+            max_retries_per_task=2,
         ).wait_until_complete(client=deadline_client)
 
         retain_instance_job = submit_custom_job(
             job_name="Test Job to retain the instance",
-            client=deadline_client,
+            deadline_client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             run_script=countdown_script(job_time),
+            max_retries_per_task=2,
         )
 
         try:
             # Check administrator membership
-            check_admin_permissions(session_worker, defaultName)
+            check_admin_permissions(session_worker, default_name)
 
             # Check for verified permissions
             check_security_permissions(
                 session=session_worker,
-                username=defaultName,
+                username=default_name,
                 permissions=["SeServiceLogonRight"],
                 should_exist=True,
             )
 
             check_security_permissions(
                 session=session_worker,
-                username=defaultName,
+                username=default_name,
                 permissions=["SeAssignPrimary"],
                 should_exist=True,
             )
@@ -134,7 +136,7 @@ Get-Content "$env:TEMP\security.cfg" | Select-String "{permissions_str}"
             # Check permissions that should not be assigned
             check_security_permissions(
                 session=session_worker,
-                username=defaultName,
+                username=default_name,
                 permissions=["SeShutdown", "SeIncreaseQuota"],
                 should_exist=False,
             )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- We want more test coverage around the Windows Worker Agent installer

### What was the solution? (How)
- I'm adding a test to confirm
  - Default `deadline-worker` is created by the installer
  - `deadline-worker` has admin privileges
  - `deadline-worker` has default Windows Security permissions

### What is the impact of this change?
- Adding more test coverage to the worker agent for Windows installer

### How was this change tested?
- Ran the tests locally and as part of the E2E tests

### Was this change documented?
- N/A

### Is this a breaking change?
- No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*