### PR TITLE
feat(experimental): add output manifest reporting

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -416,6 +416,13 @@ class BatchGetJobEntityResponse(TypedDict):
     errors: list[EntityError]
 
 
+class ManifestInfo(TypedDict):
+    """Model for manifest information."""
+
+    outputManifestPath: NotRequired[str]
+    outputManifestHash: NotRequired[str]
+
+
 class UpdatedSessionActionInfo(TypedDict):
     completedStatus: NotRequired[CompletedActionStatus]
     processExitCode: NotRequired[int]
@@ -424,6 +431,7 @@ class UpdatedSessionActionInfo(TypedDict):
     endedAt: NotRequired[datetime]
     updatedAt: NotRequired[datetime]
     progressPercent: NotRequired[float]
+    manifests: NotRequired[list[ManifestInfo]]
 
 
 class UpdateWorkerScheduleRequest(TypedDict):

--- a/src/deadline_worker_agent/feature_flag.py
+++ b/src/deadline_worker_agent/feature_flag.py
@@ -7,3 +7,6 @@ import os
 ASSET_SYNC_JOB_USER_FEATURE = (
     os.environ.get("ASSET_SYNC_JOB_USER_FEATURE", "false").lower() == "true"
 )
+
+# Feature flag for output manifest reporting
+MANIFEST_REPORTING_FEATURE = os.environ.get("MANIFEST_REPORTING_FEATURE", "false").lower() == "true"

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -69,6 +69,7 @@ from ..log_messages import (
     WorkerLogEvent,
     WorkerLogEventOp,
 )
+from ..feature_flag import MANIFEST_REPORTING_FEATURE
 from .log import LOGGER
 from .session_cleanup import SessionUserCleanupManager
 from .session_queue import SessionActionQueue, SessionActionStatus
@@ -603,6 +604,10 @@ class WorkerScheduler:
                 updated_action["progressPercent"] = min(max(0, action_updated.status.progress), 100)
         if action_updated.end_time:
             updated_action["endedAt"] = action_updated.end_time
+
+        # Add manifest information if available and feature flag is enabled
+        if MANIFEST_REPORTING_FEATURE and action_updated.manifests is not None:
+            updated_action["manifests"] = action_updated.manifests
 
         # Truncate message to max bytes allowed by UpdateWorkerSchedule API
         if (

--- a/src/deadline_worker_agent/scheduler/session_action_status.py
+++ b/src/deadline_worker_agent/scheduler/session_action_status.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from openjd.sessions import ActionStatus
 
 if TYPE_CHECKING:
-    from ..api_models import CompletedActionStatus
+    from ..api_models import CompletedActionStatus, ManifestInfo
 
 
 @dataclass(frozen=True)
@@ -19,3 +19,4 @@ class SessionActionStatus:
     start_time: datetime | None = None
     end_time: datetime | None = None
     completed_status: CompletedActionStatus | None = None
+    manifests: list[ManifestInfo] | None = None

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
@@ -22,6 +22,7 @@ from openjd.model.v2023_09 import (
 )
 from openjd.model import ParameterValue
 
+from ...feature_flag import MANIFEST_REPORTING_FEATURE
 from ...log_messages import SessionActionLogKind
 from .openjd_action import OpenjdAction
 
@@ -190,6 +191,7 @@ class AttachmentUploadAction(OpenjdAction):
                 "DEADLINE_SESSIONACTION_ID": self._id,
                 "DEADLINE_STEP_ID": self._step_id,
                 "DEADLINE_TASK_ID": self._task_id,
+                "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,
         )

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -8,6 +8,7 @@ import os
 import boto3
 import json
 from typing import Optional
+from dataclasses import asdict
 
 from deadline.job_attachments import api
 from deadline.job_attachments.api.manifest import _manifest_snapshot, _manifest_merge
@@ -48,13 +49,22 @@ def upload(s3_root_uri: str, path_mapping_rules: str, manifests: list[str]) -> N
         time=time.time(),
     )
 
