### PR TITLE
feat(experimental): enhance download process by using WorkerManifestProperties and download_files_from_manifests

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -322,7 +322,6 @@ class AttachmentDownloadAction(OpenjdAction):
             key=lambda rule: -len(rule.source_path.parts)
         )
 
-        # ============================ DEPRECATED STARTD =====================================
         manifest_paths_by_root = session._asset_sync._check_and_write_local_manifests(
             merged_manifests_by_root=merged_manifests_by_root,
             manifest_write_dir=str(session.working_directory),
@@ -331,45 +330,37 @@ class AttachmentDownloadAction(OpenjdAction):
         # Set the manifests by root mapping to session for attachment upload to determine output
         for root_name, root_path in manifest_paths_by_root.items():
             session.add_manifest_path(root=root_name, path=root_path)
-        # ============================ DEPRECATED END =====================================
 
         # Create WorkerManifestProperties list for enhanced worker agent processing
-        # Now that we have merged_manifests_by_root and manifest_path_by_root available
-
-        download_manifest_properties_list: list[WorkerManifestProperties] = list()
         if not step_dependencies:
             for manifest_properties in manifest_properties_list:
-                # Create WorkerManifestProperties with local paths and manifest TODO
                 local_root_path: str = session._asset_sync.get_local_destination(
                     manifest_properties=manifest_properties,
                     dynamic_mapping_rules=dynamic_mapping_rules,
                     storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules_dict,
                 )
 
-                # Check if there's a manifest file for this source root path
-                manifest_path = manifest_paths_by_root.get(local_root_path)
+                # Create worker manifest property and add to session
                 worker_manifest_props = WorkerManifestProperties(
                     manifest_properties=manifest_properties,
                     local_root_path=local_root_path,
-                    local_manifest_paths=[manifest_path] if manifest_path else [],
-                    local_input_manifest_path=manifest_path,
                 )
                 session.set_worker_manifest_properties(worker_manifest_props)
-                download_manifest_properties_list.append(worker_manifest_props)
 
-        else:
-            assert session.get_worker_manifest_properties_list() is not None
-            # If we already have cached WorkerManifestProperties (e.g., for step dependency),
-            # add the manifest paths from manifest_path_by_root to the existing properties
-            for local_root_path, manifest_path in manifest_paths_by_root.items():
-                # if manifest_path:
-                session.add_local_manifest_path(
-                    local_root_path=local_root_path, manifest_path=manifest_path
-                )
-                curr = session.get_worker_manifest_properties(local_root_path=local_root_path)
-                assert curr is not None
-                curr.local_input_manifest_path(local_root_path)
-                download_manifest_properties_list.append(worker_manifest_props)
+        # Prepare input manifest for download task run
+        download_manifest_properties_list: list[WorkerManifestProperties] = list()
+        for local_root_path, manifest_path in manifest_paths_by_root.items():
+            session.add_local_manifest_path(
+                local_root_path=local_root_path, manifest_path=manifest_path
+            )
+            download_manifest = session.get_worker_manifest_properties(
+                local_root_path=local_root_path
+            )
+            assert download_manifest is not None
+            # Set the input file path for download
+            download_manifest.local_input_manifest_path = manifest_path
+            # Add to list for passing to step scripts
+            download_manifest_properties_list.append(download_manifest)
 
         #  Try to launch VFS if needed once all files are prepared
         if self._start_vfs(

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -109,16 +109,6 @@ class AttachmentDownloadAction(OpenjdAction):
         # Create embedded files for each manifest and collect temporary paths
         embedded_files = []
 
-        # Add the main attachment download script
-        with open(Path(__file__).parent / "scripts" / "attachment_download.py", "r") as f:
-            embedded_files.append(
-                EmbeddedFileText_2023_09(
-                    name="AttachmentDownload",
-                    type=EmbeddedFileTypes_2023_09.TEXT,
-                    data=DataString(f.read()),
-                )
-            )
-
         # Create embedded file for worker manifest properties
         worker_props_data = []
         for worker_props in worker_manifest_properties_list:
@@ -134,8 +124,9 @@ class AttachmentDownloadAction(OpenjdAction):
         )
 
         # Build the command arguments
+        download_script_path = Path(__file__).parent / "scripts" / "attachment_download.py"
         args = [
-            ArgString("{{ Task.File.AttachmentDownload }}"),
+            ArgString(str(download_script_path)),
             ArgString("-s3"),
             ArgString(s3_settings.to_s3_root_uri()),
             ArgString("-wp"),
@@ -332,6 +323,8 @@ class AttachmentDownloadAction(OpenjdAction):
             session.add_manifest_path(root=root_name, path=root_path)
 
         # Create WorkerManifestProperties list for enhanced worker agent processing
+        # Populate the manifest properties data from sync job input step
+        # The data is avavilable for subsequent actions such as sync step step
         if not step_dependencies:
             for manifest_properties in manifest_properties_list:
                 local_root_path: str = session._asset_sync.get_local_destination(
@@ -350,13 +343,9 @@ class AttachmentDownloadAction(OpenjdAction):
         # Prepare input manifest for download task run
         download_manifest_properties_list: list[WorkerManifestProperties] = list()
         for local_root_path, manifest_path in manifest_paths_by_root.items():
-            session.add_local_manifest_path(
+            download_manifest = session.add_local_manifest_path(
                 local_root_path=local_root_path, manifest_path=manifest_path
             )
-            download_manifest = session.get_worker_manifest_properties(
-                local_root_path=local_root_path
-            )
-            assert download_manifest is not None
             # Set the input file path for download
             download_manifest.local_input_manifest_path = manifest_path
             # Add to list for passing to step scripts

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -6,6 +6,8 @@ from concurrent.futures import (
 )
 import os
 import sys
+import json
+
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from logging import LoggerAdapter
 from typing import Any, TYPE_CHECKING, Optional
@@ -49,6 +51,7 @@ from openjd.model import ParameterValue
 
 from ...log_messages import SessionActionLogKind
 from .openjd_action import OpenjdAction
+from ..attachment_models import WorkerManifestProperties
 
 if TYPE_CHECKING:
     from ..session import Session
@@ -89,24 +92,54 @@ class AttachmentDownloadAction(OpenjdAction):
         self._step_details = step_details
         self._logger = LoggerAdapter(OPENJD_LOG, extra={"session_id": session_id})
 
-    def set_step_script(self, manifests: list[str], s3_settings: JobAttachmentS3Settings) -> None:
+    def set_step_script(
+        self,
+        worker_manifest_properties_list: list[WorkerManifestProperties],
+        s3_settings: JobAttachmentS3Settings,
+    ) -> None:
         """Sets the step script for the action
 
         Parameters
         ----------
-        manifests : list[str]
-            The job attachment manifest paths
+        worker_manifest_properties_list : list[WorkerManifestProperties]
+            The worker manifest properties list containing manifest data
         s3_settings : JobAttachmentS3Settings
             The job attachment S3 settings
         """
+        # Create embedded files for each manifest and collect temporary paths
+        embedded_files = []
+
+        # Add the main attachment download script
+        with open(Path(__file__).parent / "scripts" / "attachment_download.py", "r") as f:
+            embedded_files.append(
+                EmbeddedFileText_2023_09(
+                    name="AttachmentDownload",
+                    type=EmbeddedFileTypes_2023_09.TEXT,
+                    data=DataString(f.read()),
+                )
+            )
+
+        # Create embedded file for worker manifest properties
+        worker_props_data = []
+        for worker_props in worker_manifest_properties_list:
+            worker_props_data.append(worker_props.to_dict())
+
+        worker_props_json = json.dumps(worker_props_data, indent=2)
+        embedded_files.append(
+            EmbeddedFileText_2023_09(
+                name="WorkerManifestProperties",
+                type=EmbeddedFileTypes_2023_09.TEXT,
+                data=DataString(worker_props_json),
+            )
+        )
+
+        # Build the command arguments
         args = [
             ArgString("{{ Task.File.AttachmentDownload }}"),
-            ArgString("-pm"),
-            ArgString("{{ Session.PathMappingRulesFile }}"),
             ArgString("-s3"),
             ArgString(s3_settings.to_s3_root_uri()),
-            ArgString("-m"),
-            *[ArgString(manifest) for manifest in manifests],
+            ArgString("-wp"),
+            ArgString("{{ Task.File.WorkerManifestProperties }}"),
         ]
 
         executable_path = Path(sys.executable)
@@ -114,22 +147,15 @@ class AttachmentDownloadAction(OpenjdAction):
             "pythonservice.exe", "python.exe"
         )
 
-        with open(Path(__file__).parent / "scripts" / "attachment_download.py", "r") as f:
-            self._step_script = StepScript_2023_09(
-                actions=StepActions_2023_09(
-                    onRun=Action_2023_09(
-                        command=CommandString(str(python_path)),
-                        args=args,
-                    )
-                ),
-                embeddedFiles=[
-                    EmbeddedFileText_2023_09(
-                        name="AttachmentDownload",
-                        type=EmbeddedFileTypes_2023_09.TEXT,
-                        data=DataString(f.read()),
-                    )
-                ],
-            )
+        self._step_script = StepScript_2023_09(
+            actions=StepActions_2023_09(
+                onRun=Action_2023_09(
+                    command=CommandString(str(python_path)),
+                    args=args,
+                )
+            ),
+            embeddedFiles=embedded_files,
+        )
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -296,6 +322,7 @@ class AttachmentDownloadAction(OpenjdAction):
             key=lambda rule: -len(rule.source_path.parts)
         )
 
+        # ============================ DEPRECATED STARTD =====================================
         manifest_paths_by_root = session._asset_sync._check_and_write_local_manifests(
             merged_manifests_by_root=merged_manifests_by_root,
             manifest_write_dir=str(session.working_directory),
@@ -304,6 +331,49 @@ class AttachmentDownloadAction(OpenjdAction):
         # Set the manifests by root mapping to session for attachment upload to determine output
         for root_name, root_path in manifest_paths_by_root.items():
             session.add_manifest_path(root=root_name, path=root_path)
+        # ============================ DEPRECATED END =====================================
+
+        # Create WorkerManifestProperties list for enhanced worker agent processing
+        # Now that we have merged_manifests_by_root and manifest_path_by_root available
+
+        download_manifest_properties_list: list[WorkerManifestProperties] = list()
+        if manifest_properties_list:
+            for manifest_properties in manifest_properties_list:
+                # Create WorkerManifestProperties with local paths and manifest TODO
+                local_root_path: str = session._asset_sync.get_local_destination(
+                    manifest_properties=manifest_properties,
+                    dynamic_mapping_rules=dynamic_mapping_rules,
+                    storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules_dict,
+                )
+
+                # Check if there's a manifest file for this source root path
+                manifest_path = manifest_paths_by_root.get(local_root_path)
+                worker_manifest_props = WorkerManifestProperties(
+                    manifest_properties=manifest_properties,
+                    local_root_path=local_root_path,
+                    local_manifest_paths=[manifest_path] if manifest_path else [],
+                )
+                session.set_worker_manifest_properties(worker_manifest_props)
+                download_manifest_properties_list.append(worker_manifest_props)
+
+        elif session.get_worker_manifest_properties_list():
+            # If we already have cached WorkerManifestProperties (e.g., for step dependency),
+            # add the manifest paths from manifest_path_by_root to the existing properties
+            for local_root_path, manifest_path in manifest_paths_by_root.items():
+                if manifest_path:
+                    session.add_local_manifest_path(
+                        local_root_path=local_root_path, manifest_path=manifest_path
+                    )
+                    curr = session.get_worker_manifest_properties(local_root_path=local_root_path)
+                    if curr:
+                        worker_manifest_props = WorkerManifestProperties(
+                            manifest_properties=curr.manifest_properties,
+                            local_root_path=local_root_path,
+                            local_manifest_paths=[manifest_path],
+                        )
+                        download_manifest_properties_list.append(worker_manifest_props)
+        else:
+            self._logger.info("Nothing to sync for AttachmentDownloadAction")
 
         #  Try to launch VFS if needed once all files are prepared
         if self._start_vfs(
@@ -329,13 +399,16 @@ class AttachmentDownloadAction(OpenjdAction):
             )
         else:
             self.set_step_script(
-                manifests=manifest_paths_by_root.values(),  # type: ignore
                 s3_settings=s3_settings,
+                worker_manifest_properties_list=download_manifest_properties_list,
             )
             assert self._step_script is not None
             session.run_task(
                 step_script=self._step_script,
                 task_parameter_values=dict[str, ParameterValue](),
+                os_env_vars={
+                    "DEADLINE_QUEUE_ID": session._queue_id,
+                },
                 log_task_banner=False,
             )
 

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -337,7 +337,7 @@ class AttachmentDownloadAction(OpenjdAction):
         # Now that we have merged_manifests_by_root and manifest_path_by_root available
 
         download_manifest_properties_list: list[WorkerManifestProperties] = list()
-        if manifest_properties_list:
+        if not step_dependencies:
             for manifest_properties in manifest_properties_list:
                 # Create WorkerManifestProperties with local paths and manifest TODO
                 local_root_path: str = session._asset_sync.get_local_destination(
@@ -352,28 +352,24 @@ class AttachmentDownloadAction(OpenjdAction):
                     manifest_properties=manifest_properties,
                     local_root_path=local_root_path,
                     local_manifest_paths=[manifest_path] if manifest_path else [],
+                    local_input_manifest_path=manifest_path,
                 )
                 session.set_worker_manifest_properties(worker_manifest_props)
                 download_manifest_properties_list.append(worker_manifest_props)
 
-        elif session.get_worker_manifest_properties_list():
+        else:
+            assert session.get_worker_manifest_properties_list() is not None
             # If we already have cached WorkerManifestProperties (e.g., for step dependency),
             # add the manifest paths from manifest_path_by_root to the existing properties
             for local_root_path, manifest_path in manifest_paths_by_root.items():
-                if manifest_path:
-                    session.add_local_manifest_path(
-                        local_root_path=local_root_path, manifest_path=manifest_path
-                    )
-                    curr = session.get_worker_manifest_properties(local_root_path=local_root_path)
-                    if curr:
-                        worker_manifest_props = WorkerManifestProperties(
-                            manifest_properties=curr.manifest_properties,
-                            local_root_path=local_root_path,
-                            local_manifest_paths=[manifest_path],
-                        )
-                        download_manifest_properties_list.append(worker_manifest_props)
-        else:
-            self._logger.info("Nothing to sync for AttachmentDownloadAction")
+                # if manifest_path:
+                session.add_local_manifest_path(
+                    local_root_path=local_root_path, manifest_path=manifest_path
+                )
+                curr = session.get_worker_manifest_properties(local_root_path=local_root_path)
+                assert curr is not None
+                curr.local_input_manifest_path(local_root_path)
+                download_manifest_properties_list.append(worker_manifest_props)
 
         #  Try to launch VFS if needed once all files are prepared
         if self._start_vfs(

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
@@ -35,16 +35,13 @@ def load_worker_manifest_properties(worker_properties_file: str) -> List[WorkerM
         json.JSONDecodeError: If the file contains invalid JSON
         ValueError: If the JSON structure is invalid
     """
-    worker_manifest_properties = []
-
     with open(worker_properties_file, "r") as f:
         worker_manifest_properties_data = json.load(f)
 
-    for item in worker_manifest_properties_data or []:
-        worker_prop = WorkerManifestProperties.from_dict(item)
-        worker_manifest_properties.append(worker_prop)
+    if isinstance(worker_manifest_properties_data, dict):
+        raise ValueError("Expected a list but got a dictionary in worker properties file")
 
-    return worker_manifest_properties
+    return [WorkerManifestProperties.from_dict(item) for item in worker_manifest_properties_data]
 
 
 def build_merged_manifests_by_root(
@@ -135,22 +132,15 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-    s3_uri = args.s3_uri
 
-    print(f"args.worker_properties is {args.worker_properties}")
-
-    # Load worker manifest properties
     worker_manifest_properties = load_worker_manifest_properties(args.worker_properties)
 
-    # Build merged manifests by root
     manifests_by_root = build_merged_manifests_by_root(worker_manifest_properties)
 
     print("\nStarting download...")
 
-    # Create S3 settings
-    s3_settings = JobAttachmentS3Settings.from_s3_root_uri(s3_uri)
+    s3_settings = JobAttachmentS3Settings.from_s3_root_uri(args.s3_uri)
 
-    # Perform download
     perform_download(
         s3_settings, manifests_by_root, os.environ.get("DEADLINE_QUEUE_ID", "queue-unknown")
     )

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
@@ -63,21 +63,23 @@ def build_merged_manifests_by_root(
         FileNotFoundError: If a manifest file doesn't exist
         ValueError: If manifest decoding fails
     """
-    merged_manifests_by_root = {}
+    manifests_by_root = {}
 
     for worker_prop in worker_manifest_properties:
-        if worker_prop.local_manifest_paths and len(worker_prop.local_manifest_paths) > 0:
-            with open(worker_prop.local_manifest_paths[0], "r") as manifest_file:
-                merged_manifests_by_root[worker_prop.local_root_path] = decode_manifest(
+        if worker_prop.local_input_manifest_path:
+            with open(worker_prop.local_input_manifest_path, "r") as manifest_file:
+                manifests_by_root[worker_prop.local_root_path] = decode_manifest(
                     manifest_file.read()
                 )
+        else:
+            print(f"Root {worker_prop.root_path} contains no input manifest to sync.")
 
-    return merged_manifests_by_root
+    return manifests_by_root
 
 
 def perform_download(
     s3_settings: JobAttachmentS3Settings,
-    merged_manifests_by_root: Dict[str, BaseAssetManifest],
+    manifests_by_root: Dict[str, BaseAssetManifest],
     queue_id: str,
 ) -> DownloadSummaryStatistics:
     """
@@ -85,7 +87,7 @@ def perform_download(
 
     Args:
         s3_settings: S3 settings for the download
-        merged_manifests_by_root: Dictionary mapping root paths to manifests
+        manifests_by_root: Dictionary mapping root paths to manifests
         queue_id: Queue ID for telemetry
 
     Returns:
@@ -97,7 +99,7 @@ def perform_download(
     try:
         download_summary_statistics = download_files_from_manifests(
             s3_bucket=s3_settings.s3BucketName,
-            manifests_by_root=merged_manifests_by_root,
+            manifests_by_root=manifests_by_root,
             cas_prefix=s3_settings.full_cas_prefix(),
             session=boto3.session.Session(),
         )
@@ -141,7 +143,7 @@ def main() -> None:
     worker_manifest_properties = load_worker_manifest_properties(args.worker_properties)
 
     # Build merged manifests by root
-    merged_manifests_by_root = build_merged_manifests_by_root(worker_manifest_properties)
+    manifests_by_root = build_merged_manifests_by_root(worker_manifest_properties)
 
     print("\nStarting download...")
 
@@ -150,7 +152,7 @@ def main() -> None:
 
     # Perform download
     perform_download(
-        s3_settings, merged_manifests_by_root, os.environ.get("DEADLINE_QUEUE_ID", "queue-unknown")
+        s3_settings, manifests_by_root, os.environ.get("DEADLINE_QUEUE_ID", "queue-unknown")
     )
 
     total = time.perf_counter() - start_time

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
@@ -2,49 +2,160 @@
 
 #! /usr/bin/env python3
 import argparse
+import json
 import time
+import os
 import boto3
+from typing import Dict, List
 
-from deadline.job_attachments import api
-
-"""
-A small script to download job output using attachment download.
-This is available in deadline-cloud as python API and AWS Deadline Cloud CLI.
-
-Example usage:
-
-python attachment_download.py \
-    -pm /sessions/session-f63c206fb5f04c04aa17821001aa3847fajfm5x4/path_mapping.json \
-    -s3 s3://test-job-attachment/DeadlineCloud \
-    -m /sessions/session-f63c206fb5f04c04aa17821001aa3847fajfm5x4/manifests/0bb7eb91fdf8780c4a7e6174de6dfc5e_manifest \
-    -m /sessions/session-f63c206fb5f04c04aa17821001aa3847fajfm5x4/manifests/0bb7eb91fdf8780c4a7e6174de6dfc5e_manifest
-"""
+from deadline.job_attachments.download import download_files_from_manifests
+from deadline.job_attachments.asset_manifests.decode import decode_manifest
+from deadline.job_attachments.asset_manifests import BaseAssetManifest
+from deadline.job_attachments.models import JobAttachmentS3Settings
+from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+from deadline_worker_agent.sessions.attachment_models import WorkerManifestProperties
+from deadline_worker_agent.aws.deadline import (
+    record_sync_inputs_fail_telemetry_event,
+    record_sync_inputs_telemetry_event,
+)
 
 
-def download(s3_root_uri: str, path_mapping_rules: str, manifests: list[str]) -> None:
-    api.attachment_download(
-        manifests=manifests,
-        s3_root_uri=s3_root_uri,
-        boto3_session=boto3.session.Session(),
-        path_mapping_rules=path_mapping_rules,
-    )
+def load_worker_manifest_properties(worker_properties_file: str) -> List[WorkerManifestProperties]:
+    """
+    Load and parse worker manifest properties from a JSON file.
+
+    Args:
+        worker_properties_file: Path to the worker properties JSON file
+
+    Returns:
+        List of WorkerManifestProperties objects
+
+    Raises:
+        FileNotFoundError: If the worker properties file doesn't exist
+        json.JSONDecodeError: If the file contains invalid JSON
+        ValueError: If the JSON structure is invalid
+    """
+    worker_manifest_properties = []
+
+    with open(worker_properties_file, "r") as f:
+        worker_manifest_properties_data = json.load(f)
+
+    for item in worker_manifest_properties_data or []:
+        worker_prop = WorkerManifestProperties.from_dict(item)
+        worker_manifest_properties.append(worker_prop)
+
+    return worker_manifest_properties
 
 
-if __name__ == "__main__":
+def build_merged_manifests_by_root(
+    worker_manifest_properties: List[WorkerManifestProperties],
+) -> Dict[str, BaseAssetManifest]:
+    """
+    Build a dictionary mapping local root paths to decoded asset manifests.
+
+    Args:
+        worker_manifest_properties: List of WorkerManifestProperties objects
+
+    Returns:
+        Dictionary mapping local_root_path to BaseAssetManifest objects
+
+    Raises:
+        FileNotFoundError: If a manifest file doesn't exist
+        ValueError: If manifest decoding fails
+    """
+    merged_manifests_by_root = {}
+
+    for worker_prop in worker_manifest_properties:
+        if worker_prop.local_manifest_paths and len(worker_prop.local_manifest_paths) > 0:
+            with open(worker_prop.local_manifest_paths[0], "r") as manifest_file:
+                merged_manifests_by_root[worker_prop.local_root_path] = decode_manifest(
+                    manifest_file.read()
+                )
+
+    return merged_manifests_by_root
+
+
+def perform_download(
+    s3_settings: JobAttachmentS3Settings,
+    merged_manifests_by_root: Dict[str, BaseAssetManifest],
+    queue_id: str,
+) -> DownloadSummaryStatistics:
+    """
+    Perform the actual download of files from S3 using the provided manifests.
+
+    Args:
+        s3_settings: S3 settings for the download
+        merged_manifests_by_root: Dictionary mapping root paths to manifests
+        queue_id: Queue ID for telemetry
+
+    Returns:
+        DownloadSummaryStatistics object containing download results
+
+    Raises:
+        Exception: Any exception that occurs during download (after recording telemetry)
+    """
+    try:
+        download_summary_statistics = download_files_from_manifests(
+            s3_bucket=s3_settings.s3BucketName,
+            manifests_by_root=merged_manifests_by_root,
+            cas_prefix=s3_settings.full_cas_prefix(),
+            session=boto3.session.Session(),
+        )
+
+        # Record successful download telemetry
+        record_sync_inputs_telemetry_event(
+            queue_id, download_summary_statistics.convert_to_summary_statistics()
+        )
+
+        return download_summary_statistics
+
+    except Exception as exc:
+        # Record failure telemetry
+        record_sync_inputs_fail_telemetry_event(
+            queue_id=queue_id,
+            failure_reason=f"Error downloading files: {exc}",
+        )
+        raise
+
+
+def main() -> None:
+    """Main function to handle command line execution."""
     start_time = time.perf_counter()
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-pm", "--path-mapping", type=str, help="", required=True)
-    parser.add_argument("-s3", "--s3-uri", type=str, help="", required=True)
-    parser.add_argument("-m", "--manifests", nargs="*", type=str, help="", required=True)
+    parser.add_argument("-s3", "--s3-uri", type=str, help="S3 root URI", required=True)
+    parser.add_argument(
+        "-wp",
+        "--worker-properties",
+        type=str,
+        help="Worker manifest properties file",
+        required=False,
+    )
 
     args = parser.parse_args()
-    path_mapping = args.path_mapping
-    manifests = args.manifests
     s3_uri = args.s3_uri
 
+    print(f"args.worker_properties is {args.worker_properties}")
+
+    # Load worker manifest properties
+    worker_manifest_properties = load_worker_manifest_properties(args.worker_properties)
+
+    # Build merged manifests by root
+    merged_manifests_by_root = build_merged_manifests_by_root(worker_manifest_properties)
+
     print("\nStarting download...")
-    download(s3_root_uri=s3_uri, path_mapping_rules=path_mapping, manifests=manifests)
+
+    # Create S3 settings
+    s3_settings = JobAttachmentS3Settings.from_s3_root_uri(s3_uri)
+
+    # Perform download
+    perform_download(
+        s3_settings, merged_manifests_by_root, os.environ.get("DEADLINE_QUEUE_ID", "queue-unknown")
+    )
 
     total = time.perf_counter() - start_time
     print(f"Finished downloading after {total} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deadline_worker_agent/sessions/attachment_models.py
+++ b/src/deadline_worker_agent/sessions/attachment_models.py
@@ -139,13 +139,12 @@ class WorkerManifestProperties:
             outputRelativeDirectories=manifest_props_data.get("outputRelativeDirectories"),
         )
 
-        worker_props = cls(
+        return cls(
             manifest_properties=manifest_properties,
             local_manifest_paths=data.get("localManifestPaths", []),
             local_root_path=data["localRootPath"],
+            local_input_manifest_path=data.get("localInputManifestPath"),
         )
-        worker_props.local_input_manifest_path = data.get("localInputManifestPath")
-        return worker_props
 
     def __eq__(self, other: object) -> bool:
         """

--- a/src/deadline_worker_agent/sessions/attachment_models.py
+++ b/src/deadline_worker_agent/sessions/attachment_models.py
@@ -28,17 +28,20 @@ class WorkerManifestProperties:
         manifest_properties: ManifestProperties,
         local_root_path: str,
         local_manifest_paths: Optional[List[str]] = None,
+        local_input_manifest_path: Optional[str] = None,
     ):
         """
         Initialize WorkerManifestProperties.
         Args:
             manifest_properties: The original manifest properties
             local_root_path: Local root path for attachment files
-            local_manifest_paths: Optional list of local paths for manifest files (supports step dependencies)
+            local_manifest_paths: Optional list of local paths for all manifest files
+            local_input_manifest_path: Optional local file path for input manifest
         """
         self.manifest_properties = manifest_properties
         self.local_root_path = local_root_path
         self.local_manifest_paths = list(local_manifest_paths) if local_manifest_paths else []
+        self.local_input_manifest_path = local_input_manifest_path
 
     @property
     def root_path(self) -> str:
@@ -108,6 +111,7 @@ class WorkerManifestProperties:
             "manifestProperties": self.manifest_properties.to_dict(),
             "localManifestPaths": self.local_manifest_paths,
             "localRootPath": self.local_root_path,
+            "localInputManifestPath": self.local_input_manifest_path,
         }
 
     @classmethod
@@ -135,11 +139,13 @@ class WorkerManifestProperties:
             outputRelativeDirectories=manifest_props_data.get("outputRelativeDirectories"),
         )
 
-        return cls(
+        worker_props = cls(
             manifest_properties=manifest_properties,
             local_manifest_paths=data.get("localManifestPaths", []),
             local_root_path=data["localRootPath"],
         )
+        worker_props.local_input_manifest_path = data.get("localInputManifestPath")
+        return worker_props
 
     def __eq__(self, other: object) -> bool:
         """
@@ -156,6 +162,7 @@ class WorkerManifestProperties:
             self.manifest_properties == other.manifest_properties
             and self.local_root_path == other.local_root_path
             and self.local_manifest_paths == other.local_manifest_paths
+            and self.local_input_manifest_path == other.local_input_manifest_path
         )
 
     def __hash__(self) -> int:
@@ -169,5 +176,6 @@ class WorkerManifestProperties:
                 self.manifest_properties,
                 self.local_root_path,
                 tuple(self.local_manifest_paths),  # Convert list to tuple for hashing
+                self.local_input_manifest_path,
             )
         )

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -347,7 +347,9 @@ class Session:
         """
         return list(self._worker_manifest_properties_by_local_root.values())
 
-    def add_local_manifest_path(self, local_root_path: str, manifest_path: str) -> None:
+    def add_local_manifest_path(
+        self, local_root_path: str, manifest_path: str
+    ) -> WorkerManifestProperties:
         """Add a local manifest path to the worker manifest properties
 
         Parameters
@@ -364,6 +366,8 @@ class Session:
         """
         if worker_props := self._worker_manifest_properties_by_local_root.get(local_root_path):
             worker_props.local_manifest_paths.append(manifest_path)
+
+            return worker_props
         else:
             raise ValueError(
                 f"Worker manifest properties not found for local_root_path: {local_root_path}"

--- a/test/unit/sessions/actions/scripts/test_attachment_download.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_download.py
@@ -118,6 +118,7 @@ class TestBuildMergedManifestsByRoot:
             manifest_properties=manifest_props,
             local_root_path="/local/test/path",
             local_manifest_paths=["/local/manifest1.json", "/local/manifest2.json"],
+            local_input_manifest_path="/local/manifest1.json"
         )
 
     @pytest.fixture
@@ -231,11 +232,13 @@ class TestBuildMergedManifestsByRoot:
                 manifest_properties=mock_manifest_properties,
                 local_root_path="/local/path1",
                 local_manifest_paths=["/manifest1.json"],
+                local_input_manifest_path="/manifest1.json",
             ),
             WorkerManifestProperties(
                 manifest_properties=mock_manifest_properties,
                 local_root_path="/local/path2",
                 local_manifest_paths=["/manifest2.json"],
+                local_input_manifest_path="/manifest2.json",
             ),
         ]
 

--- a/test/unit/sessions/actions/scripts/test_attachment_download.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_download.py
@@ -1,0 +1,433 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+import os
+import tempfile
+from unittest.mock import Mock, patch, mock_open, ANY
+import pytest
+
+from deadline.job_attachments.models import ManifestProperties, PathFormat, JobAttachmentS3Settings
+from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import AssetManifest
+from deadline_worker_agent.sessions.attachment_models import WorkerManifestProperties
+
+# Import the functions we want to test
+from deadline_worker_agent.sessions.actions.scripts.attachment_download import (
+    load_worker_manifest_properties,
+    build_merged_manifests_by_root,
+    perform_download,
+    main,
+)
+
+
+class TestLoadWorkerManifestProperties:
+    """Test cases for load_worker_manifest_properties function."""
+
+    @pytest.fixture
+    def worker_properties_file(self):
+        """Create a temporary worker properties file for testing."""
+        manifest_props = ManifestProperties(
+            rootPath="/test/root/path",
+            rootPathFormat=PathFormat.POSIX,
+            fileSystemLocationName="test-location",
+            inputManifestPath="/test/input/manifest.json",
+            inputManifestHash="test-hash-123",
+            outputRelativeDirectories=["/output/dir1", "/output/dir2"],
+        )
+        worker_props = WorkerManifestProperties(
+            manifest_properties=manifest_props,
+            local_root_path="/local/test/path",
+            local_manifest_paths=["/local/manifest1.json", "/local/manifest2.json"],
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([worker_props.to_dict()], f)
+            temp_file_path = f.name
+
+        yield temp_file_path
+        if os.path.exists(temp_file_path):
+            os.unlink(temp_file_path)
+
+    def test_load_worker_manifest_properties_success(self, worker_properties_file):
+        """Test successful loading of worker manifest properties."""
+        # WHEN
+        result = load_worker_manifest_properties(worker_properties_file)
+
+        # THEN
+        assert len(result) == 1
+        assert isinstance(result[0], WorkerManifestProperties)
+        assert result[0].local_root_path == "/local/test/path"
+        assert result[0].local_manifest_paths == ["/local/manifest1.json", "/local/manifest2.json"]
+
+    def test_load_worker_manifest_properties_file_not_found(self):
+        """Test handling of non-existent worker properties file."""
+        with pytest.raises(FileNotFoundError):
+            load_worker_manifest_properties("/non/existent/file.json")
+
+    def test_load_worker_manifest_properties_invalid_json(self):
+        """Test handling of invalid JSON in worker properties file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("invalid json content")
+            temp_file_path = f.name
+
+        try:
+            with pytest.raises(json.JSONDecodeError):
+                load_worker_manifest_properties(temp_file_path)
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_load_worker_manifest_properties_empty_list(self):
+        """Test loading empty worker properties list."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([], f)
+            temp_file_path = f.name
+
+        try:
+            result = load_worker_manifest_properties(temp_file_path)
+            assert result == []
+        finally:
+            os.unlink(temp_file_path)
+
+
+class TestBuildMergedManifestsByRoot:
+    """Test cases for build_merged_manifests_by_root function."""
+
+    @pytest.fixture
+    def mock_manifest_properties(self):
+        """Create a mock ManifestProperties object for testing."""
+        return ManifestProperties(
+            rootPath="/test/root/path",
+            rootPathFormat=PathFormat.POSIX,
+            fileSystemLocationName="test-location",
+            inputManifestPath="/test/input/manifest.json",
+            inputManifestHash="test-hash-123",
+            outputRelativeDirectories=["/output/dir1", "/output/dir2"],
+        )
+
+    @pytest.fixture
+    def worker_manifest_properties(self):
+        """Create a WorkerManifestProperties object for testing."""
+        manifest_props = ManifestProperties(
+            rootPath="/test/root/path",
+            rootPathFormat=PathFormat.POSIX,
+            fileSystemLocationName="test-location",
+            inputManifestPath="/test/input/manifest.json",
+            inputManifestHash="test-hash-123",
+            outputRelativeDirectories=["/output/dir1", "/output/dir2"],
+        )
+        return WorkerManifestProperties(
+            manifest_properties=manifest_props,
+            local_root_path="/local/test/path",
+            local_manifest_paths=["/local/manifest1.json", "/local/manifest2.json"],
+        )
+
+    @pytest.fixture
+    def mock_manifest_content(self):
+        """Create mock manifest file content."""
+        return json.dumps(
+            {
+                "manifestVersion": "2023-03-03",
+                "hashAlg": "xxh128",
+                "totalSize": 1024,
+                "paths": [
+                    {"path": "/test/file1.txt", "hash": "abc123", "size": 1024, "mtime": 1234567890}
+                ],
+            }
+        )
+
+    @pytest.fixture
+    def mock_asset_manifest(self):
+        """Create a mock AssetManifest object."""
+        mock_manifest = Mock(spec=AssetManifest)
+        mock_manifest.get_default_hash_alg.return_value = "xxh128"
+        return mock_manifest
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_download.decode_manifest")
+    def test_build_merged_manifests_by_root_success(
+        self, mock_decode_manifest, mock_file_open, worker_manifest_properties
+    ):
+        """Test successful building of merged manifests by root."""
+        # GIVEN
+        mock_file_open.return_value.read.return_value = json.dumps(
+            {
+                "manifestVersion": "2023-03-03",
+                "hashAlg": "xxh128",
+                "totalSize": 1024,
+                "paths": [
+                    {"path": "/test/file1.txt", "hash": "abc123", "size": 1024, "mtime": 1234567890}
+                ],
+            }
+        )
+        mock_decode_manifest.return_value = Mock(spec=AssetManifest)
+
+        # WHEN
+        result = build_merged_manifests_by_root([worker_manifest_properties])
+
+        # THEN
+        assert len(result) == 1
+        assert "/local/test/path" in result
+        mock_decode_manifest.assert_called_once()
+
+    def test_build_merged_manifests_by_root_empty_manifest_paths(self):
+        """Test handling of worker properties with empty manifest paths."""
+        # GIVEN
+        manifest_props = ManifestProperties(
+            rootPath="/test/root/path",
+            rootPathFormat=PathFormat.POSIX,
+            fileSystemLocationName="test-location",
+            inputManifestPath="/test/input/manifest.json",
+            inputManifestHash="test-hash-123",
+            outputRelativeDirectories=["/output/dir1", "/output/dir2"],
+        )
+        worker_prop = WorkerManifestProperties(
+            manifest_properties=manifest_props,
+            local_root_path="/local/test/path",
+            local_manifest_paths=[],
+        )
+
+        # WHEN
+        result = build_merged_manifests_by_root([worker_prop])
+
+        # THEN
+        assert result == {}
+
+    def test_build_merged_manifests_by_root_no_manifest_paths(self, mock_manifest_properties):
+        """Test handling of worker properties with None manifest paths."""
+        # GIVEN
+        worker_prop = WorkerManifestProperties(
+            manifest_properties=mock_manifest_properties,
+            local_root_path="/local/test/path",
+            local_manifest_paths=None,
+        )
+
+        # WHEN
+        result = build_merged_manifests_by_root([worker_prop])
+
+        # THEN
+        assert result == {}
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_download.decode_manifest")
+    def test_build_merged_manifests_by_root_multiple_properties(
+        self, mock_decode_manifest, mock_file_open, mock_manifest_properties
+    ):
+        """Test building manifests with multiple worker properties."""
+        # GIVEN
+        valid_manifest = json.dumps(
+            {
+                "manifestVersion": "2023-03-03",
+                "hashAlg": "xxh128",
+                "totalSize": 1024,
+                "paths": [
+                    {"path": "/test/file1.txt", "hash": "abc123", "size": 1024, "mtime": 1234567890}
+                ],
+            }
+        )
+        mock_file_open.return_value.read.return_value = valid_manifest
+        mock_decode_manifest.return_value = Mock()
+
+        worker_props = [
+            WorkerManifestProperties(
+                manifest_properties=mock_manifest_properties,
+                local_root_path="/local/path1",
+                local_manifest_paths=["/manifest1.json"],
+            ),
+            WorkerManifestProperties(
+                manifest_properties=mock_manifest_properties,
+                local_root_path="/local/path2",
+                local_manifest_paths=["/manifest2.json"],
+            ),
+        ]
+
+        # WHEN
+        result = build_merged_manifests_by_root(worker_props)
+
+        # THEN
+        assert len(result) == 2
+        assert "/local/path1" in result
+        assert "/local/path2" in result
+        assert mock_decode_manifest.call_count == 2
+
+    @patch("builtins.open", side_effect=FileNotFoundError("Manifest file not found"))
+    def test_build_merged_manifests_by_root_manifest_file_not_found(
+        self, mock_file_open, worker_manifest_properties
+    ):
+        """Test handling of missing manifest files."""
+        with pytest.raises(FileNotFoundError):
+            build_merged_manifests_by_root([worker_manifest_properties])
+
+
+class TestPerformDownload:
+    """Test cases for perform_download function."""
+
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_download.download_files_from_manifests"
+    )
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_download.record_sync_inputs_telemetry_event"
+    )
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_download.boto3")
+    def test_perform_download_success(
+        self, mock_boto3, mock_success_telemetry, mock_download_files
+    ):
+        """Test successful download with telemetry recording."""
+        # GIVEN
+        from deadline.job_attachments.progress_tracker import SummaryStatistics
+
+        mock_session = Mock()
+        mock_boto3.session.Session.return_value = mock_session
+
+        mock_download_summary = Mock()
+        mock_summary_stats = SummaryStatistics(
+            total_time=1.5,
+            total_files=10,
+            total_bytes=1024,
+            processed_files=10,
+            processed_bytes=1024,
+            skipped_files=0,
+            skipped_bytes=0,
+            transfer_rate=682.67,
+        )
+        mock_download_summary.convert_to_summary_statistics.return_value = mock_summary_stats
+        mock_download_files.return_value = mock_download_summary
+
+        s3_settings = JobAttachmentS3Settings.from_s3_root_uri("s3://test-bucket/test-prefix")
+
+        # WHEN
+        result = perform_download(s3_settings, {}, "test-queue")
+
+        # THEN
+        assert result == mock_download_summary
+        mock_download_files.assert_called_once()
+        mock_success_telemetry.assert_called_once_with("test-queue", mock_summary_stats)
+
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_download.download_files_from_manifests"
+    )
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_download.record_sync_inputs_fail_telemetry_event"
+    )
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_download.boto3")
+    def test_perform_download_failure(self, mock_boto3, mock_fail_telemetry, mock_download_files):
+        """Test download failure with telemetry recording."""
+        # GIVEN
+        mock_session = Mock()
+        mock_boto3.session.Session.return_value = mock_session
+        mock_download_files.side_effect = Exception("Download failed")
+
+        s3_settings = JobAttachmentS3Settings.from_s3_root_uri("s3://test-bucket/test-prefix")
+
+        # WHEN/THEN
+        with pytest.raises(Exception, match="Download failed"):
+            perform_download(s3_settings, {}, "test-queue")
+
+        mock_fail_telemetry.assert_called_once_with(
+            queue_id="test-queue",
+            failure_reason="Error downloading files: Download failed",
+        )
+
+
+class TestMainFunction:
+    """Test cases for main function."""
+
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_download.perform_download")
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_download.build_merged_manifests_by_root"
+    )
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_download.load_worker_manifest_properties"
+    )
+    @patch("time.perf_counter")
+    @patch("argparse.ArgumentParser.parse_args")
+    @patch.dict("os.environ", {"DEADLINE_QUEUE_ID": "test-queue-id"})
+    def test_main_success(
+        self,
+        mock_parse_args,
+        mock_perf_counter,
+        mock_load_worker_props,
+        mock_build_manifests,
+        mock_perform_download,
+    ):
+        """Test successful main function execution."""
+        # GIVEN
+        mock_args = Mock()
+        mock_args.s3_uri = "s3://test-bucket/test-prefix"
+        mock_args.worker_properties = "/path/to/worker/props.json"
+        mock_parse_args.return_value = mock_args
+
+        mock_perf_counter.side_effect = [0.0, 5.5]  # start_time, end_time
+
+        mock_worker_props = [Mock()]
+        mock_load_worker_props.return_value = mock_worker_props
+
+        mock_manifests = {"root": Mock()}
+        mock_build_manifests.return_value = mock_manifests
+
+        mock_download_summary = Mock()
+        mock_perform_download.return_value = mock_download_summary
+
+        # WHEN
+        main()
+
+        # THEN
+        mock_load_worker_props.assert_called_once_with("/path/to/worker/props.json")
+        mock_build_manifests.assert_called_once_with(mock_worker_props)
+        mock_perform_download.assert_called_once()
+
+        # Verify perform_download was called with correct arguments
+        mock_perform_download.assert_called_once_with(
+            ANY,  # s3_settings - we'll verify the bucket name separately
+            mock_manifests,
+            "test-queue-id",
+        )
+        # Verify S3 settings bucket name
+        call_args = mock_perform_download.call_args
+        s3_settings = call_args[0][0]
+        assert s3_settings.s3BucketName == "test-bucket"
+
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_download.perform_download")
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_download.build_merged_manifests_by_root"
+    )
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_download.load_worker_manifest_properties"
+    )
+    @patch("time.perf_counter")
+    @patch("argparse.ArgumentParser.parse_args")
+    @patch.dict("os.environ", {}, clear=True)  # Clear environment to test default
+    def test_main_with_default_queue_id(
+        self,
+        mock_parse_args,
+        mock_perf_counter,
+        mock_load_worker_props,
+        mock_build_manifests,
+        mock_perform_download,
+    ):
+        """Test main function execution with default queue ID when environment variable is not set."""
+        # GIVEN
+        mock_args = Mock()
+        mock_args.s3_uri = "s3://test-bucket/test-prefix"
+        mock_args.worker_properties = "/path/to/worker/props.json"
+        mock_parse_args.return_value = mock_args
+
+        mock_perf_counter.side_effect = [0.0, 5.5]  # start_time, end_time
+
+        mock_worker_props = [Mock()]
+        mock_load_worker_props.return_value = mock_worker_props
+
+        mock_manifests = {"root": Mock()}
+        mock_build_manifests.return_value = mock_manifests
+
+        mock_download_summary = Mock()
+        mock_perform_download.return_value = mock_download_summary
+
+        # WHEN
+        main()
+
+        # THEN
+        # Verify perform_download was called with default queue_id
+        mock_perform_download.assert_called_once_with(
+            ANY,  # s3_settings
+            mock_manifests,
+            "queue-unknown",
+        )

