### PR TITLE
ci: change release_publish.yml e2e test currency group

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -48,7 +48,7 @@ jobs:
       os: linux
       tag: ${{ needs.TagRelease.outputs.tag }}
     concurrency:
-      group: linuxe2e
+      group: linuxe2erelease
 
   WindowsE2ETests:
     needs: [TagRelease, UnitIntegTests]
@@ -64,7 +64,7 @@ jobs:
       os: windows
       tag: ${{ needs.TagRelease.outputs.tag }}
     concurrency:
-      group: windowse2e
+      group: windowse2erelease
 
   PreRelease:
     needs: [TagRelease, WindowsE2ETests, LinuxE2ETests]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The release process is sharing the same concurrency group with the mainline tests. This could result in the mainline e2e tests canceling the release process tests.

### What was the solution? (How)
Update the release_publish.yml to use its own concurrency group

### What is the impact of this change?
prevent release e2e test cancelations

### How was this change tested?
n/a

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*