### PR TITLE
docs: developer documentation outline of architecture

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,3 +1,56 @@
-# Software Architecture
+# Worker Agent Architecture
+
+This guide provides developers with a comprehensive overview of the worker agent's architecture, and a breakdown of its components, and the execution model. Whether you're fixing bugs, adding features, or improving performance, understanding the core concepts outlined here will help you understand the architecture of the project.
+
+**Outline:**
+
+*  [1. High-Level Architecture](#1-high-level-architecture)
+   *  [1.1. Responsibilities](#11-responsibilities)
+*  [2. Software Architecture](#2-software-architecture)
+   *  [2.1. Class Diagram](#21-class-diagram)
+*  [3. Code Organization](#3-code-organization)
+   *  [3.1. Key Files](#31-key-files)
+*  [4. Thread Model and Concurrency](#4-thread-model-and-concurrency)
+   *  [4.1. Thread Lifecycle Diagram](#41-thread-lifecycle-diagram)
+   *  [4.2. Concurrency Control and Locks](#42-concurrency-control-and-locks)
+      *  [4.2.1. Lock Acquisition Order](#421-lock-acquisition-order)
+
+## 1. High-Level Architecture
+
+Coming soon&hellip;
+
+### 1.1. Responsibilities
+
+Coming soon&hellip;
+
+## 2. Software Architecture
+
+Coming soon&hellip;
+
+### 2.1. Class Diagram
+
+Coming soon&hellip;
+
+## 3. Code Organization
+
+Coming soon&hellip;
+
+### 3.1. Key Files
+
+Coming soon&hellip;
+
+## 4. Thread Model and Concurrency
+
+Coming soon&hellip;
+
+### 4.1. Thread Lifecycle Diagram
+
+Coming soon&hellip;
+
+### 4.2. Concurrency Control and Locks
+
+Coming soon&hellip;
+
+#### 4.2.1. Lock Acquisition Order
 
 Coming soon&hellip;


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Contributors looking to onboard to worker agent development are not met with sufficient documentation to learn and become productive quickly.

In #613, we created a high-level structure for the developer-focused documentation with placeholders for the content. The architecture topic remains undocumented.

### What was the solution? (How)

Created an initial outline for the architecture documentation. This includes:

*  an introductory paragraph explaining the doc topic's purpose
*  a table of contents
*  numbered headings for the sections to be populated w/ content placeholders

### What is the impact of this change?

We have an introduction and an outline of sections for the architecture documentation.

### How was this change tested?

Previewed the rendered markdown in GitHub.

### Was this change documented?

This change IS documentation.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*