### PR TITLE
test: add cleanup script for e2e tests

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -11,7 +11,10 @@ test = "pytest test/unit --numprocesses=auto {args}"
 # See: https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers
 version = "hatch version"
 metadata = "hatch project metadata {args:}"
-e2e-test= "pytest --no-cov test/e2e {args:}"
+e2e-test= [
+  "python test/e2e/pre_test_cleanup.py",
+  "pytest --no-cov test/e2e {args:}",
+]
 integ-test = "pytest --no-cov test/integ {args:}"
 typing = "mypy {args:src test}"
 style = [

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -5,6 +5,7 @@ import dataclasses
 import logging
 import os
 import pytest
+
 from dataclasses import dataclass, field, InitVar
 from typing import Callable, Generator, Type
 from contextlib import contextmanager
@@ -20,6 +21,7 @@ from deadline_test_fixtures import (
     BootstrapResources,
     PosixSessionUser,
     OperatingSystem,
+    Ec2Tag,
 )
 import pytest
 
@@ -71,7 +73,9 @@ class DeadlineResources:
             Queue(id=jobs_run_as_agent_user_queue_id, farm=self.farm),
         )
         object.__setattr__(
-            self, "non_valid_role_queue", Queue(id=non_valid_role_queue_id, farm=self.farm)
+            self,
+            "non_valid_role_queue",
+            Queue(id=non_valid_role_queue_id, farm=self.farm),
         )
         object.__setattr__(self, "fleet", Fleet(id=fleet_id, farm=self.farm, autoscaling=False))
         object.__setattr__(self, "scaling_queue", Queue(id=scaling_queue_id, farm=self.farm))
@@ -94,6 +98,7 @@ def deadline_resources() -> Generator[DeadlineResources, None, None]:
         SCALING_QUEUE_ID: ID of the Deadline scaling queue to use.
         SCALING_FLEET_ID: ID of the Deadline scaling fleet to use.
         JOB_STORAGE_PROFILE_ID: ID of the Deadline storage profile to use
+        TEST_CATEGORY: The type of test that's being run. Will usually be one of dev, <OS>Mainline, or <OS>Release
 
     Returns:
         DeadlineResources: The Deadline resources used for tests
@@ -108,6 +113,7 @@ def deadline_resources() -> Generator[DeadlineResources, None, None]:
     scaling_queue_id = os.environ["SCALING_QUEUE_ID"]
     scaling_fleet_id = os.environ["SCALING_FLEET_ID"]
     job_storage_profile_id = os.environ["JOB_STORAGE_PROFILE_ID"]
+    test_category = os.environ.get("TEST_CATEGORY", "dev")
 
     LOG.info(
         f"Configured Deadline Cloud Resources - Farm ID: {farm_id}, "
@@ -118,6 +124,7 @@ def deadline_resources() -> Generator[DeadlineResources, None, None]:
         f"Queue B ID: {queue_b_id}, "
         f"Fleet ID: {fleet_id}, "
         f"Jobs Run As Agent User Queue ID: {jobs_run_as_agent_user_queue_id}, "
+        f"Test Type: {test_category}, "
     )
 
     sts_client = boto3.client("sts")
