### PR TITLE
feat(HOST_CONFIGURATION_FEATURE): Prevent Windows ACL inheritance for host config script and log and grant full control to Administrators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline == 0.49.*",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.10.1",
+    "openjd-sessions == 0.10.2",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "tomlkit == 0.13.*",

--- a/src/deadline_worker_agent/file_system_operations.py
+++ b/src/deadline_worker_agent/file_system_operations.py
@@ -40,6 +40,9 @@ def touch_file(
     user_permission: Optional[FileSystemPermissionEnum] = None,
     permitted_user: Optional[SessionUser] = None,
     agent_user_permission: Optional[FileSystemPermissionEnum] = None,
+    group: Optional[str] = None,
+    group_permission: Optional[FileSystemPermissionEnum] = None,
+    disable_permission_inheritance: bool = False,
 ):
     if os.name == "nt":
         permitted_user = cast(WindowsSessionUser, permitted_user)
@@ -52,6 +55,9 @@ def touch_file(
             user=permitted_user.user if permitted_user else None,
             user_permission=user_permission,
             agent_user_permission=agent_user_permission,
+            group=group,
+            group_permission=group_permission,
+            disable_permission_inheritance=disable_permission_inheritance,
         )
 
 
@@ -84,6 +90,7 @@ def _set_windows_permissions(
     group_permission: Optional[FileSystemPermissionEnum] = None,
     agent_user_permission: Optional[FileSystemPermissionEnum] = None,
     users_group_permission: Optional[FileSystemPermissionEnum] = None,
+    disable_permission_inheritance: bool = False,
 ):
     import win32security
     import ntsecuritycon
