### PR TITLE
fix: Disk Read/Write Bytes per Second Metrics Always Increase

### DIFF
--- a/src/deadline_worker_agent/boto/shim.py
+++ b/src/deadline_worker_agent/boto/shim.py
@@ -244,7 +244,7 @@ class DeadlineClient:
         return UpdateWorkerScheduleResponse(
             assignedSessions=mapped_sessions,
             cancelSessionActions=response["cancelSessionActions"],
-            desiredWorkerStatus=response.get("desiredWorkerStatus", None),
+            desiredWorkerStatus=response.get("desiredWorkerStatus", None),  # type: ignore
             updateIntervalSeconds=response["updateIntervalSeconds"],
         )
 

--- a/src/deadline_worker_agent/metrics.py
+++ b/src/deadline_worker_agent/metrics.py
@@ -21,11 +21,13 @@ class HostMetricsLogger:
     interval_s: float
     _timer: Timer | None
     _prev_network: Any | None
+    _prev_disk_counters: Any | None
 
     def __init__(self, logger: Logger, interval_s: float) -> None:
         assert interval_s > 0, "interval_s must be a positive number"
         self._timer = None
         self._prev_network = None
+        self._prev_disk_counters = None
         self.logger = logger
         self.interval_s = interval_s
 
@@ -64,8 +66,20 @@ class HostMetricsLogger:
                 # TODO: Support disk speed on NetBSD and OpenBSD
                 disk_read = disk_write = "NOT_SUPPORTED"
             else:
-                disk_read = str(round(disk_counters.read_bytes / self.interval_s))
-                disk_write = str(round(disk_counters.write_bytes / self.interval_s))
+                if self._prev_disk_counters:
+                    disk_read_bps = round(
+                        (disk_counters.read_bytes - self._prev_disk_counters.read_bytes)
+                        / self.interval_s
+                    )
+                    disk_write_bps = round(
+                        (disk_counters.write_bytes - self._prev_disk_counters.write_bytes)
+                        / self.interval_s
+                    )
+                else:
+                    disk_read_bps = disk_write_bps = 0
+                disk_read = str(disk_read_bps)
+                disk_write = str(disk_write_bps)
+            self._prev_disk_counters = disk_counters
 
             # We need to poll network IO to get rate
             if network is None:

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -14,6 +14,18 @@ from deadline_worker_agent.metrics import HostMetricsLogger
 import deadline_worker_agent.metrics as metrics_mod
 from deadline_worker_agent.log_messages import MetricsLogEvent
 
+dioc = namedtuple(
+    "dioc",
+    [
+        "read_count",
+        "write_count",
+        "read_bytes",
+        "write_bytes",
+        "read_time",
+        "write_time",
+    ],
+)
+
 
 @pytest.fixture(autouse=True)
 def mock_psutil_module() -> Generator[MagicMock, None, None]:
@@ -135,18 +147,7 @@ class TestHostMetricsLogger:
             return nioc(123, 321, 100, 300, 2, 3, 1, 0)
 
         @pytest.fixture
-        def disk_io_counters(self) -> tuple:
-            dioc = namedtuple(
-                "dioc",
-                [
-                    "read_count",
-                    "write_count",
-                    "read_bytes",
-                    "write_bytes",
-                    "read_time",
-                    "write_time",
-                ],
-            )
+        def disk_io_counters(self) -> dioc:
             return dioc(123, 321, 123123, 321321, 100, 200)
 
         @pytest.fixture(autouse=True)
@@ -207,11 +208,43 @@ class TestHostMetricsLogger:
             assert log_line.metrics.get("total-disk-used-percent", "") == "0.2"
             assert log_line.metrics.get("user-disk-available-bytes", "") == "75"
 
