### PR TITLE
fix(experimental): Job Attachments does not fall back to COPIED when launching VFS fails

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -399,14 +399,12 @@ class AttachmentDownloadAction(OpenjdAction):
             and isinstance(fs_permission_settings, PosixFileSystemPermissionSettings)
         ):
             assert session._asset_sync is not None
-            session._asset_sync._launch_vfs(
+            return session._asset_sync._launch_vfs(
                 s3_settings=s3_settings,
                 session_dir=session.working_directory,
                 fs_permission_settings=fs_permission_settings,
                 merged_manifests_by_root=merged_manifests_by_root,
                 os_env_vars=dict(session._env),  # type: ignore
             )
-            return True
-
         else:
             return False

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -271,7 +271,8 @@ class TestStart:
 
 class TestVFS:
     @pytest.mark.skipif(sys.platform == "win32", reason="Test not supported on Windows")
-    def test_start_vfs_success(
+    @pytest.mark.parametrize("launch_vfs_return_value", [True, False])
+    def test_start_vfs_calling_asset_sync(
         self,
         executor: Mock,
         session: Mock,
@@ -279,9 +280,10 @@ class TestVFS:
         session_dir: Path,
         mock_asset_sync: MagicMock,
         job_details: JobDetails,
+        launch_vfs_return_value: bool,
     ) -> None:
         """
-        Tests that _start_vfs successfully launches VFS when all conditions are met
+        Tests that _start_vfs returns the correct value based on _launch_vfs result when all conditions are met
         """
 
         # Mock platform to be non-Windows
@@ -289,6 +291,9 @@ class TestVFS:
             # Set up session with required attributes for VFS
             session._os_user = PosixSessionUser(user="test-user", group="test-group")
             session._env = {"AWS_PROFILE": "test-profile"}
+
+            # Configure the mock to return the parameterized value when _launch_vfs is called
+            mock_asset_sync._launch_vfs.return_value = launch_vfs_return_value
 
             # Create attachments with VIRTUAL file system
             attachments = Attachments(
@@ -312,7 +317,7 @@ class TestVFS:
             )
 
             # THEN
-            assert result is True
+            assert result is launch_vfs_return_value
             mock_asset_sync._launch_vfs.assert_called_once_with(
                 s3_settings=s3_settings,
                 session_dir=session_dir,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `_start_vfs` method in `AttachmentDownloadAction` was not properly handling the boolean return value from `asset_sync._launch_vfs()`. 

The `_launch_vfs` method returns a boolean indicating whether VFS was successfully launched (`True` for success, `False` for failure to launch vfs), but `_start_vfs` was not correctly propagating this return value. As a result, when trying to launch vfs and fails, this is not falling back to `COPIED` correctly.

### What was the solution? (How)
Fix the value by directly returning the `asset_sync._launch_vfs()` result when attempting to launch vfs.

### What is the impact of this change?
Fix the bug when launch vfs fails, it should fallback to COPIED mode.

### How was this change tested?
1. added unit tests
2. run E2E test with `VIRTUAL` file system and made sure the sync falls back to COPIED
```
2025/10/02 21:08:09-07:00 Running Session Actions as user: job-user
2025/10/02 21:08:09-07:00 ==============================================
2025/10/02 21:08:09-07:00 --------- Job Attachments Download for Job
2025/10/02 21:08:09-07:00 ==============================================
2025/10/02 21:08:09-07:00 Cwd when finding deadline_vfs is /home/deadline-worker
2025/10/02 21:08:09-07:00 DEADLINE_VFS_PATH env var not set
2025/10/02 21:08:09-07:00 Failed to find deadline_vfs!
2025/10/02 21:08:09-07:00 Failed to find both executables!
2025/10/02 21:08:09-07:00 Virtual File System not found, falling back to COPIED for JobAttachmentsFileSystem.
2025/10/02 21:08:09-07:00 ----------------------------------------------
2025/10/02 21:08:09-07:00 Phase: Setup
2025/10/02 21:08:09-07:00 ----------------------------------------------
2025/10/02 21:08:09-07:00 Writing embedded files for Task to disk.
2025/10/02 21:08:09-07:00 Mapping: Task.File.AttachmentDownload -> /sessions/session-b5a2c4099ab9479192b4bd660811c58fyshbq_ru/embedded_fileszfjd_opw/tmp5cx0nsn2
2025/10/02 21:08:09-07:00 Wrote: AttachmentDownload -> /sessions/session-b5a2c4099ab9479192b4bd660811c58fyshbq_ru/embedded_fileszfjd_opw/tmp5cx0nsn2
2025/10/02 21:08:09-07:00 ----------------------------------------------
2025/10/02 21:08:09-07:00 Phase: Running action
2025/10/02 21:08:09-07:00 ----------------------------------------------
2025/10/02 21:08:09-07:00 Running command sudo -u job-user -i setsid -w /sessions/session-b5a2c4099ab9479192b4bd660811c58fyshbq_ru/tmp9xexgpkm.sh
2025/10/02 21:08:10-07:00 Command started as pid: 27219
2025/10/02 21:08:10-07:00 Output:
2025/10/02 21:08:10-07:00  
2025/10/02 21:08:10-07:00 Starting download...
2025/10/02 21:08:10-07:00 Processed 4 files totaling 380 B.
2025/10/02 21:08:10-07:00 Skipped re-processing 0 files totaling 0 B.
2025/10/02 21:08:10-07:00 Total processing time of 0.21004 seconds at 1.81 KB/s.
2025/10/02 21:08:10-07:00  
2025/10/02 21:08:10-07:00 Finished downloading after 0.34159305800000084 seconds
2025/10/02 21:08:10-07:00 Process pid 27219 exited with code: 0 (unsigned) / 0x0 (hex)
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*