### PR TITLE
test: Verify deny shutdown on stop keeps instance

### DIFF
--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -71,7 +71,7 @@ class TestWindowsInstaller:
             start_service=False,
             fleet=deadline_resources.scaling_fleet,
         )
-    
+
     @pytest.fixture(scope="class")
     def test_job(
         self,
@@ -204,9 +204,9 @@ Get-LocalUser | Select-Object Name, Enabled | Format-Table -AutoSize
         assert test_job.task_run_status == TaskStatus.SUCCEEDED
 
     def test_deny_shutdown_on_stop(
-          self,
-          class_worker: EC2InstanceWorker,
-          test_job: Job,
+        self,
+        class_worker: EC2InstanceWorker,
+        test_job: Job,
     ) -> None:
         # Check if the job has run for the set of tests
         if test_job.task_run_status != TaskStatus.SUCCEEDED:
@@ -215,11 +215,10 @@ Get-LocalUser | Select-Object Name, Enabled | Format-Table -AutoSize
 
         LOG.info("Wait for Worker Service to begin Stopping")
         # This can take over 5 minutes
-        class_worker.wait_until_worker_stopping(
-            seconds_between_checks=25
-        )
-  
+        class_worker.wait_until_worker_stopping(seconds_between_checks=25)
+
         ec2_client = boto3.client("ec2")
+
         @backoff.on_exception(
             backoff.constant,
             Exception,
@@ -230,10 +229,10 @@ Get-LocalUser | Select-Object Name, Enabled | Format-Table -AutoSize
             instance_status = ec2_client.describe_instance_status(
                 InstanceIds=[class_worker.instance_id], IncludeAllInstances=True
             )["InstanceStatuses"][0]["InstanceState"]
-            if instance_status['Name'] != "running":
+            if instance_status["Name"] != "running":
                 LOG.warning(f"Instance is not running, current state: {instance_status['Name']}")
                 return  # Exit the function early
-            
+
             cmd_result = class_worker.send_command(
                 command="""
 $content = Get-Content "C:\\ProgramData\\Amazon\\Deadline\\Logs\\worker-agent.log"
@@ -241,9 +240,7 @@ $pattern = "NOT shutting down the host"
 $content | Select-String -Pattern $pattern
 """
             )
-            assert cmd_result.exit_code == 0, (
-                "Failed to get shutdown status from worker-agent.log"
-            )
+            assert cmd_result.exit_code == 0, "Failed to get shutdown status from worker-agent.log"
             assert "NOT shutting down the host" in cmd_result.stdout, (
                 "Worker Agent should not be shutting down the host"
             )

--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -5,13 +5,17 @@ Deadline Cloud worker and checking that the result/output of the worker agent is
 """
 
 import pytest
+import backoff
 import boto3
 import botocore
 import dataclasses
 import logging
 import os
 
-from e2e.utils import submit_custom_job
+from e2e.utils import (
+    get_shutdown_on_stop_status_from_toml,
+    submit_custom_job,
+)
 from e2e.conftest import DeadlineResources
 from deadline_test_fixtures import (
     DeadlineClient,
@@ -44,6 +48,7 @@ class TestInstaller:
 
 
 @pytest.mark.skipif(os.environ["OPERATING_SYSTEM"] == "linux", reason="Windows specific tests")
+@pytest.mark.usefixtures("test_job")
 class TestWindowsInstaller:
     # Names for tests
     CUSTOM_AGENT_NAME = "custom-agent-worker"
@@ -56,12 +61,29 @@ class TestWindowsInstaller:
     @pytest.fixture(scope="class")
     def worker_config(
         self,
+        deadline_resources: DeadlineResources,
         worker_config: DeadlineWorkerConfiguration,
     ) -> DeadlineWorkerConfiguration:
         return dataclasses.replace(
             worker_config,
             agent_user=self.CUSTOM_AGENT_NAME,
             allow_shutdown=False,
+            start_service=False,
+            fleet=deadline_resources.scaling_fleet,
+        )
+    
+    @pytest.fixture(scope="class")
+    def test_job(
+        self,
+        deadline_client: DeadlineClient,
+        deadline_resources: DeadlineResources,
+    ) -> Job:
+        return submit_custom_job(
+            job_name="Windows: Test Custom Worker Agent Runs Job as User",
+            deadline_client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.scaling_queue,
+            run_script=self.WHOAMI_COMMAND,
         )
 
     # Shared Class Methods
@@ -87,8 +109,8 @@ class TestWindowsInstaller:
         for permission in permissions:
             cmd_result = worker.send_command(
                 command=f"""
-secedit /export /cfg "$env:TEMP\security.cfg" | Out-Null
-Get-Content "$env:TEMP\security.cfg" | Select-String "{permission}"
+secedit /export /cfg "$env:TEMP\\security.cfg" | Out-Null
+Get-Content "$env:TEMP\\security.cfg" | Select-String "{permission}"
 """
             )
             assert cmd_result.exit_code == 0, (
@@ -103,28 +125,6 @@ Get-Content "$env:TEMP\security.cfg" | Select-String "{permission}"
                 assert username not in cmd_result.stdout, (
                     f"{username} has unexpected permissions: {permission}"
                 )
-
-    @staticmethod
-    def check_allow_shutdown_windows_toml(
-        worker: EC2InstanceWorker,
-        allow_shutdown: bool,
-    ) -> None:
-        cmd_result = worker.send_command(
-            command="""
-$content = Get-Content "C:\ProgramData\Amazon\Deadline\Config\worker.toml"
-$content | Select-String -Pattern "^# shutdown_on_stop =|^shutdown_on_stop ="
-"""
-        )
-        assert cmd_result.exit_code == 0, (
-            "Failed to retrieve shutdown_on_stop settings from worker.toml"
-        )
-        result_output = cmd_result.stdout.strip()
-        # LOG.info(f"Allow Shutdown Permissions Found: {result_output}")
-        assert result_output, "Expected to find shutdown_on_stop in worker.toml"
-        if allow_shutdown:
-            assert result_output == "shutdown_on_stop = true", "Allow Shutdown should be enabled"
-        else:
-            assert result_output != "shutdown_on_stop = true", "Allow Shutdown should be disabled"
 
     # Windows Installer Tests
     def test_custom_worker_agent_permissions(
@@ -155,14 +155,14 @@ $content | Select-String -Pattern "^# shutdown_on_stop =|^shutdown_on_stop ="
             )
 
             # Verify shutdown permissions in worker.toml
-            self.check_allow_shutdown_windows_toml(
-                worker=class_worker,
-                allow_shutdown=False,
+            shutdown_status = get_shutdown_on_stop_status_from_toml(class_worker)
+            assert shutdown_status != "shutdown_on_stop = true", (
+                "Shutdown on stop should be disabled"
             )
         finally:
             # Cleanup the temp directory
             cmd_result = class_worker.send_command(
-                command='Remove-Item "$env:TEMP\security.cfg" -Force'
+                command='Remove-Item "$env:TEMP\\security.cfg" -Force'
             )
             assert cmd_result.exit_code == 0, "Failed to cleanup security configuration file"
 
@@ -183,21 +183,16 @@ Get-LocalUser | Select-Object Name, Enabled | Format-Table -AutoSize
 
     def test_custom_agent_runs_job_as_user(
         self,
+        class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
-        deadline_resources: DeadlineResources,
+        test_job: Job,
     ) -> None:
-        # Submit a job that prints the job users username
-        job_result: Job = submit_custom_job(
-            job_name="Test Custom Worker Agent Runs Job as User",
-            deadline_client=deadline_client,
-            farm=deadline_resources.farm,
-            queue=deadline_resources.queue_a,
-            run_script=self.WHOAMI_COMMAND,
-        )
+        LOG.info("Start worker service and complete test job")
+        class_worker.start_worker_service()
+        test_job.wait_until_complete(client=deadline_client)
 
-        job_result.wait_until_complete(client=deadline_client)
-
-        job_result.assert_single_task_log_contains(
+        LOG.info("Assert the queue job user is correct")
+        test_job.assert_single_task_log_contains(
             deadline_client=deadline_client,
             logs_client=boto3.client(
                 "logs",
@@ -206,4 +201,57 @@ Get-LocalUser | Select-Object Name, Enabled | Format-Table -AutoSize
             expected_pattern=f"{self.DEFAULT_JOB_USER}",
         )
 
-        assert job_result.task_run_status == TaskStatus.SUCCEEDED
+        assert test_job.task_run_status == TaskStatus.SUCCEEDED
+
+    def test_deny_shutdown_on_stop(
+          self,
+          class_worker: EC2InstanceWorker,
+          test_job: Job,
+    ) -> None:
+        # Check if the job has run for the set of tests
+        if test_job.task_run_status != TaskStatus.SUCCEEDED:
+            LOG.info("Job hasn't been completed, start the worker service")
+            class_worker.start_worker_service()
+
+        LOG.info("Wait for Worker Service to begin Stopping")
+        # This can take over 5 minutes
+        class_worker.wait_until_worker_stopping(
+            seconds_between_checks=25
+        )
+  
+        ec2_client = boto3.client("ec2")
+        @backoff.on_exception(
+            backoff.constant,
+            Exception,
+            max_time=30,
+            interval=10,
+        )
+        def check_worker_agent_log() -> None:
+            instance_status = ec2_client.describe_instance_status(
+                InstanceIds=[class_worker.instance_id], IncludeAllInstances=True
+            )["InstanceStatuses"][0]["InstanceState"]
+            if instance_status['Name'] != "running":
+                LOG.warning(f"Instance is not running, current state: {instance_status['Name']}")
+                return  # Exit the function early
+            
+            cmd_result = class_worker.send_command(
+                command="""
+$content = Get-Content "C:\\ProgramData\\Amazon\\Deadline\\Logs\\worker-agent.log"
+$pattern = "NOT shutting down the host"
+$content | Select-String -Pattern $pattern
+"""
+            )
+            assert cmd_result.exit_code == 0, (
+                "Failed to get shutdown status from worker-agent.log"
+            )
+            assert "NOT shutting down the host" in cmd_result.stdout, (
+                "Worker Agent should not be shutting down the host"
+            )
+
+        check_worker_agent_log()
+
+        LOG.info("Assert EC2 Instance is still Running")
+        instance_status = ec2_client.describe_instance_status(
+            InstanceIds=[class_worker.instance_id], IncludeAllInstances=True
+        )["InstanceStatuses"][0]["InstanceState"]
+        assert instance_status["Name"] == "running"

--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -56,7 +56,7 @@ class TestWindowsInstaller:
     DEFAULT_JOB_USER = "job-user"
     ADMIN_SID = "S-1-5-32-544"
 
-    WHOAMI_COMMAND = 'Write-Output "Jobs Run As: $((whoami).split(\'\\\')[1])"'
+    WHOAMI_COMMAND = "Write-Output \"Jobs Run As: $((whoami).split('\\')[1])\""
 
     @pytest.fixture(scope="class")
     def worker_config(

--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -56,7 +56,7 @@ class TestWindowsInstaller:
     DEFAULT_JOB_USER = "job-user"
     ADMIN_SID = "S-1-5-32-544"
 
-    WHOAMI_COMMAND = '((whoami).split("\\")[1])'
+    WHOAMI_COMMAND = 'Write-Output "Jobs Run As: $((whoami).split(\'\\\')[1])"'
 
     @pytest.fixture(scope="class")
     def worker_config(
@@ -198,7 +198,7 @@ Get-LocalUser | Select-Object Name, Enabled | Format-Table -AutoSize
                 "logs",
                 config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
             ),
-            expected_pattern=f"{self.DEFAULT_JOB_USER}",
+            expected_pattern=rf"Jobs Run As: {self.DEFAULT_JOB_USER}",
         )
 
         assert test_job.task_run_status == TaskStatus.SUCCEEDED

--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -215,7 +215,9 @@ Get-LocalUser | Select-Object Name, Enabled | Format-Table -AutoSize
 
         LOG.info("Wait for Worker Service to begin Stopping")
         # This can take over 5 minutes
-        class_worker.wait_until_worker_stopping(seconds_between_checks=25)
+        class_worker.wait_until_desired_worker_status(
+            seconds_between_checks=25, desired_status="STOPPING"
+        )
 
         ec2_client = boto3.client("ec2")
 

--- a/test/e2e/test_worker_config.py
+++ b/test/e2e/test_worker_config.py
@@ -177,11 +177,10 @@ class TestWorkerConfiguration:
         )["InstanceStatuses"][0]["InstanceState"]
         assert instance_status["Name"] == "running"
 
-        assert get_shutdown_on_stop_status_from_toml(
-            worker=worker_in_autoscaling_fleet_with_shut_down
-        ) == "shutdown_on_stop = true", (
-            "Shutdown on stop should be enabled"
-        )
+        assert (
+            get_shutdown_on_stop_status_from_toml(worker=worker_in_autoscaling_fleet_with_shut_down)
+            == "shutdown_on_stop = true"
+        ), "Shutdown on stop should be enabled"
 
         job.wait_until_complete(client=deadline_client)
 

--- a/test/e2e/test_worker_config.py
+++ b/test/e2e/test_worker_config.py
@@ -21,7 +21,11 @@ from deadline_test_fixtures import (
     OperatingSystem,
 )
 
-from e2e.utils import submit_custom_job, submit_sleep_job
+from e2e.utils import (
+    get_shutdown_on_stop_status_from_toml,
+    submit_custom_job,
+    submit_sleep_job,
+)
 from e2e.conftest import DeadlineResources
 
 LOG = logging.getLogger(__name__)
@@ -173,13 +177,20 @@ class TestWorkerConfiguration:
         )["InstanceStatuses"][0]["InstanceState"]
         assert instance_status["Name"] == "running"
 
+        assert get_shutdown_on_stop_status_from_toml(
+            worker=worker_in_autoscaling_fleet_with_shut_down
+        ) == "shutdown_on_stop = true", (
+            "Shutdown on stop should be enabled"
+        )
+
         job.wait_until_complete(client=deadline_client)
 
         # Check that the worker instance has been shut down
+        # Should not take more than 10 minutes to stop
         @backoff.on_exception(
             backoff.constant,
             Exception,
-            max_time=800,
+            max_time=600,
             interval=30,
         )
         def check_instance_stopping() -> None:

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -6,6 +6,7 @@ from deadline.job_attachments._aws.deadline import get_queue
 from deadline.job_attachments import download
 from deadline_test_fixtures import (
     DeadlineClient,
+    EC2InstanceWorker,
     Job,
     Farm,
     Queue,
@@ -187,3 +188,31 @@ def is_worker_stopped(
     )
     worker_status = get_worker_response["status"]
     return worker_status == "STOPPED"
+
+
+def get_shutdown_on_stop_status_from_toml(
+    worker: EC2InstanceWorker,
+) -> str:
+    if os.environ["OPERATING_SYSTEM"] == "linux":
+        cmd_result = worker.send_command(
+            command="""
+grep -E \
+  '^(# shutdown_on_stop =|shutdown_on_stop =)' \
+  /etc/amazon/deadline/worker.toml
+"""
+        )
+        assert cmd_result.exit_code == 0, "Failed to execute Linux command on .toml"
+        assert "shutdown_on_stop" in cmd_result.stdout, "shutdown_on_stop not found in .toml"
+        return cmd_result.stdout.strip()
+    elif os.environ["OPERATING_SYSTEM"] == "windows":
+        cmd_result = worker.send_command(
+            command="""
+$content = Get-Content "C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml"
+$content | Select-String -Pattern "^# shutdown_on_stop =|^shutdown_on_stop ="
+"""
+        )
+        assert cmd_result.exit_code == 0, "Failed to execute Windows command on .toml"
+        assert "shutdown_on_stop" in cmd_result.stdout, "shutdown_on_stop not found in .toml"
+        return cmd_result.stdout.strip()
+    else:
+        raise Exception(f"Unsupported operating system: {os.environ['OPERATING_SYSTEM']}")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- There were no tests that made sure we weren't shutting down a customers workstation when it shouldn't be

### What was the solution? (How)
- Added a test to ensure that the instance remains running
  - Modified the Windows Installer class worker to use the autoscaling resources
  - Reformatted the test class to have a job submitted immediately, so there is a job for the worker to do when the service is started.
  - Wait for the worker service to begin stopping and confirm that the instance remains running
- Updated the [deadline-cloudtest-fixtures/worker.py](https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/185) to better handle the `start-service` flag being set to false. 
  - (This is required for the tests here to work)


### What is the impact of this change?
- Adds test coverage for circumstances when a customer doesn't want their workstation to shutdown when the job is complete.
- The [deadline-cloudtest-fixtures/worker.py](https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/185) had to be updated to handle the `start-service` flag for these tests
- Simplified the method for obtaining the shutdown_status from the `.toml` file and moved it to `utils.py`
  - Works with both Windows and Linux and is used in `test_installer.py` and `test_worker_config.py`

### How was this change tested?
- Extensively tested the `TestWindowsInstaller` and `TestWorkerConfiguration` classes against the local `deadline-cloud-test-fixtures` changes I made.
- Windows and Linux E2E tests

### Was this change documented?
No

### Is this a breaking change?
- Required First: https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/185

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*