-        def test_logs_disk_rate(self, log_line: str):
+        def test_logs_disk_rate(
+            self,
+            host_metrics_logger: HostMetricsLogger,
+            logger: MagicMock,
+            disk_io_counters: dioc,
+        ):
+            # GIVEN
+            # First call to set up previous disk counters
+            with patch.object(host_metrics_logger, "_set_timer"):
+                host_metrics_logger.log_metrics()
+
+            # Reset the logger mock to clear the first call
+            logger.reset_mock()
+
+            # Increase read_bytes by 1000 and write_bytes by 2000
+            new_counters = dioc(
+                read_count=disk_io_counters.read_count,
+                write_count=disk_io_counters.write_count,
+                read_bytes=disk_io_counters.read_bytes + 1000,
+                write_bytes=disk_io_counters.write_bytes + 2000,
+                read_time=disk_io_counters.read_time,
+                write_time=disk_io_counters.write_time,
+            )
+
+            # WHEN
+            with patch.object(metrics_mod, "psutil") as mock_psutil:
+                mock_psutil.disk_io_counters.return_value = new_counters
+
+                with patch.object(host_metrics_logger, "_set_timer"):
+                    host_metrics_logger.log_metrics()
+
             # THEN
+            log_line = get_first_and_only_call_arg(logger.info)
             assert isinstance(log_line, MetricsLogEvent)
-            assert log_line.metrics.get("disk-read-bytes-per-second", "") == "123123"
-            assert log_line.metrics.get("disk-write-bytes-per-second", "") == "321321"
+            # Should report the difference divided by interval (which is 1 second)
+            assert log_line.metrics.get("disk-read-bytes-per-second", "") == "1000"
+            assert log_line.metrics.get("disk-write-bytes-per-second", "") == "2000"
 
         def test_logs_network_rate(self, log_line: str):
             # THEN


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was an issue where the disk IO metrics would always be increasing because psutil is actually just returning a counter, and not a sum since the last call.

### What was the solution? (How)

[Similar to what we do for network IO](https://github.com/aws-deadline/deadline-cloud-worker-agent/blame/mainline/src/deadline_worker_agent/metrics.py#L70-L84), keep track of previous values to get the difference, then return the difference. 

### What is the impact of this change?

The disk IO metrics are useful!

### How was this change tested?

Deployed two workers, one without this change, and one with. 

On the worker without the change noticed the following metric logs:

```
2025/06/03 15:58:11-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ...,  "disk-read-bytes-per-second": "4999561", "disk-write-bytes-per-second": "3723477"}
2025/06/03 15:59:11-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ...,  "disk-read-bytes-per-second": "4999561", "disk-write-bytes-per-second": "3728393"}
2025/06/03 16:00:11-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ...,  "disk-read-bytes-per-second": "4999561", "disk-write-bytes-per-second": "3759181"}
2025/06/03 16:01:11-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ...,  "disk-read-bytes-per-second": "4999561", "disk-write-bytes-per-second": "3764369"}
2025/06/03 16:02:11-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ...,  "disk-read-bytes-per-second": "4999561", "disk-write-bytes-per-second": "3781982"}
2025/06/03 16:03:11-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ...,  "disk-read-bytes-per-second": "4999561", "disk-write-bytes-per-second": "3787170"}
```

On a worker with the change, noticed the following metric logs
```
2025/06/03 15:47:35-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ..., "disk-read-bytes-per-second": "0", "disk-write-bytes-per-second": "0"}
2025/06/03 15:48:35-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ..., "disk-read-bytes-per-second": "3072", "disk-write-bytes-per-second": "1187089"}
2025/06/03 15:49:35-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ..., "disk-read-bytes-per-second": "0", "disk-write-bytes-per-second": "21914"}
2025/06/03 15:50:35-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ..., "disk-read-bytes-per-second": "0", "disk-write-bytes-per-second": "1775"}
2025/06/03 15:51:35-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ..., "disk-read-bytes-per-second": "0", "disk-write-bytes-per-second": "25259"}
2025/06/03 15:52:35-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ..., "disk-read-bytes-per-second": "1570", "disk-write-bytes-per-second": "3823"}
2025/06/03 15:53:35-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ..., "disk-read-bytes-per-second": "0", "disk-write-bytes-per-second": "21436"}
2025/06/03 15:54:35-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ..., "disk-read-bytes-per-second": "0", "disk-write-bytes-per-second": "1638"}
2025/06/03 15:55:35-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ..., "disk-read-bytes-per-second": "7646", "disk-write-bytes-per-second": "159061"}
```
### Was this change documented?

Yes in the commit title

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*