@@ -143,6 +150,12 @@ def _set_windows_permissions(
 
     # Get the security descriptor of the object
     sd = win32security.GetFileSecurity(str(path.resolve()), win32security.DACL_SECURITY_INFORMATION)
+
+    # Disable inheritance and convert inherited ACEs to explicit ACEs
+    if disable_permission_inheritance:
+        sd.SetSecurityDescriptorControl(
+            win32security.SE_DACL_PROTECTED, win32security.SE_DACL_PROTECTED
+        )
 
     # Set the security descriptor's DACL to the newly-created DACL
     # Arguments:

--- a/src/deadline_worker_agent/windows/win_admin_runner.py
+++ b/src/deadline_worker_agent/windows/win_admin_runner.py
@@ -124,8 +124,14 @@ class _WindowsScriptRunner:
         touch_file(
             file_path=Path(self._logfile),
             agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
+            group="Administrators",
+            group_permission=FileSystemPermissionEnum.FULL_CONTROL,
+            disable_permission_inheritance=True,
         )
         touch_file(
             file_path=Path(self._script_path),
             agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
+            group="Administrators",
+            group_permission=FileSystemPermissionEnum.FULL_CONTROL,
+            disable_permission_inheritance=True,
         )

--- a/test/integ/startup/test_host_configuration.py
+++ b/test/integ/startup/test_host_configuration.py
@@ -335,41 +335,82 @@ def _windows_file_permissions_test(file_path: str) -> None:
     import win32security
     import ntsecuritycon
 
-    users_group_sid, _, _ = win32security.LookupAccountName(None, "Users")
+    # Get relevant SIDs
     current_user_sid, _, _ = win32security.LookupAccountName(None, getpass.getuser())
+    administrators_sid, _, _ = win32security.LookupAccountName(None, "Administrators")
+    users_group_sid, _, _ = win32security.LookupAccountName(None, "Users")
+
+    # Get security descriptor
     sd = win32security.GetFileSecurity(
         str(file_path),
         win32con.DACL_SECURITY_INFORMATION | win32con.OWNER_SECURITY_INFORMATION,
     )
     dacl = sd.GetSecurityDescriptorDacl()
 
-    users_group_permission_found: bool = False
-    current_user_permission_read_found: bool = False
-    current_user_permission_write_found: bool = False
-
     if dacl is None:
-        assert False, "All users have access to the file."
+        assert False, "No DACL found - all users have access to the file."
 
-    # Iterate through each ACE in the DACL
+    # Track permissions for allowed entities
+    current_user_permissions = 0
+    admin_permissions = 0
+    other_sids_found = []
+
+    # Explicit check that Users group has no permissions at all
     for i in range(dacl.GetAceCount()):
         ace = dacl.GetAce(i)
         (ace_type, ace_flags), ace_mask, sid = ace
 
+        assert ace_type == ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE, (
+            f"Unexpected ace type found for sid {sid}"
+        )
+
         if sid == users_group_sid:
-            # Check for read or write permission
-            if (ace_mask & ntsecuritycon.FILE_GENERIC_READ == ntsecuritycon.FILE_GENERIC_READ) or (
-                ace_mask & ntsecuritycon.FILE_GENERIC_WRITE == ntsecuritycon.FILE_GENERIC_WRITE
-            ):
-                users_group_permission_found = True
-        elif sid == current_user_sid:
-            # Check for read permission
-            if ace_mask & ntsecuritycon.FILE_GENERIC_READ == ntsecuritycon.FILE_GENERIC_READ:
-                current_user_permission_read_found = True
+            assert False, (
+                f"Users group should not have any permissions, but found ACE with mask: {ace_mask}"
+            )
 
-            # Check for write permission
-            if ace_mask & ntsecuritycon.FILE_GENERIC_WRITE == ntsecuritycon.FILE_GENERIC_WRITE:
-                current_user_permission_write_found = True
+        if sid == current_user_sid:
+            current_user_permissions |= ace_mask
+        elif sid == administrators_sid:
+            admin_permissions |= ace_mask
+        else:  # We already checked Users group
+            # Keep track of any other SIDs that have access
+            other_sids_found.append((win32security.LookupAccountSid(None, sid)[0], ace_mask))
 
-    assert not users_group_permission_found
-    assert current_user_permission_read_found
-    assert current_user_permission_write_found
+    # Check that no other SIDs have access
+    assert not other_sids_found, f"Found unexpected SIDs with access: {other_sids_found}"
+
+    # Define required permissions for current user and admin.
+    # This is the scoped down set from checking the underlying application.
+    required_permissions = (
+        ntsecuritycon.FILE_READ_DATA  # 0x1
+        | ntsecuritycon.FILE_WRITE_DATA  # 0x2
+        | ntsecuritycon.FILE_APPEND_DATA  # 0x4
+        | ntsecuritycon.FILE_READ_EA  # 0x8
+        | ntsecuritycon.FILE_WRITE_EA  # 0x10
+        | ntsecuritycon.FILE_EXECUTE  # 0x20
+        | ntsecuritycon.FILE_DELETE_CHILD  # 0x40
+        | ntsecuritycon.FILE_READ_ATTRIBUTES  # 0x80
+        | ntsecuritycon.FILE_WRITE_ATTRIBUTES  # 0x100
+        | ntsecuritycon.DELETE  # 0x10000
+        | ntsecuritycon.READ_CONTROL  # 0x20000
+        | ntsecuritycon.WRITE_DAC  # 0x40000
+        | ntsecuritycon.WRITE_OWNER  # 0x80000
+        | ntsecuritycon.SYNCHRONIZE  # 0x100000
+    )
+
+    # Check current user permissions
+    assert current_user_permissions == required_permissions, (
+        f"Current user does not have correct permissions. Has: {current_user_permissions}, "
+        f"Needs: {required_permissions}"
+    )
+
+    # Check Administrator group has required permissions.
+    assert admin_permissions == required_permissions, (
+        f"Administrator does not have correct permissions. Has: {current_user_permissions}, "
+        f"Needs: {required_permissions}"
+    )
+
+    # Check that inheritance is disabled
+    control = sd.GetSecurityDescriptorControl()
+    assert control[0] & win32security.SE_DACL_PROTECTED, "DACL should be protected from inheritance"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- From my Prior PR, we had an open comment to improve the security stance of the logging and host config script.
- After deep diving, I found the files had inherited access. 
- Also Current User + Admin had a looser file access permission bits.
- The previous implementation also checked for User access as a subset of permission bits.

### What was the solution? (How)
- Disable File inheritance - See https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-control, SE_DACL_PROTECTED
- Explicit permission set for current user (worker agent), and Administrators
- Explicit check users group is not allowed
- Explicit check no other DACL SIDs exists (eg other users or groups)

### Addendum
- Also updated openjd-sessions to `0.10.2` to incorporate latest version.

### What is the impact of this change?
- The files involved with Host Configuration are fully locked down.

### How was this change tested?
- hatch build
- hatch run fmt
- hatch run lint
- hatch run test
- hatch run integ-test
- hatch run e2e-test (windows, Host Config test not published yet.)

### Was this change documented?
- No.

### Is this a breaking change?
- No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*