-    api.attachment_upload(
+    # Call attachment_upload and get manifest information
+    manifest_infos = api.attachment_upload(
         manifests=manifests,
         s3_root_uri=s3_root_uri,
         boto3_session=boto3.session.Session(),
         path_mapping_rules=path_mapping_rules,
         upload_manifest_path=s3_path,
     )
+
+    # Check if manifest reporting feature is enabled via environment variable
+    manifest_reporting_enabled = (
+        os.environ.get("MANIFEST_REPORTING_FEATURE", "false").lower() == "true"
+    )
+
+    if manifest_reporting_enabled:
+        print(f"ja_upload: {json.dumps([asdict(info) for info in manifest_infos])}")
 
 
 def merge(

--- a/src/deadline_worker_agent/sessions/log_config.py
+++ b/src/deadline_worker_agent/sessions/log_config.py
@@ -1,16 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Generator
 from contextlib import closing, contextmanager, nullcontext
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
 
-import json
 from pathlib import Path
-import re
-from typing import Any, Callable, ContextManager, Generator
-import logging
+from typing import Any, Callable, ContextManager
 
 from ..log_sync.cloudwatch import (
     LOG_CONFIG_OPTION_GROUP_NAME_KEY,
@@ -130,11 +132,9 @@ class ActionOutputCaptureFilter(logging.Filter):
     """
 
     _FILTER_MATCHER = re.compile(
-        (
-            "^(?:"
-            f"{'|'.join(f'(?P<{re.escape(v.value)}>{re.escape(v.value)})' for v in ActionOutputMessageKind)}"
-            "): (.+)$"
-        )
+        "^(?:"
+        f"{'|'.join(f'(?P<{re.escape(v.value)}>{re.escape(v.value)})' for v in ActionOutputMessageKind)}"
+        "): (.+)$"
     )
     """Regular expression pattern used to match and extract action output messages.
 
@@ -164,7 +164,7 @@ class ActionOutputCaptureFilter(logging.Filter):
         }
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if not hasattr(record, "session_id") or getattr(record, "session_id") != self._session_id:
+        if not hasattr(record, "session_id") or record.session_id != self._session_id:
             # Not a record for us to process
             return True
         if not isinstance(record.msg, str):
@@ -197,7 +197,7 @@ class ActionOutputCaptureFilter(logging.Filter):
             try:
                 handler(message)
             except ValueError as e:
-                record.msg = record.msg + f" -- ERROR: {str(e)}"
+                record.msg = record.msg + f" -- ERROR: {e!s}"
                 # There was an error. Don't suppress the message from the log.
                 return True
 
@@ -220,8 +220,7 @@ class ActionOutputCaptureFilter(logging.Filter):
         Args:
             message (str): The message after the leading 'ja_upload: ' prefix
         """
-        # TODO - implement for UpdateWorkerSchedule reporting upload result
-        pass
+        self._callback(ActionOutputMessageKind.JA_UPLOAD, message)
 
 
 @dataclass

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import json
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -30,8 +31,12 @@ from deadline_worker_agent.api_models import (
     SyncInputJobAttachmentsAction,
     AttachmentDownloadAction,
     AttachmentUploadAction,
+    ManifestInfo,
 )
-from deadline_worker_agent.feature_flag import ASSET_SYNC_JOB_USER_FEATURE
+from deadline_worker_agent.feature_flag import (
+    ASSET_SYNC_JOB_USER_FEATURE,
+    MANIFEST_REPORTING_FEATURE,
+)
 
 if TYPE_CHECKING:
     from ..api_models import CompletedActionStatus, EnvironmentAction, TaskRunAction
@@ -60,6 +65,7 @@ from deadline.job_attachments.models import (
     JobAttachmentS3Settings,
     ManifestProperties,
     PathFormat,
+    UploadManifestInfo,
 )
 from deadline.job_attachments.os_file_permission import (
     FileSystemPermissionSettings,
@@ -169,6 +175,7 @@ class Session:
     _retain_session_dir: bool = False
     _job_details: JobDetails
     _job_attachment_details: JobAttachmentDetails | None = None
+    _upload_manifest_list: list[UploadManifestInfo] = []
 
     # Event that is set only when this Session is not running at all
     # i.e. it has exited, or never started, its main run loop/logic.
@@ -1069,7 +1076,7 @@ class Session:
         ):
             self._action_updated_impl(action_status=action_status, now=now)
 
-    def _action_output_log_filter_callback(
+    def action_output_log_filter_callback(
         self, message_type: ActionOutputMessageKind, value: Any
     ) -> None:
         """Callback for the action output log filter
@@ -1077,6 +1084,18 @@ class Session:
         """
         if message_type == ActionOutputMessageKind.JA_SNAPSHOT:
             self.add_manifest_path(root=value["root"], path=value["manifest"])
+        if MANIFEST_REPORTING_FEATURE and message_type == ActionOutputMessageKind.JA_UPLOAD:
+            try:
+                manifest_list_data = json.loads(value)
+                self._upload_manifest_list = [
+                    UploadManifestInfo(**item) for item in manifest_list_data
+                ]
+            except (TypeError, ValueError) as e:
+                logger.error(
+                    f"Failed to parse manifest snapshot: {e}",
+                    exc_info=True,
+                )
+                self._upload_manifest_list = []
 
     def _action_updated_impl(
         self,
@@ -1140,6 +1159,42 @@ class Session:
 
         if self._output_sync_target_action is not None:
             if OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS.get(action_status.state, None):
+                manifests_list = None
+
+                # Get job attachment details to access input manifests
+                job_attachment_details = self._job_attachment_details
+
+                if job_attachment_details:
+                    # Create a list of ManifestInfo objects with the same length as the input manifests list
+                    manifests_list = []
+
+                    # For each input manifest, find the corresponding output manifest
+                    for input_manifest in job_attachment_details.manifests:
+                        asset_root = input_manifest.root_path
+                        manifest_info = None
+
+                        for output_manifest in self._upload_manifest_list:
+                            if (
+                                output_manifest.source_path is not None
+                                and output_manifest.source_path == asset_root
+                            ):
+                                manifest_info = output_manifest
+                                break
+
+                        # Create a ManifestInfo dictionary with the appropriate values
+                        manifest_info_obj: ManifestInfo = {}
+
+                        if manifest_info and manifest_info.output_manifest_path is not None:
+                            manifest_info_obj["outputManifestPath"] = (
+                                manifest_info.output_manifest_path
+                            )
+                        if manifest_info and manifest_info.output_manifest_hash is not None:
+                            manifest_info_obj["outputManifestHash"] = (
+                                manifest_info.output_manifest_hash
+                            )
+
+                        manifests_list.append(manifest_info_obj)
+
                 # if the current action is a sync output job attachments upload action and it's completed
                 # then we can update and clear the corresponding task run sync target action
                 task_run_action = self._output_sync_target_action
@@ -1148,7 +1203,10 @@ class Session:
                 if self._action_output_log_filter:
                     OPENJD_LOG.removeFilter(self._action_output_log_filter)
 
-                self._handle_action_update(is_unsuccessful, action_status, task_run_action, now)
+                # Handle the action update
+                self._handle_action_update(
+                    is_unsuccessful, action_status, task_run_action, now, manifests_list
+                )
             else:
                 logger.debug(
                     f"SYNC_OUTPUT_JOB_ATTACHMENTS for {self._output_sync_target_action} is still running"
@@ -1176,7 +1234,7 @@ class Session:
 
                 if not self._action_output_log_filter:
                     self._action_output_log_filter = ActionOutputCaptureFilter(
-                        session_id=self.id, callback=self._action_output_log_filter_callback
+                        session_id=self.id, callback=self.action_output_log_filter_callback
                     )
 
                 OPENJD_LOG.addFilter(self._action_output_log_filter)
@@ -1198,6 +1256,7 @@ class Session:
                     self._sync_asset_outputs,
                     current_action=current_action,
                 )
+
                 on_done_with_sync_asset_outputs = partial(
                     self._on_done_with_sync_asset_outputs,
                     is_unsuccessful=is_unsuccessful,
@@ -1249,7 +1308,11 @@ class Session:
         action_status: ActionStatus,
         current_action: CurrentAction,
         now: datetime,
+        manifests: list[ManifestInfo] | None = None,
     ):
+        if manifests is None:
+            manifests = []
+
         completed_status = OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS.get(
             action_status.state, None
         )
@@ -1308,6 +1371,9 @@ class Session:
         # Only report action update when it's not attachment upload for syncing job attachment outputs,
         # progress reporting is not supported by the output upload yet.
         if not self._output_sync_target_action:
+            # Only include manifests if feature flag is enabled
+            session_manifests = manifests if MANIFEST_REPORTING_FEATURE else None
+
             self._report_action_update(
                 SessionActionStatus(
                     id=current_action.definition.id,
@@ -1316,6 +1382,7 @@ class Session:
                     end_time=now if action_status.state != ActionState.RUNNING else None,
                     update_time=now if action_status.state == ActionState.RUNNING else None,
                     completed_status=completed_status,
+                    manifests=session_manifests,
                 )
             )
 
@@ -1371,6 +1438,7 @@ class Session:
         from .actions import RunStepTaskAction
 
         assert isinstance(current_action.definition, RunStepTaskAction)
+
         upload_summary_statistics: SummaryStatistics = self._asset_sync.sync_outputs(
             s3_settings=s3_settings,
             attachments=attachments,

--- a/test/unit/scheduler/test_manifest_in_scheduler.py
+++ b/test/unit/scheduler/test_manifest_in_scheduler.py
@@ -1,0 +1,126 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+
+from deadline_worker_agent.scheduler.scheduler import WorkerScheduler
+from deadline_worker_agent.scheduler.session_action_status import SessionActionStatus
+from deadline_worker_agent.api_models import ManifestInfo
+from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
+from openjd.sessions import ActionStatus, ActionState
+
+
+@pytest.mark.skipif(
+    not MANIFEST_REPORTING_FEATURE,
+    reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
+)
+class TestSchedulerManifests:
+    @pytest.fixture
+    def scheduler(self):
+        # Create a minimal scheduler for testing
+        scheduler = MagicMock()
+        scheduler._updated_action_to_boto = WorkerScheduler._updated_action_to_boto.__get__(
+            scheduler, WorkerScheduler
+        )
+        return scheduler
+
+    def test_updated_action_to_boto_includes_manifests(self, scheduler):
+        # Arrange
+        now = datetime.now(timezone.utc)
+        action_status = ActionStatus(state=ActionState.SUCCESS)
+        manifests = [
+            ManifestInfo(
+                outputManifestPath="s3://bucket/Manifests/key1",
+                outputManifestHash="hash1",
+            ),
+            ManifestInfo(
+                outputManifestPath="s3://bucket/Manifests/key2",
+                outputManifestHash="hash2",
+            ),
+            ManifestInfo(),  # Empty object for a root with no changes
+        ]
+
+        action_updated = SessionActionStatus(
+            id="test_action_id",
+            status=action_status,
+            start_time=now,
+            end_time=now,
+            completed_status="SUCCEEDED",
+            manifests=manifests,
+        )
+
+        # Act
+        result = scheduler._updated_action_to_boto(action_updated)
+
+        # Assert
+        assert "manifests" in result
+        assert result["manifests"] == manifests
+
+    @patch("deadline_worker_agent.scheduler.scheduler.MANIFEST_REPORTING_FEATURE", False)
+    def test_updated_action_to_boto_excludes_manifests_when_feature_disabled(self, scheduler):
+        # Arrange
+        now = datetime.now(timezone.utc)
+        action_status = ActionStatus(state=ActionState.SUCCESS)
+        manifests = [
+            ManifestInfo(
+                outputManifestPath="s3://bucket/Manifests/key1",
+                outputManifestHash="hash1",
+            ),
+        ]
+
+        action_updated = SessionActionStatus(
+            id="test_action_id",
+            status=action_status,
+            start_time=now,
+            end_time=now,
+            completed_status="SUCCEEDED",
+            manifests=manifests,
+        )
+
+        # Act
+        result = scheduler._updated_action_to_boto(action_updated)
+
+        # Assert
+        assert "manifests" not in result
+
+    def test_updated_action_to_boto_excludes_manifests_when_none(self, scheduler):
+        # Arrange
+        now = datetime.now(timezone.utc)
+        action_status = ActionStatus(state=ActionState.SUCCESS)
+
+        action_updated = SessionActionStatus(
+            id="test_action_id",
+            status=action_status,
+            start_time=now,
+            end_time=now,
+            completed_status="SUCCEEDED",
+            # No manifests field
+        )
+
+        # Act
+        result = scheduler._updated_action_to_boto(action_updated)
+
+        # Assert
+        assert "manifests" not in result
+
+    def test_updated_action_to_boto_handles_empty_manifests_list(self, scheduler):
+        # Arrange
+        now = datetime.now(timezone.utc)
+        action_status = ActionStatus(state=ActionState.SUCCESS)
+
+        action_updated = SessionActionStatus(
+            id="test_action_id",
+            status=action_status,
+            start_time=now,
+            end_time=now,
+            completed_status="SUCCEEDED",
+            manifests=[],  # Empty list
+        )
+
+        # Act
+        result = scheduler._updated_action_to_boto(action_updated)
+
+        # Assert
+        assert "manifests" in result
+        assert result["manifests"] == []

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -8,6 +8,9 @@ from typing import Generator, Optional
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 import logging
 
+from deadline_worker_agent.api_models import ManifestInfo
+from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
+
 from openjd.sessions import (
     ActionState,
     ActionStatus,
@@ -704,6 +707,41 @@ class TestSchedulerSync:
             assert status_as_boto.get("processExitCode", "ABSENT") == "ABSENT"
         else:
             assert status_as_boto.get("processExitCode", "FAIL") == expected_result
+
+    @pytest.mark.skipif(
+        not MANIFEST_REPORTING_FEATURE,
+        reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
+    )
+    def test_updated_action_to_boto_with_empty_manifests(self, scheduler: WorkerScheduler) -> None:
+        # GIVEN
+        manifests = [
+            ManifestInfo(
+                outputManifestPath="s3://bucket/path/to/manifest1", outputManifestHash="hash1"
+            ),
+            ManifestInfo(),  # Empty manifest for asset root with no changes
+            ManifestInfo(
+                outputManifestPath="s3://bucket/path/to/manifest3", outputManifestHash="hash3"
+            ),
+        ]
+        action_status = SessionActionStatus(
+            id="1234", status=ActionStatus(state=ActionState.SUCCESS), manifests=manifests
+        )
+
+        # WHEN
+        status_as_boto = scheduler._updated_action_to_boto(action_status)
+
+        # THEN
+        assert "manifests" in status_as_boto
+        assert len(status_as_boto["manifests"]) == 3
+        assert status_as_boto["manifests"][0] == {
+            "outputManifestPath": "s3://bucket/path/to/manifest1",
+            "outputManifestHash": "hash1",
+        }
+        assert status_as_boto["manifests"][1] == {}
+        assert status_as_boto["manifests"][2] == {
+            "outputManifestPath": "s3://bucket/path/to/manifest3",
+            "outputManifestHash": "hash3",
+        }
 
 
 class TestCreateNewSessions:

--- a/test/unit/sessions/actions/test_run_attachment_upload.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload.py
@@ -13,6 +13,7 @@ import pytest
 
 import deadline_worker_agent.sessions.actions as actions_module
 from deadline_worker_agent.sessions.job_entities.job_details import JobDetails
+from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
 from openjd.sessions import SessionUser, PathMappingRule, PathFormat
 from openjd.model import ParameterValue
 from pathlib import PurePosixPath
@@ -127,6 +128,7 @@ class TestStart:
         step_id: str,
         task_id: str,
         action_id: str,
+        session_dir: str,
     ) -> None:
         """
         Tests that AttachmentUploadAction.start() calls AssetSync functions to prepare input
@@ -143,8 +145,12 @@ class TestStart:
         )
         session.manifest_out_rel_dirs_by_source = {}
 
-        # WHEN
-        action.start(session=session, executor=executor)
+        session.working_directory = Path(session_dir)
+
+        # Mock file operations to avoid actual file access
+        with patch("os.path.exists", return_value=False):
+            # WHEN
+            action.start(session=session, executor=executor)
 
         with open(
             Path(os.path.dirname(actions_module.__file__)) / "scripts" / "attachment_upload.py",
@@ -184,6 +190,7 @@ class TestStart:
                 "DEADLINE_SESSIONACTION_ID": action_id,
                 "DEADLINE_STEP_ID": step_id,
                 "DEADLINE_TASK_ID": task_id,
+                "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,
         )
@@ -286,6 +293,7 @@ class TestStart:
                 "DEADLINE_SESSIONACTION_ID": action_id,
                 "DEADLINE_STEP_ID": step_id,
                 "DEADLINE_TASK_ID": task_id,
+                "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,
         )

