### PR TITLE
feat(experimental): run admin host configuration scripts once worker becomes STARTED

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -53,10 +53,10 @@ Log events may also contain a `type`, `subtype`, icon (`ti`), and additional fie
 | AgentInfo | None | None | platform; python[interpreter,version]; agent[version,installedAt,runningAs]; depenencies | Information about the running Agent software. |
 | API | Req | 📤 | operation; request_url; params; resource (optional) | A request to an AWS API. Only requests to AWS Deadline Cloud APIs contain a resource field. |
 | API | Resp | 📥 | operation; params; status_code, request_id; error (optional) | A response from an AWS API request. |
-| FileSystem | Read/Write/Create/Delete | 💾 | filepath; message | A filesystem operation. |
 | AWSCreds | Load/Install/Delete | 🔑 | resource; message; role_arn (optional) | Related to an operation for AWS Credentials. |
 | AWSCreds | Query | 🔑 | resource; message; role_arn (optional); expiry (optional) | Related to an operation for AWS Credentials. |
 | AWSCreds | Refresh | 🔑 | resource; message; role_arn (optional); expiry (optional); scheduled_time (optional) | Related to an operation for AWS Credentials. |
+| FileSystem | Read/Write/Create/Delete | 💾 | filepath; message | A filesystem operation. |
 | Metrics | System | 📊 | many | System metrics. |
 | Session | Starting/Failed/AWSCreds/Complete/Info | 🔷 | queue_id; job_id; session_id | An update or information related to a Session. |
 | Session | Add/Remove | 🔷 | queue_id; job_id; session_id; action_ids; queued_actions | Adding or removing SessionActions in a Session. |
@@ -64,6 +64,7 @@ Log events may also contain a `type`, `subtype`, icon (`ti`), and additional fie
 | Session | User | 🔷 | queue_id; job_id; session_id; user | The user that a Session is running Actions as. |
 | Session | Runtime | 🔷 | queue_id; job_id; session_id | Information related to the running Session. This includes information about the host, process control, and encountered Exceptions which could contain information like filepaths. |
 | Worker | Create/Load/ID/Status/Delete | 💻 | farm_id; fleet_id; worker_id (optional); message | A notification related to a Worker resource within AWS Deadline Cloud. |
+| Worker | HostConfiguration | 📜 | farm_id; fleet_id; worker_id (optional); message; status; exit_code (optional); success (optional) | Worker Host configuration event. |
 
 If you prefer structured logs to be emited on your host, then you can configure your Worker Agent to emit structured logs instead. Please see the
 `structured_logs` option in the [`worker.toml.example`](../src/deadline_worker_agent/installer/worker.toml.example)

--- a/docs/state.md
+++ b/docs/state.md
@@ -45,7 +45,8 @@ The worker maintains a worker state which is a JSON representation of the follow
 ```jsonc
 {
     "worker_id": "<WORKER_ID>",
-    "instance_id": "<INSTANCE_ID>"  # OPTIONAL
+    "instance_id": "<INSTANCE_ID>",  # OPTIONAL
+    "host_configuration_succeeded": bool # OPTINAL
 }
 ```
 
@@ -58,6 +59,9 @@ This contains a unique identifier that represents the worker in your AWS Deadlin
 
 This is an optional parameter which contains an identifier of the EC2 instance running the worker, if applicable. 
 
+#### `host_configuration_succeeded`
+
+This is an optional parameter which indicates host configuration has been executed on the worker. Workers will only run once per worker.
 
 #### How the State File Affects Startup Behavior
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.34.75",
     "deadline == 0.49.*",
-    "openjd-sessions == 0.10.*",
+    # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
+    "openjd-sessions == 0.10.1",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "tomlkit == 0.13.*",

--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -103,6 +103,14 @@ class AttachmentUploadAction(TypedDict):
     taskId: str
 
 
+class HostConfiguration(TypedDict):
+    scriptBody: str
+    """Host Configuration Script Body."""
+
+    scriptTimeoutSeconds: int
+    """Customer Supplied timeout."""
+
+
 class LogConfiguration(TypedDict):
     error: NotRequired[str]
     logDriver: str
@@ -414,6 +422,7 @@ class UpdateWorkerScheduleRequest(TypedDict):
 
 class UpdateWorkerResponse(TypedDict):
     log: NotRequired[LogConfiguration]
+    hostConfiguration: NotRequired[HostConfiguration]
 
 
 class IpAddresses(TypedDict):

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -113,6 +113,17 @@ class DeadlineRequestInterrupted(Exception):
 
 
 @dataclass(frozen=True)
+class WorkerHostConfiguration:
+    """Host Configuration after a worker has started."""
+
+    script_body: str
+    """Host Configuration Script Body."""
+
+    script_timeout_seconds: int
+    """Customer Supplied timeout."""
+
+
+@dataclass(frozen=True)
 class WorkerLogConfig:
     """The destination where the Worker Agent should synchronize its logs to"""
 

--- a/src/deadline_worker_agent/feature_flag.py
+++ b/src/deadline_worker_agent/feature_flag.py
@@ -7,3 +7,5 @@ import os
 ASSET_SYNC_JOB_USER_FEATURE = (
     os.environ.get("ASSET_SYNC_JOB_USER_FEATURE", "false").lower() == "true"
 )
+
+HOST_CONFIGURATION_FEATURE = os.environ.get("HOST_CONFIGURATION_FEATURE", "false").lower() == "true"

--- a/src/deadline_worker_agent/log_messages.py
+++ b/src/deadline_worker_agent/log_messages.py
@@ -164,6 +164,7 @@ class WorkerLogEventOp(str, Enum):
     ID = "ID"  # The ID that the Agent is running as
     STATUS = "Status"
     DELETE = "Delete"
+    HOST_CONFIGURATION = "HostConfiguration"
 
 
 class WorkerLogEvent(BaseLogEvent):
@@ -198,6 +199,53 @@ class WorkerLogEvent(BaseLogEvent):
         dd.update(farm_id=self.farm_id, fleet_id=self.fleet_id)
         if self.worker_id:
             dd.update(worker_id=self.worker_id)
+        return self.add_exception_to_dict(dd)
+
+
+class WorkerHostConfigurationStatus(str, Enum):
+    RUNNING = "Running"
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    SKIPPED = "Skipped"
+
+
+class WorkerHostConfigurationLogEvent(WorkerLogEvent):
+    ti = "📜"
+    type = "Worker"
+    status: WorkerHostConfigurationStatus
+    exit_code: Optional[int]
+    success: Optional[bool]
+
+    def __init__(
+        self,
+        *,
+        farm_id: str,
+        fleet_id: str,
+        message: str,
+        status: WorkerHostConfigurationStatus,
+        worker_id: Optional[str] = None,
+        exit_code: Optional[int] = None,
+        success: Optional[bool] = None,
+    ) -> None:
+        self.exit_code = exit_code
+        self.success = success
+        self.status = status
+
+        super().__init__(
+            op=WorkerLogEventOp.HOST_CONFIGURATION,
+            farm_id=farm_id,
+            fleet_id=fleet_id,
+            worker_id=worker_id,
+            message=message,
+        )
+
+    def asdict(self) -> dict[str, str]:
+        dd = super().asdict()
+        dd.update(status=self.status)
+        if self.exit_code:
+            dd.update(exit_code=self.exit_code)
+        if self.success:
+            dd.update(success=self.success)
         return self.add_exception_to_dict(dd)
 
 

