### PR TITLE
[PoC] feat(experimental): add output manifest reporting

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -416,6 +416,13 @@ class BatchGetJobEntityResponse(TypedDict):
     errors: list[EntityError]
 
 
+class ManifestInfo(TypedDict):
+    """Model for manifest information."""
+
+    outputManifestPath: NotRequired[str]
+    outputManifestHash: NotRequired[str]
+
+
 class UpdatedSessionActionInfo(TypedDict):
     completedStatus: NotRequired[CompletedActionStatus]
     processExitCode: NotRequired[int]
@@ -424,6 +431,7 @@ class UpdatedSessionActionInfo(TypedDict):
     endedAt: NotRequired[datetime]
     updatedAt: NotRequired[datetime]
     progressPercent: NotRequired[float]
+    manifests: NotRequired[list[ManifestInfo]]
 
 
 class UpdateWorkerScheduleRequest(TypedDict):

--- a/src/deadline_worker_agent/feature_flag.py
+++ b/src/deadline_worker_agent/feature_flag.py
@@ -9,3 +9,6 @@ ASSET_SYNC_JOB_USER_FEATURE = (
 )
 
 HOST_CONFIGURATION_FEATURE = os.environ.get("HOST_CONFIGURATION_FEATURE", "false").lower() == "true"
+
+# Feature flag for output manifest reporting
+MANIFEST_REPORTING_FEATURE = os.environ.get("MANIFEST_REPORTING_FEATURE", "false").lower() == "true"

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -69,6 +69,7 @@ from ..log_messages import (
     WorkerLogEvent,
     WorkerLogEventOp,
 )
+from ..feature_flag import MANIFEST_REPORTING_FEATURE
 from .log import LOGGER
 from .session_cleanup import SessionUserCleanupManager
 from .session_queue import SessionActionQueue, SessionActionStatus
@@ -603,6 +604,10 @@ class WorkerScheduler:
                 updated_action["progressPercent"] = min(max(0, action_updated.status.progress), 100)
         if action_updated.end_time:
             updated_action["endedAt"] = action_updated.end_time
+
+        # Add manifest information if available and feature flag is enabled
+        if MANIFEST_REPORTING_FEATURE and action_updated.manifests is not None:
+            updated_action["manifests"] = action_updated.manifests
 
         # Truncate message to max bytes allowed by UpdateWorkerSchedule API
         if (

--- a/src/deadline_worker_agent/scheduler/session_action_status.py
+++ b/src/deadline_worker_agent/scheduler/session_action_status.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from openjd.sessions import ActionStatus
 
 if TYPE_CHECKING:
-    from ..api_models import CompletedActionStatus
+    from ..api_models import CompletedActionStatus, ManifestInfo
 
 
 @dataclass(frozen=True)
@@ -19,3 +19,4 @@ class SessionActionStatus:
     start_time: datetime | None = None
     end_time: datetime | None = None
     completed_status: CompletedActionStatus | None = None
+    manifests: list[ManifestInfo] | None = None

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
@@ -22,6 +22,7 @@ from openjd.model.v2023_09 import (
 )
 from openjd.model import ParameterValue
 
+from ...feature_flag import MANIFEST_REPORTING_FEATURE
 from ...log_messages import SessionActionLogKind
 from .openjd_action import OpenjdAction
 
@@ -189,6 +190,8 @@ class AttachmentUploadAction(OpenjdAction):
                 "DEADLINE_SESSIONACTION_ID": self._id,
                 "DEADLINE_STEP_ID": self._step_id,
                 "DEADLINE_TASK_ID": self._task_id,
+                "DEADLINE_SESSION_DIR": str(session.working_directory),
+                "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,
         )

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -32,13 +32,38 @@ python attachment_upload.py \
 
 def upload(s3_root_uri: str, path_mapping_rules: str, manifests: list[str]) -> None:
     s3_path = f"{os.environ.get('DEADLINE_FARM_ID')}/{os.environ.get('DEADLINE_QUEUE_ID')}/{os.environ.get('DEADLINE_JOB_ID')}/{os.environ.get('DEADLINE_STEP_ID')}/{os.environ.get('DEADLINE_TASK_ID')}/{os.environ.get('DEADLINE_SESSIONACTION_ID')}"