--- a/test/unit/sessions/test_attachment_upload_status.py
+++ b/test/unit/sessions/test_attachment_upload_status.py
@@ -1,0 +1,205 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from openjd.sessions import ActionState, ActionStatus
+
+from deadline_worker_agent.api_models import ManifestInfo
+from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
+from deadline_worker_agent.scheduler.session_action_status import SessionActionStatus
+
+
+@pytest.fixture
+def action_id() -> str:
+    return "action-123456"
+
+
+@pytest.fixture
+def step_id() -> str:
+    return "step-abcdef"
+
+
+@pytest.fixture
+def task_id() -> str:
+    return "task-987654"
+
+
+@pytest.fixture
+def action_start_time() -> datetime:
+    return datetime(2023, 1, 2, 3, 4, 5)
+
+
+@pytest.fixture
+def action_complete_time() -> datetime:
+    return datetime(2023, 1, 2, 3, 4, 5)
+
+
+@pytest.mark.skipif(
+    not MANIFEST_REPORTING_FEATURE,
+    reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
+)
+class TestAttachmentUploadHandling:
+    """Test the handling of attachment upload completion"""
+
+    def test_attachment_upload_success(
+        self,
+        action_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        action_complete_time: datetime,
+    ) -> None:
+        """Tests that when attachment upload action completes successfully, the original task action is reported as succeeded"""
+        # GIVEN
+        # Create mock action
+        run_step_task_action = MagicMock()
+        run_step_task_action.id = action_id
+        run_step_task_action.step_id = step_id
+        run_step_task_action.task_id = task_id
+
+        # Create success status
+        success_action_status = ActionStatus(
+            exit_code=0,
+            state=ActionState.SUCCESS,
+        )
+
+        # WHEN - Direct testing of action completion handling
+        session_action_status = SessionActionStatus(
+            id=action_id,
+            status=success_action_status,
+            start_time=action_start_time,
+            end_time=action_complete_time,
+            completed_status="SUCCEEDED",
+        )
+
+        # THEN - Verify expected status values
+        assert session_action_status.id == action_id
+        assert session_action_status.status == success_action_status
+        assert session_action_status.start_time == action_start_time
+        assert session_action_status.end_time == action_complete_time
+        assert session_action_status.completed_status == "SUCCEEDED"
+
+    def test_attachment_upload_with_manifests(
+        self,
+        action_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        action_complete_time: datetime,
+    ) -> None:
+        """Tests that when attachment upload completes with manifests, they are included in the status"""
+        # GIVEN
+        # Create mock action
+        run_step_task_action = MagicMock()
+        run_step_task_action.id = action_id
+        run_step_task_action.step_id = step_id
+        run_step_task_action.task_id = task_id
+
+        # Create test manifests
+        manifests = [
+            ManifestInfo(outputManifestPath="/test/path/1", outputManifestHash="test-manifest-1"),
+            ManifestInfo(outputManifestPath="/test/path/2", outputManifestHash="test-manifest-2"),
+        ]
+
+        # Create success status
+        success_action_status = ActionStatus(
+            exit_code=0,
+            state=ActionState.SUCCESS,
+        )
+
+        # WHEN - Create session action status with manifests
+        session_action_status = SessionActionStatus(
+            id=action_id,
+            status=success_action_status,
+            start_time=action_start_time,
+            end_time=action_complete_time,
+            completed_status="SUCCEEDED",
+            manifests=manifests,
+        )
+
+        # THEN - Verify manifests are included
+        assert session_action_status.manifests == manifests
+        assert len(session_action_status.manifests) == 2
+        assert session_action_status.manifests[0]["outputManifestHash"] == "test-manifest-1"
+        assert session_action_status.manifests[1]["outputManifestHash"] == "test-manifest-2"
+
+    def test_attachment_upload_failure(
+        self,
+        action_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        action_complete_time: datetime,
+    ) -> None:
+        """Tests that when attachment upload fails, original task is reported as failed"""
+        # GIVEN
+        # Create mock action
+        run_step_task_action = MagicMock()
+        run_step_task_action.id = action_id
+        run_step_task_action.step_id = step_id
+        run_step_task_action.task_id = task_id
+
+        # Create failed status
+        failed_action_status = ActionStatus(
+            exit_code=1,
+            state=ActionState.FAILED,
+            fail_message="Upload failed",
+        )
+
+        # WHEN - Create session action status for failed upload
+        session_action_status = SessionActionStatus(
+            id=action_id,
+            status=failed_action_status,
+            start_time=action_start_time,
+            end_time=action_complete_time,
+            completed_status="FAILED",
+        )
+
+        # THEN - Verify failure is properly represented
+        assert session_action_status.id == action_id
+        assert session_action_status.status is not None
+        assert session_action_status.status.state == ActionState.FAILED
+        assert session_action_status.status.fail_message == "Upload failed"
+        assert session_action_status.completed_status == "FAILED"
+
+    def test_attachment_upload_canceled(
+        self,
+        action_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        action_complete_time: datetime,
+    ) -> None:
+        """Tests that when attachment upload is canceled, original task is reported as canceled"""
+        # GIVEN
+        # Create mock action
+        run_step_task_action = MagicMock()
+        run_step_task_action.id = action_id
+        run_step_task_action.step_id = step_id
+        run_step_task_action.task_id = task_id
+
+        # Create canceled status
+        canceled_action_status = ActionStatus(
+            exit_code=1,
+            state=ActionState.CANCELED,
+            fail_message="Upload canceled",
+        )
+
+        # WHEN - Create session action status for canceled upload
+        session_action_status = SessionActionStatus(
+            id=action_id,
+            status=canceled_action_status,
+            start_time=action_start_time,
+            end_time=action_complete_time,
+            completed_status="CANCELED",
+        )
+
+        # THEN - Verify cancellation is properly represented
+        assert session_action_status.id == action_id
+        assert session_action_status.status is not None
+        assert session_action_status.status.state == ActionState.CANCELED
+        assert session_action_status.status.fail_message == "Upload canceled"
+        assert session_action_status.completed_status == "CANCELED"

