### PR TITLE
chore(bump): update openjd-sessions to 0.10.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline == 0.50.*",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.10.3",
+    "openjd-sessions == 0.10.4",
     "openjd-model >= 0.8.1, < 0.9",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We are not on the latest version of `openjd-sessions`

### What was the solution? (How)
Bump to the latest version, `0.10.4`

### What is the impact of this change?
Up to date on released dependencies.

### How was this change tested?
Ran the unit tests and confirmed they passed.

### Was this change documented?
N/A.

### Is this a breaking change?
No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*