### PR TITLE
fix(experimental): ASSET_SYNC_JOB_USER_FEATURE does not attempt to launch VFS

### DIFF
--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Iterable, Generic, Literal, TypeVar, TYPE_CHEC
 
 from openjd.model import UnsupportedSchema
 from openjd.sessions import ActionState, ActionStatus
-from deadline.job_attachments.models import JobAttachmentsFileSystem
 
 from ..feature_flag import ASSET_SYNC_JOB_USER_FEATURE
 from ..api_models import (
@@ -178,11 +177,7 @@ class SessionActionQueue:
                     ),
                 )
             elif action_type == "SYNC_INPUT_JOB_ATTACHMENTS":
-                if (
-                    ASSET_SYNC_JOB_USER_FEATURE
-                    and self._job_entities.job_attachment_details().job_attachments_file_system
-                    == JobAttachmentsFileSystem.COPIED.value
-                ):
+                if ASSET_SYNC_JOB_USER_FEATURE:
                     action_definition = cast(AttachmentDownloadActionApiModel, action_definition)
                 else:
                     action_definition = cast(
@@ -369,11 +364,7 @@ class SessionActionQueue:
                     )
                 elif action_type == "SYNC_INPUT_JOB_ATTACHMENTS":
                     action = cast(AttachmentDownloadActionApiModel, action)
-                    if (
-                        ASSET_SYNC_JOB_USER_FEATURE
-                        and self._job_entities.job_attachment_details().job_attachments_file_system
-                        == JobAttachmentsFileSystem.COPIED.value
-                    ):
+                    if ASSET_SYNC_JOB_USER_FEATURE:
                         action = cast(AttachmentDownloadActionApiModel, action)
                         if "stepId" not in action:
                             queue_entry = AttachmentDownloadActionQueueEntry(
@@ -535,12 +526,7 @@ class SessionActionQueue:
 
             elif action_type == "SYNC_INPUT_JOB_ATTACHMENTS":
                 action_definition = action_queue_entry.definition
-                if (
-                    ASSET_SYNC_JOB_USER_FEATURE
-                    # Temporary fallback until the VFS integration for the new code path is complete
-                    and self._job_entities.job_attachment_details().job_attachments_file_system
-                    == JobAttachmentsFileSystem.COPIED.value
-                ):
+                if ASSET_SYNC_JOB_USER_FEATURE:
                     action_definition = cast(AttachmentDownloadActionApiModel, action_definition)
                     if "stepId" not in action_definition:
                         action_queue_entry = cast(

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -310,13 +310,15 @@ class AttachmentDownloadAction(OpenjdAction):
             merged_manifests_by_root=merged_manifests_by_root,
             s3_settings=s3_settings,
         ):
-            # successfully launched VFS, LINUX only, for the session to proceed
+            # Successfully launched VFS, running a echo step with openjd
+            # for the session to proceed to the next action
+            # LINUX and VIRTUAL only
             session.run_task(
                 step_script=StepScript_2023_09(
                     actions=StepActions_2023_09(
                         onRun=Action_2023_09(
                             command="echo",
-                            args=["VFS launched successfully for VIRTUAL"],
+                            args=["Job Attachments mode VIRTUAL, VFS launched"],
                         )
                     ),
                 ),
@@ -400,7 +402,7 @@ class AttachmentDownloadAction(OpenjdAction):
                 session_dir=session.working_directory,
                 fs_permission_settings=fs_permission_settings,
                 merged_manifests_by_root=merged_manifests_by_root,
-                os_env_vars=dict(session._env),
+                os_env_vars=dict(session._env),  # type: ignore
             )
             return True
 

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -272,15 +272,6 @@ class AttachmentDownloadAction(OpenjdAction):
             )
         )
 
-        if self._start_vfs(
-            session=session,
-            attachments=attachments,
-            merged_manifests_by_root=merged_manifests_by_root,
-            s3_settings=s3_settings,
-        ):
-            # successfully launched VFS
-            return
-
         dynamic_mapping_rules.update(generated_path_mapping)
         job_attachment_path_mappings = list([asdict(r) for r in dynamic_mapping_rules.values()])
 
@@ -312,16 +303,37 @@ class AttachmentDownloadAction(OpenjdAction):
         for root_name, root_path in manifest_paths_by_root.items():
             session.add_manifest_path(root=root_name, path=root_path)
 
