### PR TITLE
fix: Add warning messages when persistence directories exist

### DIFF
--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -435,24 +435,43 @@ def provision_directories(
     logging.info(f"Done provisioning root directory ({deadline_dir})")
 
     deadline_log_subdir = os.path.join(deadline_dir, "Logs")
-    logging.info(f"Provisioning log directory ({deadline_log_subdir})")
-    os.makedirs(deadline_log_subdir, exist_ok=True)
-    logging.info(f"Done provisioning log directory ({deadline_log_subdir})")
+    if os.path.exists(deadline_log_subdir):
+        logging.warning(
+            f"Log directory already exists, permissions maybe inherited for all users to view files in this directory. ({deadline_log_subdir})"
+        )
+    else:
+        logging.info(f"Provisioning log directory ({deadline_log_subdir})")
+        os.makedirs(deadline_log_subdir, exist_ok=True)
+        logging.info(f"Done provisioning log directory ({deadline_log_subdir})")
 
     deadline_persistence_subdir = os.path.join(deadline_dir, "Cache")
-    logging.info(f"Provisioning persistence directory ({deadline_persistence_subdir})")
-    os.makedirs(deadline_persistence_subdir, exist_ok=True)
-    logging.info(f"Done provisioning persistence directory ({deadline_persistence_subdir})")
+    if os.path.exists(deadline_persistence_subdir):
+        logging.warning(
+            f"Persistence directory already exists, permissions maybe inherited for all users to view files in this directory. ({deadline_persistence_subdir})"
+        )
+    else:
+        logging.info(f"Provisioning persistence directory ({deadline_persistence_subdir})")
+        os.makedirs(deadline_persistence_subdir, exist_ok=True)
+        logging.info(f"Done provisioning persistence directory ({deadline_persistence_subdir})")
 
     deadline_persistence_queues_subdir = os.path.join(deadline_persistence_subdir, "queues")
-    logging.info(f"Provisioning persistence directory ({deadline_persistence_queues_subdir})")
+    logging.info(
+        f"Provisioning persistence queues directory ({deadline_persistence_queues_subdir})"
+    )
     os.makedirs(deadline_persistence_queues_subdir, exist_ok=True)
-    logging.info(f"Done provisioning persistence directory ({deadline_persistence_queues_subdir})")
+    logging.info(
+        f"Done provisioning persistence queues directory ({deadline_persistence_queues_subdir})"
+    )
 
     deadline_config_subdir = os.path.join(deadline_dir, "Config")
-    logging.info(f"Provisioning config directory ({deadline_config_subdir})")
-    os.makedirs(deadline_config_subdir, exist_ok=True)
-    logging.info(f"Done provisioning config directory ({deadline_config_subdir})")
+    if os.path.exists(deadline_config_subdir):
+        logging.warning(
+            f"Config directory already exists, permissions maybe inherited for all users to view files in this directory. ({deadline_config_subdir})"
+        )
+    else:
+        logging.info(f"Provisioning config directory ({deadline_config_subdir})")
+        os.makedirs(deadline_config_subdir, exist_ok=True)
+        logging.info(f"Done provisioning config directory ({deadline_config_subdir})")
 
     logging.info(f"Porvisioning session root directory ({session_root_dir})")
     os.makedirs(session_root_dir, exist_ok=True)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- From testing, CMF customers are able to create and customize the Worker Agent persistence directory. This can potentially open security loop holes such as allowing any user on the system to view logs, or cached credentials.
- Users may accidentally create the cache folders with general read / write access.
- Note that Deadline Cloud provisions these persistence directories by default with the correct least privilege access. Releases are secure by default. Tests exist and are part of the win_installer tests in integration.

### What was the solution? (How)
- Instead of overwriting the folder with "exists ok", we will now print a warning.
- There is part of the shared responsibility of running Deadline Worker Agent to ensure the execution environment is secure.
    - For example, a customer debugging a CMF instance may change the cache folder for debugging but forgets to change it back.

### What is the impact of this change?
- Better messaging for folder access permissions.

### How was this change tested?
- Run the install deadline worker agent script on top of an existing installation. See that the new message is printed to the installation log. For example:
<img width="1117" alt="Screenshot 2025-05-26 at 3 19 21 PM" src="https://github.com/user-attachments/assets/86f41ab6-8e05-4603-bd2f-470ba0c2c777" />


### Was this change documented?
- Not Applicable.

### Is this a breaking change?
- Not Applicable.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*