### PR TITLE
fix: Worker Agent crashes with corrupted credential cache file 

### DIFF
--- a/src/deadline_worker_agent/aws_credentials/temporary_credentials.py
+++ b/src/deadline_worker_agent/aws_credentials/temporary_credentials.py
@@ -6,12 +6,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Optional, Type
 import logging
+import json
 
 from typing_extensions import TypedDict
 
 from botocore.credentials import JSONFileCache
 
 from ..api_models import AwsCredentials
+from ..log_messages import AwsCredentialsLogEvent, AwsCredentialsLogEventOp
 
 _logger = logging.getLogger(__name__)
 
@@ -63,17 +65,45 @@ class TemporaryCredentials:
         cache_key: str,
     ) -> Optional[TemporaryCredentials]:
         """Obtains temporary credentials from a botocore JSONFileCache"""
-        if cache_key not in cache:
+        try:
+            if cache_key not in cache:
+                return None
+
+            result = cache[cache_key]
+        except (json.JSONDecodeError, KeyError) as e:
+            # Handle corrupted cache file
+            full_filename = cache._convert_cache_key(cache_key)
+            _logger.error(
+                AwsCredentialsLogEvent(
+                    op=AwsCredentialsLogEventOp.LOAD,
+                    resource=full_filename,
+                    message=f"Error reading AWS Credentials from cache file: {str(e)}",
+                )
+            )
+            # Delete the corrupted cache entry to allow fresh credentials to be obtained
+            del cache[cache_key]
+            _logger.info(
+                AwsCredentialsLogEvent(
+                    op=AwsCredentialsLogEventOp.DELETE,
+                    resource=full_filename,
+                    message="Deleted corrupted AWS Credentials cache file",
+                )
+            )
             return None
-        result = cache[cache_key]
+
         try:
             credentials = cls.validate_file_credentials(result)
         except Exception as e:
             full_filename = cache._convert_cache_key(cache_key)
             _logger.error(
-                "Error reading AWS Credentials from cache file (%s): %s", full_filename, str(e)
+                AwsCredentialsLogEvent(
+                    op=AwsCredentialsLogEventOp.LOAD,
+                    resource=full_filename,
+                    message=f"Error reading AWS Credentials from cache file: {str(e)}",
+                )
             )
             return None
+
         return cls.from_file_format(credentials)
 
     def to_deadline(self) -> AwsCredentials:

--- a/test/unit/aws_credentials/test_temporary_credentials.py
+++ b/test/unit/aws_credentials/test_temporary_credentials.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from dateutil.tz import tzlocal
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
+import logging
 
 from pytest import fixture, mark, param, raises
 
@@ -154,6 +155,58 @@ class TestTemporaryCredentials:
             mock_validate.assert_not_called()
             mock_from_file_format.assert_not_called()
             assert result is None