-        self.set_step_script(
-            manifests=manifest_paths_by_root.values(),  # type: ignore
+        #  Try to launch VFS if needed once all files are prepared
+        if self._start_vfs(
+            session=session,
+            attachments=attachments,
+            merged_manifests_by_root=merged_manifests_by_root,
             s3_settings=s3_settings,
-        )
-        assert self._step_script is not None
-        session.run_task(
-            step_script=self._step_script,
-            task_parameter_values=dict[str, ParameterValue](),
-            log_task_banner=False,
-        )
+        ):
+            # successfully launched VFS, LINUX only, for the session to proceed
+            session.run_task(
+                step_script=StepScript_2023_09(
+                    actions=StepActions_2023_09(
+                        onRun=Action_2023_09(
+                            command="echo",
+                            args=["VFS launched successfully for VIRTUAL"],
+                        )
+                    ),
+                ),
+                task_parameter_values=dict[str, ParameterValue](),
+                log_task_banner=False,
+            )
+        else:
+            self.set_step_script(
+                manifests=manifest_paths_by_root.values(),  # type: ignore
+                s3_settings=s3_settings,
+            )
+            assert self._step_script is not None
+            session.run_task(
+                step_script=self._step_script,
+                task_parameter_values=dict[str, ParameterValue](),
+                log_task_banner=False,
+            )
 
     @staticmethod
     def _get_output_dirs(
@@ -378,8 +390,8 @@ class AttachmentDownloadAction(OpenjdAction):
             attachments.fileSystem == JobAttachmentsFileSystem.VIRTUAL.value
             and sys.platform != "win32"
             and fs_permission_settings is not None
-            and os.environ is not None
-            and "AWS_PROFILE" in os.environ
+            and session._env is not None
+            and "AWS_PROFILE" in session._env
             and isinstance(fs_permission_settings, PosixFileSystemPermissionSettings)
         ):
             assert session._asset_sync is not None
@@ -388,7 +400,7 @@ class AttachmentDownloadAction(OpenjdAction):
                 session_dir=session.working_directory,
                 fs_permission_settings=fs_permission_settings,
                 merged_manifests_by_root=merged_manifests_by_root,
-                os_env_vars=dict(os.environ),
+                os_env_vars=dict(session._env),
             )
             return True
 

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -60,7 +60,6 @@ from deadline.job_attachments.models import (
     JobAttachmentS3Settings,
     ManifestProperties,
     PathFormat,
-    JobAttachmentsFileSystem,
 )
 from deadline.job_attachments.os_file_permission import (
     FileSystemPermissionSettings,
@@ -1162,12 +1161,8 @@ class Session:
             and isinstance(current_action.definition, RunStepTaskAction)
             and self._asset_sync is not None
         ):
-            if (
-                ASSET_SYNC_JOB_USER_FEATURE
-                and self._job_attachment_details
-                and self._job_attachment_details.job_attachments_file_system
-                == JobAttachmentsFileSystem.COPIED.value
-            ):
+            # Job attachment details check to make sure the queue has job attachment configured
+            if ASSET_SYNC_JOB_USER_FEATURE and self._job_attachment_details:
                 # Finished task run for a run step task action.
                 # This session has attachment, create attachment upload action and insert to the front of queue
 

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -331,25 +331,14 @@ class TestSessionActionQueueDequeue:
         session_queue._actions = [action]
         session_queue._actions_by_id[action.definition["sessionActionId"]] = action
 
-        # Create a JobAttachmentDetails instance with the desired properties
-        job_attachment_details = JobAttachmentDetails(
-            job_attachments_file_system=JobAttachmentsFileSystem.COPIED, manifests=[]
-        )
+        # WHEN
+        result = session_queue.dequeue()
 
-        # Use patch as a context manager
-        with patch.object(
-            session_queue._job_entities,
-            "job_attachment_details",
-            return_value=job_attachment_details,
-        ):
-            # WHEN
-            result = session_queue.dequeue()
-
-            # THEN
-            assert type(result) is type(expected)
-            assert result.id == expected.id  # type: ignore
-            assert len(session_queue._actions) == 0
-            assert len(session_queue._actions_by_id) == 0
+        # THEN
+        assert type(result) is type(expected)
+        assert result.id == expected.id  # type: ignore
+        assert len(session_queue._actions) == 0
+        assert len(session_queue._actions_by_id) == 0
 
     def test_attachment_upload_insert_dequeue(
         self,
@@ -422,10 +411,6 @@ class TestSessionActionQueueDequeue:
                 ),
                 JobAttachmentDetailsError,
                 id="Job Attachments Details Error",
