### PR TITLE
ci: set mainline e2e tests to use mainline env

### DIFF
--- a/.github/workflows/mainline_e2e_test.yml
+++ b/.github/workflows/mainline_e2e_test.yml
@@ -37,7 +37,7 @@ jobs:
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      environment: release
+      environment: mainline
       os: linux
     concurrency:
       group: linuxe2e
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
-      environment: release
+      environment: mainline
       os: windows
     concurrency:
       group: windowse2e


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In this [PR](https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/643/files#diff-acdfe66f322c9f70e4823016fb318ee3848202c375a4992273d2f06d97c4ff71L56) the environment was incorrectly changed from `mainline` to `release`

### What was the solution? (How)
Change the environment of the mainline e2e tests from `release` to `mainline`

### What is the impact of this change?
mainline e2e tests will run against the mainline branch again.

### How was this change tested?
n/a

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*