@@ -164,7 +171,11 @@ def worker_config(
     """
     return dataclasses.replace(
         worker_config,
-        job_users=[posix_job_user, posix_config_override_job_user, posix_env_override_job_user],
+        job_users=[
+            posix_job_user,
+            posix_config_override_job_user,
+            posix_env_override_job_user,
+        ],
         windows_job_users=windows_job_users,
     )
 
@@ -269,6 +280,7 @@ def create_worker(
         security_group_id = os.getenv("SECURITY_GROUP_ID")
         instance_type = os.getenv("WORKER_INSTANCE_TYPE", default="t3.large")
         instance_shutdown_behavior = os.getenv("WORKER_INSTANCE_SHUTDOWN_BEHAVIOR", default="stop")
+        test_category = os.getenv("TEST_CATEGORY", "dev")
 
         assert subnet_id, "SUBNET_ID is required when deploying an EC2 worker"
         assert security_group_id, "SECURITY_GROUP_ID is required when deploying an EC2 worker"
@@ -296,6 +308,7 @@ def create_worker(
             configuration=worker_config,
             instance_type=instance_type,
             instance_shutdown_behavior=instance_shutdown_behavior,
+            additional_tags=[Ec2Tag(key="TestCategory", value=test_category)],
         )
 
     @contextmanager

--- a/test/e2e/pre_test_cleanup.py
+++ b/test/e2e/pre_test_cleanup.py
@@ -1,0 +1,242 @@
+"""
+Utility script for cleaning up the test environment before running
+Deadline Cloud Worker Agent E2E tests. Will terminate all instances
+tagged with InstanceIdentification=DeadlineScaffoldingWorker and
+TestCategory=<Value of TEST_CATEGORY environment variable> by default
+test instances are tagged with "dev"
+
+You must first follow the E2E test setup instructions in DEVELOPMENT.md and source
+the environment files before running this script.
+
+This script will automatically run before the tests, if the tests are run with
+hatch run e2e-test
+"""
+
+from typing import Any
+import time
+import boto3
+import boto3.session
+
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from botocore.client import BaseClient
+from botocore.exceptions import ClientError
+from botocore.config import Config
+
+from deadline.client.api import _list_jobs_by_filter_expression
+from deadline_test_fixtures.deadline.resources import COMPLETE_TASK_STATUSES, TaskStatus
+
+
+LOG = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+
+@dataclass
+class QueueJob:
+    job_id: str
+    queue_id: str
+
+
+def terminate_instances_and_wait(ec2_client: BaseClient, instances: list[str]) -> None:
+    if not instances:
+        LOG.info("No instances to terminate")
+        return
+    instances_to_wait_on: list[str] = []
+
+    # Delete instances one by one instead of terminating them
+    # in a batch call, otherwise the error handling can get messy.
+    # If there's at least one instance that isn't valid in the
+    # InstanceIds list then the whole call fails.
+    LOG.info("Terminating %s leftover instances", len(instances))
+    for instance in instances:
+        try:
+            LOG.info("Terminating %s", instance)
+            ec2_client.terminate_instances(
+                InstanceIds=[instance],
+                Force=True,
+                SkipOsShutdown=True,
+            )
+            # We only want to wait on instances to terminate
+            # that exist
+            instances_to_wait_on.append(instance)
+            LOG.info("Succesfully terminated %s", instance)
+        except ClientError as e:
+            # If an instance id isn't valid anymore we can assume
+            # it's already been deleted, so we can ignore it.
+            if e.response["Error"]["Code"].startswith("InvalidInstanceID"):
+                LOG.warning(
+                    "Instance %s failed to be terminated, doesn't exist: %s", instance, exc_info=e
+                )
+                continue
+            LOG.error("Error encountered cleaning up instance %s", instance, exc_info=e)
+            raise e
+
+    waiter = ec2_client.get_waiter("instance_terminated")
+
+    LOG.info("Waiting for instances to terminate")
+    waiter.wait(InstanceIds=instances_to_wait_on)
+    LOG.info("All instances have been terminated")
+
+
+def get_all_test_tagged_instances(ec2_client: BaseClient) -> list[str]:
+    paginator = ec2_client.get_paginator("describe_instances")
+    tagged_instances: list[str] = []
+
+    test_category = os.getenv("TEST_CATEGORY", "dev")
+
+    response_iterator = paginator.paginate(
+        Filters=[
+            {
+                "Name": "tag:InstanceIdentification",
+                "Values": [
+                    "DeadlineScaffoldingWorker",
+                ],
+            },
+            {"Name": "tag:TestCategory", "Values": [test_category]},
+        ],
+    )
+
+    LOG.info("Collecting all tests tagged with TestCategory: %s", test_category)
+
+    for response in response_iterator:
+        for reservation in response["Reservations"]:
+            for instance in reservation["Instances"]:
+                tagged_instances.append(instance["InstanceId"])
+
+    return tagged_instances
+
+
+def cleanup_ec2_instances(ec2_client: BaseClient) -> None:
+    test_tagged_instances = get_all_test_tagged_instances(ec2_client)
+    terminate_instances_and_wait(ec2_client, test_tagged_instances)
+
+
+def get_incomplete_jobs(
+    boto3_session: boto3.Session, farm_id: str, queues: list[str]
+) -> list[QueueJob]:
+    filters: list[dict[str, dict[str, str]]] = []
+    jobs: list[QueueJob] = []
+
+    for status in COMPLETE_TASK_STATUSES:
+        filters.append(
+            {
+                "stringFilter": {
+                    "name": "TASK_RUN_STATUS",
+                    "operator": "NOT_EQUAL",
+                    "value": status,
+                }
+            }
+        )
+
+    list_jobs: list[dict[str, Any]] = []
+
+    LOG.info("Fetching jobs that aren't yet completed")
+    for queue in queues:
+        list_jobs.extend(
+            _list_jobs_by_filter_expression._list_jobs_by_filter_expression(
+                boto3_session,
+                farm_id,
+                queue,
+                filter_expression={
+                    "filters": filters,
+                    "operator": "AND",
+                },
+            )
+        )
+
+    for job in list_jobs:
+        jobs.append(QueueJob(job_id=job["jobId"], queue_id=job["queueId"]))
+
+    return jobs
+
+
+def cancel_job(deadline_client: BaseClient, farm_id: str, job: QueueJob) -> None:
+    LOG.info("Cancelling job: %s", job.job_id)
+    deadline_client.update_job(
+        farmId=farm_id,
+        queueId=job.queue_id,
+        jobId=job.job_id,
+        targetTaskRunStatus=TaskStatus.CANCELED,
+    )
+
+
+def wait_for_jobs_to_be_cancelled(
+    deadline_client: BaseClient, farm_id: str, jobs: list[QueueJob]
+) -> None:
+    max_retries_seconds = 30
+
+    LOG.info("Waiting for jobs to be cancelled")
+    for job in jobs:
+        tries = 0
+        while True:
+            response = deadline_client.get_job(
+                farmId=farm_id, queueId=job.queue_id, jobId=job.job_id
+            )
+
+            if response["taskRunStatus"] == TaskStatus.CANCELED:
+                break
+
+            tries += 1
+
+            if tries >= max_retries_seconds:
+                raise RuntimeError(f"Job {job.job_id} failed to cancel in {max_retries_seconds}")
+
+            time.sleep(1)
+
+
+def cleanup_queues(
+    session: boto3.Session, deadline_client: BaseClient, farm_id: str, queues: list[str]
+) -> None:
+    jobs = get_incomplete_jobs(session, farm_id, queues)
+
+    if not jobs:
+        LOG.info("No jobs to cleanup")
+        return
+
+    LOG.info("Attempting to cancel %s jobs", len(jobs))
+    for job in jobs:
+        cancel_job(deadline_client, farm_id, job)
+
+    wait_for_jobs_to_be_cancelled(deadline_client, farm_id, jobs)
+
+
+def get_queues() -> list[str]:
+    try:
+        return [
+            os.environ["QUEUE_A_ID"],
+            os.environ["QUEUE_B_ID"],
+            os.environ["JOBS_RUN_AS_AGENT_USER_QUEUE_ID"],
+            os.environ["NON_VALID_ROLE_QUEUE_ID"],
+            os.environ["SCALING_QUEUE_ID"],
+        ]
+    except KeyError as e:
+        LOG.error("Missing needed queue environment variables", exc_info=e)
+        raise e
+
+
+def get_farm() -> str:
+    try:
+        return os.environ["FARM_ID"]
+    except KeyError as e:
+        LOG.error("Missing needed farm environment variable", exc_info=e)
+        raise e
+
+
+def cleanup_test_environment() -> None:
+    config = Config(retries={"mode": "adaptive"})
+
+    ec2_client = boto3.client("ec2", config=config)
+    cleanup_ec2_instances(ec2_client)
+
+    queues = get_queues()
+    farm_id = get_farm()
+
+    deadline_client = boto3.client("deadline", config=config)
+    session = boto3.session.Session()
+    cleanup_queues(session, deadline_client, farm_id, queues)
+
+
+if __name__ == "__main__":
+    cleanup_test_environment()

--- a/test/e2e/pre_test_cleanup.py
+++ b/test/e2e/pre_test_cleanup.py
@@ -1,3 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
 Utility script for cleaning up the test environment before running
 Deadline Cloud Worker Agent E2E tests. Will terminate all instances


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to be able to clean up old E2E tests resources before running E2E tests so that we can ensure that our tests are running in a clean environment.

### What was the solution? (How)
When tests create EC2 instances they will tag instances with the test category it'll be running as. Examples of this are LinuxMainline, WindowsMainline, LinuxRelease, WindowsRelease, etc.

I added a script that runs before the E2E tests when running `hatch run e2e-test`, the script will terminate all instances tagged with the appropriate test category (this will be in an environment variable) and cancel all unfinished jobs in the tests queues. The reason for tagging instances is so that a cleanup doesn't mess with test runs that are already going in the same account.

#### Why not a pytest fixture
Good question!

We only need to run this once at test start. All tests require the cleanup to run so we'd have to add the fixture to every test/test class as a session fixture, meaning it'd be easy for a dev to forget in the future. Additionally session fixtures get messy when parallelizing tests. The script avoids all of that. A nice side effect is that devs can also run the script without the tests if they just want to cleanup their environment without running tests.

#### Why can't we just delete instances tagged with the farm and queues of the running tests?
Another great question!

There's an edge case where the tests timeout and exit before the worker starts, so leftover instances may not have the tags that Deadline Cloud puts on the instances.

### What is the impact of this change?
Less flaky tests.

### How was this change tested?
Ran E2E tests and cancelled them early, ensuring that instances and unfinished jobs would be kept around. I then ran `hatch run e2e-test` and ensured that all appropriate resources were cleaned up and tests succeeded. I made sure to run a Windows test and Linux test at the same time cancelling both randomly and starting them again, ensuring that the only jobs and instances cleaned up were the ones that belonged to the previous test run.

### Was this change documented?
N/A

### Is this a breaking change?
No
----

NOTE: This can't be merged until https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/210 is in and released. This change depends on a change in that package.
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*