-                marks=pytest.mark.skipif(
-                    ASSET_SYNC_JOB_USER_FEATURE,
-                    reason="Skip this parameter when due to temporary patching for asset sync feature",
-                ),
             ),
             pytest.param(
                 SyncInputJobAttachmentsStepDependenciesQueueEntry(
@@ -438,10 +423,6 @@ class TestSessionActionQueueDequeue:
                 ),
                 StepDetailsError,
                 id="Job Attachments Step Details Error",
-                marks=pytest.mark.skipif(
-                    ASSET_SYNC_JOB_USER_FEATURE,
-                    reason="Skip this parameter when due to temporary patching for asset sync feature",
-                ),
             ),
         ),
     )

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -268,6 +268,7 @@ class TestStart:
 
 
 class TestVFS:
+    @pytest.mark.skipif(sys.platform == "win32", reason="Test not supported on Windows")
     def test_start_vfs_success(
         self,
         executor: Mock,
@@ -333,7 +334,6 @@ class TestVFS:
         # Mock platform to be Windows
         with patch("sys.platform", "win32"):
             # Set up session with required attributes
-            session._os_user = PosixSessionUser(user="test-user", group="test-group")
             session._env = {"AWS_PROFILE": "test-profile"}
 
             # Create attachments with VIRTUAL file system
@@ -361,6 +361,7 @@ class TestVFS:
             assert result is False
             mock_asset_sync._launch_vfs.assert_not_called()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Test not supported on Windows")
     def test_start_vfs_non_virtual_filesystem(
         self,
         executor: Mock,
@@ -404,6 +405,7 @@ class TestVFS:
             assert result is False
             mock_asset_sync._launch_vfs.assert_not_called()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Test not supported on Windows")
     def test_start_vfs_missing_aws_profile(
         self,
         executor: Mock,
@@ -416,10 +418,6 @@ class TestVFS:
         """
         Tests that _start_vfs returns False when AWS_PROFILE is missing
         """
-        # GIVEN
-        from deadline.job_attachments.models import JobAttachmentsFileSystem, Attachments
-        from openjd.sessions import PosixSessionUser
-
         # Mock platform to be non-Windows
         with patch("sys.platform", "linux"):
             # Set up session with required attributes but missing AWS_PROFILE

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -12,7 +12,7 @@ import pytest
 
 import deadline_worker_agent.sessions.actions as actions_module
 from deadline_worker_agent.sessions.job_entities.job_details import JobDetails
-from openjd.sessions import SessionUser
+from openjd.sessions import SessionUser, PosixSessionUser
 from openjd.model import ParameterValue
 from openjd.model.v2023_09 import (
     EmbeddedFileTypes as EmbeddedFileTypes_2023_09,
@@ -23,7 +23,12 @@ from openjd.model.v2023_09 import (
 )
 
 import deadline_worker_agent.sessions.session as session_mod
-from deadline.job_attachments.models import JobAttachmentS3Settings
+from deadline.job_attachments.models import (
+    Attachments,
+    JobAttachmentS3Settings,
+    JobAttachmentsFileSystem,
+)
+from deadline.job_attachments.asset_manifests import BaseAssetManifest
 
 if TYPE_CHECKING:
     from deadline_worker_agent.sessions.job_entities import JobAttachmentDetails
@@ -81,38 +86,39 @@ def action(
     )
 
 
+@pytest.fixture
+def session(
+    session_id: str,
+    session_dir: Path,
+    job_details: JobDetails,
+    job_user: SessionUser,
+    job_attachment_details: JobAttachmentDetails,
+    mock_openjd_session_cls: Mock,
+) -> Mock:
+    session = Mock()
+    session.id = session_id
+    session._job_details = job_details
+    session._job_attachment_details = job_attachment_details
+    session._os_user = job_user
+    session.openjd_session = mock_openjd_session_cls
+    session.working_directory = session_dir
+    session._queue_id = TestStart.QUEUE_ID
+    session._queue._job_id = TestStart.JOB_ID
+    return session
+
+
+@pytest.fixture(autouse=True)
+def mock_asset_sync(session: Mock) -> Generator[MagicMock, None, None]:
+    with patch.object(session, "_asset_sync") as mock_asset_sync:
+        yield mock_asset_sync
+
+
 class TestStart:
     """Tests for AttachmentDownloadAction.start()"""
 
     QUEUE_ID = "queue-test"
     JOB_ID = "job-test"
     DIR_NAME = "unique_dir_name"
-
-    @pytest.fixture
-    def session(
-        self,
-        session_id: str,
-        session_dir: Path,
-        job_details: JobDetails,
-        job_user: SessionUser,
-        job_attachment_details: JobAttachmentDetails,
-        mock_openjd_session_cls: Mock,
-    ) -> Mock:
-        session = Mock()
-        session.id = session_id
-        session._job_details = job_details
-        session._job_attachment_details = job_attachment_details
-        session._os_user = job_user
-        session.openjd_session = mock_openjd_session_cls
-        session.working_directory = session_dir
-        session._queue_id = TestStart.QUEUE_ID
-        session._queue._job_id = TestStart.JOB_ID
-        return session
-
-    @pytest.fixture(autouse=True)
-    def mock_asset_sync(self, session: Mock) -> Generator[MagicMock, None, None]:
-        with patch.object(session, "_asset_sync") as mock_asset_sync:
-            yield mock_asset_sync
 
     @pytest.fixture
     def mock_get_unique_dest_dir_name(self):
@@ -259,3 +265,188 @@ class TestStart:
             manifest_write_dir=str(session_dir),
             manifest_name_suffix="job",
         )
+
+
+class TestVFS:
+    def test_start_vfs_success(
+        self,
+        executor: Mock,
+        session: Mock,
+        action: actions_module.AttachmentDownloadAction,
+        session_dir: Path,
+        mock_asset_sync: MagicMock,
+        job_details: JobDetails,
+    ) -> None:
+        """
+        Tests that _start_vfs successfully launches VFS when all conditions are met
+        """
+
+        # Mock platform to be non-Windows
+        with patch("sys.platform", "linux"):
+            # Set up session with required attributes for VFS
+            session._os_user = PosixSessionUser(user="test-user", group="test-group")
+            session._env = {"AWS_PROFILE": "test-profile"}
+
+            # Create attachments with VIRTUAL file system
+            attachments = Attachments(
+                manifests=[], fileSystem=JobAttachmentsFileSystem.VIRTUAL.value
+            )
+
+            # Mock merged_manifests_by_root
+            merged_manifests_by_root: dict[str, BaseAssetManifest] = dict()
+
+            # Create S3 settings
+            s3_settings = JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            )
+
+            # WHEN
+            result = action._start_vfs(
+                session=session,
+                attachments=attachments,
+                merged_manifests_by_root=merged_manifests_by_root,
+                s3_settings=s3_settings,
+            )
+
+            # THEN
+            assert result is True
+            mock_asset_sync._launch_vfs.assert_called_once_with(
+                s3_settings=s3_settings,
+                session_dir=session_dir,
+                fs_permission_settings=ANY,
+                merged_manifests_by_root=merged_manifests_by_root,
+                os_env_vars=session._env,
+            )
+
+    def test_start_vfs_windows_platform(
+        self,
+        executor: Mock,
+        session: Mock,
+        action: actions_module.AttachmentDownloadAction,
+        session_dir: Path,
+        mock_asset_sync: MagicMock,
+        job_details: JobDetails,
+    ) -> None:
+        """
+        Tests that _start_vfs returns False on Windows platform
+        """
+        # Mock platform to be Windows
+        with patch("sys.platform", "win32"):
+            # Set up session with required attributes
+            session._os_user = PosixSessionUser(user="test-user", group="test-group")
+            session._env = {"AWS_PROFILE": "test-profile"}
+
+            # Create attachments with VIRTUAL file system
+            attachments = Attachments(
+                manifests=[], fileSystem=JobAttachmentsFileSystem.VIRTUAL.value
+            )
+
+            # Mock merged_manifests_by_root
+            merged_manifests_by_root: dict[str, BaseAssetManifest] = dict()
+
+            # Create S3 settings
+            s3_settings = JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            )
+
+            # WHEN
+            result = action._start_vfs(
+                session=session,
+                attachments=attachments,
+                merged_manifests_by_root=merged_manifests_by_root,
+                s3_settings=s3_settings,
+            )
+
+            # THEN
+            assert result is False
+            mock_asset_sync._launch_vfs.assert_not_called()
+
+    def test_start_vfs_non_virtual_filesystem(
+        self,
+        executor: Mock,
+        session: Mock,
+        action: actions_module.AttachmentDownloadAction,
+        session_dir: Path,
+        mock_asset_sync: MagicMock,
+        job_details: JobDetails,
+    ) -> None:
+        """
+        Tests that _start_vfs returns False when file system is not VIRTUAL
+        """
+        # Mock platform to be non-Windows
+        with patch("sys.platform", "linux"):
+            # Set up session with required attributes
+            session._os_user = PosixSessionUser(user="test-user", group="test-group")
+            session._env = {"AWS_PROFILE": "test-profile"}
+
+            # Create attachments with COPIED file system
+            attachments = Attachments(
+                manifests=[], fileSystem=JobAttachmentsFileSystem.COPIED.value
+            )
+
+            # Mock merged_manifests_by_root
+            merged_manifests_by_root: dict[str, BaseAssetManifest] = dict()
+
+            # Create S3 settings
+            s3_settings = JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            )
+
+            # WHEN
+            result = action._start_vfs(
+                session=session,
+                attachments=attachments,
+                merged_manifests_by_root=merged_manifests_by_root,
+                s3_settings=s3_settings,
+            )
+
+            # THEN
+            assert result is False
+            mock_asset_sync._launch_vfs.assert_not_called()
+
+    def test_start_vfs_missing_aws_profile(
+        self,
+        executor: Mock,
+        session: Mock,
+        action: actions_module.AttachmentDownloadAction,
+        session_dir: Path,
+        mock_asset_sync: MagicMock,
+        job_details: JobDetails,
+    ) -> None:
+        """
+        Tests that _start_vfs returns False when AWS_PROFILE is missing
+        """
+        # GIVEN
+        from deadline.job_attachments.models import JobAttachmentsFileSystem, Attachments
+        from openjd.sessions import PosixSessionUser
+
+        # Mock platform to be non-Windows
+        with patch("sys.platform", "linux"):
+            # Set up session with required attributes but missing AWS_PROFILE
+            session._os_user = PosixSessionUser(user="test-user", group="test-group")
+            session._env = {}  # No AWS_PROFILE
+
+            # Create attachments with VIRTUAL file system
+            attachments = Attachments(
+                manifests=[], fileSystem=JobAttachmentsFileSystem.VIRTUAL.value
+            )
+
+            # Mock merged_manifests_by_root
+            merged_manifests_by_root: dict[str, BaseAssetManifest] = dict()
+
+            # Create S3 settings
+            s3_settings = JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            )
+
+            # WHEN
+            result = action._start_vfs(
+                session=session,
+                attachments=attachments,
+                merged_manifests_by_root=merged_manifests_by_root,
+                s3_settings=s3_settings,
+            )
+
+            # THEN
+            assert result is False
+            mock_asset_sync._launch_vfs.assert_not_called()

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1572,9 +1572,6 @@ class TestSessionActionUpdatedImpl:
         sync is performed, and AFTER that, the action success is returned."""
         # GIVEN
         session._job_attachment_details = MagicMock()
-        session._job_attachment_details.job_attachments_file_system = (
-            JobAttachmentsFileSystem.COPIED.value
-        )
 
         current_action = CurrentAction(
             definition=RunStepTaskAction(
@@ -1818,9 +1815,6 @@ class TestSessionActionUpdatedImpl:
         """Tests that ActionOutputCaptureFilter is properly integrated when a task run succeeds"""
         # GIVEN
         session._job_attachment_details = MagicMock()
-        session._job_attachment_details.job_attachments_file_system = (
-            JobAttachmentsFileSystem.COPIED.value
-        )
 
         current_action = CurrentAction(
             definition=RunStepTaskAction(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
ASSET_SYNC_JOB_USER_FEATURE does not attempt to launch VFS even though the condition should be met. There is a bug in passing the variable for the condition check and launching VFS.

### What was the solution? (How)
1. Fix the wrong variable being passed in, i.e. `os.environ` vs `session._env`
2. Add echo step script to make sure the session proceeds to next action
3. Remove the temporary code to fall back to previous path for VIRTUAL

### What is the impact of this change?
ASSET_SYNC_JOB_USER_FEATURE should work with VFS

### How was this change tested?
Built the whl, deploy with AMI and ran the test
```
test_step_dep_bundle[VIRTUAL-linux] passed 1 out of the required 1 times. Success!
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*