--- a/test/unit/sessions/actions/scripts/test_attachment_download.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_download.py
@@ -118,7 +118,7 @@ class TestBuildMergedManifestsByRoot:
             manifest_properties=manifest_props,
             local_root_path="/local/test/path",
             local_manifest_paths=["/local/manifest1.json", "/local/manifest2.json"],
-            local_input_manifest_path="/local/manifest1.json"
+            local_input_manifest_path="/local/manifest1.json",
         )
 
     @pytest.fixture

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -169,7 +169,7 @@ class TestStart:
 
         session.set_worker_manifest_properties = Mock()
         session.get_worker_manifest_properties_list = Mock(return_value=[])
-        session.add_local_manifest_path = Mock()
+        session.add_local_manifest_path = Mock(return_value=mock_worker_manifest_props)
         session.get_worker_manifest_properties = Mock(return_value=mock_worker_manifest_props)
         session.add_manifest_path = Mock()
         session.add_manifest_out_rel_dirs = Mock()
@@ -210,47 +210,38 @@ class TestStart:
         )
 
         # Verify the step script structure with new arguments
-        with open(
-            Path(os.path.dirname(actions_module.__file__)) / "scripts" / "attachment_download.py",
-            "r",
-        ) as f:
-            expected_script = StepScript_2023_09(
-                actions=StepActions_2023_09(
-                    onRun=Action_2023_09(
-                        command=CommandString(python_path),
-                        args=[
-                            ArgString("{{ Task.File.AttachmentDownload }}"),
-                            ArgString("-s3"),
-                            ArgString(s3_settings.to_s3_root_uri()),
-                            ArgString("-wp"),
-                            ArgString("{{ Task.File.WorkerManifestProperties }}"),
-                        ],
-                    )
+        download_script_path = (
+            Path(os.path.dirname(actions_module.__file__)) / "scripts" / "attachment_download.py"
+        )
+        expected_script = StepScript_2023_09(
+            actions=StepActions_2023_09(
+                onRun=Action_2023_09(
+                    command=CommandString(python_path),
+                    args=[
+                        ArgString(str(download_script_path)),
+                        ArgString("-s3"),
+                        ArgString(s3_settings.to_s3_root_uri()),
+                        ArgString("-wp"),
+                        ArgString("{{ Task.File.WorkerManifestProperties }}"),
+                    ],
+                )
+            ),
+            embeddedFiles=[
+                EmbeddedFileText_2023_09(
+                    name="WorkerManifestProperties",
+                    type=EmbeddedFileTypes_2023_09.TEXT,
+                    data=DataString(ANY),  # JSON data will vary
                 ),
-                embeddedFiles=[
-                    EmbeddedFileText_2023_09(
-                        name="AttachmentDownload",
-                        type=EmbeddedFileTypes_2023_09.TEXT,
-                        data=DataString(f.read()),
-                    ),
-                    EmbeddedFileText_2023_09(
-                        name="WorkerManifestProperties",
-                        type=EmbeddedFileTypes_2023_09.TEXT,
-                        data=DataString(ANY),  # JSON data will vary
-                    ),
-                ],
-            )
+            ],
+        )
 
-            # Check the basic structure
-            assert action._step_script is not None
-            assert (
-                action._step_script.actions.onRun.command == expected_script.actions.onRun.command
-            )
-            assert action._step_script.actions.onRun.args == expected_script.actions.onRun.args
-            assert action._step_script.embeddedFiles is not None
-            assert len(action._step_script.embeddedFiles) == 2
-            assert action._step_script.embeddedFiles[0].name == "AttachmentDownload"
-            assert action._step_script.embeddedFiles[1].name == "WorkerManifestProperties"
+        # Check the basic structure
+        assert action._step_script is not None
+        assert action._step_script.actions.onRun.command == expected_script.actions.onRun.command
+        assert action._step_script.actions.onRun.args == expected_script.actions.onRun.args
+        assert action._step_script.embeddedFiles is not None
+        assert len(action._step_script.embeddedFiles) == 1
+        assert action._step_script.embeddedFiles[0].name == "WorkerManifestProperties"
 
         session.run_task.assert_called_once_with(
             step_script=action._step_script,
@@ -298,7 +289,7 @@ class TestStart:
 
         session.set_worker_manifest_properties = Mock()
         session.get_worker_manifest_properties_list = Mock(return_value=[])
-        session.add_local_manifest_path = Mock()
+        session.add_local_manifest_path = Mock(return_value=mock_worker_manifest_props)
         session.get_worker_manifest_properties = Mock(return_value=mock_worker_manifest_props)
         session.add_manifest_path = Mock()
         session.add_manifest_out_rel_dirs = Mock()
@@ -398,8 +389,12 @@ class TestSetStepScript:
 
         # Check command and args
         assert action._step_script.actions.onRun.command == CommandString(python_path)
+        # The actual path is calculated from the actions module location
+        download_script_path = (
+            Path(actions_module.__file__).parent / "scripts" / "attachment_download.py"
+        )
         expected_args = [
-            ArgString("{{ Task.File.AttachmentDownload }}"),
+            ArgString(str(download_script_path)),
             ArgString("-s3"),
             ArgString(s3_settings.to_s3_root_uri()),
             ArgString("-wp"),
@@ -409,15 +404,10 @@ class TestSetStepScript:
 
         # Check embedded files
         assert action._step_script.embeddedFiles is not None
-        assert len(action._step_script.embeddedFiles) == 2
-
-        # Check AttachmentDownload file
-        attachment_file = action._step_script.embeddedFiles[0]
-        assert attachment_file.name == "AttachmentDownload"
-        assert attachment_file.type == EmbeddedFileTypes_2023_09.TEXT
+        assert len(action._step_script.embeddedFiles) == 1
 
         # Check WorkerManifestProperties file
-        worker_props_file = action._step_script.embeddedFiles[1]
+        worker_props_file = action._step_script.embeddedFiles[0]
         assert worker_props_file.name == "WorkerManifestProperties"
         assert worker_props_file.type == EmbeddedFileTypes_2023_09.TEXT
 
@@ -452,9 +442,9 @@ class TestSetStepScript:
 
         # Check that embedded files still exist but WorkerManifestProperties is empty
         assert action._step_script.embeddedFiles is not None
-        assert len(action._step_script.embeddedFiles) == 2
+        assert len(action._step_script.embeddedFiles) == 1
 
-        worker_props_file = action._step_script.embeddedFiles[1]
+        worker_props_file = action._step_script.embeddedFiles[0]
         assert worker_props_file.name == "WorkerManifestProperties"
 
         worker_props_data = json.loads(worker_props_file.data)

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from pathlib import Path
+import json
 import os
 import sys
 import tempfile
@@ -32,6 +33,7 @@ from deadline.job_attachments.models import (
     JobAttachmentsFileSystem,
 )
 from deadline.job_attachments.asset_manifests import BaseAssetManifest
+from deadline_worker_agent.sessions.attachment_models import WorkerManifestProperties
 
 if TYPE_CHECKING:
     from deadline_worker_agent.sessions.job_entities import JobAttachmentDetails
@@ -150,6 +152,21 @@ class TestStart:
         assert job_details.job_attachment_settings.s3_bucket_name is not None
         assert job_details.job_attachment_settings.root_prefix is not None
 
+        # Mock session methods for WorkerManifestProperties
+        session.set_worker_manifest_properties = Mock()
+        session.get_worker_manifest_properties_list = Mock(return_value=[])
+        session.add_local_manifest_path = Mock()
+        session.get_worker_manifest_properties = Mock(return_value=None)
+        session.add_manifest_path = Mock()
+        session.add_manifest_out_rel_dirs = Mock()
+        session.manifest_out_rel_dirs_by_source = {}
+
+        # Mock asset sync methods
+        mock_asset_sync.get_local_destination.return_value = str(session_dir)
+        mock_asset_sync._check_and_write_local_manifests.return_value = {
+            str(session_dir): "/path/to/manifest.json"
+        }
+
         # WHEN
         action.start(session=session, executor=executor)
         s3_settings = JobAttachmentS3Settings(
@@ -157,6 +174,7 @@ class TestStart:
             rootPrefix=job_details.job_attachment_settings.root_prefix,
         )
 
+        # THEN
         mock_asset_sync._aggregate_asset_root_manifests.assert_called_once_with(
             session_dir=session_dir,
             s3_settings=s3_settings,
@@ -177,21 +195,21 @@ class TestStart:
             manifest_name_suffix="job",
         )
 
+        # Verify the step script structure with new arguments
         with open(
             Path(os.path.dirname(actions_module.__file__)) / "scripts" / "attachment_download.py",
             "r",
         ) as f:
-            assert action._step_script == StepScript_2023_09(
+            expected_script = StepScript_2023_09(
                 actions=StepActions_2023_09(
                     onRun=Action_2023_09(
                         command=CommandString(python_path),
                         args=[
                             ArgString("{{ Task.File.AttachmentDownload }}"),
-                            ArgString("-pm"),
-                            ArgString("{{ Session.PathMappingRulesFile }}"),
                             ArgString("-s3"),
                             ArgString(s3_settings.to_s3_root_uri()),
-                            ArgString("-m"),
+                            ArgString("-wp"),
+                            ArgString("{{ Task.File.WorkerManifestProperties }}"),
                         ],
                     )
                 ),
@@ -200,13 +218,32 @@ class TestStart:
                         name="AttachmentDownload",
                         type=EmbeddedFileTypes_2023_09.TEXT,
                         data=DataString(f.read()),
-                    )
+                    ),
+                    EmbeddedFileText_2023_09(
+                        name="WorkerManifestProperties",
+                        type=EmbeddedFileTypes_2023_09.TEXT,
+                        data=DataString(ANY),  # JSON data will vary
+                    ),
                 ],
             )
+
+            # Check the basic structure
+            assert action._step_script is not None
+            assert (
+                action._step_script.actions.onRun.command == expected_script.actions.onRun.command
+            )
+            assert action._step_script.actions.onRun.args == expected_script.actions.onRun.args
+            assert action._step_script.embeddedFiles is not None
+            assert len(action._step_script.embeddedFiles) == 2
+            assert action._step_script.embeddedFiles[0].name == "AttachmentDownload"
+            assert action._step_script.embeddedFiles[1].name == "WorkerManifestProperties"
 
         session.run_task.assert_called_once_with(
             step_script=action._step_script,
             task_parameter_values=dict[str, ParameterValue](),
+            os_env_vars={
+                "DEADLINE_QUEUE_ID": TestStart.QUEUE_ID,
+            },
             log_task_banner=False,
         )
 
@@ -232,6 +269,21 @@ class TestStart:
 
         assert not job_details.path_mapping_rules
 
+        # Mock session methods for WorkerManifestProperties
+        session.set_worker_manifest_properties = Mock()
+        session.get_worker_manifest_properties_list = Mock(return_value=[])
+        session.add_local_manifest_path = Mock()
+        session.get_worker_manifest_properties = Mock(return_value=None)
+        session.add_manifest_path = Mock()
+        session.add_manifest_out_rel_dirs = Mock()
+        session.manifest_out_rel_dirs_by_source = {}
+
+        # Mock asset sync methods
+        mock_asset_sync.get_local_destination.return_value = str(session_dir)
+        mock_asset_sync._check_and_write_local_manifests.return_value = {
+            str(session_dir): "/path/to/manifest.json"
+        }
+
         # WHEN
         action.start(session=session, executor=executor)
         s3_settings = JobAttachmentS3Settings(
@@ -243,20 +295,19 @@ class TestStart:
         # Verify _get_unique_dest_dir_name was called with the root path
         mock_get_unique_dest_dir_name.assert_called_once_with("/foo/bar")
 
-        # Check that the method was called
-        assert mock_asset_sync._aggregate_asset_root_manifests.call_count == 1
-        # Get the call arguments
-        call_args = mock_asset_sync._aggregate_asset_root_manifests.call_args
-
-        # Check specific arguments individually
-        assert call_args[1]["session_dir"] == Path(session_dir)
-        assert call_args[1]["s3_settings"] == s3_settings
-        assert call_args[1]["queue_id"] == TestStart.QUEUE_ID
-        assert call_args[1]["job_id"] == TestStart.JOB_ID
-        assert call_args[1]["step_dependencies"] == []
-        assert call_args[1]["storage_profiles_path_mapping_rules"] == {
-            "/foo/bar": str(session.working_directory.joinpath(TestStart.DIR_NAME))
-        }
+        # Check that the method was called with correct arguments
+        mock_asset_sync._aggregate_asset_root_manifests.assert_called_once_with(
+            session_dir=Path(session_dir),
+            s3_settings=s3_settings,
+            queue_id=TestStart.QUEUE_ID,
+            job_id=TestStart.JOB_ID,
+            attachments=ANY,
+            step_dependencies=[],
+            dynamic_mapping_rules=ANY,
+            storage_profiles_path_mapping_rules={
+                "/foo/bar": str(session.working_directory.joinpath(TestStart.DIR_NAME))
+            },
+        )
 
         mock_asset_sync.generate_dynamic_path_mapping.assert_called_once_with(
             session_dir=Path(session_dir),
@@ -267,6 +318,122 @@ class TestStart:
             manifest_write_dir=str(session_dir),
             manifest_name_suffix="job",
         )
+
+        # Verify WorkerManifestProperties was created and set
+        session.set_worker_manifest_properties.assert_called_once()
+        call_args = session.set_worker_manifest_properties.call_args[0][0]
+        assert isinstance(call_args, WorkerManifestProperties)
+        assert call_args.local_root_path == str(session_dir)
+        assert call_args.local_manifest_paths == ["/path/to/manifest.json"]
+
+
+class TestSetStepScript:
+    """Tests for AttachmentDownloadAction.set_step_script()"""
+
+    def test_set_step_script_with_worker_manifest_properties(
+        self,
+        action: actions_module.AttachmentDownloadAction,
+        job_attachment_details: JobAttachmentDetails,
+        python_path: str,
+    ) -> None:
+        """
+        Tests that set_step_script creates the correct step script with worker manifest properties
+        """
+        # GIVEN
+        from deadline.job_attachments.models import ManifestProperties, PathFormat
+
+        manifest_properties = ManifestProperties(
+            rootPath="/test/root",
+            rootPathFormat=PathFormat.POSIX,
+            fileSystemLocationName="test-location",
+            inputManifestPath="/test/manifest.json",
+            inputManifestHash="test-hash",
+            outputRelativeDirectories=["/output"],
+        )
+
+        worker_manifest_properties = WorkerManifestProperties(
+            manifest_properties=manifest_properties,
+            local_root_path="/local/root",
+            local_manifest_paths=["/local/manifest.json"],
+        )
+
+        s3_settings = JobAttachmentS3Settings(
+            s3BucketName="test-bucket",
+            rootPrefix="test-prefix",
+        )
+
+        # WHEN
+        action.set_step_script(
+            worker_manifest_properties_list=[worker_manifest_properties],
+            s3_settings=s3_settings,
+        )
+
+        # THEN
+        assert action._step_script is not None
+
+        # Check command and args
+        assert action._step_script.actions.onRun.command == CommandString(python_path)
+        expected_args = [
+            ArgString("{{ Task.File.AttachmentDownload }}"),
+            ArgString("-s3"),
+            ArgString(s3_settings.to_s3_root_uri()),
+            ArgString("-wp"),
+            ArgString("{{ Task.File.WorkerManifestProperties }}"),
+        ]
+        assert action._step_script.actions.onRun.args == expected_args
+
+        # Check embedded files
+        assert action._step_script.embeddedFiles is not None
+        assert len(action._step_script.embeddedFiles) == 2
+
+        # Check AttachmentDownload file
+        attachment_file = action._step_script.embeddedFiles[0]
+        assert attachment_file.name == "AttachmentDownload"
+        assert attachment_file.type == EmbeddedFileTypes_2023_09.TEXT
+
+        # Check WorkerManifestProperties file
+        worker_props_file = action._step_script.embeddedFiles[1]
+        assert worker_props_file.name == "WorkerManifestProperties"
+        assert worker_props_file.type == EmbeddedFileTypes_2023_09.TEXT
+
+        # Verify the worker properties JSON contains expected data
+        worker_props_data = json.loads(worker_props_file.data)
+        assert len(worker_props_data) == 1
+        assert worker_props_data[0]["localRootPath"] == "/local/root"
+        assert worker_props_data[0]["localManifestPaths"] == ["/local/manifest.json"]
+
+    def test_set_step_script_with_empty_worker_manifest_properties(
+        self,
+        action: actions_module.AttachmentDownloadAction,
+        python_path: str,
+    ) -> None:
+        """
+        Tests that set_step_script works with empty worker manifest properties list
+        """
+        # GIVEN
+        s3_settings = JobAttachmentS3Settings(
+            s3BucketName="test-bucket",
+            rootPrefix="test-prefix",
+        )
+
+        # WHEN
+        action.set_step_script(
+            worker_manifest_properties_list=[],
+            s3_settings=s3_settings,
+        )
+
+        # THEN
+        assert action._step_script is not None
+
+        # Check that embedded files still exist but WorkerManifestProperties is empty
+        assert action._step_script.embeddedFiles is not None
+        assert len(action._step_script.embeddedFiles) == 2
+
+        worker_props_file = action._step_script.embeddedFiles[1]
+        assert worker_props_file.name == "WorkerManifestProperties"
+
+        worker_props_data = json.loads(worker_props_file.data)
+        assert worker_props_data == []
 
 
 class TestVFS:

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -29,6 +29,8 @@ from openjd.model.v2023_09 import (
 import deadline_worker_agent.sessions.session as session_mod
 from deadline.job_attachments.models import (
     Attachments,
+    PathFormat,
+    ManifestProperties,
     JobAttachmentS3Settings,
     JobAttachmentsFileSystem,
 )
@@ -152,11 +154,23 @@ class TestStart:
         assert job_details.job_attachment_settings.s3_bucket_name is not None
         assert job_details.job_attachment_settings.root_prefix is not None
 
-        # Mock session methods for WorkerManifestProperties
+        # Create a mock WorkerManifestProperties object
+        mock_manifest_properties = ManifestProperties(
+            rootPath="/foo/bar",
+            rootPathFormat=PathFormat.POSIX,
+            fileSystemLocationName="test-location",
+            inputManifestPath="/path/to/input/manifest.json",
+            inputManifestHash="inputmanifesthash",
+            outputRelativeDirectories=["/asset/output"],
+        )
+        mock_worker_manifest_props = WorkerManifestProperties(
+            manifest_properties=mock_manifest_properties, local_root_path=str(session_dir)
+        )
+
         session.set_worker_manifest_properties = Mock()
         session.get_worker_manifest_properties_list = Mock(return_value=[])
         session.add_local_manifest_path = Mock()
-        session.get_worker_manifest_properties = Mock(return_value=None)
+        session.get_worker_manifest_properties = Mock(return_value=mock_worker_manifest_props)
         session.add_manifest_path = Mock()
         session.add_manifest_out_rel_dirs = Mock()
         session.manifest_out_rel_dirs_by_source = {}
@@ -269,11 +283,23 @@ class TestStart:
 
         assert not job_details.path_mapping_rules
 
-        # Mock session methods for WorkerManifestProperties
+        # Create a mock WorkerManifestProperties object
+        mock_manifest_properties = ManifestProperties(
+            rootPath="/foo/bar",
+            rootPathFormat=PathFormat.POSIX,
+            fileSystemLocationName="test-location",
+            inputManifestPath="/path/to/input/manifest.json",
+            inputManifestHash="inputmanifesthash",
+            outputRelativeDirectories=["/asset/output"],
+        )
+        mock_worker_manifest_props = WorkerManifestProperties(
+            manifest_properties=mock_manifest_properties, local_root_path=str(session_dir)
+        )
+
         session.set_worker_manifest_properties = Mock()
         session.get_worker_manifest_properties_list = Mock(return_value=[])
         session.add_local_manifest_path = Mock()
-        session.get_worker_manifest_properties = Mock(return_value=None)
+        session.get_worker_manifest_properties = Mock(return_value=mock_worker_manifest_props)
         session.add_manifest_path = Mock()
         session.add_manifest_out_rel_dirs = Mock()
         session.manifest_out_rel_dirs_by_source = {}
@@ -324,7 +350,6 @@ class TestStart:
         call_args = session.set_worker_manifest_properties.call_args[0][0]
         assert isinstance(call_args, WorkerManifestProperties)
         assert call_args.local_root_path == str(session_dir)
-        assert call_args.local_manifest_paths == ["/path/to/manifest.json"]
 
 
 class TestSetStepScript:

--- a/test/unit/sessions/test_attachment_models.py
+++ b/test/unit/sessions/test_attachment_models.py
@@ -40,6 +40,7 @@ class TestWorkerManifestProperties:
         assert worker_props.manifest_properties == manifest_props
         assert worker_props.local_root_path == "/local/root"
         assert worker_props.local_manifest_paths == ["/local/manifest.json"]
+        assert worker_props.local_input_manifest_path is None
 
     def test_initialization_with_empty_string_local_root_path(self):
         """Test that empty string local_root_path is allowed (no validation)."""
@@ -137,6 +138,26 @@ class TestWorkerManifestProperties:
         assert worker_props.local_root_path == "/local/root"
         assert worker_props.local_manifest_paths == []
 
+    def test_input_manifest_path_setter(self):
+        """Test input_manifest_path property setter."""
+        # GIVEN
+        manifest_props = ManifestProperties(
+            rootPath="/source/path",
+            rootPathFormat=PathFormat.POSIX,
+            inputManifestPath="s3://input/manifest.json",
+            fileSystemLocationName="shared_storage",
+        )
+        worker_props = WorkerManifestProperties(
+            manifest_properties=manifest_props, local_root_path="/local/root"
+        )
+
+        # WHEN
+        worker_props.local_input_manifest_path = "/local/input/manifest.json"
+
+        # THEN
+        assert worker_props.input_manifest_path == "s3://input/manifest.json"
+        assert worker_props.local_input_manifest_path == "/local/input/manifest.json"
+
     def test_property_accessors_with_none_values(self):
         """Test property accessors when optional fields are None."""
         # GIVEN
@@ -198,6 +219,7 @@ class TestWorkerManifestProperties:
             manifest_properties=manifest_props,
             local_root_path="/local/session/complex_path_hash",
             local_manifest_paths=["/local/session/manifests/complex_manifest.json"],
+            local_input_manifest_path="/local/session/manifests/complex_manifest.json",
         )
 
         # THEN
@@ -212,6 +234,10 @@ class TestWorkerManifestProperties:
         assert worker_props.local_manifest_paths == [
             "/local/session/manifests/complex_manifest.json"
         ]
+        assert (
+            worker_props.local_input_manifest_path
+            == "/local/session/manifests/complex_manifest.json"
+        )
 
     def test_equality_and_comparison(self):
         """Test equality comparison between WorkerManifestProperties instances."""
@@ -435,6 +461,7 @@ class TestWorkerManifestProperties:
                 "outputRelativeDirectories": ["out1", "out2"],
             },
             "localManifestPaths": ["/local/manifest1.json", "/local/manifest2.json"],
+            "localInputManifestPath": "/local/manifest1.json",
             "localRootPath": "/local/root",
         }
 