--- a/src/deadline_worker_agent/startup/bootstrap.py
+++ b/src/deadline_worker_agent/startup/bootstrap.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, asdict, fields, field
 from time import sleep
-from typing import Optional
+from typing import Any, Dict, Optional, Tuple, cast
 import json
 import logging as _logging
 import stat
@@ -16,6 +16,7 @@ import requests
 from ..aws.deadline import (
     DeadlineRequestConditionallyRecoverableError,
     DeadlineRequestUnrecoverableError,
+    WorkerHostConfiguration,
     WorkerLogConfig,
     construct_worker_log_config,
     create_worker,
@@ -100,6 +101,8 @@ class WorkerPersistenceInfo:
     )
     """The EC2 instance ID of the Worker, if applicable"""
 
+    host_configuration_succeeded: bool | None = field(default=None)
+
     @classmethod
     def load(cls, *, config: Configuration) -> Optional[WorkerPersistenceInfo]:
         """Load the Worker Bootstrap from the Worker Agent state persistence file"""
@@ -115,7 +118,7 @@ class WorkerPersistenceInfo:
         )
 
         with config.worker_state_file.open("r", encoding="utf8") as fh:
-            data: dict[str, str] = json.load(fh)
+            data: dict[str, str | bool] = json.load(fh)
 
         own_fields = set(f.name for f in fields(class_or_instance=WorkerPersistenceInfo))
         selected_data = {key: value for key, value in data.items() if key in own_fields}
@@ -129,7 +132,7 @@ class WorkerPersistenceInfo:
                 )
             )
 
-        return cls(**selected_data)
+        return cls(**cast(Dict[str, Any], selected_data))
 
     def save(self, *, config: Configuration) -> None:
         """Save the Worker Bootstrap to the Worker Agent state persistence file"""
@@ -185,6 +188,9 @@ class WorkerBootstrap:
     log_config: Optional[WorkerLogConfig] = None
     """The log configuration for the Worker"""
 
+    host_config: Optional[WorkerHostConfiguration] = None
+    """The host configuration for the Worker"""
+
 
 def bootstrap_worker(config: Configuration, *, use_existing_worker: bool = True) -> WorkerBootstrap:
     """Contains startup logic to ensure that the Worker is created and started"""
@@ -217,7 +223,7 @@ def bootstrap_worker(config: Configuration, *, use_existing_worker: bool = True)
 
     try:
         # raises: BootstrapWithoutWorkerLoad, SystemExit
