### PR TITLE
chore: bump test-fixtures dependecy version to 0.18.*

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,8 +1,7 @@
 backoff == 2.2.*
 coverage[toml] ~= 7.8
 coverage-conditional-plugin == 0.9.*
-# The fixture code relies on a bugfix in 0.17.1
-deadline-cloud-test-fixtures >= 0.17.1, < 0.19
+deadline-cloud-test-fixtures == 0.18.*
 flaky == 3.8.*
 pytest ~= 8.4
 pytest-cov == 6.1.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Several bug fixes in test-fixtures 0.18.* that we want picked up

### What was the solution? (How)

Updated requirements-testing.txt

### What is the impact of this change?

New test fixtures version should reduce flaky e2e tests.

### How was this change tested?

Locally ran the e2e tests with the new version of test fixtures. 

### Was this change documented?

no

### Is this a breaking change?

no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*