### PR TITLE
chore: fix dev script for running worker agent without AWS_ENDPOINT_URL_DEADLINE env var

### DIFF
--- a/scripts/run_posix_docker.sh
+++ b/scripts/run_posix_docker.sh
@@ -114,7 +114,7 @@ if test "${PIP_INDEX_URL:-}" != ""; then
     echo "PIP_INDEX_URL=${PIP_INDEX_URL}" >> $TMP_ENV_FILE
 fi
 
-if test "${AWS_ENDPOINT_URL_DEADLINE}" != ""; then
+if test "${AWS_ENDPOINT_URL_DEADLINE:-}" != ""; then
     echo "AWS_ENDPOINT_URL_DEADLINE=${AWS_ENDPOINT_URL_DEADLINE}" >> $TMP_ENV_FILE
 fi
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent has a developer script (`scripts/run_posix_docker.sh`) for running the worker agent in a Docker container to test cross-user setups in a consistent reproducible environment.

When trying to run the script without the `AWS_ENDPOINT_URL_DEADLINE` environment variable defined, it fails with the error:

```
scripts/run_posix_docker.sh: line 117: AWS_ENDPOINT_URL_DEADLINE: unbound variable
```

### What was the solution? (How)

Use the `${VAR_NAME:-}` syntax when using the variable to default to an empty string.

### What is the impact of this change?

The script will work when a developer does not have the `AWS_ENDPOINT_URL_DEADLINE` environment variable set.

### How was this change tested?

Ran the script without the `AWS_ENDPOINT_URL_DEADLINE` environment variable and it worked as expected.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*