-        log_config = _start_worker(
+        log_config, host_config = _start_worker(
             deadline_client=deadline_client,
             config=config,
             worker_id=worker_info.worker_id,
@@ -246,6 +252,7 @@ def bootstrap_worker(config: Configuration, *, use_existing_worker: bool = True)
         worker_info=worker_info,
         session=worker_session,
         log_config=log_config,
+        host_config=host_config,
     )
 
 
@@ -437,7 +444,7 @@ def _start_worker(
     config: Configuration,
     worker_id: str,
     has_existing_worker: bool,
-) -> Optional[WorkerLogConfig]:
+) -> Tuple[Optional[WorkerLogConfig], Optional[WorkerHostConfiguration]]:
     """Updates the Worker in the service to the STARTED state.
 
     Returns:
@@ -445,7 +452,8 @@ def _start_worker(
             contained a log configuration for the Worker Agent to use for writing
             its own logs. The returned WorkerLogConfig is the configuration that it
             should use.
-
+        Optional[WorkerHostConfiguration] -- Non-None if UpdateWorker request contains a
+            host configuration for the Worker Agent to configure the host.
     Raises:
         BootstrapWithoutWorkerLoad
         SystemExit
@@ -498,9 +506,19 @@ def _start_worker(
         )
     )
 
+    logging_config = None
     if log_config := response.get("log"):
-        return construct_worker_log_config(log_config=log_config)
-    return None
+        logging_config = construct_worker_log_config(log_config=log_config)
+
+    host_config = None
+    if response_host_config := response.get("hostConfiguration"):
+        # scriptTimeoutSeconds is technically always there from the backend.
+        host_config = WorkerHostConfiguration(
+            script_body=response_host_config.get("scriptBody", ""),
+            script_timeout_seconds=response_host_config["scriptTimeoutSeconds"],
+        )
+
+    return logging_config, host_config
 
 
 def _enforce_no_instance_profile_or_stop_worker(

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -15,6 +15,8 @@ from threading import Event
 from typing import Optional
 from pathlib import Path
 
+from ..feature_flag import HOST_CONFIGURATION_FEATURE
+
 from ..api_models import WorkerStatus
 from ..aws.deadline import (
     update_worker,
@@ -30,13 +32,16 @@ from ..linux.capabilities import drop_kill_cap_from_inheritable
 from ..log_messages import (
     AgentInfoLogEvent,
     LogRecordStringTranslationFilter,
+    WorkerHostConfigurationStatus,
     WorkerLogEvent,
     WorkerLogEventOp,
+    WorkerHostConfigurationLogEvent,
 )
 from ..log_sync.cloudwatch import stream_cloudwatch_logs
 from ..log_sync.loggers import ROOT_LOGGER, logger as log_sync_logger
 from ..worker import Worker
 from .bootstrap import bootstrap_worker
+from .host_configuration_script import HostConfigurationScriptRunner
 
 __all__ = ["entrypoint"]
 _logger = logging.getLogger(__name__)
@@ -162,6 +167,78 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
             # Re-send the agent info to the log so that it also appears in the
             # logs that we forward to CloudWatch.
             _log_agent_info()
+
+            # If there was a host config, and it was bootstrapped before, only log a message.
+            if worker_bootstrap.host_config and not HOST_CONFIGURATION_FEATURE:
+                _logger.info(
+                    WorkerHostConfigurationLogEvent(
+                        farm_id=config.farm_id,
+                        fleet_id=config.fleet_id,
+                        worker_id=worker_id,
+                        message="Host Configuration Feature is not enabled.",
+                        status=WorkerHostConfigurationStatus.SKIPPED,
+                    )
+                )
+            elif (
+                worker_bootstrap.host_config
+                and worker_bootstrap.worker_info.host_configuration_succeeded
+            ):
+                _logger.info(
+                    WorkerHostConfigurationLogEvent(
+                        farm_id=config.farm_id,
+                        fleet_id=config.fleet_id,
+                        worker_id=worker_id,
+                        message="Host Configuration has been setup before. Not running config scripts.",
+                        status=WorkerHostConfigurationStatus.SKIPPED,
+                    )
+                )
+            # Before the run looop starts, run the Host Configuration script.
+            elif worker_bootstrap.host_config:
+                _logger.info(
+                    WorkerHostConfigurationLogEvent(
+                        farm_id=config.farm_id,
+                        fleet_id=config.fleet_id,
+                        worker_id=worker_id,
+                        message="Running host configuration script.",
+                        status=WorkerHostConfigurationStatus.RUNNING,
+                    )
+                )
+                host_config_runner = HostConfigurationScriptRunner(
+                    logger=_logger,
+                    configuration=config,
+                    worker_id=worker_id,
+                    session_directory=config.worker_persistence_dir,
+                    worker_boto3_session=session,
+                    host_configuration_script=worker_bootstrap.host_config.script_body,
+                    host_configuration_timeout_seconds=worker_bootstrap.host_config.script_timeout_seconds,
+                )
+                exit_code = host_config_runner.run()
+                if exit_code == 0:
+                    _logger.info(
+                        WorkerHostConfigurationLogEvent(
+                            farm_id=config.farm_id,
+                            fleet_id=config.fleet_id,
+                            worker_id=worker_id,
+                            message="Worker Agent host configuration succeeded. Starting worker session loop.",
+                            status=WorkerHostConfigurationStatus.SUCCEEDED,
+                            exit_code=exit_code,
+                        )
+                    )
+                    # Persist host configuration has been performed.
+                    worker_bootstrap.worker_info.host_configuration_succeeded = True
+                    worker_bootstrap.worker_info.save(config=config)
+                else:
+                    _logger.critical(
+                        WorkerHostConfigurationLogEvent(
+                            farm_id=config.farm_id,
+                            fleet_id=config.fleet_id,
+                            worker_id=worker_id,
+                            message=f"Worker Agent host configuration failed with exit code {exit_code}. Cannot run jobs, exiting.",
+                            status=WorkerHostConfigurationStatus.FAILED,
+                            exit_code=exit_code,
+                        )
+                    )
+                    sys.exit(1)
 
             worker_sessions = Worker(
                 farm_id=config.farm_id,

--- a/src/deadline_worker_agent/startup/host_configuration_script.py
+++ b/src/deadline_worker_agent/startup/host_configuration_script.py
@@ -1,0 +1,204 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from datetime import timedelta
+from logging import Logger
+from pathlib import Path
+from threading import Event
+from openjd.model import SymbolTable
+from typing import Optional
+import sys
+
+from deadline_worker_agent.utils import FileContext
+
+
+from ..config.config import Configuration
+from openjd.sessions._runner_base import ScriptRunnerBase, TerminateCancelMethod
+from openjd.sessions._embedded_files import EmbeddedFilesScope
+from openjd.sessions._session_user import PosixSessionUser
+from openjd.model.v2023_09 import (
+    EmbeddedFileText as EmbeddedFileText_2023_09,
+)
+from openjd.model.v2023_09 import (
+    EmbeddedFileTypes as EmbeddedFileTypes_2023_09,
+)
+from openjd.model.v2023_09 import DataString as DataString_2023_09
+from ..aws_credentials.worker_boto3_session import WorkerBoto3Session
+from openjd.sessions._types import ActionState
+from openjd.sessions._logging import LoggerAdapter
+from ..log_messages import WorkerHostConfigurationLogEvent, WorkerHostConfigurationStatus
+
+if sys.platform == "win32":
+    from ..windows.win_admin_runner import _WindowsScriptRunner
+
+
+class HostConfigurationScriptRunner(ScriptRunnerBase):
+    """Host Configuration Script Runner. Borrows from OpenJD Script Runner Base, similar to Session Actions"""
+
+    _host_configuration_script: str
+    """
+    The host configuiration script to run once the worker agent reaches STARTED state.
+    """
+
+    _host_configuration_timeout_seconds: int
+    """
+    The amount of time to allow the host configuration script to run before timing out.
+    """
+
+    _session_directory: Path
+    """The location in the filesystem where embedded files will be materialized.
+    """
+
+    _worker_boto3_session: WorkerBoto3Session
+    """Boto3 Fleet Session credentials."""
+
+    _configuration: Configuration
+    """The configuration for the worker agent."""
+
+    def __init__(
+        self,
+        logger: Logger,
+        configuration: Configuration,
+        worker_id: str,
+        session_directory: Path,
+        worker_boto3_session: WorkerBoto3Session,
+        host_configuration_script: str,
+        host_configuration_timeout_seconds: int = 300,
+        runas_user=PosixSessionUser(user="root") if sys.platform != "win32" else None,
+    ) -> None:
+        self._configuration = configuration
+        self._worker_id = worker_id
+        self._worker_boto3_session = worker_boto3_session
+        self._host_configuration_script = host_configuration_script
+        self._host_configuration_timeout_seconds = host_configuration_timeout_seconds
+        self._log = logger
+        self._logger_adapter = LoggerAdapter(logger=logger, extra={"worker_id": self._worker_id})
+        self._session_files_directory = session_directory
+        # Internal flag to turn off Windows RunAs during unit testing.
+        self._windows_run_as_admin = True
+        self._runas_user = runas_user
+
+        # Async processing event.
+        self._action_event = Event()
+        self._action_state: Optional[ActionState] = None
+
+        # Super init is after setting members for computing env vars.
+        super().__init__(
+            logger=self._logger_adapter,
+            user=self._runas_user,
+            os_env_vars=self._host_configuration_env_vars(),
+            session_working_directory=session_directory,
+            startup_directory=session_directory,
+            callback=self._action_callback,
+        )
+
+    def _script_file_name(self) -> str:
+        return "host_configuration.ps1" if sys.platform == "win32" else "host_configuration.sh"
+
+    def _write_script_file(self) -> str:
+        """Returns the full path with file name after writing the script to disk."""
+        # Materialize the input script to the session directory.
+        script_file_name = self._script_file_name()
+        host_config_script = EmbeddedFileText_2023_09(
+            name="WorkerHostConfigurationScript",
+            type=EmbeddedFileTypes_2023_09.TEXT,
+            filename=script_file_name,
+            data=DataString_2023_09(self._host_configuration_script),
+            runnable=True,  # chmod +x
+        )
+        self._materialize_files(
+            scope=EmbeddedFilesScope.ENV,  # env files are runnable.
+            files=[host_config_script],
+            dest_directory=self._session_files_directory,
+            symtab=SymbolTable(),
+        )
+
+        script_file_path = str(self._session_files_directory / script_file_name)
+        return script_file_path
+
+    def run(self) -> int:
+        """
+        Run the host configuration script
+        returns The exit code 0 for success, number otherwise.
+        """
+        if self._host_configuration_script is None:
+            self._log.info(
+                WorkerHostConfigurationLogEvent(
+                    farm_id=self._configuration.farm_id,
+                    fleet_id=self._configuration.fleet_id,
+                    worker_id=self._worker_id,
+                    message="No host configuration script provided.",
+                    status=WorkerHostConfigurationStatus.SKIPPED,
+                )
+            )
+            return 0
+
+        script_file_path = self._write_script_file()
+        with FileContext(script_file_path) as _:
+            if sys.platform == "win32":
+                exit_code = self._run_win32(script_file_path)
+            else:
+                exit_code = self._run_posix()
+
+        return exit_code
+
+    def _run_posix(self) -> int:
+        """
+        Run the host configuration script on posix.
+        returns the exit code.
+        """
+        # Now that we have a script, run it.
+        command = ["./host_configuration.sh"]
+
+        self._action_event.clear()
+        self._run(command)
+
+        # Wait for the completion event.
+        # Async callback prints out a message based on run state.
+        self._action_event.wait()
+
+        if self._action_state is ActionState.SUCCESS and self.exit_code == 0:
+            return self.exit_code
+        else:
+            return self.exit_code if self.exit_code is not None else -1
+
+    def _run_win32(self, script_file_path: str) -> int:
+        if sys.platform == "win32":
+            win32_runner = _WindowsScriptRunner(
+                script_path=script_file_path,
+                working_directory=self._session_files_directory,
+                logger=self._log,
+            )
+            exit_code = win32_runner.run_powershell(self._host_configuration_env_vars())
+            return exit_code
+
+        assert False, "This method should never be run outside of Win32."
+
+    def _host_configuration_env_vars(self) -> Optional[dict[str, Optional[str]]]:
+        credentials = self._worker_boto3_session.get_credentials()
+        env = {
+            "DEADLINE_FARM_ID": self._configuration.farm_id,
+            "DEADLINE_FLEET_ID": self._configuration.fleet_id,
+            "DEADLINE_WORKER_ID": self._worker_id,
+            "HOST_CONFIG_TIMEOUT_SECONDS": str(self._host_configuration_timeout_seconds),
+            "AWS_ACCESS_KEY_ID": credentials.access_key,
+            "AWS_SECRET_ACCESS_KEY": credentials.secret_key,
+            "AWS_SESSION_TOKEN": credentials.token,
+        }
+        return env
+
+    def _action_callback(self, state: ActionState) -> None:
+        """This method is inherited from the base class and only used for posix"""
+        self._action_state = state
+
+        if state in ActionState.RUNNING:
+            return
+
+        # Unblock to exit.
+        self._action_event.set()
+
+    def cancel(
+        self, *, time_limit: Optional[timedelta] = None, mark_action_failed: bool = False
+    ) -> None:
+        """This method is inherited from the base class and only used for posix."""
+        # Action cancellation. In this case, we terminate the child.
+        self._cancel(TerminateCancelMethod(), time_limit, mark_action_failed)

--- a/src/deadline_worker_agent/utils.py
+++ b/src/deadline_worker_agent/utils.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import MutableMapping
-from typing import Callable, Generic, Iterator, TypeVar
+import os
+from types import TracebackType
+from typing import Any, Callable, Generic, Iterator, TypeVar
 
 _K = TypeVar("_K")
 _V = TypeVar("_V")
@@ -54,3 +56,24 @@ class MappingWithCallbacks(MutableMapping, Generic[_K, _V]):
 
     def __len__(self) -> int:
         return len(self._dict)
+
+
+class FileContext:
+    """File context, ensures a file is deleted."""
+
+    def __init__(self, file_path: str):
+        self._file_path = file_path
+
+    def __enter__(self):
+        return self._file_path
+
+    def __exit__(
+        self,
+        type: TypeVar,
+        value: Any,
+        traceback: TracebackType,
+    ):
+        # Delete the file
+        if self._file_path and os.path.exists(self._file_path):
+            os.remove(self._file_path)
+        return False

--- a/test/integ/startup/test_host_configuration.py
+++ b/test/integ/startup/test_host_configuration.py
@@ -1,0 +1,373 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for the Host Configuration Script Runner"""
+
+import os
+import sys
+from enum import Enum
+from logging import INFO, Logger, getLogger
+from botocore.credentials import Credentials
+from pathlib import Path
+import random
+import string
+from typing import Any, List
+import pytest
+
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+
+from logging.handlers import QueueHandler
+from queue import Empty, SimpleQueue
+
+from deadline_worker_agent.config.cli_args import ParsedCommandLineArguments
+from deadline_worker_agent.config.config import Configuration
+from deadline_worker_agent.startup.host_configuration_script import HostConfigurationScriptRunner
+from deadline_worker_agent.log_messages import (
+    LogRecordStringTranslationFilter,
+    WorkerHostConfigurationLogEvent,
+)
+
+
+@pytest.fixture(scope="function")
+def message_queue() -> SimpleQueue:
+    return SimpleQueue()
+
+
+@pytest.fixture(scope="function")
+def queue_handler(message_queue: SimpleQueue) -> QueueHandler:
+    return QueueHandler(message_queue)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def config_file_mock() -> Generator[MagicMock, None, None]:
+    """Fixture that mocks deadline_worker_agent.config.config_file.ConfigFile.load() to raise a
+    FileNotFound error.
+
+    This can be used to avoid tests being impacted by the contents of a worker agent config file
+    present in the development environment.
+    """
+    with patch(
+        "deadline_worker_agent.config.config_file.ConfigFile.load",
+        side_effect=FileNotFoundError(),
+    ) as mock_config_file_load:
+        yield mock_config_file_load
+
+
+def _config(
+    tmp_dir: Path,
+) -> Configuration:
+    cli_args = ParsedCommandLineArguments()
+    cli_args.farm_id = "farm-00000000000000000000000000000000"
+    cli_args.fleet_id = "fleet-00000000000000000000000000000000"
+    cli_args.run_jobs_as_agent_user = False
+    cli_args.posix_job_user = "some-user:some-group"
+    cli_args.no_shutdown = True
+    cli_args.profile = None
+    cli_args.verbose = None
+    cli_args.disallow_instance_profile = False
+    # Direct the logs and persistence state into a temporary directory
+    cli_args.logs_dir = tmp_dir / "temp-logs-dir"
+    cli_args.persistence_dir = tmp_dir / "temp-persist-dir"
+    config = Configuration(parsed_cli_args=cli_args)
+
+    # These directories need to exist
+    cli_args.logs_dir.mkdir()
+    cli_args.persistence_dir.mkdir()
+
+    return config
+
+
+def build_logger(handler: QueueHandler) -> Logger:
+    charset = string.ascii_letters + string.digits + string.punctuation
+    name_suffix = "".join(random.choices(charset, k=32))
+    log = getLogger(".".join((__name__, name_suffix)))
+    log.setLevel(INFO)
+    log.addHandler(handler)
+
+    string_translation_filter = LogRecordStringTranslationFilter()
+    log.addFilter(string_translation_filter)
+    return log
+
+
+def collect_queue_messages(queue: SimpleQueue) -> list[str]:
+    """Extract the text of messages from a SimpleQueue containing LogRecords"""
+    messages: list[Any] = []
+    try:
+        while True:
+            messages.append(queue.get_nowait().getMessage())
+    except Empty:
+        pass
+
+    str_messages = [message for message in messages if isinstance(message, str)]
+    structure_messages = [
+        structured_message.msg
+        for structured_message in messages
+        if isinstance(structured_message, WorkerHostConfigurationLogEvent)
+    ]
+    all_messages = str_messages + structure_messages
+    # On linux, ' is escaped, this is just a way to make the logs consistent with OSX.
+    return [msg.replace("'", "") for msg in all_messages]
+
+
+class TestOS(Enum):
+    LINUX = 1
+    WIN32 = 2
+    ALL = 3
+
+
+class TestHostConfigurationScriptRunner:
+    """Tests for the Host Configuration Script Runner"""
+
+    def _create_host_configuration_script_runner(
+        self,
+        script: str,
+        timeout: int,
+        tmp: Path,
+        queue_handler: QueueHandler,
+    ) -> HostConfigurationScriptRunner:
+        """Create a Host Configuration Script Runner"""
+
+        configuration = _config(tmp)
+
+        mock_boto = MagicMock()
+        mock_boto.get_credentials.return_value = Credentials(
+            access_key="access_key_id",
+            secret_key="secret_access_key",
+            token="session_token",
+        )
+
+        runner = HostConfigurationScriptRunner(
+            logger=build_logger(queue_handler),
+            configuration=configuration,
+            worker_id="worker-00000000000000000000000000000000",
+            session_directory=tmp,
+            worker_boto3_session=mock_boto,
+            host_configuration_script=script,
+            host_configuration_timeout_seconds=timeout,
+            runas_user=None,  # We cannot use root for tests.
+        )
+        return runner
+
+    @pytest.mark.parametrize(
+        ("script", "timeout", "success", "expected_logs", "test_os"),
+        (
+            pytest.param(
+                None,
+                300,
+                True,
+                [],
+                TestOS.ALL,
+                id="None Config Script. Should be no-op",
+            ),
+            pytest.param(
+                "echo Hello\nexit 0",
+                300,
+                True,
+                ["Hello"],
+                TestOS.LINUX,
+                id="Hello successful test case",
+            ),
+            pytest.param(
+                "echo Sleep\nsleep 2\nexit 0",
+                5,
+                True,
+                ["Sleep"],
+                TestOS.LINUX,
+                id="Timed out test case",
+            ),
+            pytest.param(
+                "echo Error\nexit 1",
+                300,
+                False,
+                ["Error"],
+                TestOS.LINUX,
+                id="Script exit non-zero test case",
+            ),
+            pytest.param(
+                "set\nexit 0",
+                300,
+                True,
+                [
+                    "DEADLINE_FARM_ID=farm-00000000000000000000000000000000",
+                    "DEADLINE_FLEET_ID=fleet-00000000000000000000000000000000",
+                    "DEADLINE_WORKER_ID=worker-00000000000000000000000000000000",
+                    "HOST_CONFIG_TIMEOUT_SECONDS=300",
+                    "AWS_ACCESS_KEY_ID=access_key_id",
+                    "AWS_SECRET_ACCESS_KEY=secret_access_key",
+                    "AWS_SESSION_TOKEN=session_token",
+                ],
+                TestOS.LINUX,
+                id="Environment Variables are set test case",
+            ),
+            pytest.param(
+                """echo Hello
+                exit 0""",
+                300,
+                True,
+                ["Hello"],
+                TestOS.WIN32,
+                id="Hello successful windows test case",
+            ),
+            pytest.param(
+                "echo Sleep\nsleep 2\necho DoneSleeping\nexit 0",
+                5,
+                True,
+                ["Sleep", "DoneSleeping"],
+                TestOS.WIN32,
+                id="Timed out windows test case",
+            ),
+            pytest.param(
+                "echo Error\nexit 1",
+                300,
+                False,
+                ["Error"],
+                TestOS.WIN32,
+                id="Script exit non-zero windows test case",
+            ),
+            pytest.param(
+                r"""
+ls env:
+Get-ChildItem env: | ForEach-Object { "$($_.Name)=$($_.Value)" }
+                """,
+                300,
+                True,
+                [
+                    "DEADLINE_FARM_ID=farm-00000000000000000000000000000000",
+                    "DEADLINE_FLEET_ID=fleet-00000000000000000000000000000000",
+                    "DEADLINE_WORKER_ID=worker-00000000000000000000000000000000",
+                    "HOST_CONFIG_TIMEOUT_SECONDS=300",
+                    "AWS_ACCESS_KEY_ID=access_key_id",
+                    "AWS_SECRET_ACCESS_KEY=secret_access_key",
+                    "AWS_SESSION_TOKEN=session_token",
+                ],
+                TestOS.WIN32,
+                id="Environment Variables are set test case",
+            ),
+        ),
+    )
+    def test_host_configuration_script_runner(
+        self,
+        script: str,
+        timeout: int,
+        success: bool,
+        expected_logs: List[str],
+        test_os: TestOS,
+        message_queue: SimpleQueue,
+        queue_handler: QueueHandler,
+        tmp_path: Path,
+    ):
+        """Test the Host Configuration Script Runner basic happy path"""
+
+        if sys.platform == "win32" and test_os == TestOS.LINUX:
+            # Skip when a linux test case runs on windows.
+            return
+        elif sys.platform != "win32" and test_os == TestOS.WIN32:
+            # Skip when a windows test case runs on linux.
+            return
+
+        # Given
+        runner = self._create_host_configuration_script_runner(
+            script=script,
+            timeout=timeout,
+            tmp=tmp_path,
+            queue_handler=queue_handler,
+        )
+
+        # When
+        exit_code = runner.run()
+        run_success = exit_code == 0
+
+        # Then
+        assert success == run_success
+        messages = collect_queue_messages(message_queue)
+
+        for log in expected_logs:
+            assert any(log in m for m in messages)
+
+    def test_script_file_access(self, queue_handler: QueueHandler, tmp_path: Path):
+        """Tests the script file is only accessible by worker agent user."""
+
+        # Given
+        runner = self._create_host_configuration_script_runner(
+            script="echo Hello",
+            timeout=300,
+            tmp=tmp_path,
+            queue_handler=queue_handler,
+        )
+
+        # When
+        script_file = runner._write_script_file()
+
+        # Then
+        if sys.platform != "win32":
+            assert os.path.exists(script_file)
+
+            # Verify no read/write/execute access by other users.
+            mode = os.stat(script_file).st_mode
+            assert not mode & 0o004
+            assert not mode & 0o002
+            assert not mode & 0o001
+        else:
+            import getpass
+            import win32con
+            import win32security
+            import ntsecuritycon
+            from deadline_worker_agent.windows.win_admin_runner import _WindowsScriptRunner
+
+            # Need to prepare the file permissions on Windows
+            win32_runner = _WindowsScriptRunner(
+                script_path=script_file,
+                working_directory=runner._session_files_directory,
+                logger=runner._log,
+            )
+            win32_runner._prepare_file_permissions()
+
+            users_group_sid, _, _ = win32security.LookupAccountName(None, "Users")
+            current_user_sid, _, _ = win32security.LookupAccountName(None, getpass.getuser())
+            sd = win32security.GetFileSecurity(
+                str(script_file),
+                win32con.DACL_SECURITY_INFORMATION | win32con.OWNER_SECURITY_INFORMATION,
+            )
+            dacl = sd.GetSecurityDescriptorDacl()
+
+            users_group_permission_found: bool = False
+            administrator_group_permission_read_found: bool = False
+            administrator_group_permission_write_found: bool = False
+
+            if dacl is None:
+                assert False, "All users have access to the file."
+
+            # Iterate through each ACE in the DACL
+            for i in range(dacl.GetAceCount()):
+                ace = dacl.GetAce(i)
+                (ace_type, ace_flags), ace_mask, sid = ace
+
+                if sid == users_group_sid:
+                    # Check for read or write permission
+                    if (
+                        ace_mask & ntsecuritycon.FILE_GENERIC_READ
+                        == ntsecuritycon.FILE_GENERIC_READ
+                    ) or (
+                        ace_mask & ntsecuritycon.FILE_GENERIC_WRITE
+                        == ntsecuritycon.FILE_GENERIC_WRITE
+                    ):
+                        users_group_permission_found = True
+                elif sid == current_user_sid:
+                    # Check for read permission
+                    if (
+                        ace_mask & ntsecuritycon.FILE_GENERIC_READ
+                        == ntsecuritycon.FILE_GENERIC_READ
+                    ):
+                        administrator_group_permission_read_found = True
+
+                    # Check for write permission
+                    if (
+                        ace_mask & ntsecuritycon.FILE_GENERIC_WRITE
+                        == ntsecuritycon.FILE_GENERIC_WRITE
+                    ):
+                        administrator_group_permission_write_found = True
+
+            assert not users_group_permission_found
+            assert administrator_group_permission_read_found
+            assert administrator_group_permission_write_found