--- a/test/unit/sessions/test_log_config.py
+++ b/test/unit/sessions/test_log_config.py
@@ -1,23 +1,24 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from __future__ import annotations
+
+import json
+import logging
 from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock, patch
-import logging
 
 import pytest
-import json
 
+import deadline_worker_agent.sessions.log_config as log_config_mod
 from deadline_worker_agent.api_models import (
     LogConfiguration as BotoLogConfiguration,
 )
 from deadline_worker_agent.sessions.log_config import (
+    ActionOutputCaptureFilter,
     LogConfiguration,
     LogProvisioningError,
-    ActionOutputCaptureFilter,
 )
-import deadline_worker_agent.sessions.log_config as log_config_mod
 
 
 class TestLogProvisioningError:
@@ -197,7 +198,7 @@ class TestActionOutputCaptureFilter:
             args=(),
             exc_info=None,
         )
-        setattr(record, "session_id", "different-session-id")
+        record.session_id = "different-session-id"
 
         # Filter the record
         result = action_output_capture_filter.filter(record)
@@ -227,7 +228,7 @@ class TestActionOutputCaptureFilter:
             args=(),
             exc_info=None,
         )
-        setattr(record, "session_id", self.session_id)
+        record.session_id = self.session_id
 
         # Filter the record
         result = action_output_capture_filter.filter(record)
