### PR TITLE
feat: Add GPU Utilization Metrics in Worker Host Metric Logging

### DIFF
--- a/src/deadline_worker_agent/metrics.py
+++ b/src/deadline_worker_agent/metrics.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from logging import Logger, getLogger
 from threading import Timer
-from typing import Any
+from typing import Any, Dict
 
 import os
 import psutil
+import subprocess
 
 from .log_messages import MetricsLogEvent, MetricsLogEventSubtype
 
@@ -22,6 +23,7 @@ class HostMetricsLogger:
     _timer: Timer | None
     _prev_network: Any | None
     _prev_disk_counters: Any | None
+    _host_has_no_gpu: bool | None = None
 
     def __init__(self, logger: Logger, interval_s: float) -> None:
         assert interval_s > 0, "interval_s must be a positive number"
@@ -40,6 +42,80 @@ class HostMetricsLogger:
             self._timer.cancel()
             self._timer = None
 
+    def _get_gpu_metrics(self) -> Dict[str, str]:
+        """
+        Get GPU metrics using nvidia-smi.
+
+        Returns:
+            Dict[str, str]: A dictionary of GPU metrics or empty dict if nvidia-smi is not available.
+        """
+        if self._host_has_no_gpu:
+            return {}
+
+        gpu_metrics = {}
+
+        try:
+            # Query GPU metrics for all GPUs
+            metrics_to_query = [
+                "utilization.gpu",
+                "memory.used",
+                "memory.total",
+                "utilization.memory",
+            ]
+
+            query_str = ",".join(metrics_to_query)
+
+            # Query GPU metrics
+            output = subprocess.check_output(
+                ["nvidia-smi", f"--query-gpu={query_str}", "--format=csv,noheader,nounits"],
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+            )
+
+            # Variables to sum metrics across GPUs
+            gpu_util_sum = mem_used_sum = mem_total_sum = mem_util_sum = valid_gpu_count = 0.0
+
+            # Process each GPU
+            for line in output.strip().split("\n"):
+                try:
+                    gpu_util, mem_used, mem_total, mem_util = (
+                        float(v.strip()) for v in line.split(",")
+                    )
+                except ValueError:
+                    module_logger.debug(
+                        "nvidia-smi output was not able to be parsed into GPU utilization metrics"
+                    )
+                    continue
+
+                mem_used_sum += mem_used
+                mem_total_sum += mem_total
+                mem_util_sum += mem_util
+                gpu_util_sum += gpu_util
+                valid_gpu_count += 1
+
+            # Calculate consolidated metrics
+            if valid_gpu_count > 0:
+                avg_gpu_util = round(gpu_util_sum / valid_gpu_count, 1)
+                gpu_metrics["gpu-utilization-percent"] = str(avg_gpu_util)
+
+                gpu_metrics["gpu-memory-used-mib"] = str(int(mem_used_sum))
+                gpu_metrics["gpu-memory-total-mib"] = str(int(mem_total_sum))
+                avg_mem_used_percent = round((mem_used_sum / mem_total_sum) * 100, 1)
+                gpu_metrics["gpu-memory-used-percent"] = str(avg_mem_used_percent)
+
+                avg_mem_util = round(mem_util_sum / valid_gpu_count, 1)
+                gpu_metrics["gpu-memory-utilization-percent"] = str(avg_mem_util)
+        except FileNotFoundError:
+            module_logger.debug("nvidia-smi not found, skipping GPU metrics collection")
+        except subprocess.CalledProcessError:
+            module_logger.debug("Error running nvidia-smi, skipping GPU metrics collection")
+        except Exception as e:
+            module_logger.debug(f"Unexpected error collecting GPU metrics: {e}")
+        if not gpu_metrics:
+            self._host_has_no_gpu = True
+
+        return gpu_metrics
+
     def log_metrics(self):
         """
         Queries information about the host machine and logs the information as a space-delimited
@@ -52,6 +128,7 @@ class HostMetricsLogger:
             disk = psutil.disk_usage(os.sep)
             disk_counters = psutil.disk_io_counters(nowrap=True)
             network = psutil.net_io_counters(nowrap=True)
+            gpu_metrics = self._get_gpu_metrics()
         except Exception as e:
             module_logger.warning(
                 f"Failed to get host metrics. Skipping host metrics log message. Error: {e}"
@@ -113,6 +190,9 @@ class HostMetricsLogger:
                 "disk-read-bytes-per-second": disk_read,
                 "disk-write-bytes-per-second": disk_write,
             }
+
+            # Add GPU metrics to stats
+            stats.update(gpu_metrics)
 
             self.logger.info(MetricsLogEvent(subtype=MetricsLogEventSubtype.SYSTEM, metrics=stats))
         finally:

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from collections import namedtuple
 
 import logging
-from typing import Any, Generator
+import subprocess
+from typing import Any, Dict, Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -88,6 +89,12 @@ class TestHostMetricsLogger:
         )
         mock_timer_cls.return_value.start.assert_called_once()
 
+    @pytest.fixture
+    def mock_subprocess(self) -> Generator[MagicMock, None, None]:
+        with patch.object(metrics_mod, "subprocess") as mock:
+            mock.CalledProcessError = subprocess.CalledProcessError
+            yield mock
+
     def test_log_metrics_sets_timer(
         self,
         host_metrics_logger: HostMetricsLogger,
@@ -102,6 +109,105 @@ class TestHostMetricsLogger:
 
         # THEN
         mock_set_timer.assert_called_once()
+
+    # GPU test scenarios
+    @pytest.mark.parametrize(
+        "metrics_output,expected_metrics",
+        [
+            pytest.param(
+                "75, 2000, 8192, 25\n50, 1000, 8192, 12",
+                {
+                    "gpu-utilization-percent": "62.5",
+                    "gpu-memory-used-mib": "3000",
+                    "gpu-memory-total-mib": "16384",
+                    "gpu-memory-used-percent": "18.3",
+                    "gpu-memory-utilization-percent": "18.5",
+                },
+                id="multiple_gpus",
+            ),
+            pytest.param("", {}, id="no_gpus"),
+            pytest.param("Failed to get metrics", {}, id="malformed_output"),
+            pytest.param("N/A, 2000, 8192, 25", {}, id="missing_values"),
+            pytest.param("2000, 8192, 25", {}, id="omitted_values"),
+            pytest.param(
+                "100, 8192, 8192, 100",
+                {
+                    "gpu-utilization-percent": "100.0",
+                    "gpu-memory-used-mib": "8192",
+                    "gpu-memory-total-mib": "8192",
+                    "gpu-memory-used-percent": "100.0",
+                    "gpu-memory-utilization-percent": "100.0",
+                },
+                id="full_utlization",
+            ),
+        ],
+    )
+    def test_get_gpu_metrics(
+        self,
+        metrics_output,
+        expected_metrics,
+        host_metrics_logger,
+        mock_subprocess,
+    ):
+        """Parametrized test for GPU metrics collection with different scenarios"""
+        # GIVEN
+        mock_subprocess.check_output.side_effect = [metrics_output]
+
+        # WHEN
+        gpu_metrics = host_metrics_logger._get_gpu_metrics()
+
+        # THEN
+        # Check if the expected metrics are present
+        for key, value in expected_metrics.items():
+            assert gpu_metrics.get(key) == value
+        if expected_metrics:
+            assert not host_metrics_logger._host_has_no_gpu
+
+        # Special case checks
+        if metrics_output is None:
+            assert gpu_metrics == {}
+
+        # Verify subprocess calls
+        query_str = "utilization.gpu,memory.used,memory.total,utilization.memory"
+        mock_subprocess.check_output.assert_called_with(
+            ["nvidia-smi", f"--query-gpu={query_str}", "--format=csv,noheader,nounits"],
+            stderr=mock_subprocess.PIPE,
+            universal_newlines=True,
+        )
+
+    @pytest.mark.parametrize(
+        "exception,expected_result",
+        [
+            pytest.param(FileNotFoundError("nvidia-smi not found"), {}, id="file_not_found"),
+            pytest.param(
+                subprocess.CalledProcessError(1, "nvidia-smi"), {}, id="called_process_error"
+            ),
+            pytest.param(Exception("Unexpected error"), {}, id="unexpected_error"),
+        ],
+    )
+    def test_get_gpu_metrics_exceptions(
+        self, exception, expected_result, host_metrics_logger, mock_subprocess
+    ):
+        """Test GPU metrics collection with various exceptions"""
+        # GIVEN
+        mock_subprocess.check_output.side_effect = exception
+
+        # WHEN
+        gpu_metrics = host_metrics_logger._get_gpu_metrics()
+
+        # THEN
+        assert gpu_metrics == expected_result
+        assert host_metrics_logger._host_has_no_gpu
+
+        # Test that subsequent calls do not attempt to query GPU metrics
+        # GIVEN
+        mock_subprocess.check_output.reset_mock()
+
+        # WHEN (again)
+        host_metrics_logger._get_gpu_metrics()
+
+        # THEN
+        mock_subprocess.check_output.assert_not_called()
 
     class TestLogMetrics:
         @pytest.fixture(autouse=True)
@@ -306,6 +412,69 @@ class TestHostMetricsLogger:
             assert isinstance(log_line, MetricsLogEvent)
             assert log_line.metrics.get("network-sent-bytes-per-second", "") == "NOT_AVAILABLE"
             assert log_line.metrics.get("network-recv-bytes-per-second", "") == "NOT_AVAILABLE"
+
+        @pytest.mark.parametrize(
+            "gpu_metrics,gpu_available",
+            [
+                (
+                    {
+                        "gpu-utilization-percent": "62.5",
+                        "gpu-memory-used-mib": "3000",
+                        "gpu-memory-total-mib": "16384",
+                        "gpu-memory-used-percent": "18.3",
+                        "gpu-memory-utilization-percent": "18.5",
+                    },
+                    True,
+                ),
+                (
+                    {},
+                    False,
+                ),
+            ],
+            ids=["gpu_metrics_available", "no_gpu_device"],
+        )
+        def test_logs_gpu_metrics(
+            self,
+            host_metrics_logger: HostMetricsLogger,
+            logger: MagicMock,
+            gpu_metrics: Dict[str, str],
+            gpu_available: bool,
+        ):
+            # GIVEN
+            # gpu_metrics is provided by the parametrize decorator
+
+            # WHEN
+            with (
+                patch.object(host_metrics_logger, "_get_gpu_metrics", return_value=gpu_metrics),
+                patch.object(host_metrics_logger, "_set_timer"),
+            ):
+                host_metrics_logger.log_metrics()
+
+            # THEN
+            log_line = get_first_and_only_call_arg(logger.info)
+            assert isinstance(log_line, MetricsLogEvent)
+
+            if gpu_available:
+                # Verify GPU metrics are included in the logged metrics
+                for key, value in gpu_metrics.items():
+                    assert log_line.metrics.get(key, "") == value
+
+                # Verify each metric specifically
+                assert log_line.metrics.get("gpu-utilization-percent") == "62.5"
+                assert log_line.metrics.get("gpu-memory-used-mib") == "3000"
+                assert log_line.metrics.get("gpu-memory-total-mib") == "16384"
+                assert log_line.metrics.get("gpu-memory-used-percent") == "18.3"
+                assert log_line.metrics.get("gpu-memory-utilization-percent") == "18.5"
+            else:
+                # Verify no GPU metrics are included when no GPU device is found
+                for key in [
+                    "gpu-utilization-percent",
+                    "gpu-memory-used-mib",
+                    "gpu-memory-total-mib",
+                    "gpu-memory-used-percent",
+                    "gpu-memory-utilization-percent",
+                ]:
+                    assert key not in log_line.metrics
 
         def test_log_metrics_correct_encoding(
             self,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We are missing metric reporting for GPU devices. This data is useful to those running GPU workloads.

### What was the solution? (How)

Add GPU metrics to the metric logging using nvidia-smi. New GPU metrics being collected include:
	- GPU utilization percentage
	- GPU memory usage (used and total in MiB)
	- GPU memory utilization percentage

Consolidates metrics for multiple GPUs

### What is the impact of this change?

There is metric reporting for GPU devices now. 

### How was this change tested?

Spun up a GPU worker and submitted a render job using GPU. Observed the following metrics (removed some fields for reviewing simplicity)

```
2025/06/05 14:50:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "0.0", "gpu-memory-used-mib": "1", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "0.0", "gpu-memory-utilization-percent": "0.0"}
2025/06/05 14:51:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "0.0", "gpu-memory-used-mib": "1", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "0.0", "gpu-memory-utilization-percent": "0.0"}
2025/06/05 14:52:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "0.0", "gpu-memory-used-mib": "1", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "0.0", "gpu-memory-utilization-percent": "0.0"}
2025/06/05 14:53:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "0.0", "gpu-memory-used-mib": "1", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "0.0", "gpu-memory-utilization-percent": "0.0"}
2025/06/05 14:54:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "99.0", "gpu-memory-used-mib": "849", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "5.5", "gpu-memory-utilization-percent": "59.0"}
2025/06/05 14:55:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "100.0", "gpu-memory-used-mib": "849", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "5.5", "gpu-memory-utilization-percent": "44.0"}
2025/06/05 14:56:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "100.0", "gpu-memory-used-mib": "849", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "5.5", "gpu-memory-utilization-percent": "44.0"}
2025/06/05 14:57:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "100.0", "gpu-memory-used-mib": "849", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "5.5", "gpu-memory-utilization-percent": "47.0"}
2025/06/05 14:58:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "100.0", "gpu-memory-used-mib": "849", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "5.5", "gpu-memory-utilization-percent": "48.0"}
2025/06/05 14:59:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "10.0", "gpu-memory-used-mib": "3", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "0.0", "gpu-memory-utilization-percent": "2.0"}
2025/06/05 15:00:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "0.0", "gpu-memory-used-mib": "1", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "0.0", "gpu-memory-utilization-percent": "0.0"}
2025/06/05 15:01:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "0.0", "gpu-memory-used-mib": "1", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "0.0", "gpu-memory-utilization-percent": "0.0"}
2025/06/05 15:02:19-05:00 {"level": "INFO", "ti": "📊", "type": "Metrics", ... "gpu-utilization-percent": "0.0", "gpu-memory-used-mib": "1", "gpu-memory-total-mib": "15360", "gpu-memory-used-percent": "0.0", "gpu-memory-utilization-percent": "0.0"}

```

Also ran a worker without a GPU and confirmed that none of the GPU metrics were reported.


### Was this change documented?

In the commit title which will appear in the changelog

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*