@@ -455,6 +482,7 @@ class TestWorkerManifestProperties:
             "/local/manifest1.json",
             "/local/manifest2.json",
         ]
+        assert worker_props.local_input_manifest_path == "/local/manifest1.json"
         assert worker_props.local_root_path == "/local/root"
 
     def test_from_dict_with_missing_optional_fields(self):
@@ -544,6 +572,7 @@ class TestWorkerManifestProperties:
             manifest_properties=manifest_props,
             local_root_path="/local/minimal",
         )
+        original_worker_props.local_input_manifest_path = "/local/input/manifest.json"
 
         # Mock ManifestProperties.to_dict() with data compatible with from_dict
         mock_manifest_dict = {"rootPath": "/minimal/path", "rootPathFormat": "posix"}

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -2899,7 +2899,7 @@ class TestSessionWorkerManifestProperties:
         initial_paths = worker_manifest_properties.local_manifest_paths.copy()
 
         # WHEN
-        session.add_local_manifest_path(
+        returned_props = session.add_local_manifest_path(
             worker_manifest_properties.local_root_path, new_manifest_path
         )
 
@@ -2908,6 +2908,7 @@ class TestSessionWorkerManifestProperties:
             worker_manifest_properties.local_root_path
         )
         assert updated_props is not None
+        assert returned_props is updated_props  # Verify return value is the same object
         assert len(updated_props.local_manifest_paths) == len(initial_paths) + 1
         assert new_manifest_path in updated_props.local_manifest_paths
         assert all(path in updated_props.local_manifest_paths for path in initial_paths)
