### PR TITLE
feat: Enable extensions declared in openjd-model in created sessions …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "deadline == 0.50.*",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
     "openjd-sessions == 0.10.3",
-    "openjd-model == 0.8.*",
+    "openjd-model >= 0.8.1, < 0.9",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "tomlkit == 0.13.*",

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -44,7 +44,12 @@ if TYPE_CHECKING:
     from .actions import SessionActionDefinition
     from .job_entities import JobAttachmentDetails, JobDetails
 
-from openjd.model import TaskParameterSet
+from openjd.model import (
+    TaskParameterSet,
+    RevisionExtensions,
+    SpecificationRevision,
+)
+from openjd.model.v2023_09 import ExtensionName
 from openjd.sessions import (
     ActionState,
     ActionStatus,
@@ -231,6 +236,13 @@ class Session:
             callback=openjd_session_action_callback,
             os_env_vars=self._env,
             session_root_directory=session_root_dir,
+            # Currently for simplicity request that our session allow all extensions
+            # This does not obey the spec.  It should be changed at a later date to the list of requested
+            # extensions once those are returned by BatchGetJobEntity
+            revision_extensions=RevisionExtensions(
+                spec_rev=SpecificationRevision.v2023_09,
+                supported_extensions=[v.value for v in ExtensionName],
+            ),
         )
 
         self._queue = queue

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -26,6 +26,7 @@ from openjd.model.v2023_09 import (
     CommandString,
     ArgListType,
     ArgString,
+    ExtensionName,
 )
 from openjd.sessions import (
     ActionState,
@@ -2654,3 +2655,46 @@ class TestSessionStartAction:
         session_exit_env.call_args.kwargs["os_env_vars"] == {
             "DEADLINE_SESSIONACTION_ID": exit_env_action.id,
         }
+
+    def test_session_includes_redacted_env_vars_extension(
+        self,
+        session_id: str,
+        job_details: MagicMock,
+        session_action_queue: MagicMock,
+        session_root_dir: Path,
+        os_user: SessionUser,
+        queue_id: str,
+        action_update_callback: MagicMock,
+        action_update_lock: MagicMock,
+        asset_sync: MagicMock,
+    ) -> None:
+        """Tests that the REDACTED_ENV_VARS extension is included in the supported extensions
+        This test should be updated when BatchGetJobEntity returns the list of requested extensions
+        to use those intead - Session will likely take those extensions as a parameter of some sort"""
+        # GIVEN
+        from deadline_worker_agent.sessions.session import Session
+
+        # WHEN
+        with patch("deadline_worker_agent.sessions.session.OPENJDSession") as mock_openjd_session:
+            _ = Session(
+                id=session_id,
+                job_details=job_details,
+                queue=session_action_queue,
+                queue_id=queue_id,
+                job_id="job-1234",
+                asset_sync=asset_sync,
+                session_root_dir=session_root_dir,
+                os_user=os_user,
+                action_update_callback=action_update_callback,
+                action_update_lock=action_update_lock,
+                retain_session_dir=False,
+            )
+
+        # THEN
+        # Verify that the REDACTED_ENV_VARS extension is included in the supported extensions
+        mock_openjd_session.assert_called_once()
+        _, kwargs = mock_openjd_session.call_args
+        assert "revision_extensions" in kwargs
+        revision_extensions = kwargs["revision_extensions"]
+        # Check that REDACTED_ENV_VARS is in the list of extensions
+        assert ExtensionName.REDACTED_ENV_VARS.value in revision_extensions.extensions


### PR DESCRIPTION
…by default.  This session list should come from BatchGetJobEntity in the future most likely, but until it's available we want to allow the use of supported extensions.

### What was the problem/requirement? (What/Why)

The BatchGetJobEntity api doesn't currently return information about extensions requested by a job, so when creating sessions the worker agent doesn't have a list to request support for.

### What was the solution? (How)

Allow all extensions supported by the model until BatchGetJobEntity is updated to return them.  This breaks strict adherence to the spec but allows us to support requested features through extensions until the API is updated.

### What is the impact of this change?

Customers can use features from the new extensions such as REDACTED_ENV_VARS, but don't need to explicitly request them in the extensions list.  Using the token without requesting the extension is expected to perform redaction but print a warning and NOT set the environment variable - with this change it will perform redaction and set the environment variable.

### How was this change tested?

Ran a job with a CMF worker without this change and saw the warning messages:

Received openjd_redacted_env message but REDACTED_ENV_VARS extension is not enabled

Redaction was obeyed but environment variables weren't set, as expected.  With this update ran another job and saw the environment variable set and redaction obeyed.

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*