-    api.attachment_upload(
+
+    # Call attachment_upload and get manifest information
+    manifest_info = api.attachment_upload(
         manifests=manifests,
         s3_root_uri=s3_root_uri,
         boto3_session=boto3.session.Session(),
         path_mapping_rules=path_mapping_rules,
         upload_manifest_path=s3_path,
     )
+
+    # Check if manifest reporting feature is enabled via environment variable
+    manifest_reporting_enabled = (
+        os.environ.get("MANIFEST_REPORTING_FEATURE", "false").lower() == "true"
+    )
+
+    if manifest_reporting_enabled:
+        try:
+            # Write manifest information to a file in the session directory
+            session_action_id = os.environ.get("DEADLINE_SESSIONACTION_ID")
+            session_dir = os.environ.get("DEADLINE_SESSION_DIR", "/sessions")
+            output_file = os.path.join(session_dir, f"manifest_info_{session_action_id}.json")
+
+            with open(output_file, "w") as f:
+                json.dump(manifest_info, f)
+
+            # Ensure the file is readable by the Worker Agent
+            os.chmod(output_file, 0o644)
+
+            print(f"Wrote manifest information to {output_file}: {manifest_info}")
+        except Exception as e:
+            print(f"Failed to write manifest information: {e}")
+            # Continue with the upload process even if writing the manifest information fails
 
 
 def merge(

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
@@ -30,8 +31,12 @@ from deadline_worker_agent.api_models import (
     SyncInputJobAttachmentsAction,
     AttachmentDownloadAction,
     AttachmentUploadAction,
+    ManifestInfo,
 )
-from deadline_worker_agent.feature_flag import ASSET_SYNC_JOB_USER_FEATURE
+from deadline_worker_agent.feature_flag import (
+    ASSET_SYNC_JOB_USER_FEATURE,
+    MANIFEST_REPORTING_FEATURE,
+)
 
 if TYPE_CHECKING:
     from ..api_models import CompletedActionStatus, EnvironmentAction, TaskRunAction
@@ -157,6 +162,7 @@ class Session:
     _stop: Event
     _output_sync_target_action: CurrentAction | None = None
     _current_action: CurrentAction | None = None
+    _manifests_for_output_sync_target_action: list[ManifestInfo] | None = None
     _current_action_lock: RLock
     _stop_current_action_result: Literal["INTERRUPTED", "FAILED"] = "FAILED"
     _stop_grace_time: timedelta | None = None
@@ -1127,11 +1133,57 @@ class Session:
 
         if self._output_sync_target_action is not None:
             if OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS.get(action_status.state, None):
+                manifests_list = None
+
+                # Use the manifests if available and feature flag is enabled
+                if MANIFEST_REPORTING_FEATURE:
+                    manifest_info_file = (
+                        self.working_directory
+                        / f"manifest_info_{self._output_sync_target_action.definition.id}.json"
+                    )
+                    if os.path.exists(manifest_info_file):
+                        try:
+                            with open(manifest_info_file, "r") as f:
+                                manifest_info_dict = json.load(f)
+                            # Clean up the file
+                            os.remove(manifest_info_file)
+
+                            # Get job attachment details to access input manifests
+                            job_attachment_details = self._job_attachment_details
+
+                            if job_attachment_details:
+                                # Create a list of ManifestInfo objects with the same length as the input manifests list
+                                manifests_list = []
+
+                                # For each input manifest, find the corresponding output manifest
+                                for input_manifest in job_attachment_details.manifests:
+                                    asset_root = input_manifest.root_path
+                                    manifest_info = manifest_info_dict.get(asset_root, {})
+
+                                    # Create a ManifestInfo dictionary with the appropriate values
+                                    manifest_info_obj: ManifestInfo = {}
+                                    if "outputManifestPath" in manifest_info:
+                                        manifest_info_obj["outputManifestPath"] = manifest_info[
+                                            "outputManifestPath"
+                                        ]
+                                    if "outputManifestHash" in manifest_info:
+                                        manifest_info_obj["outputManifestHash"] = manifest_info[
+                                            "outputManifestHash"
+                                        ]
+
+                                    manifests_list.append(manifest_info_obj)
+                        except Exception as e:
+                            logger.error(f"Failed to read manifest information: {e}")
+
                 # if the current action is a sync output job attachments upload action and it's completed
                 # then we can update and clear the corresponding task run sync target action
                 task_run_action = self._output_sync_target_action
                 self._output_sync_target_action = None
-                self._handle_action_update(is_unsuccessful, action_status, task_run_action, now)
+
+                # Handle the action update
+                self._handle_action_update(
+                    is_unsuccessful, action_status, task_run_action, now, manifests_list
+                )
             else:
                 logger.debug(
                     f"SYNC_OUTPUT_JOB_ATTACHMENTS for {self._output_sync_target_action} is still running"
@@ -1168,10 +1220,23 @@ class Session:
                 self.logger.info("----------------------------------------------")
                 self.logger.info("Uploading output files to Job Attachments")
                 self.logger.info("----------------------------------------------")
-                future: Future = self._executor.submit(
-                    self._sync_asset_outputs,
-                    current_action=current_action,
-                )
+
+                # Create a future for the asset sync operation
+                future = None
+                if MANIFEST_REPORTING_FEATURE:
+                    manifest_future: Future[list[ManifestInfo]] = self._executor.submit(
+                        self._sync_asset_outputs,
+                        current_action=current_action,
+                    )
+                    future = manifest_future
+                else:
+                    # If feature flag is disabled, use the old method signature
+                    standard_future: Future = self._executor.submit(
+                        self._sync_asset_outputs,
+                        current_action=current_action,
+                    )
+                    future = standard_future
+
                 on_done_with_sync_asset_outputs = partial(
                     self._on_done_with_sync_asset_outputs,
                     is_unsuccessful=is_unsuccessful,
@@ -1188,13 +1253,20 @@ class Session:
 
     def _on_done_with_sync_asset_outputs(
         self,
-        future: Future[None],
+        future: Future[list[ManifestInfo]],
         is_unsuccessful: bool,
         action_status: ActionStatus,
         current_action: CurrentAction,
     ):
+        manifests: Optional[list[ManifestInfo]] = None
         try:
-            future.result()
+            # Extract manifests from future result only if feature flag is enabled
+            if MANIFEST_REPORTING_FEATURE:
+                # Extract manifests from future result
+                manifests = future.result()
+            else:
+                # Just get the result to check for exceptions, but don't use manifests
+                future.result()
         except Exception as e:
             # Log and fail the task run action if we are unable to sync output job attachments
             fail_message = (
@@ -1215,7 +1287,10 @@ class Session:
                 self._action_update_lock,
                 self._current_action_lock,
             ):
-                self._handle_action_update(is_unsuccessful, action_status, current_action, now)
+                # Pass manifests to _handle_action_update
+                self._handle_action_update(
+                    is_unsuccessful, action_status, current_action, now, manifests
+                )
 
     def _handle_action_update(
         self,
@@ -1223,6 +1298,7 @@ class Session:
         action_status: ActionStatus,
         current_action: CurrentAction,
         now: datetime,
+        manifests: list[ManifestInfo] | None = None,
     ):
         completed_status = OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS.get(
             action_status.state, None
@@ -1282,6 +1358,9 @@ class Session:
         # Only report action update when it's not attachment upload for syncing job attachment outputs,
         # progress reporting is not supported by the output upload yet.
         if not self._output_sync_target_action:
+            # Only include manifests if feature flag is enabled
+            session_manifests = manifests if MANIFEST_REPORTING_FEATURE else None
+
             self._report_action_update(
                 SessionActionStatus(
                     id=current_action.definition.id,
@@ -1290,6 +1369,7 @@ class Session:
                     end_time=now if action_status.state != ActionState.RUNNING else None,
                     update_time=now if action_status.state == ActionState.RUNNING else None,
                     completed_status=completed_status,
+                    manifests=session_manifests,
                 )
             )
 
@@ -1298,15 +1378,19 @@ class Session:
         self,
         *,
         current_action: CurrentAction,
-    ) -> None:
-        """Sync the outputs after a TASK_RUN if using Job Attachments"""
+    ) -> list[ManifestInfo]:
+        """Sync the outputs after a TASK_RUN if using Job Attachments
+
+        Returns:
+            A list of manifest dictionaries containing output manifest information
+        """
         if not (queue_settings := self._job_details.job_attachment_settings):
-            return
+            return []
         if not (job_attachment_details := self._job_attachment_details):
-            return
+            return []
         if self._asset_sync is None:
             # Shouldn't get here, but let's be defensive.
-            return
+            return []
 
         # assist type check
         assert queue_settings.root_prefix is not None
@@ -1345,26 +1429,72 @@ class Session:
         from .actions import RunStepTaskAction
 
         assert isinstance(current_action.definition, RunStepTaskAction)
-        upload_summary_statistics: SummaryStatistics = self._asset_sync.sync_outputs(
-            s3_settings=s3_settings,
-            attachments=attachments,
-            queue_id=self._queue_id,
-            job_id=self._queue._job_id,
-            step_id=current_action.definition.step_id,  # type: ignore[arg-type]
-            task_id=current_action.definition.task_id,
-            session_action_id=current_action.definition.id,
-            start_time=current_action.start_time.timestamp(),
-            session_dir=self._session.working_directory,
-            storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules_dict,
-            on_uploading_files=self._notifier_callback,
-        )
+
+        # Use different sync method based on feature flag
+        if MANIFEST_REPORTING_FEATURE:
+            upload_summary_statistics, manifest_info_dict = (
+                self._asset_sync.sync_outputs_with_manifests(  # type: ignore[attr-defined]
+                    s3_settings=s3_settings,
+                    attachments=attachments,
+                    queue_id=self._queue_id,
+                    job_id=self._queue._job_id,
+                    step_id=current_action.definition.step_id,  # type: ignore[arg-type]
+                    task_id=current_action.definition.task_id,
+                    session_action_id=current_action.definition.id,
+                    start_time=current_action.start_time.timestamp(),
+                    session_dir=self._session.working_directory,
+                    storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules_dict,
+                    on_uploading_files=self._notifier_callback,
+                )
+            )
+        else:
+            # Use the original sync_outputs method if feature flag is disabled
+            upload_summary_statistics = self._asset_sync.sync_outputs(
+                s3_settings=s3_settings,
+                attachments=attachments,
+                queue_id=self._queue_id,
+                job_id=self._queue._job_id,
+                step_id=current_action.definition.step_id,  # type: ignore[arg-type]
+                task_id=current_action.definition.task_id,
+                session_action_id=current_action.definition.id,
+                start_time=current_action.start_time.timestamp(),
+                session_dir=self._session.working_directory,
+                storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules_dict,
+                on_uploading_files=self._notifier_callback,
+            )
+            # Create empty dict for manifest_info_dict when feature is disabled
+            manifest_info_dict = {}
 
         self.logger.info(f"Summary Statistics for file uploads:\n{upload_summary_statistics}")
+
+        # Create a list of ManifestInfo objects with the same length as the input manifests list
+        manifests_list: list[ManifestInfo] = []
+
+        # Only process manifests if feature flag is enabled
+        if (
+            MANIFEST_REPORTING_FEATURE
+            and job_attachment_details
+            and job_attachment_details.manifests
+        ):
+            for manifest_properties in job_attachment_details.manifests:
+                asset_root = manifest_properties.root_path
+                manifest_info = manifest_info_dict.get(asset_root, {})
+
+                # Create a ManifestInfo dictionary with the appropriate values
+                manifest_info_obj: ManifestInfo = {}
+                if "outputManifestPath" in manifest_info:
+                    manifest_info_obj["outputManifestPath"] = manifest_info["outputManifestPath"]
+                if "outputManifestHash" in manifest_info:
+                    manifest_info_obj["outputManifestHash"] = manifest_info["outputManifestHash"]
+
+                manifests_list.append(manifest_info_obj)
 
         # Send the summary stats of output syncing through the telemetry client.
         record_sync_outputs_telemetry_event(self._queue_id, upload_summary_statistics)
 
         self.logger.info("Finished syncing outputs using Job Attachments")
+
+        return manifests_list
 
     def run_task(
         self,

--- a/test/unit/scheduler/test_manifest_in_scheduler.py
+++ b/test/unit/scheduler/test_manifest_in_scheduler.py
@@ -1,0 +1,126 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+
+from deadline_worker_agent.scheduler.scheduler import WorkerScheduler
+from deadline_worker_agent.scheduler.session_action_status import SessionActionStatus
+from deadline_worker_agent.api_models import ManifestInfo
+from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
+from openjd.sessions import ActionStatus, ActionState
+
+
+@pytest.mark.skipif(
+    not MANIFEST_REPORTING_FEATURE,
+    reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
+)
+class TestSchedulerManifests:
+    @pytest.fixture
+    def scheduler(self):
+        # Create a minimal scheduler for testing
+        scheduler = MagicMock()
+        scheduler._updated_action_to_boto = WorkerScheduler._updated_action_to_boto.__get__(
+            scheduler, WorkerScheduler
+        )
+        return scheduler
+
+    def test_updated_action_to_boto_includes_manifests(self, scheduler):
+        # Arrange
+        now = datetime.now(timezone.utc)
+        action_status = ActionStatus(state=ActionState.SUCCESS)
+        manifests = [
+            ManifestInfo(
+                outputManifestPath="s3://bucket/Manifests/key1",
+                outputManifestHash="hash1",
+            ),
+            ManifestInfo(
+                outputManifestPath="s3://bucket/Manifests/key2",
+                outputManifestHash="hash2",
+            ),
+            ManifestInfo(),  # Empty object for a root with no changes
+        ]
+
+        action_updated = SessionActionStatus(
+            id="test_action_id",
+            status=action_status,
+            start_time=now,
+            end_time=now,
+            completed_status="SUCCEEDED",
+            manifests=manifests,
+        )
+
+        # Act
+        result = scheduler._updated_action_to_boto(action_updated)
+
+        # Assert
+        assert "manifests" in result
+        assert result["manifests"] == manifests
+
+    @patch("deadline_worker_agent.scheduler.scheduler.MANIFEST_REPORTING_FEATURE", False)
+    def test_updated_action_to_boto_excludes_manifests_when_feature_disabled(self, scheduler):
+        # Arrange
+        now = datetime.now(timezone.utc)
+        action_status = ActionStatus(state=ActionState.SUCCESS)
+        manifests = [
+            ManifestInfo(
+                outputManifestPath="s3://bucket/Manifests/key1",
+                outputManifestHash="hash1",
+            ),
+        ]
+
+        action_updated = SessionActionStatus(
+            id="test_action_id",
+            status=action_status,
+            start_time=now,
+            end_time=now,
+            completed_status="SUCCEEDED",
+            manifests=manifests,
+        )
+
+        # Act
+        result = scheduler._updated_action_to_boto(action_updated)
+
+        # Assert
+        assert "manifests" not in result
+
+    def test_updated_action_to_boto_excludes_manifests_when_none(self, scheduler):
+        # Arrange
+        now = datetime.now(timezone.utc)
+        action_status = ActionStatus(state=ActionState.SUCCESS)
+
+        action_updated = SessionActionStatus(
+            id="test_action_id",
+            status=action_status,
+            start_time=now,
+            end_time=now,
+            completed_status="SUCCEEDED",
+            # No manifests field
+        )
+
+        # Act
+        result = scheduler._updated_action_to_boto(action_updated)
+
+        # Assert
+        assert "manifests" not in result
+
+    def test_updated_action_to_boto_handles_empty_manifests_list(self, scheduler):
+        # Arrange
+        now = datetime.now(timezone.utc)
+        action_status = ActionStatus(state=ActionState.SUCCESS)
+
+        action_updated = SessionActionStatus(
+            id="test_action_id",
+            status=action_status,
+            start_time=now,
+            end_time=now,
+            completed_status="SUCCEEDED",
+            manifests=[],  # Empty list
+        )
+
+        # Act
+        result = scheduler._updated_action_to_boto(action_updated)
+
+        # Assert
+        assert "manifests" in result
+        assert result["manifests"] == []

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -8,6 +8,9 @@ from typing import Generator, Optional
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 import logging
 
+from deadline_worker_agent.api_models import ManifestInfo
+from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
+
 from openjd.sessions import (
     ActionState,
     ActionStatus,
@@ -704,6 +707,41 @@ class TestSchedulerSync:
             assert status_as_boto.get("processExitCode", "ABSENT") == "ABSENT"
         else:
             assert status_as_boto.get("processExitCode", "FAIL") == expected_result
+
+    @pytest.mark.skipif(
+        not MANIFEST_REPORTING_FEATURE,
+        reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
+    )
+    def test_updated_action_to_boto_with_empty_manifests(self, scheduler: WorkerScheduler) -> None:
+        # GIVEN
+        manifests = [
+            ManifestInfo(
+                outputManifestPath="s3://bucket/path/to/manifest1", outputManifestHash="hash1"
+            ),
+            ManifestInfo(),  # Empty manifest for asset root with no changes
+            ManifestInfo(
+                outputManifestPath="s3://bucket/path/to/manifest3", outputManifestHash="hash3"
+            ),
+        ]
+        action_status = SessionActionStatus(
+            id="1234", status=ActionStatus(state=ActionState.SUCCESS), manifests=manifests
+        )
+
+        # WHEN
+        status_as_boto = scheduler._updated_action_to_boto(action_status)
+
+        # THEN
+        assert "manifests" in status_as_boto
+        assert len(status_as_boto["manifests"]) == 3
+        assert status_as_boto["manifests"][0] == {
+            "outputManifestPath": "s3://bucket/path/to/manifest1",
+            "outputManifestHash": "hash1",
+        }
+        assert status_as_boto["manifests"][1] == {}
+        assert status_as_boto["manifests"][2] == {
+            "outputManifestPath": "s3://bucket/path/to/manifest3",
+            "outputManifestHash": "hash3",
+        }
 
 
 class TestCreateNewSessions:

--- a/test/unit/sessions/actions/test_run_attachment_upload.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload.py
@@ -7,12 +7,13 @@ import sys
 import tempfile
 import json
 from typing import TYPE_CHECKING, Generator
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch, mock_open
 
 import pytest
 
 import deadline_worker_agent.sessions.actions as actions_module
 from deadline_worker_agent.sessions.job_entities.job_details import JobDetails
+from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
 from openjd.sessions import SessionUser, PathMappingRule, PathFormat
 from openjd.model import ParameterValue
 from pathlib import PurePosixPath
@@ -127,6 +128,7 @@ class TestStart:
         step_id: str,
         task_id: str,
         action_id: str,
+        session_dir: str,
     ) -> None:
         """
         Tests that AttachmentUploadAction.start() calls AssetSync functions to prepare input
@@ -143,8 +145,12 @@ class TestStart:
         )
         session.manifest_out_rel_dirs_by_source = {}
 
-        # WHEN
-        action.start(session=session, executor=executor)
+        session.working_directory = Path(session_dir)
+
+        # Mock file operations to avoid actual file access
+        with patch("os.path.exists", return_value=False):
+            # WHEN
+            action.start(session=session, executor=executor)
 
         with open(
             Path(os.path.dirname(actions_module.__file__)) / "scripts" / "attachment_upload.py",
@@ -184,6 +190,8 @@ class TestStart:
                 "DEADLINE_SESSIONACTION_ID": action_id,
                 "DEADLINE_STEP_ID": step_id,
                 "DEADLINE_TASK_ID": task_id,
+                "DEADLINE_SESSION_DIR": str(session.working_directory),
+                "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,
         )
@@ -286,6 +294,93 @@ class TestStart:
                 "DEADLINE_SESSIONACTION_ID": action_id,
                 "DEADLINE_STEP_ID": step_id,
                 "DEADLINE_TASK_ID": task_id,
+                "DEADLINE_SESSION_DIR": str(session.working_directory),
+                "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,
         )
+
+    @pytest.mark.skipif(
+        not MANIFEST_REPORTING_FEATURE,
+        reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
+    )
+    def test_reads_manifest_information_from_file(
+        self,
+        executor: Mock,
+        session: Mock,
+        action: actions_module.AttachmentUploadAction,
+        job_details: JobDetails,
+        session_dir: str,
+        action_id: str,
+    ) -> None:
+        """
+        Tests that AttachmentUploadAction.start() correctly reads manifest information
+        from a file and updates the session with the manifest data
+        """
+        # GIVEN
+        # Setup test manifest info
+        manifest_info = {
+            "/asset/root1": {
+                "outputManifestPath": "s3://bucket/Manifests/key1",
+                "outputManifestHash": "hash1",
+            },
+            "/asset/root2": {
+                "outputManifestPath": "s3://bucket/Manifests/key2",
+                "outputManifestHash": "hash2",
+            },
+        }
+
+        # Setup job attachment details with manifests
+        job_attachment_details = MagicMock()
+        job_attachment_details.manifests = [
+            MagicMock(root_path="/asset/root1"),
+            MagicMock(root_path="/asset/root2"),
+            MagicMock(root_path="/asset/root3"),  # Root with no changes
+        ]
+        session._queue._job_entities.job_attachment_details.return_value = job_attachment_details
+
+        # Set up session working directory and create a Path object for it
+        session.working_directory = Path(session_dir)
+
+        # Create expected manifest file path
+        manifest_file_path = os.path.join(session_dir, f"manifest_info_{action_id}.json")
+
+        # Mock all necessary file operations
+        with patch(
+            "deadline_worker_agent.sessions.actions.run_attachment_upload.open",
+            mock_open(read_data="script content"),
+        ) as mock_file:
+            # Mock the specific open call for the manifest file
+            def side_effect_open(file_path, mode, *args, **kwargs):
+                if str(file_path).endswith("attachment_upload.py"):
+                    return mock_open(read_data="script content")(file_path, mode, *args, **kwargs)
+                elif str(file_path) == manifest_file_path or str(file_path).endswith(
+                    f"manifest_info_{action_id}.json"
+                ):
+                    return mock_open(read_data=json.dumps(manifest_info))(
+                        file_path, mode, *args, **kwargs
+                    )
+                return mock_open()(file_path, mode, *args, **kwargs)
+
+            mock_file.side_effect = side_effect_open
+
+            with patch("os.path.exists", return_value=True):
+                with patch("os.remove") as mock_remove:
+                    with patch("json.load", return_value=manifest_info):
+                        # WHEN
+                        action.start(session=session, executor=executor)
+
+        # THEN
+        # Verify manifest information was stored correctly
+        expected_manifests = [
+            {"outputManifestPath": "s3://bucket/Manifests/key1", "outputManifestHash": "hash1"},
+            {"outputManifestPath": "s3://bucket/Manifests/key2", "outputManifestHash": "hash2"},
+            {},  # Empty object for root3 with no changes
+        ]
+        assert len(session._manifests_for_output_sync_target_action) == len(expected_manifests)
+        for i, manifest in enumerate(session._manifests_for_output_sync_target_action):
+            for key, value in expected_manifests[i].items():
+                assert manifest.get(key) == value
+
+        # Verify os.remove was called once (without checking the exact path argument)
+        mock_remove.assert_called_once()

--- a/test/unit/sessions/test_attachment_upload_status.py
+++ b/test/unit/sessions/test_attachment_upload_status.py
@@ -1,0 +1,205 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from openjd.sessions import ActionState, ActionStatus
+
+from deadline_worker_agent.api_models import ManifestInfo
+from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
+from deadline_worker_agent.scheduler.session_action_status import SessionActionStatus
+
+
+@pytest.fixture
+def action_id() -> str:
+    return "action-123456"
+
+
+@pytest.fixture
+def step_id() -> str:
+    return "step-abcdef"
+
+
+@pytest.fixture
+def task_id() -> str:
+    return "task-987654"
+
+
+@pytest.fixture
+def action_start_time() -> datetime:
+    return datetime(2023, 1, 2, 3, 4, 5)
+
+
+@pytest.fixture
+def action_complete_time() -> datetime:
+    return datetime(2023, 1, 2, 3, 4, 5)
+
+
+@pytest.mark.skipif(
+    not MANIFEST_REPORTING_FEATURE,
+    reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
+)
+class TestAttachmentUploadHandling:
+    """Test the handling of attachment upload completion"""
+
+    def test_attachment_upload_success(
+        self,
+        action_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        action_complete_time: datetime,
+    ) -> None:
+        """Tests that when attachment upload action completes successfully, the original task action is reported as succeeded"""
+        # GIVEN
+        # Create mock action
+        run_step_task_action = MagicMock()
+        run_step_task_action.id = action_id
+        run_step_task_action.step_id = step_id
+        run_step_task_action.task_id = task_id
+
+        # Create success status
+        success_action_status = ActionStatus(
+            exit_code=0,
+            state=ActionState.SUCCESS,
+        )
+
+        # WHEN - Direct testing of action completion handling
+        session_action_status = SessionActionStatus(
+            id=action_id,
+            status=success_action_status,
+            start_time=action_start_time,
+            end_time=action_complete_time,
+            completed_status="SUCCEEDED",
+        )
+
+        # THEN - Verify expected status values
+        assert session_action_status.id == action_id
+        assert session_action_status.status == success_action_status
+        assert session_action_status.start_time == action_start_time
+        assert session_action_status.end_time == action_complete_time
+        assert session_action_status.completed_status == "SUCCEEDED"
+
+    def test_attachment_upload_with_manifests(
+        self,
+        action_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        action_complete_time: datetime,
+    ) -> None:
+        """Tests that when attachment upload completes with manifests, they are included in the status"""
+        # GIVEN
+        # Create mock action
+        run_step_task_action = MagicMock()
+        run_step_task_action.id = action_id
+        run_step_task_action.step_id = step_id
+        run_step_task_action.task_id = task_id
+
+        # Create test manifests
+        manifests = [
+            ManifestInfo(outputManifestPath="/test/path/1", outputManifestHash="test-manifest-1"),
+            ManifestInfo(outputManifestPath="/test/path/2", outputManifestHash="test-manifest-2"),
+        ]
+
+        # Create success status
+        success_action_status = ActionStatus(
+            exit_code=0,
+            state=ActionState.SUCCESS,
+        )
+
+        # WHEN - Create session action status with manifests
+        session_action_status = SessionActionStatus(
+            id=action_id,
+            status=success_action_status,
+            start_time=action_start_time,
+            end_time=action_complete_time,
+            completed_status="SUCCEEDED",
+            manifests=manifests,
+        )
+
+        # THEN - Verify manifests are included
+        assert session_action_status.manifests == manifests
+        assert len(session_action_status.manifests) == 2
+        assert session_action_status.manifests[0]["outputManifestHash"] == "test-manifest-1"
+        assert session_action_status.manifests[1]["outputManifestHash"] == "test-manifest-2"
+
+    def test_attachment_upload_failure(
+        self,
+        action_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        action_complete_time: datetime,
+    ) -> None:
+        """Tests that when attachment upload fails, original task is reported as failed"""
+        # GIVEN
+        # Create mock action
+        run_step_task_action = MagicMock()
+        run_step_task_action.id = action_id
+        run_step_task_action.step_id = step_id
+        run_step_task_action.task_id = task_id
+
+        # Create failed status
+        failed_action_status = ActionStatus(
+            exit_code=1,
+            state=ActionState.FAILED,
+            fail_message="Upload failed",
+        )
+
+        # WHEN - Create session action status for failed upload
+        session_action_status = SessionActionStatus(
+            id=action_id,
+            status=failed_action_status,
+            start_time=action_start_time,
+            end_time=action_complete_time,
+            completed_status="FAILED",
+        )
+
+        # THEN - Verify failure is properly represented
+        assert session_action_status.id == action_id
+        assert session_action_status.status is not None
+        assert session_action_status.status.state == ActionState.FAILED
+        assert session_action_status.status.fail_message == "Upload failed"
+        assert session_action_status.completed_status == "FAILED"
+
+    def test_attachment_upload_canceled(
+        self,
+        action_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        action_complete_time: datetime,
+    ) -> None:
+        """Tests that when attachment upload is canceled, original task is reported as canceled"""
+        # GIVEN
+        # Create mock action
+        run_step_task_action = MagicMock()
+        run_step_task_action.id = action_id
+        run_step_task_action.step_id = step_id
+        run_step_task_action.task_id = task_id
+
+        # Create canceled status
+        canceled_action_status = ActionStatus(
+            exit_code=1,
+            state=ActionState.CANCELED,
+            fail_message="Upload canceled",
+        )
+
+        # WHEN - Create session action status for canceled upload
+        session_action_status = SessionActionStatus(
+            id=action_id,
+            status=canceled_action_status,
+            start_time=action_start_time,
+            end_time=action_complete_time,
+            completed_status="CANCELED",
+        )
+
+        # THEN - Verify cancellation is properly represented
+        assert session_action_status.id == action_id
+        assert session_action_status.status is not None
+        assert session_action_status.status.state == ActionState.CANCELED
+        assert session_action_status.status.fail_message == "Upload canceled"
+        assert session_action_status.completed_status == "CANCELED"

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -37,7 +37,10 @@ from deadline_worker_agent.api_models import (
     TaskRunAction,
     AttachmentUploadAction,
 )
-from deadline_worker_agent.feature_flag import ASSET_SYNC_JOB_USER_FEATURE
+from deadline_worker_agent.feature_flag import (
+    ASSET_SYNC_JOB_USER_FEATURE,
+    MANIFEST_REPORTING_FEATURE,
+)
 from deadline_worker_agent.sessions import Session
 import deadline_worker_agent.sessions.session as session_mod
 from deadline_worker_agent.sessions.session import (
@@ -921,25 +924,25 @@ class TestSessionSyncAssetOutputs:
         with patch.object(session, "_asset_sync") as mock_asset_sync:
             yield mock_asset_sync
 
-    def test_sync_asset_outputs(
+    def _setup_sync_asset_outputs_test(
         self,
         action_id: str,
-        queue_id: str,
         step_id: str,
         task_id: str,
         action_start_time: datetime,
         session: Session,
         job_attachment_details: JobAttachmentDetails,
         mock_asset_sync: MagicMock,
-        mock_telemetry_event_for_sync_outputs: MagicMock,
-    ):
-        """
-        Tests that session's '_sync_asset_outputs' calls Job Attachment's method 'sync_outputs' correctly.
-        Also, asserts that 'record_sync_outputs_telemetry_event' is called once with the correct arguments.
-        """
-        # GIVEN
-        mock_ja_sync_outputs: MagicMock = mock_asset_sync.sync_outputs
-        mock_ja_sync_outputs.return_value = SummaryStatistics()
+    ) -> CurrentAction:
+        """Helper method to set up common test fixtures for sync_asset_outputs tests"""
+        # Set up sync methods
+        mock_asset_sync.sync_outputs.return_value = SummaryStatistics()
+        mock_asset_sync.sync_outputs_with_manifests.return_value = (
+            SummaryStatistics(),
+            {},
+        )
+
+        # Create current action
         current_action = CurrentAction(
             definition=RunStepTaskAction(
                 details=StepDetails(
@@ -962,13 +965,109 @@ class TestSessionSyncAssetOutputs:
             ),
             start_time=action_start_time,
         )
+
+        # Set job attachment details
         session._job_attachment_details = job_attachment_details
+
+        return current_action
+
+    @pytest.mark.skipif(
+        MANIFEST_REPORTING_FEATURE,
+        reason="Only relevant when MANIFEST_REPORTING_FEATURE is not enabled",
+    )
+    def test_sync_asset_outputs_without_manifest_reporting(
+        self,
+        action_id: str,
+        queue_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        session: Session,
+        job_attachment_details: JobAttachmentDetails,
+        mock_asset_sync: MagicMock,
+        mock_telemetry_event_for_sync_outputs: MagicMock,
+    ):
+        """
+        Tests that session's '_sync_asset_outputs' calls Job Attachment's method 'sync_outputs' correctly
+        when MANIFEST_REPORTING_FEATURE is disabled.
+        """
+        # GIVEN
+        current_action = self._setup_sync_asset_outputs_test(
+            action_id,
+            step_id,
+            task_id,
+            action_start_time,
+            session,
+            job_attachment_details,
+            mock_asset_sync,
+        )
 
         # WHEN
         session._sync_asset_outputs(current_action=current_action)  # type: ignore
 
         # THEN
-        mock_ja_sync_outputs.assert_called_once_with(
+        mock_asset_sync.sync_outputs.assert_called_once_with(
+            s3_settings=JobAttachmentS3Settings(
+                rootPrefix="job_attachments",
+                s3BucketName="job_attachments_bucket",
+            ),
+            attachments=Attachments(
+                manifests=ANY,
+                fileSystem=JobAttachmentsFileSystem.COPIED,
+            ),
+            queue_id=queue_id,
+            job_id=ANY,
+            step_id=step_id,
+            task_id=task_id,
+            session_action_id=action_id,
+            start_time=ANY,
+            session_dir=ANY,
+            storage_profiles_path_mapping_rules={},
+            on_uploading_files=ANY,
+        )
+        mock_asset_sync.sync_outputs_with_manifests.assert_not_called()
+        mock_telemetry_event_for_sync_outputs.assert_called_once_with(
+            queue_id,
+            SummaryStatistics(),
+        )
+
+    @pytest.mark.skipif(
+        not MANIFEST_REPORTING_FEATURE,
+        reason="Only relevant when MANIFEST_REPORTING_FEATURE is not enabled",
+    )
+    def test_sync_asset_outputs_with_manifest_reporting(
+        self,
+        action_id: str,
+        queue_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        session: Session,
+        job_attachment_details: JobAttachmentDetails,
+        mock_asset_sync: MagicMock,
+        mock_telemetry_event_for_sync_outputs: MagicMock,
+    ):
+        """
+        Tests that session's '_sync_asset_outputs' calls Job Attachment's method 'sync_outputs_with_manifests'
+        correctly when MANIFEST_REPORTING_FEATURE is enabled.
+        """
+        # GIVEN
+        current_action = self._setup_sync_asset_outputs_test(
+            action_id,
+            step_id,
+            task_id,
+            action_start_time,
+            session,
+            job_attachment_details,
+            mock_asset_sync,
+        )
+
+        # WHEN
+        session._sync_asset_outputs(current_action=current_action)  # type: ignore
+
+        # THEN
+        mock_asset_sync.sync_outputs.assert_not_called()
+        mock_asset_sync.sync_outputs_with_manifests.assert_called_once_with(
             s3_settings=JobAttachmentS3Settings(
                 rootPrefix="job_attachments",
                 s3BucketName="job_attachments_bucket",
@@ -988,7 +1087,7 @@ class TestSessionSyncAssetOutputs:
             on_uploading_files=ANY,
         )
         mock_telemetry_event_for_sync_outputs.assert_called_once_with(
-            "queue-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            queue_id,
             SummaryStatistics(),
         )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The worker agent needed a way to report output manifest information back to the Deadline Cloud service.

### What was the solution? (How)
Added a feature-flagged implementation of output manifest reporting that:
- Created a new feature flag `MANIFEST_REPORTING_FEATURE` to control the functionality
- Extended the `SessionActionStatus` model to include manifest information
- Modified the attachment upload script to write manifest information to a file when enabled
- Updated the session action handling to collect and report manifest information to the service
- Added support for reporting manifest paths and hashes in the worker scheduler

### What is the impact of this change?
When enabled, this feature allows the worker agent to report detailed information about output manifests back to the Deadline Cloud service. This improves traceability of job outputs and enables better data provenance tracking.

**IMPORTANT**: This is a Proof of Concept implementation that relies on https://github.com/aws-deadline/deadline-cloud/pull/671 to be merged.

### How was this change tested?
- Added unit tests in `test/unit/scheduler/test_manifest_in_scheduler.py` to verify manifest reporting in the scheduler
- Updated existing tests to accommodate the new functionality
- Added tests for attachment upload status handling
- Manually tested with a running worker

### Was this change documented?
Yes, the code includes comments explaining the feature flag and implementation details.

### Is this a breaking change?
No. The feature is behind a feature flag (`MANIFEST_REPORTING_FEATURE`) which is disabled by default.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*