### PR TITLE
docs: developer documentation for code organization

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,53 +4,7 @@ This documentation provides guidance on developer workflows for working with the
 
 ## Code Organization
 
-### `src/deadline_worker_agent`
-
-This is the root of the source code. The primary code files where most of the changes would be made exist in this root directory.
-
-Files of note include:
-
-*   `worker.py`
-
-    `Worker` class implementation containing the main thread's event loop that runs after the Worker has been bootstrapped. This is the original implementation of the Worker Agent that uses `UpdateWorkerSchedule` and `NotifyProgress` which are APIs that are unaware of Worker Sessions.
-
-## `src/deadline_worker_agent/boto`
-
-This contains logic for boto3 and botocore.
-
-### `src/deadline_worker_agent/config`
-
-This Python sub-package contains modules for the worker agent's configuration settings system.
-
-### `src/deadline_worker_agent/startup`
-
-This contains logic for the startup phase in the Worker Agent's lifecycle.
-
-### `src/deadline_worker_agent/log_sync`
-
-This Python sub-package contains code responsible for synchronizing logs emitted by AWS Deadline Cloud tasks to their destination(s) in S3 and CloudWatch Logs, and synchronizing logs emitted by agent to CloudWatch Logs.
-
-### `src/deadline_worker_agent/scheduler`
-
-This contains an impementation of the Worker Agent's scheduler. This works with the AWS Deadline Cloud farm's scheduler via `UpdateWorkerSchedule` to synchronize the assignment, completion, and status reporting of work.
-
-### `src/deadline_worker_agent/sessions`
-
-This contains the logic and APIs for managing the life-cycle of a Worker session. The primary class contained in this package, the `Session` class, is responsible for taking actions from the `SessionActionQueue` and running them within the Open Job Description session.
-
-### `src/deadline_worker_agent/sessions/actions`
-
-This package contains classes corresponding to each action and the logic for running them within the `Session`.
-
-### `src/deadline_worker_agent/sessions/job_entities`
-
-This package contains code responsible for fetching the job entities required for running Worker session actions. This coordinates efficient use of the `BatchGetJobEntity` API and provides a high-level API for asynchronously requesting (optionally in a batch) and waiting for fetched the entities.
-
-### `src/deadline_worker_agent/installer`
-
-This contains the logic for the `install_deadline_worker` entrypoint which provisions OS users, groups, sudoers rule, and file-system
-directories used by the Worker Agent. Finally it configures a systemd service on Linux systems that runs the Worker Agent
-on boot and restarts the process if it crashes unexpectedly.
+See [code organization](./docs/dev/architecture.md#3-code-organization).
 
 ## Build / Test
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -33,11 +33,43 @@ Coming soon&hellip;
 
 ## 3. Code Organization
 
-Coming soon&hellip;
+The worker agent codebase is organized into several key directories:
+
+```
+deadline-cloud-worker-agent/
+├── src/
+│   └── deadline_worker_agent/  # Main source code
+│       ├── aws/                # AWS service APIs
+│       │   └── deadline/       # AWS Deadline Cloud APIs
+│       ├── aws_credentials/    # AWS credentials management
+│       ├── boto/               # Boto3 and botocore configuration and shim layer
+│       ├── config/             # Configuration handling
+│       ├── installer/          # Worker agent installation logic
+│       ├── linux/              # Linux-specific code
+│       ├── log_sync/           # Log synchronization
+│       ├── scheduler/          # Worker scheduler
+│       ├── sessions/           # Session management
+│       │   ├── actions/        # Session actions
+│       │   │   └── scripts/    # Helper scripts for actions
+│       │   └── job_entities/   # Job entity handling
+│       ├── startup/            # Startup and shutdown phase
+│       └── windows/            # Windows-specific code
+├── pipeline/                   # CI/CD pipeline scripts
+├── scripts/                    # Utility scripts for development and testing
+├── tests/
+│   ├── e2e/                    # End-to-end tests
+│   ├── integration/            # Integration tests
+│   └── unit/                   # Unit tests
+└── docs/                       # Documentation
+```
 
 ### 3.1. Key Files
 
-Coming soon&hellip;
+The key source files relative to `src/deadlne_worker_agent/` are:
+- `startup/entrypoint.py` &mdash; The main code entrypoint
+- `worker.py` &mdash; Contains the `Worker` class which handles OS signals, host metrics logging, EC2 monitoring, and creates/monitors/manages of a `WorkerScheduler` instance.
+- `scheduler/scheduler.py` &mdash; Contains the `WorkerScheduler` class responsible for managing the worker's schedule in coordination with the Deadline Cloud service
+- `sessions/session.py` &mdash; Contains the `Session` class that manages and individual session's life-cycle
 
 ## 4. Thread Model and Concurrency
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Contributors looking to onboard to worker agent development are not met with sufficient documentation to learn and become productive quickly.

In #613, we created a high-level structure for the developer-focused documentation with placeholders for the content. In #617, we created an initial outline of the worker agent architecture documentation topic.

Within the architecture topic of the developer documentation of the worker agent, the code organization section remains undocumented.

### What was the solution? (How)

Added documentation for the code organization of the worker life-cycle including a summary of the directory structure and a section pointing out key files of mention.

This content had previously resided in `DEVELOPMENT.md` in the root of the repository. This file will eventually become a link to the `docs/dev` directory once its content has fully migrated. For now, this PR removes the code organization content from `DEVELOPMENT.md` and instead links to the new content.

### What is the impact of this change?

The repository code organization is documented in the developer guide.

### How was this change tested?

Previewed the rendered markdown in GitHub.

### Was this change documented?

This change IS documentation.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*