@@ -2935,8 +2936,20 @@ class TestSessionWorkerManifestProperties:
         initial_count = len(worker_manifest_properties.local_manifest_paths)
 
         # WHEN
+        returned_props_list = []
         for path in new_paths:
-            session.add_local_manifest_path(worker_manifest_properties.local_root_path, path)
+            returned_props = session.add_local_manifest_path(
+                worker_manifest_properties.local_root_path, path
+            )
+            returned_props_list.append(returned_props)
+
+            # THEN
+            updated_props = session.get_worker_manifest_properties(
+                worker_manifest_properties.local_root_path
+            )
+            assert updated_props is not None
+            assert returned_props is updated_props
+            assert path in updated_props.local_manifest_paths
 
         # THEN
         updated_props = session.get_worker_manifest_properties(
@@ -2944,8 +2957,6 @@ class TestSessionWorkerManifestProperties:
         )
         assert updated_props is not None
         assert len(updated_props.local_manifest_paths) == initial_count + len(new_paths)
-        for path in new_paths:
-            assert path in updated_props.local_manifest_paths
 
     def test_worker_manifest_properties_dict_property_reflects_changes(
         self, session: Session, worker_manifest_properties: WorkerManifestProperties
@@ -2976,7 +2987,7 @@ class TestSessionWorkerManifestProperties:
         session.set_worker_manifest_properties(second_worker_manifest_properties)
 
         # WHEN - Add manifest path to first properties
-        session.add_local_manifest_path(
+        returned_props = session.add_local_manifest_path(
             worker_manifest_properties.local_root_path, additional_manifest_path
         )
 
@@ -2994,6 +3005,7 @@ class TestSessionWorkerManifestProperties:
         assert len(all_properties) == 2
         assert first_properties is not None
         assert second_properties is not None
+        assert returned_props is first_properties  # Verify return value is correct
         assert additional_manifest_path in first_properties.local_manifest_paths
         assert additional_manifest_path not in second_properties.local_manifest_paths
         assert len(properties_dict) == 2


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The job attachment download needed better tracking of manifest properties including local paths during the download process.

### What was the solution? (How)
1. **Enhanced WorkerManifestProperties model**: Added a new `local_input_manifest_path` field to the `WorkerManifestProperties` class to store the local path to the input manifest file during download operations.

2. **Updated attachment download logic**: Modified the `run_attachment_download.py` to properly set and utilize the WorkerManifestProperties.

3. **Refactored download script**: Enhanced the `attachment_download.py` script to handle the new manifest path information more effectively. Use `download_files_from_manifests` to replace `attachment_download` API.

### What is the impact of this change?
- **Improved tracking**: Better visibility and control over local input manifest paths during job attachment downloads
- **Enhanced reliability**: More robust download process with proper manifest path management  

### How was this change tested?
1. hatch run test
2. run job submission e2e tests

### Was this change documented?
Documentation is tracked separately.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*