--- a/test/integ/windows/test_installer.py
+++ b/test/integ/windows/test_installer.py
@@ -288,9 +288,10 @@ def verify_least_privilege(windows_user: str, path: Path, is_session_root: bool 
                 # we set ntsecuritycon.GENERIC_ALL but that gets converted to win32File.FILE_ALL_ACCESS
                 mask == win32file.FILE_ALL_ACCESS
             ), f"Expected only FILE_FULL_ACCESS aces for {path} but found {mask}"
-            assert sid in [builtin_admin_group_sid, user_sid], (
-                f"Unexpected sid found in ace for {path}"
-            )
+            assert sid in [
+                builtin_admin_group_sid,
+                user_sid,
+            ], f"Unexpected sid found in ace for {path}"
         # Check for Users group ACE with LIST_DIRECTORY_AND_READ permissions
         elif sid == users_group_sid:
             assert ace_type == ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE, (

--- a/test/unit/startup/test_bootstrap.py
+++ b/test/unit/startup/test_bootstrap.py
@@ -11,6 +11,7 @@ from botocore.exceptions import ClientError
 from pytest import fixture, mark, param, raises
 
 from deadline_worker_agent.api_models import (
+    HostConfiguration,
     HostProperties,
     LogConfiguration,
     UpdateWorkerResponse,
@@ -28,6 +29,7 @@ from deadline_worker_agent.startup import bootstrap as bootstrap_mod
 from deadline_worker_agent.aws.deadline import (
     DeadlineRequestConditionallyRecoverableError,
     DeadlineRequestUnrecoverableError,
+    WorkerHostConfiguration,
     WorkerLogConfig,
     construct_worker_log_config,
 )
@@ -49,6 +51,8 @@ AWSLOGS_LOG_CONFIGURATION = LogConfiguration(
         LOG_CONFIG_OPTION_STREAM_NAME_KEY: CLOUDWATCH_LOG_STREAM,
     },
 )
+
+HOST_CONFIGURATION = HostConfiguration(scriptBody="echo HELLOWORLD", scriptTimeoutSeconds=456)
 
 INSTANCE_ID = "i-aaaaaaaaaaaaaaaa"
 WORKER_ID = f"worker-{32 * 'a'}"
@@ -143,6 +147,16 @@ def cloudwatch_log_group() -> str:
 @fixture
 def cloudwatch_log_stream() -> str:
     return "log-stream"
+
+
+@fixture
+def host_configuration_script() -> str:
+    return "echo Hello"
+
+
+@fixture
+def host_configuration_script_timeout() -> int:
+    return 456
 
 
 @fixture
@@ -367,6 +381,15 @@ class TestBootstrapWorker:
             cloudwatch_log_stream=cloudwatch_log_stream,
         )
 
