### PR TITLE
fix: output manifest name format not working with old job output download leading to no files being downloaded

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -72,7 +72,8 @@ def upload(s3_root_uri: str, path_mapping_rules: str, manifests: list[str]) -> N
 def merge(
     manifest_paths_by_root: dict[str, list[str]], path_mapping_rules_file: str
 ) -> dict[str, str]:
-    manifest_path = os.path.join(os.getcwd(), "manifest")
+    print(f"Starting merge for {manifest_paths_by_root}")
+    manifest_path = os.path.join(os.getcwd(), "merge")
     merged_manifests = dict()
     with open(path_mapping_rules_file, "r") as file:
         path_mapping_rules = json.load(file).get("path_mapping_rules", [])
@@ -104,7 +105,8 @@ def merge(
 def snapshot(
     manifest_path_by_root: dict[str, str], out_rel_dirs_by_root: dict[str, list[str]]
 ) -> list[str]:
-    output_path = os.path.join(os.getcwd(), "diff")
+    # Retaining interim diff manifest files to be safe until we confirm the override behavior works as expected.
+    output_path = os.path.join(os.getcwd(), f"diff-{int(time.time() * 1000)}")
     manifests = list()
 
     for root, path in manifest_path_by_root.items():
@@ -115,8 +117,7 @@ def snapshot(
             root=root,
             # directory to put the generated diff manifests
             destination=str(output_path),
-            # `output` is used for job download to discover output manifests
-            # manifest file name need to contain the hash of root path for attachment CLI path mapping
+            # TODO - name as part of the name for the fallback below, can be removed once other branches are verified
             name=f"output-{os.path.basename(path)}",
             # this path to manifest servers as a base for the snapshot, generate only difference since this manifest
             diff=path,

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -108,6 +108,7 @@ def snapshot(
     manifests = list()
 
     for root, path in manifest_path_by_root.items():
+        input_manifest_file_name = os.path.basename(path)
         # TODO - use the public api for manifest snapshot once that's final and made public
         include_dirs = [subdir + "/**" for subdir in out_rel_dirs_by_root.get(root, [])]
         manifest: Optional[ManifestSnapshot] = _manifest_snapshot(
@@ -122,8 +123,25 @@ def snapshot(
             include=include_dirs,
         )
         if manifest:
-            manifests.append(manifest.manifest)
-            print(f"ja_snapshot: {json.dumps({'root': root, 'manifest': manifest.manifest})}")
+            if "merge" in input_manifest_file_name:
+                # This is a merged manifest that has merge-{rootHash}-{timestamp}.manifest name format
+                output_manifest_prefix = input_manifest_file_name.split("-")[1]
+            elif "job" or "step" in input_manifest_file_name:
+                # This is a input manifest that has {rootHash}_job or {rootHash}_step name format
+                output_manifest_prefix = input_manifest_file_name.split("_")[0]
+            else:
+                # Fallback to use the current file name
+                output_manifest_prefix = os.path.basename(manifest.manifest)
+
+            directory = os.path.dirname(manifest.manifest)
+            # `output` as postfix is used for job download to discover output manifests
+            new_file_path = os.path.join(directory, f"{output_manifest_prefix}_output")
+            # Rename the file since the file name will be used as manifest s3 object name for upload
+            os.rename(manifest.manifest, new_file_path)
+
+            manifests.append(new_file_path)
+            # Log handling IPC to communicate between job user and worker agent user
+            print(f"ja_snapshot: {json.dumps({'root': root, 'manifest': new_file_path})}")
 
     return manifests
 

--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -241,12 +241,19 @@ class TestAttachmentUpload:
         mock_manifest_merge.assert_called_once_with(
             root="/source_root1",  # Should use the source path from mapping
             manifest_files=["/path/to/manifest1", "/path/to/manifest2"],
-            destination=os.path.join(os.getcwd(), "manifest"),
+            destination=os.path.join(os.getcwd(), "merge"),
             name="merge",
         )
 
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload._manifest_snapshot")
-    def test_manifest_snapshot_diff_include(self, mock_manifest_snapshot: Mock, tmpdir_path: str):
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.time")
+    def test_manifest_snapshot_diff_include(
+        self, mock_time: Mock, mock_manifest_snapshot: Mock, tmpdir_path: str
+    ):
+        # Freeze time to a specific timestamp
+        frozen_timestamp = 1625097600.0  # 2021-07-01 00:00:00 UTC
+        mock_time.time.return_value = frozen_timestamp
+
         # Create the result files that will be returned by the mock
         result1_path = os.path.join(tmpdir_path, "result1")
         result2_path = os.path.join(tmpdir_path, "result2")
@@ -320,10 +327,17 @@ class TestAttachmentUpload:
         # Verify _manifest_snapshot was called with the correct arguments
         assert mock_manifest_snapshot.call_count == 2
 
+        # Verify time.time() was called to generate the timestamp for the diff directory
+        mock_time.time.assert_called_once()
+
+        # Verify the diff directory name contains the expected timestamp (milliseconds)
+        expected_timestamp_ms = int(frozen_timestamp * 1000)
+        expected_diff_dir = os.path.join(os.getcwd(), f"diff-{expected_timestamp_ms}")
+
         # Check first call
         mock_manifest_snapshot.assert_any_call(
             root="/root1",
-            destination=os.path.join(os.getcwd(), "diff"),
+            destination=expected_diff_dir,
             name=f"output-{os.path.basename(hash1_job_path)}",
             diff=hash1_job_path,
             include=[f"{include_dir1}/**", f"{include_dir2}/**"],
@@ -332,7 +346,7 @@ class TestAttachmentUpload:
         # Check second call
         mock_manifest_snapshot.assert_any_call(
             root="/root2",
-            destination=os.path.join(os.getcwd(), "diff"),
+            destination=expected_diff_dir,
             name=f"output-{os.path.basename(merge_hash2_path)}",
             diff=merge_hash2_path,
             include=[f"{include_dir3}/**"],

--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -16,19 +16,24 @@ from deadline_worker_agent.sessions.actions.scripts.attachment_upload import (
 
 
 @pytest.fixture
-def path_mapping_file_path():
+def tmpdir_path():
     with tempfile.TemporaryDirectory() as tmpdir_path:
-        path_mapping_file_path: str = os.path.join(tmpdir_path, "mapping.json")
-        # Write the path mapping rules to the file
-        path_mapping_rules = {
-            "path_mapping_rules": [
-                {"destination_path": "/root1", "source_path": "/source_root1"},
-                {"destination_path": "/root2", "source_path": "/source_root2"},
-            ]
-        }
-        with open(path_mapping_file_path, "w") as f:
-            json.dump(path_mapping_rules, f)
-        yield path_mapping_file_path
+        yield tmpdir_path
+
+
+@pytest.fixture
+def path_mapping_file_path(tmpdir_path):
+    path_mapping_file_path: str = os.path.join(tmpdir_path, "mapping.json")
+    # Write the path mapping rules to the file
+    path_mapping_rules = {
+        "path_mapping_rules": [
+            {"destination_path": "/root1", "source_path": "/source_root1"},
+            {"destination_path": "/root2", "source_path": "/source_root2"},
+        ]
+    }
+    with open(path_mapping_file_path, "w") as f:
+        json.dump(path_mapping_rules, f)
+    yield path_mapping_file_path
 
 
 @pytest.fixture
@@ -241,33 +246,76 @@ class TestAttachmentUpload:
         )
 
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload._manifest_snapshot")
-    def test__manifest_snapshot_diff_include(self, mock_manifest_snapshot: Mock):
+    def test_manifest_snapshot_diff_include(self, mock_manifest_snapshot: Mock, tmpdir_path: str):
+        # Create the result files that will be returned by the mock
+        result1_path = os.path.join(tmpdir_path, "result1")
+        result2_path = os.path.join(tmpdir_path, "result2")
+
+        # Write some content to the result files
+        with open(result1_path, "w") as f:
+            f.write("This is result1 content")
+
+        with open(result2_path, "w") as f:
+            f.write("This is result2 content")
+
         # Setup mock for _manifest_snapshot to return some manifests
         mock_manifest_snapshot.side_effect = [
             Mock(
-                manifest="/path/to/result1",
+                manifest=result1_path,
             ),
             Mock(
-                manifest="/path/to/result2",
+                manifest=result2_path,
             ),
         ]
 
+        # Create base directory and files
+        base_dir = os.path.join(tmpdir_path, "base")
+        os.makedirs(base_dir, exist_ok=True)
+
+        hash1_job_path = os.path.join(base_dir, "hash1_job")
+        with open(hash1_job_path, "w") as f:
+            f.write("hash1_job content")
+
+        merge_hash2_path = os.path.join(base_dir, "merge-hash2-timestamp.manifest")
+        with open(merge_hash2_path, "w") as f:
+            f.write("merge-hash2-timestamp.manifest content")
+
         # Define test input data
         manifest_path_by_root = {
-            "/root1": "/path/to/base/manifest1",
-            "/root2": "/path/to/base/manifest2",
+            "/root1": hash1_job_path,
+            "/root2": merge_hash2_path,
         }
 
+        # Create include directories
+        include_dir1 = os.path.join(tmpdir_path, "include", "dir1")
+        include_dir2 = os.path.join(tmpdir_path, "include", "dir2")
+        include_dir3 = os.path.join(tmpdir_path, "include", "dir3")
+
         out_rel_dirs_by_root = {
-            "/root1": ["/path/to/include/dir1", "/path/to/include/dir2"],
-            "/root2": ["/path/to/include/dir3"],
+            "/root1": [include_dir1, include_dir2],
+            "/root2": [include_dir3],
         }
 
         # Call the function under test
         result = snapshot(manifest_path_by_root, out_rel_dirs_by_root)
 
         # Verify the results
-        assert result == ["/path/to/result1", "/path/to/result2"]
+        expected_results = [
+            os.path.join(tmpdir_path, "hash1_output"),
+            os.path.join(tmpdir_path, "hash2_output"),
+        ]
+        assert result == expected_results
+
+        # Verify that the files in expected_results actually exist on disk
+        for file_path in expected_results:
+            assert os.path.exists(file_path), f"File {file_path} does not exist on disk"
+            assert os.path.isfile(file_path), f"Path {file_path} is not a file"
+            with open(file_path, "r") as f:
+                content = f.read()
+                reusult = "result1" if "hash1" in file_path else "result2"
+                assert f"This is {reusult} content" in content, (
+                    f"File {file_path} doesn't contain expected content"
+                )
 
         # Verify _manifest_snapshot was called with the correct arguments
         assert mock_manifest_snapshot.call_count == 2
@@ -276,18 +324,18 @@ class TestAttachmentUpload:
         mock_manifest_snapshot.assert_any_call(
             root="/root1",
             destination=os.path.join(os.getcwd(), "diff"),
-            name=f"output-{os.path.basename('/path/to/base/manifest1')}",
-            diff="/path/to/base/manifest1",
-            include=["/path/to/include/dir1/**", "/path/to/include/dir2/**"],
+            name=f"output-{os.path.basename(hash1_job_path)}",
+            diff=hash1_job_path,
+            include=[f"{include_dir1}/**", f"{include_dir2}/**"],
         )
 
         # Check second call
         mock_manifest_snapshot.assert_any_call(
             root="/root2",
             destination=os.path.join(os.getcwd(), "diff"),
-            name=f"output-{os.path.basename('/path/to/base/manifest2')}",
-            diff="/path/to/base/manifest2",
-            include=["/path/to/include/dir3/**"],
+            name=f"output-{os.path.basename(merge_hash2_path)}",
+            diff=merge_hash2_path,
+            include=[f"{include_dir3}/**"],
         )
 
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.api.attachment_upload")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have detected an issue with job download-output when using Linux Service Managed Fleet with Deadline CLI < 0.49.4. When download output the command claim to succeed but will not download the job output. That's because the new asset sync as job user feature changed the output manifest name format, and old client was not able to support it.

### What was the solution? (How)
Quick fix to update the manifest name format back from caller.

### What is the impact of this change?
Job runs under the run as job user code path is able to produce output manifest in s3 that works with old client for `job download-output`.

### How was this change tested?
- Ran E2E tests
- Verified file names in s3
- Verify `job output-download` result
```
 ~> deadline job download-output --job-id job-3e61434c43304712ab8202c82fbc5c53
Downloading output from Job 'Step-Step Dependency Test'

Summary of files to download:
bealine-wa/deadline-cloud-worker-agent/test/e2e/job_attachment_bundle/dep_data_flow/linux_bundle/data_dir (8 files)

You are about to download files which may come from multiple root directories. Here are a list of the current root directories:
[0]bealine-wa/deadline-cloud-worker-agent/test/e2e/job_attachment_bundle/dep_data_flow/linux_bundle
> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download (0, y, n) [y]: ~/Download/
Error: '~/Download/' is not one of '0', 'y', 'n'.
> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download (0, y, n) [y]: y

Summary of file paths to download:
 bealine-wa/deadline-cloud-worker-agent/test/e2e/job_attachment_bundle/dep_data_flow/linux_bundle/data_dir/Step1-2.%d.out (4 files, sequence 8-11)
bealine-wa/deadline-cloud-worker-agent/test/e2e/job_attachment_bundle/dep_data_flow/linux_bundle/data_dir/Step1-2-3.out (1 file)
bealine-wa/deadline-cloud-worker-agent/test/e2e/job_attachment_bundle/dep_data_flow/linux_bundle/data_dir/Step1-2-34-5.out (1 file)
bealine-wa/deadline-cloud-worker-agent/test/e2e/job_attachment_bundle/dep_data_flow/linux_bundle/data_dir/Step1-2-4.out (1 file)
bealine-wa/deadline-cloud-worker-agent/test/e2e/job_attachment_bundle/dep_data_flow/linux_bundle/data_dir/Step1.out (1 file)

Downloading Outputs  [####################################]  100%
Download Summary:
    Downloaded 8 files totaling 1.95 KB.
    Total download time of 0.35701 seconds at 5.46 KB/s.
    Download locations (total file counts):
bealine-wa/deadline-cloud-worker-agent/test/e2e/job_attachment_bundle/dep_data_flow/linux_bundle (8 files)
```

### Was this change documented?
Not applicable

### Is this a breaking change?
This is a fix for a breaking change to restore backward compatibility.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*