@@ -256,7 +257,7 @@ class TestActionOutputCaptureFilter:
             args=(),
             exc_info=None,
         )
-        setattr(ja_snapshot_record, "session_id", self.session_id)
+        ja_snapshot_record.session_id = self.session_id
 
         ja_upload_record = logging.LogRecord(
             name="test_logger",
@@ -267,7 +268,7 @@ class TestActionOutputCaptureFilter:
             args=(),
             exc_info=None,
         )
-        setattr(ja_upload_record, "session_id", self.session_id)
+        ja_upload_record.session_id = self.session_id
 
         # Test that the filter correctly matches the patterns
         assert action_output_capture_filter.filter(ja_snapshot_record) is True
@@ -293,7 +294,7 @@ class TestActionOutputCaptureFilter:
             args=(),
             exc_info=None,
         )
-        setattr(ja_snapshot_record, "session_id", self.session_id)
+        ja_snapshot_record.session_id = self.session_id
 
         # Filter the record
         action_output_capture_filter.filter(ja_snapshot_record)
@@ -303,6 +304,25 @@ class TestActionOutputCaptureFilter:
         mock_callback.assert_called_once_with(
             log_config_mod.ActionOutputMessageKind.JA_SNAPSHOT,
             self.snapshot_result,
+        )
+
+        ja_upload_record = logging.LogRecord(
+            name="test_logger",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="ja_upload: This is an upload message",
+            args=(),
+            exc_info=None,
+        )
+        ja_upload_record.session_id = self.session_id
+
+        # Verify the callback was called with the correct arguments
+        # The third parameter is a boolean that we're not testing here
+        assert action_output_capture_filter.filter(ja_upload_record) is True
+        mock_callback.assert_called_with(
+            log_config_mod.ActionOutputMessageKind.JA_UPLOAD,
+            "This is an upload message",
         )
 
     def test_handler_error_handling(self):
