### PR TITLE
revert: "feat: Enable extensions declared in openjd-model in created …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "deadline == 0.50.*",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
     "openjd-sessions == 0.10.3",
-    "openjd-model >= 0.8.1, < 0.9",
+    "openjd-model == 0.8.*",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "tomlkit == 0.13.*",

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -44,12 +44,7 @@ if TYPE_CHECKING:
     from .actions import SessionActionDefinition
     from .job_entities import JobAttachmentDetails, JobDetails
 
-from openjd.model import (
-    TaskParameterSet,
-    RevisionExtensions,
-    SpecificationRevision,
-)
-from openjd.model.v2023_09 import ExtensionName
+from openjd.model import TaskParameterSet
 from openjd.sessions import (
     ActionState,
     ActionStatus,
@@ -236,13 +231,6 @@ class Session:
             callback=openjd_session_action_callback,
             os_env_vars=self._env,
             session_root_directory=session_root_dir,
-            # Currently for simplicity request that our session allow all extensions
-            # This does not obey the spec.  It should be changed at a later date to the list of requested
-            # extensions once those are returned by BatchGetJobEntity
-            revision_extensions=RevisionExtensions(
-                spec_rev=SpecificationRevision.v2023_09,
-                supported_extensions=[v.value for v in ExtensionName],
-            ),
         )
 
         self._queue = queue

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -26,7 +26,6 @@ from openjd.model.v2023_09 import (
     CommandString,
     ArgListType,
     ArgString,
-    ExtensionName,
 )
 from openjd.sessions import (
     ActionState,
@@ -2655,46 +2654,3 @@ class TestSessionStartAction:
         session_exit_env.call_args.kwargs["os_env_vars"] == {
             "DEADLINE_SESSIONACTION_ID": exit_env_action.id,
         }
-
-    def test_session_includes_redacted_env_vars_extension(
-        self,
-        session_id: str,
-        job_details: MagicMock,
-        session_action_queue: MagicMock,
-        session_root_dir: Path,
-        os_user: SessionUser,
-        queue_id: str,
-        action_update_callback: MagicMock,
-        action_update_lock: MagicMock,
-        asset_sync: MagicMock,
-    ) -> None:
-        """Tests that the REDACTED_ENV_VARS extension is included in the supported extensions
-        This test should be updated when BatchGetJobEntity returns the list of requested extensions
-        to use those intead - Session will likely take those extensions as a parameter of some sort"""
-        # GIVEN
-        from deadline_worker_agent.sessions.session import Session
-
-        # WHEN
-        with patch("deadline_worker_agent.sessions.session.OPENJDSession") as mock_openjd_session:
-            _ = Session(
-                id=session_id,
-                job_details=job_details,
-                queue=session_action_queue,
-                queue_id=queue_id,
-                job_id="job-1234",
-                asset_sync=asset_sync,
-                session_root_dir=session_root_dir,
-                os_user=os_user,
-                action_update_callback=action_update_callback,
-                action_update_lock=action_update_lock,
-                retain_session_dir=False,
-            )
-
-        # THEN
-        # Verify that the REDACTED_ENV_VARS extension is included in the supported extensions
-        mock_openjd_session.assert_called_once()
-        _, kwargs = mock_openjd_session.call_args
-        assert "revision_extensions" in kwargs
-        revision_extensions = kwargs["revision_extensions"]
-        # Check that REDACTED_ENV_VARS is in the list of extensions
-        assert ExtensionName.REDACTED_ENV_VARS.value in revision_extensions.extensions


### PR DESCRIPTION
…sessions by default.  This session list should come from BatchGetJobEntity in the future most likely, but until it's available we want to allow the use of supported extensions. (#691)"

This reverts commit 5564caa73b25492c98154ea62dcb33ec121a1ef7.

### What was the problem/requirement? (What/Why)
Reverting to resolve mainline test failures. We will re-merge when a fix is in place.

### What was the solution? (How)
revert change

### What is the impact of this change?
reverts change

### How was this change tested?
```
hatch run test
```

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*