### PR TITLE
fix(experimental): mixed action types between old and new sync for ASSET_SYNC_JOB_USER_FEATURE

### DIFF
--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -369,7 +369,11 @@ class SessionActionQueue:
                     )
                 elif action_type == "SYNC_INPUT_JOB_ATTACHMENTS":
                     action = cast(AttachmentDownloadActionApiModel, action)
-                    if ASSET_SYNC_JOB_USER_FEATURE:
+                    if (
+                        ASSET_SYNC_JOB_USER_FEATURE
+                        and self._job_entities.job_attachment_details().job_attachments_file_system
+                        == JobAttachmentsFileSystem.COPIED.value
+                    ):
                         action = cast(AttachmentDownloadActionApiModel, action)
                         if "stepId" not in action:
                             queue_entry = AttachmentDownloadActionQueueEntry(
@@ -531,7 +535,12 @@ class SessionActionQueue:
 
             elif action_type == "SYNC_INPUT_JOB_ATTACHMENTS":
                 action_definition = action_queue_entry.definition
-                if ASSET_SYNC_JOB_USER_FEATURE:
+                if (
+                    ASSET_SYNC_JOB_USER_FEATURE
+                    # Temporary fallback until the VFS integration for the new code path is complete
+                    and self._job_entities.job_attachment_details().job_attachments_file_system
+                    == JobAttachmentsFileSystem.COPIED.value
+                ):
                     action_definition = cast(AttachmentDownloadActionApiModel, action_definition)
                     if "stepId" not in action_definition:
                         action_queue_entry = cast(

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -1913,11 +1913,20 @@ class TestJobSubmission:
         os.environ["OPERATING_SYSTEM"] == "windows",
         reason="Linux specific job bundle to test job attachments dependency data flow",
     )
+    @pytest.mark.parametrize(
+        "file_system",
+        [
+            "COPIED",
+            # Worker E2E test doesn't run VFS, but this helps verify VIRTUAL fallback and job run successfully
+            "VIRTUAL",
+        ],
+    )
     def test_worker_job_attachments_dep_data_flow_linux(
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
         session_worker: EC2InstanceWorker,
+        file_system: str,
     ) -> None:
         job_bundle_path: str = os.path.join(
             os.path.dirname(__file__), "job_attachment_bundle", "dep_data_flow", "linux_bundle"
@@ -1928,6 +1937,8 @@ class TestJobSubmission:
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             bundle_path=job_bundle_path,
+            job_attachments_file_system=file_system,
+            max_retries_per_task=0,
         )
 
         job.wait_until_complete(client=deadline_client)
@@ -1935,7 +1946,9 @@ class TestJobSubmission:
 
         # Get job output path
         os.makedirs(name=self.JOB_OUTPUT_PATH, exist_ok=True)
-        output_root_path = tempfile.mkdtemp(dir=self.JOB_OUTPUT_PATH, prefix="dep_data_flow_linux")
+        output_root_path = tempfile.mkdtemp(
+            dir=self.JOB_OUTPUT_PATH, prefix=f"dep_data_flow_linux-{file_system}"
+        )
         output_path: dict[str, list[str]] = wait_for_job_output(
             job=job,
             deadline_client=deadline_client,

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -331,14 +331,25 @@ class TestSessionActionQueueDequeue:
         session_queue._actions = [action]
         session_queue._actions_by_id[action.definition["sessionActionId"]] = action
 
-        # WHEN
-        result = session_queue.dequeue()
+        # Create a JobAttachmentDetails instance with the desired properties
+        job_attachment_details = JobAttachmentDetails(
+            job_attachments_file_system=JobAttachmentsFileSystem.COPIED, manifests=[]
+        )
 
-        # THEN
-        assert type(result) is type(expected)
-        assert result.id == expected.id  # type: ignore
-        assert len(session_queue._actions) == 0
-        assert len(session_queue._actions_by_id) == 0
+        # Use patch as a context manager
+        with patch.object(
+            session_queue._job_entities,
+            "job_attachment_details",
+            return_value=job_attachment_details,
+        ):
+            # WHEN
+            result = session_queue.dequeue()
+
+            # THEN
+            assert type(result) is type(expected)
+            assert result.id == expected.id  # type: ignore
+            assert len(session_queue._actions) == 0
+            assert len(session_queue._actions_by_id) == 0
 
     def test_attachment_upload_insert_dequeue(
         self,
@@ -411,6 +422,10 @@ class TestSessionActionQueueDequeue:
                 ),
                 JobAttachmentDetailsError,
                 id="Job Attachments Details Error",
+                marks=pytest.mark.skipif(
+                    ASSET_SYNC_JOB_USER_FEATURE,
+                    reason="Skip this parameter when due to temporary patching for asset sync feature",
+                ),
             ),
             pytest.param(
                 SyncInputJobAttachmentsStepDependenciesQueueEntry(
@@ -423,6 +438,10 @@ class TestSessionActionQueueDequeue:
                 ),
                 StepDetailsError,
                 id="Job Attachments Step Details Error",
+                marks=pytest.mark.skipif(
+                    ASSET_SYNC_JOB_USER_FEATURE,
+                    reason="Skip this parameter when due to temporary patching for asset sync feature",
+                ),
             ),
         ),
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When`ASSET_SYNC_JOB_USER_FEATURE` is turned on and it's `VIRTUAL` mode for Job Attachment, it turned to go through both old code path which is `AssetSync` and the new code path for `AttachmentUpload/DownloadAction`.

### What was the solution? (How)
Add the `COPIED` check to other places along with `ASSET_SYNC_JOB_USER_FEATURE`

### What is the impact of this change?
When`ASSET_SYNC_JOB_USER_FEATURE` is turned on and it's `VIRTUAL`, it will run with old code path for now until VFS is integrated with the new code path.

### How was this change tested?
1. unit tests
2. added E2E test to verify `VIRTUAL` job runs successfully

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*