@@ -325,7 +345,7 @@ class TestActionOutputCaptureFilter:
             args=(),
             exc_info=None,
         )
-        setattr(ja_snapshot_record, "session_id", self.session_id)
+        ja_snapshot_record.session_id = self.session_id
 
         # Filter the record - this should not raise an exception
         result = action_output_capture_filter.filter(ja_snapshot_record)
@@ -365,7 +385,7 @@ class TestActionOutputCaptureFilter:
                 args=(),
                 exc_info=None,
             )
-            setattr(record, "session_id", self.session_id)
+            record.session_id = self.session_id
 
             # Filter the record
             result = action_output_capture_filter.filter(record)

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1,18 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from __future__ import annotations
+
+import os
+from collections.abc import Generator, Iterable
 from concurrent.futures import wait
 from datetime import datetime, timedelta
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from threading import Event, RLock
 from types import TracebackType
-from typing import Generator, Iterable, Literal, Optional
-from unittest.mock import patch, MagicMock, ANY
+from typing import Literal, Optional
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from openjd.model import ParameterValue
-import os
 
+from openjd.model import ParameterValue
 from openjd.model.v2023_09 import (
     Action,
     Environment,
@@ -27,8 +29,8 @@ from openjd.sessions import (
     ActionStatus,
     PathFormat,
     PathMappingRule,
-    SessionUser,
     PosixSessionUser,
+    SessionUser,
     WindowsSessionUser,
 )
 
@@ -36,8 +38,12 @@ from deadline_worker_agent.api_models import (
     EnvironmentAction,
     TaskRunAction,
     AttachmentUploadAction,
+    ManifestInfo,
 )
-from deadline_worker_agent.feature_flag import ASSET_SYNC_JOB_USER_FEATURE
+from deadline_worker_agent.feature_flag import (
+    ASSET_SYNC_JOB_USER_FEATURE,
+    MANIFEST_REPORTING_FEATURE,
+)
 from deadline_worker_agent.sessions import Session
 import deadline_worker_agent.sessions.session as session_mod
 from deadline_worker_agent.sessions.session import (
@@ -66,12 +72,17 @@ from deadline.job_attachments.models import (
     JobAttachmentsFileSystem,
     JobAttachmentS3Settings,
     JobAttachmentsFileSystem,
+    UploadManifestInfo,
 )
 from deadline.job_attachments.os_file_permission import (
     FileSystemPermissionSettings,
     PosixFileSystemPermissionSettings,
     WindowsFileSystemPermissionSettings,
     WindowsPermissionEnum,
+)
+import deadline_worker_agent.sessions.log_config as log_config_mod
+from deadline_worker_agent.sessions.job_entities.job_attachment_details import (
+    JobAttachmentManifestProperties,
 )
 
 from deadline.job_attachments.progress_tracker import (
@@ -922,25 +933,25 @@ class TestSessionSyncAssetOutputs:
         with patch.object(session, "_asset_sync") as mock_asset_sync:
             yield mock_asset_sync
 
-    def test_sync_asset_outputs(
+    def _setup_sync_asset_outputs_test(
         self,
         action_id: str,
-        queue_id: str,
         step_id: str,
         task_id: str,
         action_start_time: datetime,
         session: Session,
         job_attachment_details: JobAttachmentDetails,
         mock_asset_sync: MagicMock,
-        mock_telemetry_event_for_sync_outputs: MagicMock,
-    ):
-        """
-        Tests that session's '_sync_asset_outputs' calls Job Attachment's method 'sync_outputs' correctly.
-        Also, asserts that 'record_sync_outputs_telemetry_event' is called once with the correct arguments.
-        """
-        # GIVEN
-        mock_ja_sync_outputs: MagicMock = mock_asset_sync.sync_outputs
-        mock_ja_sync_outputs.return_value = SummaryStatistics()
+    ) -> CurrentAction:
+        """Helper method to set up common test fixtures for sync_asset_outputs tests"""
+        # Set up sync methods
+        mock_asset_sync.sync_outputs.return_value = SummaryStatistics()
+        mock_asset_sync.sync_outputs_with_manifests.return_value = (
+            SummaryStatistics(),
+            {},
+        )
+
+        # Create current action
         current_action = CurrentAction(
             definition=RunStepTaskAction(
                 details=StepDetails(
@@ -963,13 +974,48 @@ class TestSessionSyncAssetOutputs:
             ),
             start_time=action_start_time,
         )
+
+        # Set job attachment details
         session._job_attachment_details = job_attachment_details
+
+        return current_action
+
+    @pytest.mark.skipif(
+        MANIFEST_REPORTING_FEATURE,
+        reason="Only relevant when MANIFEST_REPORTING_FEATURE is not enabled",
+    )
+    def test_sync_asset_outputs_without_manifest_reporting(
+        self,
+        action_id: str,
+        queue_id: str,
+        step_id: str,
+        task_id: str,
+        action_start_time: datetime,
+        session: Session,
+        job_attachment_details: JobAttachmentDetails,
+        mock_asset_sync: MagicMock,
+        mock_telemetry_event_for_sync_outputs: MagicMock,
+    ):
+        """
+        Tests that session's '_sync_asset_outputs' calls Job Attachment's method 'sync_outputs' correctly
+        when MANIFEST_REPORTING_FEATURE is disabled.
+        """
+        # GIVEN
+        current_action = self._setup_sync_asset_outputs_test(
+            action_id,
+            step_id,
+            task_id,
+            action_start_time,
+            session,
+            job_attachment_details,
+            mock_asset_sync,
+        )
 
         # WHEN
         session._sync_asset_outputs(current_action=current_action)  # type: ignore
 
         # THEN
-        mock_ja_sync_outputs.assert_called_once_with(
+        mock_asset_sync.sync_outputs.assert_called_once_with(
             s3_settings=JobAttachmentS3Settings(
                 rootPrefix="job_attachments",
                 s3BucketName="job_attachments_bucket",
@@ -988,8 +1034,9 @@ class TestSessionSyncAssetOutputs:
             storage_profiles_path_mapping_rules={},
             on_uploading_files=ANY,
         )
+        mock_asset_sync.sync_outputs_with_manifests.assert_not_called()
         mock_telemetry_event_for_sync_outputs.assert_called_once_with(
-            "queue-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            queue_id,
             SummaryStatistics(),
         )
 
@@ -1376,13 +1423,23 @@ class TestSessionActionUpdatedImpl:
         expected_next_action_message = failed_action_status.fail_message or (
             f"Previous action failed: {current_action.definition.id}"
         )
-        expected_action_update = SessionActionStatus(
-            id=action_id,
-            status=failed_action_status,
-            start_time=action_start_time,
-            completed_status="FAILED",
-            end_time=action_complete_time,
-        )
+        if MANIFEST_REPORTING_FEATURE:
+            expected_action_update = SessionActionStatus(
+                id=action_id,
+                status=failed_action_status,
+                start_time=action_start_time,
+                completed_status="FAILED",
+                end_time=action_complete_time,
+                manifests=[],
+            )
+        else:
+            expected_action_update = SessionActionStatus(
+                id=action_id,
+                status=failed_action_status,
+                start_time=action_start_time,
+                completed_status="FAILED",
+                end_time=action_complete_time,
+            )
 
         with patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs:
             # WHEN
@@ -1445,13 +1502,23 @@ class TestSessionActionUpdatedImpl:
         expected_next_action_message = failed_action_status.fail_message or (
             f"Previous action failed: {current_action.definition.id}"
         )
-        expected_action_update = SessionActionStatus(
-            id=action_id,
-            status=failed_action_status,
-            start_time=action_start_time,
-            completed_status="FAILED",
-            end_time=action_complete_time,
-        )
+        if MANIFEST_REPORTING_FEATURE:
+            expected_action_update = SessionActionStatus(
+                id=action_id,
+                status=failed_action_status,
+                start_time=action_start_time,
+                completed_status="FAILED",
+                end_time=action_complete_time,
+                manifests=[],
+            )
+        else:
+            expected_action_update = SessionActionStatus(
+                id=action_id,
+                status=failed_action_status,
+                start_time=action_start_time,
+                completed_status="FAILED",
+                end_time=action_complete_time,
+            )
 
         with patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs:
             # WHEN
@@ -1514,13 +1581,24 @@ class TestSessionActionUpdatedImpl:
         )
         session._current_action = current_action
         queue_cancel_all: MagicMock = session_action_queue.cancel_all
-        expected_action_update = SessionActionStatus(
-            id=action_id,
-            status=success_action_status,
-            start_time=action_start_time,
-            completed_status="SUCCEEDED",
-            end_time=action_complete_time,
-        )
+
+        if MANIFEST_REPORTING_FEATURE:
+            expected_action_update = SessionActionStatus(
+                id=action_id,
+                status=success_action_status,
+                start_time=action_start_time,
+                completed_status="SUCCEEDED",
+                end_time=action_complete_time,
+                manifests=[],
+            )
+        else:
+            expected_action_update = SessionActionStatus(
+                id=action_id,
+                status=success_action_status,
+                start_time=action_start_time,
+                completed_status="SUCCEEDED",
+                end_time=action_complete_time,
+            )
 
         def mock_now(*arg, **kwarg) -> datetime:
             return action_complete_time
@@ -1629,6 +1707,143 @@ class TestSessionActionUpdatedImpl:
         )
 
     @pytest.mark.skipif(
+        not ASSET_SYNC_JOB_USER_FEATURE or not MANIFEST_REPORTING_FEATURE,
+        reason="This test should be skipped if either feature is not implemented",
+    )
+    def test_success_task_run_attachment_upload_with_no_output_manifest(
+        self,
+        session: Session,
+        job_attachment_details: JobAttachmentDetails,
+    ) -> None:
+        # Set up a mock output sync action
+        mocked_upload_action = MagicMock()
+        # Set up a mock output sync target action
+        output_sync_target_action = MagicMock()
+
+        session._current_action = mocked_upload_action
+        session._output_sync_target_action = output_sync_target_action
+        session._job_attachment_details = job_attachment_details
+
+        # WHEN
+        # Call with a completed action status
+        completed_action_status = ActionStatus(state=ActionState.SUCCESS)
+
+        action_complete_time = datetime.now()
+
+        with (
+            patch.object(
+                session_mod,
+                "OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS",
+                {ActionState.SUCCESS: "SUCCEEDED"},
+            ),
+            patch.object(session, "_handle_action_update") as mocked_handle_action_upload,
+        ):
+            session._action_updated_impl(
+                action_status=completed_action_status,
+                now=action_complete_time,
+            )
+
+        expected_manifest_list: list[ManifestInfo] = [{}]
+
+        mocked_handle_action_upload.assert_called_once_with(
+            False,
+            completed_action_status,
+            output_sync_target_action,
+            action_complete_time,
+            expected_manifest_list,
+        )
+
+    @pytest.mark.skipif(
+        not ASSET_SYNC_JOB_USER_FEATURE or not MANIFEST_REPORTING_FEATURE,
+        reason="This test should be skipped if either feature is not implemented",
+    )
+    def test_success_task_run_attachment_upload_with_manifest(
+        self,
+        session: Session,
+        job_attachment_details: JobAttachmentDetails,
+    ) -> None:
+        # Set up a mock output sync action
+        mocked_upload_action = MagicMock()
+        # Set up a mock output sync target action
+        output_sync_target_action = MagicMock()
+
+        job_attachment_details.manifests.extend(
+            [
+                # Add a second asset root to the manifests. We won't get an output for this one.
+                JobAttachmentManifestProperties(root_path="no_output", root_path_format="posix"),
+                # Add a thir asset root to the manifests.
+                JobAttachmentManifestProperties(root_path="root_path2", root_path_format="posix"),
+            ]
+        )
+
+        session._current_action = mocked_upload_action
+        session._output_sync_target_action = output_sync_target_action
+        session._job_attachment_details = job_attachment_details
+        session._upload_manifest_list = [
+            # Extra manifest. It's not in job attachments details and should be
+            # omitted from the expected output.
+            UploadManifestInfo(
+                "fake_path1",
+                "fake_hash1",
+                "fake_source_path1",
+            ),
+            # Two Manifests match root paths in job attachments details
+            UploadManifestInfo(
+                "fake_path",
+                "fake_hash",
+                job_attachment_details.manifests[0].root_path,
+            ),
+            UploadManifestInfo(
+                "fake_path1",
+                "fake_hash1",
+                "root_path2",
+            ),
+        ]
+
+        # WHEN
+        # Call with a completed action status
+        completed_action_status = ActionStatus(state=ActionState.SUCCESS)
+
+        action_complete_time = datetime.now()
+
+        with (
+            patch.object(
+                session_mod,
+                "OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS",
+                {ActionState.SUCCESS: "SUCCEEDED"},
+            ),
+            patch.object(session, "_handle_action_update") as mocked_handle_action_upload,
+        ):
+            session._action_updated_impl(
+                action_status=completed_action_status,
+                now=action_complete_time,
+            )
+
+        expected_manifest_list = [
+            # manifest information for the source path that matches the root.
+            {
+                "outputManifestPath": "fake_path",
+                "outputManifestHash": "fake_hash",
+            },
+            # There was no output information for the 2nd root path. It should have an empty manifest info.
+            {},
+            # This manifest also matches a root path. We want to make sure that we're matching the order defined
+            # in job attachment details.
+            {
+                "outputManifestPath": "fake_path1",
+                "outputManifestHash": "fake_hash1",
+            },
+        ]
+
+        mocked_handle_action_upload.assert_called_once_with(
+            False,
+            completed_action_status,
+            output_sync_target_action,
+            action_complete_time,
+            expected_manifest_list,
+        )
+
+    @pytest.mark.skipif(
         ASSET_SYNC_JOB_USER_FEATURE,
         reason="This test will be re-written before releasing the asset sync job user feature",
     )
@@ -1678,13 +1893,23 @@ class TestSessionActionUpdatedImpl:
             state=ActionState.FAILED,
             fail_message=f"Failed to sync job output attachments for {current_action.definition.id}: {sync_outputs_exception_msg}",
         )
-        expected_action_update = SessionActionStatus(
-            id=action_id,
-            status=expected_fail_action_status,
-            start_time=action_start_time,
-            completed_status="FAILED",
-            end_time=action_complete_time,
-        )
+        if MANIFEST_REPORTING_FEATURE:
+            expected_action_update = SessionActionStatus(
+                id=action_id,
+                status=expected_fail_action_status,
+                start_time=action_start_time,
+                completed_status="FAILED",
+                end_time=action_complete_time,
+                manifests=[],
+            )
+        else:
+            expected_action_update = SessionActionStatus(
+                id=action_id,
+                status=expected_fail_action_status,
+                start_time=action_start_time,
+                completed_status="FAILED",
+                end_time=action_complete_time,
+            )
 
         def mock_now(*arg, **kwarg) -> datetime:
             return action_complete_time
@@ -1904,6 +2129,48 @@ class TestSessionActionUpdatedImpl:
         mock_openjd_log.removeFilter.assert_called_once_with(mock_filter)
         # Verify output sync target action was cleared
         assert session._output_sync_target_action is None
+
+    @pytest.mark.skipif(
+        not MANIFEST_REPORTING_FEATURE,
+        reason="This test only runs when MANIFEST_REPORTING_FEATURE is enabled",
+    )
+    def test_action_output_capture_filter_ja_upload_callback_invalid(
+        self,
+        session: Session,
+    ) -> None:
+        """Tests that the callback for ja_upload type correctly handles incorrectly formatted value"""
+
+        # WHEN
+        session.action_output_log_filter_callback(
+            log_config_mod.ActionOutputMessageKind.JA_UPLOAD, "NOT A VALID LIST OF MANIFEST INFOS"
+        )
+
+        assert session._upload_manifest_list == []
+
+        session.action_output_log_filter_callback(
+            log_config_mod.ActionOutputMessageKind.JA_UPLOAD, '[{"not":"real"}]'
+        )
+
+        assert session._upload_manifest_list == []
+
+    @pytest.mark.skipif(
+        not MANIFEST_REPORTING_FEATURE,
+        reason="This test only runs when MANIFEST_REPORTING_FEATURE is enabled",
+    )
+    def test_action_output_capture_filter_ja_upload_callback_valid(
+        self,
+        session: Session,
+    ) -> None:
+        """Tests that the callback for ja_upload type correctly handles properly formatted value"""
+
+        # WHEN
+        session.action_output_log_filter_callback(
+            log_config_mod.ActionOutputMessageKind.JA_UPLOAD,
+            '[{"source_path": "test", "output_manifest_path":"test", "output_manifest_hash":"test"}]',
+        )
+
+        assert len(session._upload_manifest_list) == 1
+        assert all(isinstance(item, UploadManifestInfo) for item in session._upload_manifest_list)
 
 
 @pytest.mark.usefixtures("mock_openjd_session")
@@ -2170,7 +2437,7 @@ class TestSessionCleanup:
         # THEN
         openjd_session_cleanup.assert_called_once_with()
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_asset_sync(self, session: Session) -> Generator[MagicMock, None, None]:
         with patch.object(session, "_asset_sync") as mock_asset_sync:
             yield mock_asset_sync


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We want to report the output manifest s3 location to the service.

### What was the solution? (How)

The attachment upload script gets the returned manifest infos from `api.attachment_upload()`. It prints out all manifest infos to the logs in the feature flag is enabled. In the session callback, we read the Manifest information and assign it to `_upload_manifest_list`. The updated manifests are cross-referenced with the job attachment manifests. Manifests without an update send an empty dictionary value, otherwise they send the updated output information. 

### What is the impact of this change?

This allows the service to know where the output manifests are in s3.

### How was this change tested?

Added unit tests.

Also, I've done testing with internal models. I've tested with jobs that produce no output, some output, run as different users and ones that have multiple asset roots. 

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*