### PR TITLE
fix(experimental): vfs not launching for ASSET_SYNC_JOB_USER_FEATURE

### DIFF
--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Iterable, Generic, Literal, TypeVar, TYPE_CHEC
 
 from openjd.model import UnsupportedSchema
 from openjd.sessions import ActionState, ActionStatus
+from deadline.job_attachments.models import JobAttachmentsFileSystem
 
 from ..feature_flag import ASSET_SYNC_JOB_USER_FEATURE
 from ..api_models import (
@@ -177,7 +178,11 @@ class SessionActionQueue:
                     ),
                 )
             elif action_type == "SYNC_INPUT_JOB_ATTACHMENTS":
-                if ASSET_SYNC_JOB_USER_FEATURE:
+                if (
+                    ASSET_SYNC_JOB_USER_FEATURE
+                    and self._job_entities.job_attachment_details().job_attachments_file_system
+                    == JobAttachmentsFileSystem.COPIED.value
+                ):
                     action_definition = cast(AttachmentDownloadActionApiModel, action_definition)
                 else:
                     action_definition = cast(

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -60,6 +60,7 @@ from deadline.job_attachments.models import (
     JobAttachmentS3Settings,
     ManifestProperties,
     PathFormat,
+    JobAttachmentsFileSystem,
 )
 from deadline.job_attachments.os_file_permission import (
     FileSystemPermissionSettings,
@@ -1161,7 +1162,12 @@ class Session:
             and isinstance(current_action.definition, RunStepTaskAction)
             and self._asset_sync is not None
         ):
-            if ASSET_SYNC_JOB_USER_FEATURE:
+            if (
+                ASSET_SYNC_JOB_USER_FEATURE
+                and self._job_attachment_details
+                and self._job_attachment_details.job_attachments_file_system
+                == JobAttachmentsFileSystem.COPIED.value
+            ):
                 # Finished task run for a run step task action.
                 # This session has attachment, create attachment upload action and insert to the front of queue
 

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -65,6 +65,7 @@ from deadline.job_attachments.models import (
     Attachments,
     JobAttachmentsFileSystem,
     JobAttachmentS3Settings,
+    JobAttachmentsFileSystem,
 )
 from deadline.job_attachments.os_file_permission import (
     FileSystemPermissionSettings,
@@ -1570,6 +1571,11 @@ class TestSessionActionUpdatedImpl:
         """Tests that if a task run succeeds (the Open Job Description action), that job attachment output
         sync is performed, and AFTER that, the action success is returned."""
         # GIVEN
+        session._job_attachment_details = MagicMock()
+        session._job_attachment_details.job_attachments_file_system = (
+            JobAttachmentsFileSystem.COPIED.value
+        )
+
         current_action = CurrentAction(
             definition=RunStepTaskAction(
                 details=StepDetails(
@@ -1811,6 +1817,11 @@ class TestSessionActionUpdatedImpl:
     ) -> None:
         """Tests that ActionOutputCaptureFilter is properly integrated when a task run succeeds"""
         # GIVEN
+        session._job_attachment_details = MagicMock()
+        session._job_attachment_details.job_attachments_file_system = (
+            JobAttachmentsFileSystem.COPIED.value
+        )
+
         current_action = CurrentAction(
             definition=RunStepTaskAction(
                 details=StepDetails(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
VFS is not launching on the new code path with ASSET_SYNC_JOB_USER_FEATURE.

### What was the solution? (How)
Fall back VFS to the old code path to run sync_input and sync_output

### What is the impact of this change?
Only runs ASSET_SYNC_JOB_USER_FEATURE code path when JobAttachmentsFileSystem is COPIED.

### How was this change tested?
1. Updated unit tests
2. Run `hatch run pytest -- test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_job_attachments_dep_data_flow_linux` to make sure there is no regression. Further testing will be done manually in environment that VFS is available.

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*