### PR TITLE
feat: Launch Host Configuration feature

### DIFF
--- a/src/deadline_worker_agent/feature_flag.py
+++ b/src/deadline_worker_agent/feature_flag.py
@@ -7,5 +7,3 @@ import os
 ASSET_SYNC_JOB_USER_FEATURE = (
     os.environ.get("ASSET_SYNC_JOB_USER_FEATURE", "false").lower() == "true"
 )
-
-HOST_CONFIGURATION_FEATURE = os.environ.get("HOST_CONFIGURATION_FEATURE", "false").lower() == "true"

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -17,8 +17,6 @@ from pathlib import Path
 
 from ..aws_credentials.worker_boto3_session import WorkerBoto3Session
 
-from ..feature_flag import HOST_CONFIGURATION_FEATURE
-
 from ..api_models import WorkerStatus
 from ..aws.deadline import (
     update_worker,
@@ -446,18 +444,7 @@ def _host_configuration(
     """
 
     # If there was a host config, and it was bootstrapped before, only log a message.
-    if worker_bootstrap.host_config and not HOST_CONFIGURATION_FEATURE:
-        _logger.info(
-            WorkerHostConfigurationLogEvent(
-                farm_id=config.farm_id,
-                fleet_id=config.fleet_id,
-                worker_id=worker_id,
-                message="Host Configuration Feature is not enabled.",
-                status=WorkerHostConfigurationStatus.SKIPPED,
-            )
-        )
-        return
-    elif worker_bootstrap.host_config and worker_bootstrap.worker_info.host_configuration_succeeded:
+    if worker_bootstrap.host_config and worker_bootstrap.worker_info.host_configuration_succeeded:
         _logger.info(
             WorkerHostConfigurationLogEvent(
                 farm_id=config.farm_id,

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -769,39 +769,6 @@ class TestCloudWatchLogStreaming:
         context_mgr_exit.assert_called_once()
 
 
-@patch("deadline_worker_agent.startup.entrypoint.HOST_CONFIGURATION_FEATURE", False)
-@patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")
-@patch.object(entrypoint_mod.sys, "exit")
-def test_host_config_feature_flag_off(
-    sys_exit_mock: MagicMock,
-    telemetry_mock: MagicMock,
-    bootstrap_worker_mock: MagicMock,
-    mock_fleet_host_configuration_runner: MagicMock,
-    worker_info: WorkerPersistenceInfo,
-) -> None:
-    # Turn OFF the feature flag for this test.
-    # Given
-
-    with patch.object(entrypoint_mod, "_logger") as logger:
-        # WHEN
-        entrypoint()
-
-    # Then
-    mock_fleet_host_configuration_runner.assert_not_called()
-
-    expected = "Host Configuration Feature is not enabled."
-
-    all_args = [
-        arg.msg
-        for args, kwargs in logger.info.call_args_list
-        for arg in list(args) + list(kwargs.values())
-        if isinstance(arg, WorkerHostConfigurationLogEvent)
-    ]
-    assert len(all_args) > 0
-    assert expected in all_args
-
-
-@patch("deadline_worker_agent.startup.entrypoint.HOST_CONFIGURATION_FEATURE", True)
 @patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")
 @patch.object(entrypoint_mod.sys, "exit")
 def test_host_config_already_run_before(
@@ -843,7 +810,6 @@ def test_host_config_already_run_before(
         pytest.param(False, 1, True, id="No Host Config"),
     ),
 )
-@patch("deadline_worker_agent.startup.entrypoint.HOST_CONFIGURATION_FEATURE", True)
 @patch.object(entrypoint_mod, "_repeatedly_attempt_host_shutdown")
 @patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")
 @patch.object(entrypoint_mod.sys, "exit")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Host Configuration feature has been launched for Deadline Cloud Service Managed fleets.
- https://aws.amazon.com/about-aws/whats-new/2025/05/aws-deadline-cloud-service-managed-fleets-configuration-scripts
- This feature has been tested and released. We are offering feature parity for Customer Managed fleets and installations, although customers can already configure a worker fully

### What was the solution? (How)
- Remove the feature flag, it is generally available.

### What is the impact of this change?
- GA'ed featured.

### How was this change tested?
- hatch build
- hatch run test
- hatch run integ:test

### Was this change documented?
- I am adding some documentation for the Worker protocol changes in another PR related to Host Configuration.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*