### PR TITLE
test: increase override worker agent job tests job wait retries

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -303,7 +303,7 @@ def create_worker(
         try:
             worker.start()
         except Exception as e:
-            LOG.exception(f"Failed to start worker: {e}")
+            LOG.error(f"Failed to start worker: {e}")
             LOG.info("Stopping worker because it failed to start")
             stop_worker(request, worker)
             raise

--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -193,14 +193,6 @@ class TestWindowsJobUserOverride:
             deadline_resources.queue_a,
         )
 
-        # This user should also take priority over jobs run as worker agent
-        override_worker_agent_job = self.submit_whoami_job(
-            test_name="override job run as worker agent",
-            deadline_client=deadline_client,
-            farm=deadline_resources.farm,
-            queue=deadline_resources.jobs_run_as_agent_user_queue,
-        )
-
         job.wait_until_complete(client=deadline_client, max_retries=20)
         job.assert_single_task_log_contains(
             deadline_client=deadline_client,
@@ -212,7 +204,15 @@ class TestWindowsJobUserOverride:
         )
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
-        override_worker_agent_job.wait_until_complete(client=deadline_client, max_retries=1)
+        # This user should also take priority over jobs run as worker agent
+        override_worker_agent_job = self.submit_whoami_job(
+            test_name="override job run as worker agent",
+            deadline_client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.jobs_run_as_agent_user_queue,
+        )
+
+        override_worker_agent_job.wait_until_complete(client=deadline_client, max_retries=20)
         override_worker_agent_job.assert_single_task_log_contains(
             deadline_client=deadline_client,
             logs_client=boto3.client(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`override_worker_agent_job` in `test_installer_user_override` has a max retry of `1`. This can cause a job timeout which results in the worker picking up another job. This can lead to the worker having incorrect configurations when attempting to pickup other jobs.

### What was the solution? (How)
Increase retries to 20 to wait for the job to complete.

I also changed `worker.start` to log an error so we don't print exception stack traces twice.

### What is the impact of this change?
test waits for job to complete

### How was this change tested?
```
hatch run lint
hatch run test
hatch run e2e-test
```

### Was this change documented?
n/a

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*