+
+    def test_from_cache_read_error_with_convert_cache_key(self) -> None:
+        # GIVEN
+        cache = MagicMock()
+        cache_key = "cache key"
+        cache.__contains__.return_value = True
+        cache.__getitem__.side_effect = KeyError("worker-id")
+        # Mock the _convert_cache_key method to return a specific path
+        cache._convert_cache_key.return_value = "/path/to/cache/file.json"
+
+        # WHEN
+        from deadline_worker_agent.log_messages import (
+            AwsCredentialsLogEvent,
+            AwsCredentialsLogEventOp,
+        )
+
+        with (
+            patch.object(
+                logging.getLogger("deadline_worker_agent.aws_credentials.temporary_credentials"),
+                "error",
+            ) as mock_error_log,
+            patch.object(
+                logging.getLogger("deadline_worker_agent.aws_credentials.temporary_credentials"),
+                "info",
+            ) as mock_info_log,
+        ):
+            result = TemporaryCredentials.from_cache(
+                cache=cache,
+                cache_key=cache_key,
+            )
+
+        # THEN
+        assert result is None
+        cache.__delitem__.assert_called_once_with(cache_key)
+        # Verify _convert_cache_key was called with the cache_key
+        cache._convert_cache_key.assert_called_once_with(cache_key)
+
+        # Verify the error log message uses AwsCredentialsLogEvent with correct parameters
+        mock_error_log.assert_called_once()
+        log_event = mock_error_log.call_args[0][0]
+        assert isinstance(log_event, AwsCredentialsLogEvent)
+        assert log_event.subtype == AwsCredentialsLogEventOp.LOAD.value
+        assert log_event.resource == "/path/to/cache/file.json"
+        assert "Error reading AWS Credentials from cache file" in log_event.msg
+
+        # Verify the info log message about deleting the corrupted file
+        mock_info_log.assert_called_once()
+        delete_log_event = mock_info_log.call_args[0][0]
+        assert isinstance(delete_log_event, AwsCredentialsLogEvent)
+        assert delete_log_event.subtype == AwsCredentialsLogEventOp.DELETE.value
+        assert delete_log_event.resource == "/path/to/cache/file.json"
+        assert "Deleted corrupted AWS Credentials cache file" in delete_log_event.msg
 
     def test_to_deadline(
         self,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Fixes https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/555

#555 describes a bug which was root caused to be a corrupted AWS credentials cache file. The worker agent doesn't handle that scenario and could not start. 

### What was the solution? (How)

Catch the `DecodeError`/`KeyError` (the KeyError is the one that ultimately shows up, but handling both as a safeguard). 

### What is the impact of this change?

### How was this change tested?

On an instance with this change installed, I did the following:

1. Started the worker agent in order to generate the cached credentials file
2. Stopped the worker agent and removed the first `{` in the file in order to 'corrupt' the file.
3. Restarted the worker agent and confirmed the error was gracefully handled, and the file deleted, and that the worker successfully bootstrapped and started again.

Observed the following logs indicating success.


```json
{"level": "INFO", "message": "👋 Worker Agent starting"}
{"level": "INFO", "type": "AgentInfo", "platform": "linux", "python": {"interpreter": "/opt/deadline/worker/bin/python3.11", "version": "3.11.11 (main, Mar 20 2025, 00:00:00) [GCC 11.5.0 20240719 (Red Hat 11.5.0-5)]"}, "agent": {"version": "0.27.1.post1.dev201", "installedAt": "/opt/deadline/worker/lib/python3.11/site-packages", "runningAs": "deadline-worker"}, "dependencies": {"openjd.model": "0.7.0", "openjd.sessions": "0.10.2", "deadline.job_attachments": "0.49.8"}}
{"level": "WARNING", "message": "Could not detect GPU count, nvidia-smi not found"}
{"level": "WARNING", "message": "Could not detect GPU memory, nvidia-smi not found"}
{"level": "INFO", "message": "Deadline Cloud telemetry is enabled."}
{"level": "INFO", "message": "CAP_KILL was found in the thread's inheritable capability set (cap_kill=eip). Dropping CAP_KILL from the thread's inheritable capability set"}
{"level": "INFO", "message": "Capabilites are: cap_kill=ep"}
{"level": "INFO", "message": "Worker host is running on instance i-0f91feac2ce0fc34c."}
{"level": "INFO", "ti": "💾", "type": "FileSystem", "subtype": "Read", "message": "Worker state from previous run.", "filepath": "/var/lib/deadline/worker.json"}
{"level": "INFO", "ti": "💻", "type": "Worker", "subtype": "Load", "message": "Worker identity loaded from prior run.", "farm_id": "farm-cbf892577334487d8392bedada50a474", "fleet_id": "fleet-af8dfbd363a240eda9075b0c2386310a", "worker_id": "worker-97e8a9f0b7f8497387515ba7cbaf5fe1"}
{"level": "ERROR", "ti": "🔑", "type": "AWSCreds", "subtype": "Load", "message": "Error reading AWS Credentials from cache file: 'worker-97e8a9f0b7f8497387515ba7cbaf5fe1'", "resource": "/var/lib/deadline/credentials/worker-97e8a9f0b7f8497387515ba7cbaf5fe1.json"}
{"level": "INFO", "ti": "🔑", "type": "AWSCreds", "subtype": "Delete", "message": "Deleted corrupted AWS Credentials cache file", "resource": "/var/lib/deadline/credentials/worker-97e8a9f0b7f8497387515ba7cbaf5fe1.json"}
{"level": "INFO", "ti": "🔑", "type": "AWSCreds", "subtype": "Query", "message": "Requesting AWS Credentials", "resource": "worker-97e8a9f0b7f8497387515ba7cbaf5fe1"}
{"level": "INFO", "ti": "📤", "type": "API", "subtype": "Req", "operation": "deadline:AssumeFleetRoleForWorker", "params": {}, "request_url": "https://scheduling.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-cbf892577334487d8392bedada50a474/fleets/fleet-af8dfbd363a240eda9075b0c2386310a/workers/worker-97e8a9f0b7f8497387515ba7cbaf5fe1/fleet-roles", "resource": {"farm-id": "farm-cbf892577334487d8392bedada50a474", "fleet-id": "fleet-af8dfbd363a240eda9075b0c2386310a", "worker-id": "worker-97e8a9f0b7f8497387515ba7cbaf5fe1"}}
{"level": "INFO", "ti": "📥", "type": "API", "subtype": "Resp", "operation": "deadline:AssumeFleetRoleForWorker", "status_code": 200, "params": {"credentials": {"accessKeyId": "ASIAZM5B5BFB4TXRVJL6", "secretAccessKey": "*REDACTED*", "sessionToken": "*REDACTED*", "expiration": "2025-05-07 20:23:32+00:00"}}, "request_id": "1d8db3ae-fb2c-4104-8df5-8642e249a18b"}
{"level": "INFO", "ti": "🔑", "type": "AWSCreds", "subtype": "Query", "message": "Obtained temporary Worker AWS Credentials.", "expiry": "2025-05-07 20:23:32+00:00", "resource": "worker-97e8a9f0b7f8497387515ba7cbaf5fe1"}
{"level": "INFO", "ti": "💾", "type": "FileSystem", "subtype": "Write", "message": "Worker AWS Credentials cached.", "filepath": "/var/lib/deadline/credentials/worker-97e8a9f0b7f8497387515ba7cbaf5fe1.json"}
{"level": "INFO", "ti": "📤", "type": "API", "subtype": "Req", "operation": "deadline:UpdateWorker", "params": {"status": "STARTED", "capabilities": {"amounts": [{"name": "amount.worker.vcpu", "value": 4.0}, {"name": "amount.worker.memory", "value": 7727.140625}, {"name": "amount.worker.disk.scratch", "value": 27097.0}, {"name": "amount.worker.gpu", "value": 0.0}, {"name": "amount.worker.gpu.memory", "value": 0.0}], "attributes": [{"name": "attr.worker.os.family", "values": ["linux"]}, {"name": "attr.worker.cpu.arch", "values": ["x86_64"]}]}, "hostProperties": {"ipAddresses": {"ipV4Addresses": ["127.0.0.1", "172.31.5.89"], "ipV6Addresses": ["FE80:0000:0000:0000:0041:FAFF:FE96:63A3"]}, "hostName": "ip-172-31-5-89.us-west-2.compute.internal"}}, "request_url": "https://scheduling.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-cbf892577334487d8392bedada50a474/fleets/fleet-af8dfbd363a240eda9075b0c2386310a/workers/worker-97e8a9f0b7f8497387515ba7cbaf5fe1", "resource": {"farm-id": "farm-cbf892577334487d8392bedada50a474", "fleet-id": "fleet-af8dfbd363a240eda9075b0c2386310a", "worker-id": "worker-97e8a9f0b7f8497387515ba7cbaf5fe1"}}
{"level": "INFO", "ti": "📥", "type": "API", "subtype": "Resp", "operation": "deadline:UpdateWorker", "status_code": 200, "params": {"log": {"logDriver": "awslogs", "options": {"logGroupName": "/aws/deadline/farm-cbf892577334487d8392bedada50a474/fleet-af8dfbd363a240eda9075b0c2386310a", "logStreamName": "worker-97e8a9f0b7f8497387515ba7cbaf5fe1"}, "parameters": {}}}, "request_id": "b2c24153-aa55-4c40-ac03-f9171c048f6c"}
{"level": "INFO", "ti": "💻", "type": "Worker", "subtype": "Status", "message": "Status set to STARTED.", "farm_id": "farm-cbf892577334487d8392bedada50a474", "fleet_id": "fleet-af8dfbd363a240eda9075b0c2386310a", "worker_id": "worker-97e8a9f0b7f8497387515ba7cbaf5fe1"}
{"level": "INFO", "ti": "💻", "type": "Worker", "subtype": "ID", "message": "Agent identity.", "farm_id": "farm-cbf892577334487d8392bedada50a474", "fleet_id": "fleet-af8dfbd363a240eda9075b0c2386310a", "worker_id": "worker-97e8a9f0b7f8497387515ba7cbaf5fe1"}
{"level": "INFO", "message": "Worker successfully bootstrapped and is now running."}
```

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*