### PR TITLE
chore(deps): update mypy from ~=1.17 to >= 1.17, <1.18 to avoid break…

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -9,7 +9,7 @@ pytest-timeout == 2.4.*
 pytest-xdist == 3.8.*
 rich == 14.1.*
 types-python-dateutil ~= 2.9
-mypy ~= 1.17
+mypy >= 1.17, < 1.18
 types-requests ~= 2.31; python_version < "3.10"
 types-requests ~= 2.32; python_version >= "3.10"
 ruff ~= 0.13.0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Mypy just released v1.18.1 that had a breaking change with pydantic (https://github.com/python/mypy/issues/19835). This caused our mypy check to fail with the following message.

```
/lib/python3.11/site-packages/pydantic/v1/env_settings.py:23: error: INTERNAL ERROR -- Please try using mypy master on GitHub:
https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
If this issue continues with mypy master, please report a bug at https://github.com/python/mypy/issues
version: 1.18.1
/lib/python3.11/site-packages/pydantic/v1/env_settings.py:23: : note: please use --show-traceback to print a traceback when reporting a bug
```

### What was the solution? (How)
Fix the version to < 1.18 until mypy release a fix.

### What is the impact of this change?
Get local and github CI mypy check to pass.

### How was this change tested?
Local mypy check and `hatch run lint` passed

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*