### PR TITLE
feat(experimental): add support for chunkInt parameter type

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -73,13 +73,19 @@ class FloatParameter(TypedDict):
     float: str
 
 
+class ChunkIntParameter(TypedDict):
+    chunkInt: str
+
+
 class TaskRunAction(TypedDict):
     sessionActionId: str
     actionType: StepActionType
     taskId: str
     stepId: str
     parameters: NotRequired[
-        dict[str, StringParameter | PathParameter | IntParameter | FloatParameter]
+        dict[
+            str, StringParameter | PathParameter | IntParameter | FloatParameter | ChunkIntParameter
+        ]
     ]
 
 
@@ -296,7 +302,15 @@ class JobDetailsData(JobDetailsIdentifierFields):
     """The Open Job Description job template schema version"""
 
     parameters: NotRequired[
-        dict[str, StringParameter | PathParameter | IntParameter | FloatParameter | str]
+        dict[
+            str,
+            StringParameter
+            | PathParameter
+            | IntParameter
+            | FloatParameter
+            | ChunkIntParameter
+            | str,
+        ]
     ]
     """The job parameters"""
 

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -30,6 +30,7 @@ from ...api_models import (
     PathMappingRule,
     PathParameter,
     StringParameter,
+    ChunkIntParameter,
 )
 from ...config import JobsRunAsUserOverride
 from .job_entity_type import JobEntityType
@@ -37,7 +38,10 @@ from .validation import Field, validate_object
 
 
 def parameters_from_api_response(
-    params: dict[str, StringParameter | PathParameter | IntParameter | FloatParameter | str],
+    params: dict[
+        str,
+        StringParameter | PathParameter | IntParameter | FloatParameter | ChunkIntParameter | str,
+    ],
 ) -> dict[str, ParameterValue]:
     result = dict[str, ParameterValue]()
     for name, value in params.items():
@@ -53,6 +57,9 @@ def parameters_from_api_response(
         elif "path" in value:
             value = cast(PathParameter, value)
             param_value = ParameterValue(type=ParameterValueType.PATH, value=value["path"])
+        elif "chunkInt" in value:
+            value = cast(ChunkIntParameter, value)
+            param_value = ParameterValue(type=ParameterValueType.CHUNK_INT, value=value["chunkInt"])
         else:
             raise ValueError(f"Parameter {name} -- unknown form in API response: {str(value)}")
         result[name] = param_value

--- a/test/unit/sessions/job_entities/test_parameters_from_api_response.py
+++ b/test/unit/sessions/job_entities/test_parameters_from_api_response.py
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+
+from openjd.model import ParameterValueType
+
+from deadline_worker_agent.sessions.job_entities.job_details import parameters_from_api_response
+
+
+class TestParametersFromApiResponse:
+    @pytest.mark.parametrize(
+        "param_name, param_dict, expected_type, expected_value",
+        [
+            ("stringParam", {"string": "value"}, ParameterValueType.STRING, "value"),
+            ("pathParam", {"path": "/path/to/file"}, ParameterValueType.PATH, "/path/to/file"),
+            ("intParam", {"int": "42"}, ParameterValueType.INT, "42"),
+            ("floatParam", {"float": "3.14"}, ParameterValueType.FLOAT, "3.14"),
+            ("chunkIntParam", {"chunkInt": "1-5"}, ParameterValueType.CHUNK_INT, "1-5"),
+        ],
+    )
+    def test_parameters_from_api_response(
+        self, param_name, param_dict, expected_type, expected_value
+    ):
+        # GIVEN
+        params = {param_name: param_dict}
+
+        # WHEN
+        result = parameters_from_api_response(params)
+
+        # THEN
+        assert len(result) == 1
+        assert result[param_name].type == expected_type
+        assert result[param_name].value == expected_value


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
OpenJobDescription has introduced an [RFC for Task Chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) to address application and scene loading overhead. This RFC proposes a mechanism for chunking in the Open Job Description job template specification to improve resource utilization. The worker agent needs to support the new `CHUNK[INT]` parameter type to enable this functionality. This PR is the first step toward supporting task chunking in the Deadline Cloud worker agent.

### What was the solution? (How)
Added support for the "chunkInt" parameter type.

### What is the impact of this change?
This change enables the worker agent to begin supporting the task chunking feature defined in the OpenJobDescription RFC. The feature is still experimental but the changes won't impact existing stable functionality.

### How was this change tested?
[x] `hatch build && hatch run fmt && hatch run lint && hatch run test`
[x] Tested with sample job using the new parameter type to verify proper parsing and handling. Verified that task run session actions using this new parameter type run correctly.

### Was this change documented?
I couldn't find documentation for existing parameter types. Since the new type is still experimental and could change in the future, we might not need to document it for now. However, we should consider adding a section for "Supported Parameter Types" to `docs/worker_api_protocol.md`.

### Is this a breaking change?
No, this is an additive change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*