### PR TITLE
feat(HOST_CONFIGURATION_FEATURE): delimit host configuration script with banners in worker logs and shutdown host on failure

### DIFF
--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -173,6 +173,7 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
             # Run Worker Host Configuration.
             _host_configuration(
                 config=config,
+                deadline_client=deadline_client,
                 worker_bootstrap=worker_bootstrap,
                 worker_id=worker_id,
                 session=session,
@@ -432,10 +433,11 @@ def _configure_base_logging(
 
 
 def _host_configuration(
-    worker_bootstrap: WorkerBootstrap,
     config: Configuration,
-    worker_id: str,
+    deadline_client: DeadlineClient,
     session: WorkerBoto3Session,
+    worker_bootstrap: WorkerBootstrap,
+    worker_id: str,
 ) -> None:
     """
     Runs all business logic related to Host Configuration.
@@ -513,7 +515,45 @@ def _host_configuration(
                     exit_code=exit_code,
                 )
             )
-            sys.exit(1)
+            # Set this worker to stopped.
+            try:
+                update_worker(
+                    deadline_client=deadline_client,
+                    farm_id=config.farm_id,
+                    fleet_id=config.fleet_id,
+                    worker_id=worker_id,
+                    status=WorkerStatus.STOPPED,
+                )
+            except Exception as e:
+                _logger.error(
+                    WorkerLogEvent(
+                        op=WorkerLogEventOp.STATUS,
+                        farm_id=config.farm_id,
+                        fleet_id=config.fleet_id,
+                        worker_id=worker_id,
+                        message="Failed to set status to STOPPED: %s" % str(e),
+                    )
+                )
+
+            # Attempt to shutdown if possible.
+            if config.no_shutdown:
+                _logger.info("NOT shutting down the host. Local configuration settings say not to.")
+                sys.exit(1)
+
+            _logger.critical(
+                WorkerHostConfigurationLogEvent(
+                    farm_id=config.farm_id,
+                    fleet_id=config.fleet_id,
+                    worker_id=worker_id,
+                    message="Worker Agent host configuration failed. Attempting host shut down.",
+                    status=WorkerHostConfigurationStatus.FAILED,
+                    exit_code=exit_code,
+                )
+            )
+            while _repeatedly_attempt_host_shutdown():
+                _host_shutdown(config=config)
+                # Sleep for 30s and then try again; hopefully we never wake up
+                sleep(30)
 
 
 def _remove_logging_handler(handler: logging.Handler) -> None:

--- a/src/deadline_worker_agent/startup/host_configuration_script.py
+++ b/src/deadline_worker_agent/startup/host_configuration_script.py
@@ -90,6 +90,7 @@ class HostConfigurationScriptRunner(ScriptRunnerBase):
             startup_directory=session_directory,
             callback=self._action_callback,
         )
+        self._print_section_banner = False
 
     def _script_file_name(self) -> str:
         return "host_configuration.ps1" if sys.platform == "win32" else "host_configuration.sh"
@@ -133,12 +134,21 @@ class HostConfigurationScriptRunner(ScriptRunnerBase):
             return 0
 
         script_file_path = self._write_script_file()
+
+        self._log_section_banner(
+            logger=self._logger_adapter, section_title="Running Host Configuration Script"
+        )
+
         with FileContext(script_file_path) as _:
             if sys.platform == "win32":
                 exit_code = self._run_win32(script_file_path)
             else:
                 exit_code = self._run_posix()
 
+        self._log_section_banner(
+            logger=self._logger_adapter,
+            section_title=f"Finished running Host Configuration Script, exit code: {exit_code}",
+        )
         return exit_code
 
     def _run_posix(self) -> int:
@@ -209,3 +219,13 @@ class HostConfigurationScriptRunner(ScriptRunnerBase):
         """This method is inherited from the base class and only used for posix."""
         # Action cancellation. In this case, we terminate the child.
         self._cancel(TerminateCancelMethod(), time_limit, mark_action_failed)
+
+    def _log_section_banner(self, logger: LoggerAdapter, section_title: str) -> None:
+        logger.info("")
+        logger.info(
+            "============================================================================================"
+        )
+        logger.info(f"--------- {section_title} ---------")
+        logger.info(
+            "============================================================================================"
+        )

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -835,24 +835,33 @@ def test_host_config_already_run_before(
 
 
 @pytest.mark.parametrize(
-    ("has_host_config", "exit_code"),
+    ("has_host_config", "exit_code", "can_shutdown"),
     (
-        pytest.param(True, 0),
-        pytest.param(True, 1),
-        pytest.param(False, 1),
+        pytest.param(True, 0, True, id="Has HostConfig, run success, can shutdown"),
+        pytest.param(True, 1, True, id="Has HostConfig, run failed, can shutdown"),
+        pytest.param(True, 1, False, id="Has HostConfig, run failed, cannot shutdown"),
+        pytest.param(False, 1, True, id="No Host Config"),
     ),
 )
 @patch("deadline_worker_agent.startup.entrypoint.HOST_CONFIGURATION_FEATURE", True)
+@patch.object(entrypoint_mod, "_repeatedly_attempt_host_shutdown")
 @patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")
 @patch.object(entrypoint_mod.sys, "exit")
+@patch.object(entrypoint_mod, "sleep")
 def test_fleet_host_config(
+    sleep_mock: MagicMock,
     sys_exit_mock: MagicMock,
     telemetry_mock: MagicMock,
+    mock_repeat_attempt_host_shutdown: MagicMock,
     has_host_config: bool,
     exit_code: int,
+    can_shutdown: bool,
     bootstrap_worker_mock: MagicMock,
     mock_fleet_host_configuration_runner: MagicMock,
     worker_info: WorkerPersistenceInfo,
+    configuration_load: MagicMock,
+    mock_host_shutdown: MagicMock,
+    worker_id: str,
 ) -> None:
     """Tests that exceptions raised by Worker.run() are logged and the program exits with a non-zero exit code"""
 
@@ -865,7 +874,18 @@ def test_fleet_host_config(
         # No script to run.
         bootstrap_worker_mock.return_value.host_config = None
 
-    with patch.object(entrypoint_mod, "_logger") as logger:
+    # Can the worker agent shutdown on script failure.
+    if can_shutdown:
+        configuration_load.return_value.no_shutdown = False
+        mock_repeat_attempt_host_shutdown.side_effect = [True, False]
+    else:
+        mock_repeat_attempt_host_shutdown.side_effect = [False]
+        configuration_load.return_value.no_shutdown = True
+
+    with (
+        patch.object(entrypoint_mod, "_logger") as logger,
+        patch.object(entrypoint_mod, "update_worker") as update_worker_mock,
+    ):
         # WHEN
         entrypoint()
 
@@ -905,4 +925,21 @@ def test_fleet_host_config(
         ]
         assert len(all_args) > 0
         assert expected in all_args
-        sys_exit_mock.assert_called_once_with(1)
+
+        # Make sure we called to the backend to STOPPED.
+        update_worker_mock.assert_any_call(
+            deadline_client=ANY,
+            farm_id=configuration_load.return_value.farm_id,
+            fleet_id=configuration_load.return_value.fleet_id,
+            worker_id=worker_id,
+            status=WorkerStatus.STOPPED,
+        )
+        # If it can shutdown, assert that we attempted to call the shutdown method.
+        if can_shutdown:
+            mock_host_shutdown.assert_called_once()
+            sleep_mock.assert_called_once()
+        # Otherwise, worker agent exits.
+        else:
+            sys_exit_mock.assert_called_once_with(1)
+            mock_host_shutdown.assert_not_called()
+            sleep_mock.assert_not_called()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- During testing, we found the debugging experience of host configuration to be difficult. The Host Configuration logs were JSON, and it was hard to find the logging section associated with Host Configuration. 

### What was the solution? (How)
- After team discussion, we decided on 2 changes.
  1. Add logging banners similar to OpenJD Sessions for Python start and end. 
  2. Shutdown the worker host if shutdown is allowed. On Service Managed Fleets shutdown is always allowed.
 
- Short blurb on the script failure experience.
  - Existing experience. When Host Config scripts fail, Worker Agent exits with error code 1. On Service Managed fleets where the agent is a daemon, the worker restarts. This leads to an infinite loop where the Worker Agent starts, runs the script, dies and re-starts.
  - With the updated experience. When Host Config scripts fail, the worker Agent Shuts down the host. This works on Deadline Service Managed Fleets, and Customer Managed Fleets with the shutdown option enabled. If shutdown is not allowed, the previous loop behavior still continues. 
  - Given the premise of this feature, we believe this is the right balance of debugging vs customer annoyance.

### What is the impact of this change?
- Improve the debuggability of Host Configuration on Deadline Cloud SMF fleets.

### How was this change tested?
- hatch build
- hatch run fmt
- hatch run all:lint
- hatch run test
- hatch run integ-test (windows & OSX)
- hatch run e2e-test (to test shutdown, E2E tests are not publicly published yet.)

### Was this change documented?
- Code comments only.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*