### PR TITLE
test: fix s3 validation tests

### DIFF
--- a/test/e2e/s3_validation_utils.py
+++ b/test/e2e/s3_validation_utils.py
@@ -78,7 +78,7 @@ def validate_s3_job_output_manifest(
 
         for step in steps:
             step_id = step["stepId"]
-            manifest_prefix = f"Deadline/Manifests/{farm_id}/{queue_id}/{job.id}/{step_id}"
+            manifest_prefix = f"rootPrefix/Manifests/{farm_id}/{queue_id}/{job.id}/{step_id}"
 
             try:
                 manifest_keys = _get_tasks_manifests_keys_from_s3(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Our S3 validation code for better testing assume the S3 prefix start with `Deadline`, but our test account set it up to start with `rootPrefix`

### What was the solution? (How)
We modify the S3 prefix to start with `rootPrefix`

### What is the impact of this change?
Mainline E2E passing again

### How was this change tested?
Run against a real job from the test account

### Was this change documented?
No


### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*