### PR TITLE
fix: Cleanup host config log file if the file already exist

### DIFF
--- a/src/deadline_worker_agent/utils.py
+++ b/src/deadline_worker_agent/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import MutableMapping
 import os
+from pathlib import Path
 from types import TracebackType
 from typing import Any, Callable, Generic, Iterator, TypeVar
 
@@ -61,10 +62,13 @@ class MappingWithCallbacks(MutableMapping, Generic[_K, _V]):
 class FileContext:
     """File context, ensures a file is deleted."""
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str, delete_existing: bool = False):
         self._file_path = file_path
+        self._delete_existing = delete_existing
 
     def __enter__(self):
+        if self._delete_existing:
+            Path(self._file_path).unlink(missing_ok=True)
         return self._file_path
 
     def __exit__(

--- a/src/deadline_worker_agent/windows/win_admin_runner.py
+++ b/src/deadline_worker_agent/windows/win_admin_runner.py
@@ -43,9 +43,9 @@ class _WindowsScriptRunner:
         """Run the executable with command. Tails the prescribed log file until process exit.
         Returns the process exit code.
         """
-        self._prepare_file_permissions()
+        with FileContext(file_path=self._logfile, delete_existing=True) as _:
+            self._prepare_file_permissions()
 
-        with FileContext(self._logfile) as _:
             # Run the command, allow the window to show.
             # https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-shellexecuteinfoa
             try:

--- a/test/integ/startup/test_host_configuration.py
+++ b/test/integ/startup/test_host_configuration.py
@@ -285,6 +285,45 @@ Get-ChildItem env: | ForEach-Object { "$($_.Name)=$($_.Value)" }
         for log in expected_logs:
             assert any(log in m for m in messages)
 
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="Windows specific test",
+    )
+    def test_windows_log_file_already_exists(
+        self, message_queue: SimpleQueue, queue_handler: QueueHandler, tmp_path: Path
+    ):
+        # Given
+        script = "echo HelloWorld\r\nexit 0"
+        expected_logs = ["HelloWorld"]
+        timeout = 300
+
+        runner = self._create_host_configuration_script_runner(
+            script=script,
+            timeout=timeout,
+            tmp=tmp_path,
+            queue_handler=queue_handler,
+        )
+
+        # Pre-create the log file
+        log_content = "FOO_BAR_QUX"
+        log_path = os.path.join(tmp_path, "host_configuration.log")
+        with open(log_path, "w+") as fp:
+            fp.write(log_content)
+
+        # When
+        exit_code = runner.run()
+        run_success = exit_code == 0
+
+        # Then
+        assert run_success
+        messages = collect_queue_messages(message_queue)
+
+        for log in expected_logs:
+            assert any(log in m for m in messages)
+
+        # Make sure the pre-created log content is not found.
+        assert not any(log_content in m for m in messages)
+
     def test_script_and_log_file_access(self, queue_handler: QueueHandler, tmp_path: Path):
         """
         Tests the script file is only accessible by worker agent user.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Customer Managed Fleet use of worker agent can exit on start if the Host Config log file was pre-created in the incorrect format. 
- The root cause is because the log file is simply amended, and not checked for format or content.

### What was the solution? (How)
- Keep it simple, delete the log file before running Host Configuration runs.
- This ensures any pre-existing file does not affect the worker agent. 

### What is the impact of this change?
- Release ready!

### How was this change tested?
- hatch build
- hatch run test
- hatch run integ-test (with and without deleting file)

### Was this change documented?
- NA.

### Is this a breaking change?
- No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*