### PR TITLE
fix: avoid embedded file name conflicts with download/upload script

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -125,7 +125,6 @@ class AttachmentDownloadAction(OpenjdAction):
                 embeddedFiles=[
                     EmbeddedFileText_2023_09(
                         name="AttachmentDownload",
-                        filename="download.py",
                         type=EmbeddedFileTypes_2023_09.TEXT,
                         data=DataString(f.read()),
                     )

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
@@ -114,7 +114,6 @@ class AttachmentUploadAction(OpenjdAction):
                 embeddedFiles=[
                     EmbeddedFileText_2023_09(
                         name="AttachmentUpload",
-                        filename="upload.py",
                         type=EmbeddedFileTypes_2023_09.TEXT,
                         data=DataString(data),
                     )

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -3026,3 +3026,164 @@ echo -n $(cat {{Param.DataDir}}/files/test_input_file)Hello > {{Param.DataDir}}/
             )
 
             job.wait_until_complete(client=deadline_client)
+
+    def test_job_submission_asset_sync_behaviour_expected_without_errors(
+        self,
+        deadline_resources,
+        session_worker: EC2InstanceWorker,
+        deadline_client: DeadlineClient,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """
+        Verify that asset sync as job user works as expected,
+        with manifest cleanup, job attachments, and embedded files working properly.
+        """
+        upload_py_content = """#!/usr/bin/env python3
+print("Upload script executed successfully")"""
+
+        download_py_content = """#!/usr/bin/env python3
+import os
+print("Download script executed successfully")
+output_path = os.path.join(r"{{ Param.DataDir }}", "output.txt")
+with open(output_path, "w") as f:
+    f.write("Job attachments working")"""
+
+        # Create job bundle with attachments
+        job_bundle_path = os.path.join(tmp_path, "job_bundle")
+
+        os.makedirs(job_bundle_path, exist_ok=True)
+
+        # Create input file for job attachments
+        input_file = os.path.join(job_bundle_path, "input.txt")
+        with open(input_file, "w") as f:
+            f.write("Test input data")
+
+        job_parameters = [
+            {"name": "DataDir", "value": job_bundle_path},
+        ]
+
+        with open(os.path.join(job_bundle_path, "template.json"), "w") as template_file:
+            template_file.write(
+                json.dumps(
+                    {
+                        "specificationVersion": "jobtemplate-2023-09",
+                        "name": "Test Job with Job Attachments and Embedded Files",
+                        "parameterDefinitions": [
+                            {
+                                "name": "DataDir",
+                                "type": "PATH",
+                                "dataFlow": "INOUT",
+                            },
+                        ],
+                        "steps": [
+                            {
+                                "hostRequirements": {
+                                    "attributes": [
+                                        {
+                                            "name": "attr.worker.os.family",
+                                            "allOf": [os.environ["OPERATING_SYSTEM"]],
+                                        }
+                                    ]
+                                },
+                                "name": "Step0",
+                                "script": {
+                                    "actions": {
+                                        "onRun": (
+                                            {
+                                                "command": "bash",
+                                                "args": [
+                                                    "-c",
+                                                    "python3 {{ Task.File.upload }} && python3 {{ Task.File.download }}",
+                                                ],
+                                            }
+                                            if os.environ["OPERATING_SYSTEM"] == "linux"
+                                            else {
+                                                "command": "powershell",
+                                                "args": [
+                                                    "-Command",
+                                                    "python {{ Task.File.upload }}; python {{ Task.File.download }}",
+                                                ],
+                                            }
+                                        ),
+                                    },
+                                    "embeddedFiles": [
+                                        {
+                                            "name": "upload",
+                                            "type": "TEXT",
+                                            "runnable": True,
+                                            "filename": "upload.py",
+                                            "data": upload_py_content,
+                                        },
+                                        {
+                                            "name": "download",
+                                            "type": "TEXT",
+                                            "runnable": True,
+                                            "filename": "download.py",
+                                            "data": download_py_content,
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    }
+                )
+            )
+
+        config = configparser.ConfigParser()
+        set_setting("defaults.farm_id", deadline_resources.farm.id, config)
+        set_setting("defaults.queue_id", deadline_resources.queue_a.id, config)
+
+        job_id = api.create_job_from_job_bundle(
+            job_bundle_path,
+            job_parameters,
+            priority=98,
+            config=config,
+            queue_parameter_definitions=[],
+        )
+        assert job_id is not None
+
+        job_details = Job.get_job_details(
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            job_id=job_id,
+        )
+        job = Job(
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            template={},
+            **job_details,
+        )
+
+        LOG.info(f"Waiting for job {job.id} to complete")
+        job.wait_until_complete(client=deadline_client)
+        LOG.info(f"Job result: {job}")
+
+        assert job.task_run_status == TaskStatus.SUCCEEDED
+
+        logs_client = boto3.client(
+            "logs",
+            config=botocore.config.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+        )
+
+        job.assert_single_task_log_contains(
+            deadline_client=deadline_client,
+            logs_client=logs_client,
+            expected_pattern=r"Upload script executed successfully",
+        )
+
+        job.assert_single_task_log_contains(
+            deadline_client=deadline_client,
+            logs_client=logs_client,
+            expected_pattern=r"Download script executed successfully",
+        )
+
+        # Verify job attachments output
+        output_path = wait_for_job_output(
+            job=job, deadline_client=deadline_client, deadline_resources=deadline_resources
+        )
+        output_file = os.path.join(list(output_path.keys())[0], "output.txt")
+        with open(output_file, "r") as f:
+            assert f.read() == "Job attachments working"
+
+        ## TODO: add verification that manifest cleanup completes successfully

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -199,7 +199,6 @@ class TestStart:
                     EmbeddedFileText_2023_09(
                         name="AttachmentDownload",
                         type=EmbeddedFileTypes_2023_09.TEXT,
-                        filename="download.py",
                         data=DataString(f.read()),
                     )
                 ],

--- a/test/unit/sessions/actions/test_run_attachment_upload.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload.py
@@ -180,7 +180,6 @@ class TestStart:
                     EmbeddedFileText_2023_09(
                         name="AttachmentUpload",
                         type=EmbeddedFileTypes_2023_09.TEXT,
-                        filename="upload.py",
                         data=DataString(f.read()),
                     )
                 ],
@@ -283,7 +282,6 @@ class TestStart:
                     EmbeddedFileText_2023_09(
                         name="AttachmentUpload",
                         type=EmbeddedFileTypes_2023_09.TEXT,
-                        filename="upload.py",
                         data=DataString(f.read()),
                     )
                 ],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The current asset sync as job user implementation creates two scripts as embedded files. `upload.py` and `download.py`, which are ran during job attachments sync to sync job attachments from/to the worker.

However, the names of these files are explicitly named, and if someone submits a job with embedded files `upload.py` and/or `download.py`, unexpected behaviour would happen, in which the file would get overridden or we could run simply into a permissions issue.

### What was the solution? (How)
Remove the explicit naming of the `upload.py` and `download.py` files. 

This would make it so that the files for the upload/download scripts are named a randomly generated unique ID. Thus, it would not conflict with any user uploaded files.

### What is the impact of this change?

Users of deadline cloud will be able to use custom embedded files named `upload.py` and `download.py` without rrunning into any issues

### How was this change tested?

Added a new test that uses embedded files named `upload.py` and `download.py`, as well as job attachments.  Verified that they work with the `ASSET_SYNC_JOB_USER_FEATURE` feature flag on.




`hatch run test`
`hatch run integ-test`

```
source .e2e_linux_infra.sh
hatch run e2e-test


source .e2e_windows_infra.sh
hatch run e2e-test

```

<img width="1142" alt="Screenshot 2025-07-07 at 3 07 07 PM" src="https://github.com/user-attachments/assets/a2759cb1-3b1a-41ba-9feb-4221d418748c" />
<img width="248" alt="image" src="https://github.com/user-attachments/assets/21c8f054-668c-45b1-b04a-f2b2be82d72b" />



### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*