### PR TITLE
docs: developer worker life-cycle documentation outline

### DIFF
--- a/docs/dev/worker_lifecycle.md
+++ b/docs/dev/worker_lifecycle.md
@@ -1,3 +1,56 @@
 # Worker Agent Lifecycle
 
+This document explains the lifecycle of the AWS Deadline Cloud Worker Agent, including its startup, running, and shutdown phases. Understanding this lifecycle is crucial for developers working on the worker agent codebase.
+
+## Overview
+
+The worker agent goes through three main phases during its lifecycle:
+
+1. **Startup Phase**: Initialization, configuration loading, and worker registration
+2. **Running Phase**: Main operational loop, handling sessions and reporting status
+3. **Shutdown Phase**: Graceful termination, cleanup, status change, and host shutdown
+
+Each phase involves specific components and operations that ensure the worker agent functions correctly within the AWS Deadline Cloud ecosystem.
+
+```mermaid
+---
+title: The Worker Life-Cycle
+---
+flowchart LR
+    %% High-level worker lifecycle
+    start([start]) --> startup[Startup Phase]
+    startup --> running[Running Phase]
+    running --> shutdown[Shutdown Phase]
+    shutdown --> terminate([end])
+    
+    %% Styling
+    classDef startupPhase fill:#c9e6ff,stroke:#0066cc
+    classDef runningPhase fill:#d8f0d8,stroke:#2d862d
+    classDef shutdownPhase fill:#ffe6cc,stroke:#cc7a00
+    classDef startEnd fill:#EEEEEE,stroke:#444444
+    
+    class startup startupPhase
+    class running runningPhase
+    class shutdown shutdownPhase
+    class start,terminate startEnd
+```
+
+## Startup Phase
+
 Coming soon&hellip;
+
+## Running Phase
+
+Coming soon&hellip;
+
+## Shutdown Phase
+
+Coming soon&hellip;
+
+## Next Steps
+
+After understanding the worker agent lifecycle, we recommend exploring:
+
+- [Session Lifecycle](session_lifecycle.md) - Comprehensive overview of how sessions are executed
+- [Architecture](architecture.md) - Overview of the worker agent architecture and components
+- [Worker API Protocol](worker_api_protocol.md) - Documentation of the API interactions with the Deadline Cloud service


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Contributors looking to onboard to worker agent development are not met with sufficient documentation to learn and become productive quickly.

In #613, we created a high-level structure for the developer-focused documentation with placeholders for the content. The worker life-cycle remains undocumented.

### What was the solution? (How)

Created an initial outline for the worker life-cycle documentation. This includes an introduction of the high-level phases of the worker agent's life-cycle:

*   Startup phase
*   Running phase
*   Shutdown phase

The introduction includes a color-coded diagram showing the order of the phases. Below the introduction, sections have been added with placeholder content.

### What is the impact of this change?

We have a high-level introduction and an outline of sections for the worker life-cycle documentation.

### How was this change tested?

Previewed the rendered markdown in GitHub.

### Was this change documented?

This change IS documentation.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*