+    @fixture
+    def worker_host_config(
+        self, host_configuration_script: str, host_configuration_script_timeout: int
+    ) -> WorkerHostConfiguration:
+        return WorkerHostConfiguration(
+            script_body=host_configuration_script,
+            script_timeout_seconds=host_configuration_script_timeout,
+        )
+
     def test_success(
         self,
         config: Configuration,
@@ -375,18 +398,20 @@ class TestBootstrapWorker:
         get_boto3_session_for_fleet_role_mock: MagicMock,
         start_worker_mock: MagicMock,
         worker_log_config: WorkerLogConfig,
+        worker_host_config: WorkerHostConfiguration,
         enforce_no_instance_profile_or_stop_worker_mock: MagicMock,
     ) -> None:
         """Test of the happy-path of bootstrap_worker()."""
         # GIVEN
         load_or_create_worker_mock.return_value = (worker_info, False)
-        start_worker_mock.return_value = worker_log_config
+        start_worker_mock.return_value = (worker_log_config, worker_host_config)
 
         # WHEN
         worker_bootstrap = bootstrap_mod.bootstrap_worker(config=config)
 
         # THEN
         assert worker_bootstrap.log_config is worker_log_config
+        assert worker_bootstrap.host_config is worker_host_config
         assert worker_bootstrap.session is get_boto3_session_for_fleet_role_mock.return_value
         assert worker_bootstrap.worker_info is worker_info
         enforce_no_instance_profile_or_stop_worker_mock.assert_called_once_with(
@@ -464,7 +489,7 @@ class TestBootstrapWorker:
         # GIVEN
         load_or_create_worker_mock.side_effect = [(worker_info, True), (worker_info, False)]
         start_worker_exception = bootstrap_mod.BootstrapWithoutWorkerLoad()
-        start_worker_mock.side_effect = [start_worker_exception, worker_log_config]
+        start_worker_mock.side_effect = [start_worker_exception, (worker_log_config, None)]
 
         # WHEN
         worker_bootstrap = bootstrap_mod.bootstrap_worker(config=config)
@@ -757,12 +782,24 @@ class TestStartWorker:
             yield mock
 
     @mark.parametrize(
-        "has_existing_worker, log_config",
+        "has_existing_worker, log_config, host_config",
         [
-            param(True, AWSLOGS_LOG_CONFIGURATION, id="has-existing-with-logs"),
-            param(False, AWSLOGS_LOG_CONFIGURATION, id="no-existing-with-logs"),
-            param(True, None, id="has-existing-no-logs"),
-            param(False, None, id="no-existing-no-logs"),
+            param(True, AWSLOGS_LOG_CONFIGURATION, None, id="has-existing-with-logs"),
+            param(False, AWSLOGS_LOG_CONFIGURATION, None, id="no-existing-with-logs"),
+            param(True, None, None, id="has-existing-no-logs"),
+            param(False, None, None, id="no-existing-no-logs"),
+            param(
+                True,
+                AWSLOGS_LOG_CONFIGURATION,
+                HOST_CONFIGURATION,
+                id="has-existing-with-host-config",
+            ),
+            param(
+                False,
+                AWSLOGS_LOG_CONFIGURATION,
+                HOST_CONFIGURATION,
+                id="no-existing-with-host-config",
+            ),
         ],
     )
     def test_success(
@@ -771,6 +808,7 @@ class TestStartWorker:
         worker_id: str,
         has_existing_worker: bool,
         log_config: Optional[LogConfiguration],
+        host_config: Optional[HostConfiguration],
         deadline_client: MagicMock,
         update_worker_mock: MagicMock,
         mock_get_host_properties: MagicMock,
@@ -782,10 +820,12 @@ class TestStartWorker:
         update_worker_response = dict[str, Any]()
         if log_config:
             update_worker_response["log"] = log_config
+        if host_config:
+            update_worker_response["hostConfiguration"] = host_config
         update_worker_mock.return_value = update_worker_response
 
         # WHEN
-        result = bootstrap_mod._start_worker(
+        log_result, host_config_result = bootstrap_mod._start_worker(
             deadline_client=deadline_client,
             config=config,
             worker_id=worker_id,
@@ -804,9 +844,18 @@ class TestStartWorker:
             host_properties=host_properties,
         )
         if not log_config:
-            assert result is None
+            assert log_result is None
         else:
-            assert result == construct_worker_log_config(log_config=log_config)
+            assert log_result == construct_worker_log_config(log_config=log_config)
+
+        if not host_config:
+            assert host_config_result is None
+        else:
+            assert host_config_result is not None
+            assert host_config_result.script_body == host_config.get("scriptBody")
+            assert host_config_result.script_timeout_seconds == host_config.get(
+                "scriptTimeoutSeconds"
+            )
 
     @mark.parametrize(
         "has_existing_worker, exception",

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -25,8 +25,8 @@ from deadline_worker_agent.startup.bootstrap import (
     WorkerBootstrap,
     WorkerPersistenceInfo,
 )
-from deadline_worker_agent.aws.deadline import WorkerLogConfig
-from deadline_worker_agent.log_messages import WorkerLogEvent
+from deadline_worker_agent.aws.deadline import WorkerHostConfiguration, WorkerLogConfig
+from deadline_worker_agent.log_messages import WorkerHostConfigurationLogEvent, WorkerLogEvent
 
 entrypoint = entrypoint_mod.entrypoint
 
@@ -39,6 +39,16 @@ def cloudwatch_log_group() -> str:
 @pytest.fixture
 def cloudwatch_log_stream() -> str:
     return "cloudwatch_log_stream"
+
+
+@pytest.fixture
+def host_configuration_script() -> str:
+    return "echo Hello"
+
+
+@pytest.fixture
+def host_configuration_script_timeout() -> int:
+    return 456
 
 
 @pytest.fixture
@@ -58,6 +68,16 @@ def worker_log_config(
     return WorkerLogConfig(
         cloudwatch_log_group=cloudwatch_log_group,
         cloudwatch_log_stream=cloudwatch_log_stream,
+    )
+
+
+@pytest.fixture
+def worker_host_config(
+    host_configuration_script: str, host_configuration_script_timeout: int
+) -> WorkerHostConfiguration:
+    return WorkerHostConfiguration(
+        script_body=host_configuration_script,
+        script_timeout_seconds=host_configuration_script_timeout,
     )
 
 
@@ -88,6 +108,7 @@ def bootstrap_worker_mock(
     worker_info: WorkerPersistenceInfo,
     mock_boto_session: MagicMock,
     worker_log_config: WorkerLogConfig,
+    worker_host_config: WorkerHostConfiguration,
 ) -> Generator[MagicMock, None, None]:
     with patch.object(
         entrypoint_mod,
@@ -96,6 +117,7 @@ def bootstrap_worker_mock(
             worker_info=worker_info,
             session=mock_boto_session,
             log_config=worker_log_config,
+            host_config=worker_host_config,
         ),
     ) as bootstrap_worker_mock:
         yield bootstrap_worker_mock
@@ -175,6 +197,14 @@ def block_rich_import() -> Generator[None, None, None]:
 def block_telemetry_client() -> Generator[MagicMock, None, None]:
     with patch.object(entrypoint_mod, "record_worker_start_telemetry_event") as telem_mock:
         yield telem_mock
+
+
+@pytest.fixture(autouse=True)
+def mock_fleet_host_configuration_runner() -> Generator[MagicMock, None, None]:
+    """This mocks the HostConfigurationScriptRunner so We can test the entry point script run behavior."""
+    with patch.object(entrypoint_mod, "HostConfigurationScriptRunner") as mock_obj:
+        mock_obj.return_value.run.return_value = 0
+        yield mock_obj
 
 
 def test_calls_worker_run(
@@ -737,3 +767,141 @@ class TestCloudWatchLogStreaming:
         )
         context_mgr_enter.assert_called_once_with()
         context_mgr_exit.assert_called_once()
+
+
+@patch("deadline_worker_agent.startup.entrypoint.HOST_CONFIGURATION_FEATURE", False)
+@patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")
+@patch.object(entrypoint_mod.sys, "exit")
+def test_host_config_feature_flag_off(
+    sys_exit_mock: MagicMock,
+    telemetry_mock: MagicMock,
+    bootstrap_worker_mock: MagicMock,
+    mock_fleet_host_configuration_runner: MagicMock,
+    worker_info: WorkerPersistenceInfo,
+) -> None:
+    # Turn OFF the feature flag for this test.
+    # Given
+
+    with patch.object(entrypoint_mod, "_logger") as logger:
+        # WHEN
+        entrypoint()
+
+    # Then
+    mock_fleet_host_configuration_runner.assert_not_called()
+
+    expected = "Host Configuration Feature is not enabled."
+
+    all_args = [
+        arg.msg
+        for args, kwargs in logger.info.call_args_list
+        for arg in list(args) + list(kwargs.values())
+        if isinstance(arg, WorkerHostConfigurationLogEvent)
+    ]
+    assert len(all_args) > 0
+    assert expected in all_args
+
+
+@patch("deadline_worker_agent.startup.entrypoint.HOST_CONFIGURATION_FEATURE", True)
+@patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")
+@patch.object(entrypoint_mod.sys, "exit")
+def test_host_config_already_run_before(
+    sys_exit_mock: MagicMock,
+    telemetry_mock: MagicMock,
+    bootstrap_worker_mock: MagicMock,
+    mock_fleet_host_configuration_runner: MagicMock,
+    worker_info: WorkerPersistenceInfo,
+) -> None:
+    # Turn ON the feature flag for this test.
+    # Given
+    worker_info.host_configuration_succeeded = True
+
+    with patch.object(entrypoint_mod, "_logger") as logger:
+        # WHEN
+        entrypoint()
+
+    # Then
+    mock_fleet_host_configuration_runner.assert_not_called()
+
+    expected = "Host Configuration has been setup before. Not running config scripts."
+
+    all_args = [
+        arg.msg
+        for args, kwargs in logger.info.call_args_list
+        for arg in list(args) + list(kwargs.values())
+        if isinstance(arg, WorkerHostConfigurationLogEvent)
+    ]
+    assert len(all_args) > 0
+    assert expected in all_args
+
+
+@pytest.mark.parametrize(
+    ("has_host_config", "exit_code"),
+    (
+        pytest.param(True, 0),
+        pytest.param(True, 1),
+        pytest.param(False, 1),
+    ),
+)
+@patch("deadline_worker_agent.startup.entrypoint.HOST_CONFIGURATION_FEATURE", True)
+@patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")
+@patch.object(entrypoint_mod.sys, "exit")
+def test_fleet_host_config(
+    sys_exit_mock: MagicMock,
+    telemetry_mock: MagicMock,
+    has_host_config: bool,
+    exit_code: int,
+    bootstrap_worker_mock: MagicMock,
+    mock_fleet_host_configuration_runner: MagicMock,
+    worker_info: WorkerPersistenceInfo,
+) -> None:
+    """Tests that exceptions raised by Worker.run() are logged and the program exits with a non-zero exit code"""
+
+    # Turn ON the feature flag for this test.
+    # GIVEN
+    if has_host_config:
+        # Did the script run successfully.
+        mock_fleet_host_configuration_runner.return_value.run.return_value = exit_code
+    else:
+        # No script to run.
+        bootstrap_worker_mock.return_value.host_config = None
+
+    with patch.object(entrypoint_mod, "_logger") as logger:
+        # WHEN
+        entrypoint()
+
+    # THEN
+    if not has_host_config:
+        mock_fleet_host_configuration_runner.assert_not_called()
+        assert not worker_info.host_configuration_succeeded
+    elif exit_code == 0:
+        # Make sure we save the host configuration marker.
+        assert worker_info.host_configuration_succeeded
+
+        expected = "Worker Agent host configuration succeeded. Starting worker session loop."
+
+        all_args = [
+            arg.msg
+            for args, kwargs in logger.info.call_args_list
+            for arg in list(args) + list(kwargs.values())
+            if isinstance(arg, WorkerHostConfigurationLogEvent)
+        ]
+        assert len(all_args) > 0
+        assert expected in all_args
+
+    else:
+        # Make sure we save the host configuration marker.
+        assert not worker_info.host_configuration_succeeded
+
+        # Check logs have been added.
+        expected = (
+            "Worker Agent host configuration failed with exit code 1. Cannot run jobs, exiting."
+        )
+
+        all_args = [
+            arg.msg
+            for args, kwargs in logger.critical.call_args_list
+            for arg in list(args) + list(kwargs.values())
+            if isinstance(arg, WorkerHostConfigurationLogEvent)
+        ]
+        assert len(all_args) > 0
+        assert expected in all_args


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Deadline Cloud is introducing features to configure a Fleet Worker prior to executing jobs. 
- On linux, scripts are Bash. On Windows, scripts are Powershell.
- On linux, scripts run as `root` to configure a system. On Windows, powershell is launched as an administrative level process.

### What was the solution? (How)
- Implement logic to process host configuration responses from Deadline Cloud.
- Re-use existing `openjd-sessions` code to materialize files, run the scripts.
- On Windows, there is a de-tour due to Adminstrative UAC prompts. We need to launch processes with the verb `runAs`.
    - Note that for a headless system, Windows must have UAC turned off for admin accounts. Refer to [msdn](https://learn.microsoft.com/en-us/windows/security/application-security/application-control/user-account-control/settings-and-configuration?tabs=intune) documentation, specifically "Behavior of the elevation prompt for administrators in Admin Approval Mode". "0" must be set for ConsentPromptBehaviorAdmin key to remove UAC prompt. 
    - `REG ADD HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System /v ConsentPromptBehaviorAdmin /t REG_DWORD /d 0 /f`

- Note that this feature is experimental and gated behind a feature flag. Users must export the environment variable `HOST_CONFIGURATION_FEATURE` to enable the feature. 
  - Usage of this feature is not fully productized. We do not recommend using this feature in production yet. 

### What is the impact of this change?
- New Worker Agent functionality.

### How was this change tested?
- hatch run build
- hatch run fmt
- hatch run test
- hatch run all:lint
- hatch run e2e on Windows and Linux EC2.
    - E2E test cases are not part of this PR and will be pushed at a later date.

Tested on MacOS and WIndows. 

### Was this change documented?
- Yes.

### Is this a breaking change?
- No, this feature is backwards compatible.

### Future works
Note that there are a few known caveats in the implementation we are aware of and maybe improved in the future.
- Credentials during the admin script configuration are not rotated. The caller role must have the same or longer expiry time. 
- Environment variables passed to the Worker Agent are done via powershell scripting. We are investigating alternatives with ShellExecuteEx.
- Script execution is not cancellable, as it is critical to worker startup prior to processing jobs. We may improve cancellation from Windows service and the Linux systemd service in the future.

- When a host configuration script execution fails, worker agent exits. This can cause the worker to "start" and re-attempt the configuration script. It is recommended to test the script on a standalone EC2 or Windows machine prior to testing on Deadline. Additional guidance will be provided in the near future.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*