### PR TITLE
feat: macOS worker can kill session processes and shutdown host

### DIFF
--- a/src/deadline_worker_agent/scheduler/session_cleanup.py
+++ b/src/deadline_worker_agent/scheduler/session_cleanup.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import subprocess
-import os
+import sys
 import getpass
 from threading import Lock
 
@@ -95,9 +95,13 @@ class SessionUserCleanupManager:
     @staticmethod
     def _posix_cleanup_user_processes(user: SessionUser):
         assert isinstance(user, PosixSessionUser)
+        pkill_opt = ["-eU", user.user]
+        if sys.platform == "darwin":
+            pkill_opt = ["-lU", user.user]
+
         try:
             pkill_result = subprocess.run(
-                args=["sudo", "-u", user.user, "/usr/bin/pkill", "-eU", user.user],
+                args=["sudo", "-u", user.user, "/usr/bin/pkill", *pkill_opt],
                 capture_output=True,
                 check=True,
                 text=True,
@@ -112,10 +116,12 @@ class SessionUserCleanupManager:
                 logger.warning(f"Failed to stop processes running as '{user.user}': {e}")
                 raise
         else:
-            # pkill stdout will look like:
+            # AL2023 pkill -e stdout will look like:
             #  killed (pid 1111)
             #  killed (pid 2222)
-            #  etc.
+            # macOS pkill -l stdout will look like:
+            #  kill -15 1111
+            #  kill -15 2222
             pkill_output = "\n".join([pkill_result.stdout, pkill_result.stderr]).rstrip()
             logger.info(f"Stopped processes:\n{pkill_output}")
 
@@ -173,7 +179,7 @@ class SessionUserCleanupManager:
 
         logger.info(f"Cleaning up remaining session user processes for '{user.user}'")
 
-        if os.name == "posix":
-            SessionUserCleanupManager._posix_cleanup_user_processes(user)
-        else:
+        if sys.platform == "win32":
             SessionUserCleanupManager._windows_cleanup_user_processes(user)
+        else:
+            SessionUserCleanupManager._posix_cleanup_user_processes(user)

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -331,6 +331,8 @@ def _host_shutdown(config: Configuration) -> None:
 
     if sys.platform == "win32":
         shutdown_command = ["shutdown", "-s"]
+    elif sys.platform == "darwin":
+        shutdown_command = ["sudo", "shutdown", "-r", "now"]
     else:
         shutdown_command = ["sudo", "shutdown", "now"]
 

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -332,7 +332,7 @@ def _host_shutdown(config: Configuration) -> None:
     if sys.platform == "win32":
         shutdown_command = ["shutdown", "-s"]
     elif sys.platform == "darwin":
-        shutdown_command = ["sudo", "shutdown", "-r", "now"]
+        shutdown_command = ["sudo", "shutdown", "-h", "now"]
     else:
         shutdown_command = ["sudo", "shutdown", "now"]
 

--- a/test/unit/scheduler/test_session_cleanup.py
+++ b/test/unit/scheduler/test_session_cleanup.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from typing import Generator
 from unittest.mock import MagicMock, patch
-import subprocess
 
 from openjd.sessions import SessionUser, PosixSessionUser, WindowsSessionUser
 import pytest
-import os
 
 from deadline_worker_agent.scheduler.session_cleanup import (
     SessionUserCleanupManager,
@@ -208,13 +209,15 @@ class TestSessionUserCleanupManager:
             assert (
                 f"Cleaning up remaining session user processes for '{os_user.user}'" in caplog.text
             )
-            if os.name == "posix":
-                subprocess_run_mock.assert_called_once_with(
-                    args=["sudo", "-u", os_user.user, "/usr/bin/pkill", "-eU", os_user.user],
-                    capture_output=True,
-                    check=True,
-                    text=True,
-                )
+            pkill_opt = ["-eU", os_user.user]
+            if sys.platform == "darwin":
+                pkill_opt = ["-lU", os_user.user]
+            subprocess_run_mock.assert_called_once_with(
+                args=["sudo", "-u", os_user.user, "/usr/bin/pkill", *pkill_opt],
+                capture_output=True,
+                check=True,
+                text=True,
+            )
             assert "Stopped processes:\n" in caplog.text
 
         @pytest.mark.skipif(os.name != "nt", reason="Windows-only test.")

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -529,6 +529,7 @@ def test_agent_self_initiated_shutdown(
     (
         pytest.param("win32", ["shutdown", "-s"], id="windows"),
         pytest.param("linux", ["sudo", "shutdown", "now"], id="linux"),
+        pytest.param("darwin", ["sudo", "shutdown", "-h", "now"], id="macOS"),
     ),
 )
 @patch.object(entrypoint_mod._logger, "info")
@@ -567,6 +568,7 @@ def test_host_shutdown(
     (
         pytest.param("win32", ["shutdown", "-s"], id="windows"),
         pytest.param("linux", ["sudo", "shutdown", "now"], id="linux"),
+        pytest.param("darwin", ["sudo", "shutdown", "-h", "now"], id="macOS"),
     ),
 )
 @patch.object(entrypoint_mod, "_logger")
@@ -617,6 +619,7 @@ def test_host_shutdown_failure(
     (
         pytest.param("win32", ["shutdown", "-s"], id="windows"),
         pytest.param("linux", ["sudo", "shutdown", "now"], id="linux"),
+        pytest.param("darwin", ["sudo", "shutdown", "-h", "now"], id="macOS"),
     ),
 )
 @patch.object(entrypoint_mod._logger, "debug")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I encountered a few problems when running the worker agent on macOS, but identified two easy wins:

1. session cleanup was failing

```
WARNING  [...][WARNING ] Failed to stop processes running as 'deadline-qa-user': Command '['sudo', '-u', 'deadline-qa-user', '/usr/bin/pkill', '-eU',                   session_cleanup.py:112
         'deadline-qa-user']' returned non-zero exit status 2.                                                                                                                                                    
WARNING  [...][WARNING ] Failed to stop session user processes: Command '['sudo', '-u', 'deadline-qa-user', '/usr/bin/pkill', '-eU', 'deadline-qa-user']' returned       session_cleanup.py:81
         non-zero exit status 2.                                                                                                                                                                                  
INFO     [...][INFO    ] 🔷 Session.Complete 🔷
```

2. host shutdown was failing:

```
INFO     [...][INFO    ] The service has requested that the host be shutdown. Setting Worker state to STOPPING.                                                                                                                                                                                                                                                                                                                             entrypoint.py:235
INFO     [...][INFO    ] 📤 API.Req 📤 [deadline:UpdateWorker] resource={'farm-id': 'farm-...', 'fleet-id': 'fleet-...', 'worker-id': 'worker-...'} params={'status': 'STOPPING'}                                                                                                                                                                session_events.py:408
            request_url=...                                                                                                                                                                                                                                                    
INFO     [...][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorker](200) params={} request_id=...                                                                                                                                                                                                                                                                                                         session_events.py:524
INFO     [...][INFO    ] 💻 Worker.Status 💻 Status set to STOPPING. [farm-.../fleet-.../worker-...]                                                                                                                                                                                                                                                 entrypoint.py:257
INFO     [...][INFO    ] Shutting down the host                                                                                                                                                                                                                                                                                                                                                                                             entrypoint.py:328
ERROR    [...][ERROR   ] Shutdown command (['sudo', 'shutdown', 'now']) failed with return code: 1: shutdown: -h, -r, -s or -k is required                                                                                                                                                                                                                                                                                                  entrypoint.py:349
            usage: shutdown [-] [-h | -r | -s | -k] [-o [-n]] [-q] time [warning-message ...]       
```

### What was the solution? (How)

1. Modify the pkill arguments on macOS to get similar behaviour.

When there are no processes:
```
INFO     [...][INFO    ] 🔷 Session.Runtime 🔷 [session-...] Process pid 72933 exited with code: 127 (unsigned) / 0x7f (hex) [queue-.../job-...]                                                                           _subprocess.py:441
INFO     [...][INFO    ] Cleaning up remaining session user processes for 'deadline-qa-user'                                                                                                                                                                                                                  session_cleanup.py:180
INFO     [...][INFO    ] No processes stopped because none were found running as 'deadline-qa-user'                                                                                                                                                                                                           session_cleanup.py:111
INFO     [...][INFO    ] 🔷 Session.Complete 🔷 [session-...] Session complete. [queue-.../job-...]
```

When there are processes:

```
$ sudo -u deadline-qa-user ps
  PID TTY           TIME CMD
98865 ttys016    0:00.01 sleep 1000
```

```
INFO     [...][INFO    ] Cleaning up remaining session user processes for 'deadline-qa-user'                                                                                                                                                                                                                  session_cleanup.py:180
INFO     [...][INFO    ] Stopped processes:                                                                                                                                                                                                                                                                   session_cleanup.py:126
            kill -15 98865                                                                                                                                                                                                                                                                                                                                 
INFO     [...][INFO    ] 🔷 Session.Complete 🔷 [session-...] Session complete. [queue-.../job-...]                                                                                                                          scheduler.py:663
```

2. Modify the arguments on macOS to get similar behaviour.

```
[...][INFO    ] The service has requested that the host be shutdown. Setting Worker state to STOPPING.
[...][INFO    ] 📤 API.Req 📤 [deadline:UpdateWorker] resource={'farm-id': '...', 'fleet-id': 'fleet-...', 'worker-id': 'worker-...'} params={'status': 'STOPPING'} request_url=...
[...][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorker](200) params={} request_id=...
[...][INFO    ] 💻 Worker.Status 💻 Status set to STOPPING. [farm-.../fleet-.../worker-...]
[...][INFO    ] Shutting down the host
```

and then my machine shutdown 😬 👍 

### What is the impact of this change?

macOS worker agents have slightly more feature parity with the other operating systems!

### How was this change tested?

Updated and ran tests. Also ran this all locally to validate it all works (as shown above in the solution section)

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*