### PR TITLE
feat: support optional task id in task run session actions

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -80,7 +80,7 @@ class ChunkIntParameter(TypedDict):
 class TaskRunAction(TypedDict):
     sessionActionId: str
     actionType: StepActionType
-    taskId: str
+    taskId: NotRequired[str]
     stepId: str
     parameters: NotRequired[
         dict[
@@ -106,7 +106,7 @@ class AttachmentUploadAction(TypedDict):
     sessionActionId: str
     actionType: AttachmentUploadActionType
     stepId: str
-    taskId: str
+    taskId: NotRequired[str]
     startTime: float
 
 

--- a/src/deadline_worker_agent/boto/shim.py
+++ b/src/deadline_worker_agent/boto/shim.py
@@ -156,9 +156,10 @@ class DeadlineClient:
             mapped_action = TaskRunAction(
                 sessionActionId=action_id,
                 actionType="TASK_RUN",
-                taskId=action["taskId"],
                 stepId=action["stepId"],
             )
+            if action.get("taskId"):
+                mapped_action["taskId"] = action["taskId"]
             if parameters := action.get("parameters", None):
                 mapped_action["parameters"] = parameters
             return mapped_action

--- a/src/deadline_worker_agent/config/config_file.py
+++ b/src/deadline_worker_agent/config/config_file.py
@@ -116,7 +116,7 @@ line below:
     SESSION_ROOT_DIR = ModifiableSettingData(
         setting_name="session_root_dir",
         table_name="worker",
-        preceding_comment="""
+        preceding_comment=r"""
 The session root directory is a parent directory where worker agent creates per-session
 subdirectories under. This value is overridden when the DEADLINE_WORKER_SESSION_ROOT_DIR environment
 variable is set or the --session-root-dir command-line argument is specified.

--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -483,7 +483,7 @@ class SessionActionQueue:
                 action_queue_entry = cast(TaskRunQueueEntry, action_queue_entry)
                 action_definition = action_queue_entry.definition
                 step_id = action_definition["stepId"]
-                task_id = action_definition["taskId"]
+                task_id = action_definition.get("taskId")
                 try:
                     step_details = self._job_entities.step_details(step_id=step_id)
                 except UnsupportedSchema as e:
@@ -509,15 +509,14 @@ class SessionActionQueue:
                     id=action_id,
                     details=step_details,
                     task_parameter_values=task_parameters,
-                    task_id=action_definition["taskId"],
+                    task_id=action_definition.get("taskId"),
                 )
             elif action_type == "SYNC_OUTPUT_JOB_ATTACHMENTS":
                 action_queue_entry = cast(AttachmentUploadActionQueueEntry, action_queue_entry)
                 action_definition = action_queue_entry.definition
                 step_id = action_definition["stepId"]
-                task_id = action_definition["taskId"]
+                task_id = action_definition.get("taskId")
                 start_time = action_definition["startTime"]
-
                 next_action = AttachmentUploadAction(
                     id=action_id,
                     session_id=self._session_id,

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
@@ -51,7 +51,7 @@ class AttachmentUploadAction(OpenjdAction):
 
     _step_script: Optional[StepScript_2023_09]
     _step_id: str
-    _task_id: str
+    _task_id: Optional[str]
     _start_time: float
 
     def __init__(
@@ -60,7 +60,7 @@ class AttachmentUploadAction(OpenjdAction):
         id: str,
         session_id: str,
         step_id: str,
-        task_id: str,
+        task_id: Optional[str] = None,
         start_time: float,
     ) -> None:
         super(AttachmentUploadAction, self).__init__(
@@ -183,15 +183,20 @@ class AttachmentUploadAction(OpenjdAction):
         )
 
         assert self._step_script is not None
+
+        env_vars = {
+            "DEADLINE_SESSIONACTION_ID": self._id,
+            "DEADLINE_SESSIONACTION_START_TIME": str(self._start_time),
+            "DEADLINE_STEP_ID": self._step_id,
+            "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
+        }
+
+        if self._task_id is not None:
+            env_vars["DEADLINE_TASK_ID"] = self._task_id
+
         session.run_task(
             step_script=self._step_script,
             task_parameter_values=dict[str, ParameterValue](),
-            os_env_vars={
-                "DEADLINE_SESSIONACTION_ID": self._id,
-                "DEADLINE_SESSIONACTION_START_TIME": str(self._start_time),
-                "DEADLINE_STEP_ID": self._step_id,
-                "DEADLINE_TASK_ID": self._task_id,
-                "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
-            },
+            os_env_vars=env_vars,
             log_task_banner=False,
         )

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from concurrent.futures import Executor
-from typing import Any, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 from openjd.model import TaskParameterSet
 
@@ -25,13 +25,13 @@ class RunStepTaskAction(OpenjdAction):
         The unique step identifier
     details : StepDetails
         The environment details
-    task_id : str
+    task_id : Optional[str]
         The unique task identifier
     task_parameter_values : TaskParameterSet
         The task parameter values
     """
 
-    task_id: str
+    task_id: Optional[str]
     _details: StepDetails
     _task_parameter_values: TaskParameterSet
 
@@ -40,7 +40,7 @@ class RunStepTaskAction(OpenjdAction):
         *,
         id: str,
         details: StepDetails,
-        task_id: str,
+        task_id: Optional[str] = None,
         task_parameter_values: TaskParameterSet,
     ) -> None:
         super(RunStepTaskAction, self).__init__(
@@ -70,11 +70,12 @@ class RunStepTaskAction(OpenjdAction):
         executor : Executor
             An executor for running futures
         """
+        env_vars = {"DEADLINE_SESSIONACTION_ID": self._id}
+        if self.task_id is not None:
+            env_vars["DEADLINE_TASK_ID"] = self.task_id
+
         session.run_task(
             step_script=self._details.step_template.script,
             task_parameter_values=self._task_parameter_values,
-            os_env_vars={
-                "DEADLINE_SESSIONACTION_ID": self._id,
-                "DEADLINE_TASK_ID": self.task_id,
-            },
+            os_env_vars=env_vars,
         )

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -269,15 +269,7 @@ def upload_output_assets(
     """
 
     # Generate S3 upload path using session context from environment variables
-    s3_upload_path = JobAttachmentS3Settings.partial_session_action_manifest_prefix(
-        farm_id=os.environ["DEADLINE_FARM_ID"],
-        queue_id=os.environ["DEADLINE_QUEUE_ID"],
-        job_id=os.environ["DEADLINE_JOB_ID"],
-        step_id=os.environ["DEADLINE_STEP_ID"],
-        task_id=os.environ["DEADLINE_TASK_ID"],
-        session_action_id=os.environ["DEADLINE_SESSIONACTION_ID"],
-        time=float(os.environ["DEADLINE_SESSIONACTION_START_TIME"]),
-    )
+    s3_upload_path = build_s3_manifest_path()
 
     # Create S3 settings from the provided URI
     s3_settings = JobAttachmentS3Settings.from_s3_root_uri(s3_uri)
@@ -326,6 +318,48 @@ def upload_output_assets(
             )
 
     return output_manifest_info_list
+
+
+def is_manifest_reporting_enabled() -> bool:
+    """Check if manifest reporting feature is enabled."""
+    return os.environ.get("MANIFEST_REPORTING_FEATURE", "false").lower() == "true"
+
+
+def should_use_task_chunking_format() -> bool:
+    """Determine if task chunking format (without task_id) should be used."""
+    return is_manifest_reporting_enabled() and not os.environ.get("DEADLINE_TASK_ID")
+
+
+def build_s3_manifest_path() -> str:
+    """Build S3 path for manifest upload based on current configuration."""
+
+    farm_id = os.environ["DEADLINE_FARM_ID"]
+    queue_id = os.environ["DEADLINE_QUEUE_ID"]
+    job_id = os.environ["DEADLINE_JOB_ID"]
+    step_id = os.environ["DEADLINE_STEP_ID"]
+    session_action_id = os.environ["DEADLINE_SESSIONACTION_ID"]
+    time = float(os.environ["DEADLINE_SESSIONACTION_START_TIME"])
+
+    if should_use_task_chunking_format():
+        return JobAttachmentS3Settings.partial_session_action_manifest_prefix_without_task(  # type: ignore[attr-defined]
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+            step_id=step_id,
+            session_action_id=session_action_id,
+            time=time,
+        )
+    else:
+        task_id = os.environ["DEADLINE_TASK_ID"]
+        return JobAttachmentS3Settings.partial_session_action_manifest_prefix(
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+            step_id=step_id,
+            task_id=task_id,
+            session_action_id=session_action_id,
+            time=time,
+        )
 
 
 @record_success_fail_telemetry_event(metric_name="attachment_upload")
@@ -385,11 +419,7 @@ def main(args=None):
         latencies.upload_output_assets = time.perf_counter_ns() - start_t
 
         # Check if manifest reporting feature is enabled via environment variable
-        manifest_reporting_enabled = (
-            os.environ.get("MANIFEST_REPORTING_FEATURE", "false").lower() == "true"
-        )
-
-        if manifest_reporting_enabled:
+        if is_manifest_reporting_enabled():
             # ja_upload: is a key word that is detected in the worker agent log filter
             # We're printing the manifest info to the logs so that we can re-load it as a manifest info in the worker agent process
             print(f"ja_upload: {json.dumps([asdict(info) for info in manifest_infos])}")

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -1276,9 +1276,10 @@ class Session:
                     sessionActionId=current_action.definition._id,
                     actionType="SYNC_OUTPUT_JOB_ATTACHMENTS",
                     stepId=current_action.definition.step_id,
-                    taskId=current_action.definition.task_id,
                     startTime=current_action.start_time.timestamp(),
                 )
+                if current_action.definition.task_id is not None:
+                    action["taskId"] = current_action.definition.task_id
 
                 if not self._action_output_log_filter:
                     self._action_output_log_filter = ActionOutputCaptureFilter(
@@ -1489,6 +1490,7 @@ class Session:
         from .actions import RunStepTaskAction
 
         assert isinstance(current_action.definition, RunStepTaskAction)
+        assert current_action.definition.task_id is not None
 
         upload_summary_statistics: SummaryStatistics = self._asset_sync.sync_outputs(
             s3_settings=s3_settings,

--- a/test/unit/boto/test_shim_optional_task_id.py
+++ b/test/unit/boto/test_shim_optional_task_id.py
@@ -1,0 +1,115 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from deadline_worker_agent.boto.shim import DeadlineClient
+
+
+class TestDeadlineClientOptionalTaskId:
+    """Tests for DeadlineClient handling optional task_id."""
+
+    def test_parse_task_run_action_with_task_id(self):
+        """Test parsing TaskRunAction with taskId field."""
+        # Arrange
+        response = {
+            "assignedSessions": {
+                "session-1": {
+                    "queueId": "queue-123",
+                    "jobId": "job-456",
+                    "sessionActions": [
+                        {
+                            "sessionActionId": "action-789",
+                            "definition": {
+                                "taskRun": {
+                                    "taskId": "task-123",
+                                    "stepId": "step-456",
+                                    "parameters": {"param1": "value1"},
+                                }
+                            },
+                        }
+                    ],
+                }
+            },
+            "cancelSessionActions": {},
+            "updateIntervalSeconds": 60,
+        }
+
+        # Act
+        result = DeadlineClient._parse_update_worker_schedule_response(response)
+
+        # Assert
+        task_action = result["assignedSessions"]["session-1"]["sessionActions"][0]
+        assert task_action["sessionActionId"] == "action-789"
+        assert task_action["actionType"] == "TASK_RUN"
+        assert task_action["stepId"] == "step-456"
+        assert task_action["taskId"] == "task-123"
+        assert task_action["parameters"] == {"param1": "value1"}
+
+    def test_parse_task_run_action_without_task_id(self):
+        """Test parsing TaskRunAction without taskId field."""
+        # Arrange
+        response = {
+            "assignedSessions": {
+                "session-1": {
+                    "queueId": "queue-123",
+                    "jobId": "job-456",
+                    "sessionActions": [
+                        {
+                            "sessionActionId": "action-789",
+                            "definition": {
+                                "taskRun": {
+                                    "stepId": "step-456",
+                                    "parameters": {"param1": "value1"},
+                                }
+                            },
+                        }
+                    ],
+                }
+            },
+            "cancelSessionActions": {},
+            "updateIntervalSeconds": 60,
+        }
+
+        # Act
+        result = DeadlineClient._parse_update_worker_schedule_response(response)
+
+        # Assert
+        task_action = result["assignedSessions"]["session-1"]["sessionActions"][0]
+        assert task_action["sessionActionId"] == "action-789"
+        assert task_action["actionType"] == "TASK_RUN"
+        assert task_action["stepId"] == "step-456"
+        assert "taskId" not in task_action
+        assert task_action["parameters"] == {"param1": "value1"}
+
+    def test_parse_task_run_action_with_none_task_id(self):
+        """Test parsing TaskRunAction with None taskId."""
+        # Arrange
+        response = {
+            "assignedSessions": {
+                "session-1": {
+                    "queueId": "queue-123",
+                    "jobId": "job-456",
+                    "sessionActions": [
+                        {
+                            "sessionActionId": "action-789",
+                            "definition": {
+                                "taskRun": {
+                                    "taskId": None,
+                                    "stepId": "step-456",
+                                }
+                            },
+                        }
+                    ],
+                }
+            },
+            "cancelSessionActions": {},
+            "updateIntervalSeconds": 60,
+        }
+
+        # Act
+        result = DeadlineClient._parse_update_worker_schedule_response(response)
+
+        # Assert
+        task_action = result["assignedSessions"]["session-1"]["sessionActions"][0]
+        assert task_action["sessionActionId"] == "action-789"
+        assert task_action["actionType"] == "TASK_RUN"
+        assert task_action["stepId"] == "step-456"
+        assert "taskId" not in task_action

--- a/test/unit/scheduler/test_session_queue_optional_task_id.py
+++ b/test/unit/scheduler/test_session_queue_optional_task_id.py
@@ -1,0 +1,152 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest.mock import Mock, patch
+import pytest
+
+from deadline_worker_agent.api_models import TaskRunAction, AttachmentUploadAction
+from deadline_worker_agent.scheduler.session_queue import (
+    SessionActionQueue,
+    TaskRunQueueEntry,
+    AttachmentUploadActionQueueEntry,
+)
+from deadline_worker_agent.sessions.actions import RunStepTaskAction
+from deadline_worker_agent.sessions.actions import (
+    AttachmentUploadAction as AttachmentUploadActionImpl,
+)
+
+
+class TestSessionActionQueueOptionalTaskId:
+    """Tests for SessionActionQueue handling optional task_id."""
+
+    @pytest.fixture
+    def mock_job_entities(self):
+        job_entities = Mock()
+        job_entities.step_details.return_value = Mock()
+        return job_entities
+
+    @pytest.fixture
+    def session_queue(self, mock_job_entities):
+        return SessionActionQueue(
+            queue_id="queue-123",
+            job_id="job-456",
+            session_id="session-789",
+            job_entities=mock_job_entities,
+            action_update_callback=Mock(),
+        )
+
+    def test_dequeue_task_run_action_without_task_id(self, session_queue, mock_job_entities):
+        """Test dequeue creates RunStepTaskAction when TaskRunAction has no taskId."""
+        # Arrange
+        action_definition = TaskRunAction(
+            sessionActionId="action-123",
+            actionType="TASK_RUN",
+            stepId="step-456",
+            # No taskId field
+        )
+
+        queue_entry = TaskRunQueueEntry(
+            cancel=Mock(),
+            definition=action_definition,
+        )
+        session_queue._actions = [queue_entry]
+        session_queue._actions_by_id = {"action-123": queue_entry}
+
+        # Mock the step details
+        mock_step_details = Mock()
+        mock_job_entities.step_details.return_value = mock_step_details
+
+        # Act
+        with patch(
+            "deadline_worker_agent.scheduler.session_queue.parameters_from_api_response",
+            return_value={},
+        ):
+            action = session_queue.dequeue()
+
+        # Assert
+        assert isinstance(action, RunStepTaskAction)
+        assert action.task_id is None
+        assert action._id == "action-123"
+
+    def test_dequeue_task_run_action_with_task_id(self, session_queue, mock_job_entities):
+        """Test dequeue creates RunStepTaskAction when TaskRunAction has taskId."""
+        # Arrange
+        action_definition = TaskRunAction(
+            sessionActionId="action-123",
+            actionType="TASK_RUN",
+            stepId="step-456",
+            taskId="task-789",
+        )
+
+        queue_entry = TaskRunQueueEntry(
+            cancel=Mock(),
+            definition=action_definition,
+        )
+        session_queue._actions = [queue_entry]
+        session_queue._actions_by_id = {"action-123": queue_entry}
+
+        # Mock the step details
+        mock_step_details = Mock()
+        mock_job_entities.step_details.return_value = mock_step_details
+
+        # Act
+        with patch(
+            "deadline_worker_agent.scheduler.session_queue.parameters_from_api_response",
+            return_value={},
+        ):
+            action = session_queue.dequeue()
+
+        # Assert
+        assert isinstance(action, RunStepTaskAction)
+        assert action.task_id == "task-789"
+        assert action._id == "action-123"
+
+    def test_dequeue_attachment_upload_action_without_task_id(self, session_queue):
+        """Test dequeue creates AttachmentUploadAction when definition has no taskId."""
+        # Arrange
+        action_definition = AttachmentUploadAction(
+            sessionActionId="action-123",
+            actionType="SYNC_OUTPUT_JOB_ATTACHMENTS",
+            stepId="step-456",
+            startTime=1234567890.0,
+        )
+
+        queue_entry = AttachmentUploadActionQueueEntry(
+            cancel=Mock(),
+            definition=action_definition,
+        )
+        session_queue._actions = [queue_entry]
+        session_queue._actions_by_id = {"action-123": queue_entry}
+
+        # Act
+        action = session_queue.dequeue()
+
+        # Assert
+        assert isinstance(action, AttachmentUploadActionImpl)
+        assert action._task_id is None
+        assert action._step_id == "step-456"
+
+    def test_dequeue_attachment_upload_action_with_task_id(self, session_queue):
+        """Test dequeue creates AttachmentUploadAction when definition has taskId."""
+        # Arrange
+        action_definition = AttachmentUploadAction(
+            sessionActionId="action-123",
+            actionType="SYNC_OUTPUT_JOB_ATTACHMENTS",
+            stepId="step-456",
+            taskId="task-789",
+            startTime=1234567890.0,
+        )
+
+        queue_entry = AttachmentUploadActionQueueEntry(
+            cancel=Mock(),
+            definition=action_definition,
+        )
+        session_queue._actions = [queue_entry]
+        session_queue._actions_by_id = {"action-123": queue_entry}
+
+        # Act
+        action = session_queue.dequeue()
+
+        # Assert
+        assert isinstance(action, AttachmentUploadActionImpl)
+        assert action._task_id == "task-789"
+        assert action._step_id == "step-456"

--- a/test/unit/sessions/actions/test_attachment_upload_path_format.py
+++ b/test/unit/sessions/actions/test_attachment_upload_path_format.py
@@ -1,0 +1,218 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from deadline_worker_agent.sessions.actions.scripts.attachment_upload import upload_output_assets
+from deadline_worker_agent.sessions.attachment_models import WorkerManifestProperties
+
+
+class TestAttachmentUploadPathFormat:
+    """Test that upload_output_assets uses correct path format based on feature flag."""
+
+    @pytest.fixture
+    def mock_env_vars(self):
+        """Mock environment variables for upload."""
+        return {
+            "DEADLINE_FARM_ID": "farm-123",
+            "DEADLINE_QUEUE_ID": "queue-456",
+            "DEADLINE_JOB_ID": "job-789",
+            "DEADLINE_STEP_ID": "step-abc",
+            "DEADLINE_TASK_ID": "task-def",
+            "DEADLINE_SESSIONACTION_ID": "sessionaction-ghi-1",
+            "DEADLINE_SESSIONACTION_START_TIME": "1234567890.0",
+        }
+
+    @pytest.fixture
+    def mock_worker_manifest_properties(self):
+        """Mock worker manifest properties."""
+        mock_props = MagicMock(spec=WorkerManifestProperties)
+        mock_props.root_path = "/test/root"
+        mock_props.local_root_path = "/local/test/root"
+        mock_props.get_hashed_source_path.return_value = "hashed_path"
+        mock_props.as_output_metadata.return_value = {}
+        return [mock_props]
+
+    @pytest.fixture
+    def mock_root_path_to_output_manifest(self):
+        """Mock root path to output manifest mapping."""
+        return {"/test/root": "/path/to/output/manifest.json"}
+
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.S3AssetUploader")
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_upload.JobAttachmentS3Settings"
+    )
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.decode_manifest")
+    @patch("builtins.open")
+    def test_old_format_when_feature_disabled(
+        self,
+        mock_open,
+        mock_decode_manifest,
+        mock_s3_settings,
+        mock_uploader_class,
+        mock_env_vars,
+        mock_worker_manifest_properties,
+        mock_root_path_to_output_manifest,
+    ):
+        """Test that old format is used when MANIFEST_REPORTING_FEATURE=false."""
+        # Arrange
+        mock_env_vars["MANIFEST_REPORTING_FEATURE"] = "false"
+        mock_s3_settings.partial_session_action_manifest_prefix.return_value = "test/path"
+        mock_s3_settings.from_s3_root_uri.return_value = MagicMock()
+
+        mock_uploader = MagicMock()
+        mock_uploader_class.return_value = mock_uploader
+        mock_uploader.upload_assets.return_value = ("key", "data")
+
+        mock_decode_manifest.return_value = {}
+        mock_open.return_value.__enter__.return_value.read.return_value = "{}"
+
+        with patch.dict(os.environ, mock_env_vars):
+            # Act
+            upload_output_assets(
+                "s3://bucket/root",
+                mock_worker_manifest_properties,
+                mock_root_path_to_output_manifest,
+            )
+
+            # Assert: Should call old format method with task_id
+            mock_s3_settings.partial_session_action_manifest_prefix.assert_called_once()
+            call_args = mock_s3_settings.partial_session_action_manifest_prefix.call_args[1]
+            assert "task_id" in call_args
+            assert call_args["task_id"] == "task-def"
+
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.S3AssetUploader")
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_upload.JobAttachmentS3Settings"
+    )
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.decode_manifest")
+    @patch("builtins.open")
+    def test_old_format_when_feature_enabled_but_task_id_present(
+        self,
+        mock_open,
+        mock_decode_manifest,
+        mock_s3_settings,
+        mock_uploader_class,
+        mock_env_vars,
+        mock_worker_manifest_properties,
+        mock_root_path_to_output_manifest,
+    ):
+        """Test that old format is used when MANIFEST_REPORTING_FEATURE=true but task_id is present."""
+        # Arrange
+        mock_env_vars["MANIFEST_REPORTING_FEATURE"] = "true"
+        # Keep task_id present
+        mock_s3_settings.partial_session_action_manifest_prefix.return_value = "test/path"
+        mock_s3_settings.from_s3_root_uri.return_value = MagicMock()
+
+        mock_uploader = MagicMock()
+        mock_uploader_class.return_value = mock_uploader
+        mock_uploader.upload_assets.return_value = ("key", "data")
+
+        mock_decode_manifest.return_value = {}
+        mock_open.return_value.__enter__.return_value.read.return_value = "{}"
+
+        with patch.dict(os.environ, mock_env_vars):
+            # Act
+            upload_output_assets(
+                "s3://bucket/root",
+                mock_worker_manifest_properties,
+                mock_root_path_to_output_manifest,
+            )
+
+            # Assert: Should call old format method with task_id
+            mock_s3_settings.partial_session_action_manifest_prefix.assert_called_once()
+            call_args = mock_s3_settings.partial_session_action_manifest_prefix.call_args[1]
+            assert "task_id" in call_args
+            assert call_args["task_id"] == "task-def"
+
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.S3AssetUploader")
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_upload.JobAttachmentS3Settings"
+    )
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.decode_manifest")
+    @patch("builtins.open")
+    def test_new_format_when_feature_enabled_task_id_not_present(
+        self,
+        mock_open,
+        mock_decode_manifest,
+        mock_s3_settings,
+        mock_uploader_class,
+        mock_env_vars,
+        mock_worker_manifest_properties,
+        mock_root_path_to_output_manifest,
+    ):
+        """Test that new format is used when MANIFEST_REPORTING_FEATURE=true."""
+        # Arrange
+        mock_env_vars["MANIFEST_REPORTING_FEATURE"] = "true"
+        # Remove task_id to simulate new format
+        del mock_env_vars["DEADLINE_TASK_ID"]
+
+        mock_s3_settings.partial_session_action_manifest_prefix_without_task.return_value = (
+            "test/path"
+        )
+        mock_s3_settings.from_s3_root_uri.return_value = MagicMock()
+
+        mock_uploader = MagicMock()
+        mock_uploader_class.return_value = mock_uploader
+        mock_uploader.upload_assets.return_value = ("key", "data")
+
+        mock_decode_manifest.return_value = {}
+        mock_open.return_value.__enter__.return_value.read.return_value = "{}"
+
+        with patch.dict(os.environ, mock_env_vars):
+            # Act
+            upload_output_assets(
+                "s3://bucket/root",
+                mock_worker_manifest_properties,
+                mock_root_path_to_output_manifest,
+            )
+
+            # Assert: Should call new format method without task_id
+            mock_s3_settings.partial_session_action_manifest_prefix_without_task.assert_called_once()
+            call_args = (
+                mock_s3_settings.partial_session_action_manifest_prefix_without_task.call_args[1]
+            )
+            assert "task_id" not in call_args
+
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.S3AssetUploader")
+    @patch(
+        "deadline_worker_agent.sessions.actions.scripts.attachment_upload.JobAttachmentS3Settings"
+    )
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.decode_manifest")
+    @patch("builtins.open")
+    def test_default_behavior_is_old_format(
+        self,
+        mock_open,
+        mock_decode_manifest,
+        mock_s3_settings,
+        mock_uploader_class,
+        mock_env_vars,
+        mock_worker_manifest_properties,
+        mock_root_path_to_output_manifest,
+    ):
+        """Test that old format is used by default when feature flag not set."""
+        # Arrange: No MANIFEST_REPORTING_FEATURE in environment
+        mock_s3_settings.partial_session_action_manifest_prefix.return_value = "test/path"
+        mock_s3_settings.from_s3_root_uri.return_value = MagicMock()
+
+        mock_uploader = MagicMock()
+        mock_uploader_class.return_value = mock_uploader
+        mock_uploader.upload_assets.return_value = ("key", "data")
+
+        mock_decode_manifest.return_value = {}
+        mock_open.return_value.__enter__.return_value.read.return_value = "{}"
+
+        with patch.dict(os.environ, mock_env_vars):
+            # Act
+            upload_output_assets(
+                "s3://bucket/root",
+                mock_worker_manifest_properties,
+                mock_root_path_to_output_manifest,
+            )
+
+            # Assert: Should default to old format with task_id
+            mock_s3_settings.partial_session_action_manifest_prefix.assert_called_once()
+            call_args = mock_s3_settings.partial_session_action_manifest_prefix.call_args[1]
+            assert "task_id" in call_args
+            assert call_args["task_id"] == "task-def"

--- a/test/unit/sessions/actions/test_run_attachment_upload_optional_task_id.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload_optional_task_id.py
@@ -1,0 +1,101 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest.mock import Mock, patch
+import pytest
+
+from deadline_worker_agent.sessions.actions.run_attachment_upload import AttachmentUploadAction
+from deadline_worker_agent.sessions.attachment_models import WorkerManifestProperties
+
+
+@pytest.fixture
+def mock_session():
+    session = Mock()
+    session.run_task = Mock()
+
+    # Mock the worker manifest properties
+    mock_worker_props = Mock(spec=WorkerManifestProperties)
+    mock_worker_props.to_dict.return_value = {"test": "data"}
+    session.get_worker_manifest_properties_list.return_value = [mock_worker_props]
+
+    # Mock job details
+    session._job_details.job_attachment_settings.s3_bucket_name = "test-bucket"
+    session._job_details.job_attachment_settings.root_prefix = "test-prefix"
+
+    return session
+
+
+@pytest.fixture
+def mock_executor():
+    return Mock()
+
+
+class TestAttachmentUploadActionOptionalTaskId:
+    """Tests for AttachmentUploadAction with optional task_id."""
+
+    def test_init_with_task_id(self):
+        """Test creating AttachmentUploadAction with task_id."""
+        action = AttachmentUploadAction(
+            id="action-123",
+            session_id="session-456",
+            step_id="step-789",
+            task_id="task-abc",
+            start_time=1234567890.0,
+        )
+
+        assert action._task_id == "task-abc"
+        assert action._step_id == "step-789"
+
+    def test_init_without_task_id(self):
+        """Test creating AttachmentUploadAction without task_id."""
+        action = AttachmentUploadAction(
+            id="action-123",
+            session_id="session-456",
+            step_id="step-789",
+            start_time=1234567890.0,
+        )
+
+        assert action._task_id is None
+        assert action._step_id == "step-789"
+
+    @patch("os.path.exists", return_value=False)
+    def test_start_with_task_id_includes_env_var(self, mock_exists, mock_session, mock_executor):
+        """Test start() includes DEADLINE_TASK_ID when task_id is provided."""
+        action = AttachmentUploadAction(
+            id="action-123",
+            session_id="session-456",
+            step_id="step-789",
+            task_id="task-abc",
+            start_time=1234567890.0,
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        mock_session.run_task.assert_called_once()
+        call_args = mock_session.run_task.call_args[1]
+
+        assert "os_env_vars" in call_args
+        env_vars = call_args["os_env_vars"]
+        assert env_vars["DEADLINE_SESSIONACTION_ID"] == "action-123"
+        assert env_vars["DEADLINE_STEP_ID"] == "step-789"
+        assert env_vars["DEADLINE_TASK_ID"] == "task-abc"
+
+    @patch("os.path.exists", return_value=False)
+    def test_start_without_task_id_excludes_env_var(self, mock_exists, mock_session, mock_executor):
+        """Test start() excludes DEADLINE_TASK_ID when task_id is None."""
+        action = AttachmentUploadAction(
+            id="action-123",
+            session_id="session-456",
+            step_id="step-789",
+            start_time=1234567890.0,
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        mock_session.run_task.assert_called_once()
+        call_args = mock_session.run_task.call_args[1]
+
+        assert "os_env_vars" in call_args
+        env_vars = call_args["os_env_vars"]
+        assert env_vars["DEADLINE_SESSIONACTION_ID"] == "action-123"
+        assert env_vars["DEADLINE_STEP_ID"] == "step-789"
+        assert "DEADLINE_TASK_ID" not in env_vars

--- a/test/unit/sessions/actions/test_run_step_task.py
+++ b/test/unit/sessions/actions/test_run_step_task.py
@@ -1,0 +1,92 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest.mock import Mock
+import pytest
+
+from deadline_worker_agent.sessions.actions.run_step_task import RunStepTaskAction
+from deadline_worker_agent.sessions.job_entities.step_details import StepDetails
+
+
+@pytest.fixture
+def mock_step_details():
+    mock = Mock(spec=StepDetails)
+    mock.step_id = "step-123"
+    mock.step_template = Mock()
+    mock.step_template.script = Mock()
+    return mock
+
+
+@pytest.fixture
+def mock_session():
+    session = Mock()
+    session.run_task = Mock()
+    return session
+
+
+@pytest.fixture
+def mock_executor():
+    return Mock()
+
+
+class TestRunStepTaskAction:
+    """Tests for RunStepTaskAction with optional task_id."""
+
+    def test_init_with_task_id(self, mock_step_details):
+        """Test creating RunStepTaskAction with task_id."""
+        action = RunStepTaskAction(
+            id="action-123",
+            details=mock_step_details,
+            task_id="task-456",
+            task_parameter_values={},
+        )
+
+        assert action.task_id == "task-456"
+        assert action._id == "action-123"
+
+    def test_init_without_task_id(self, mock_step_details):
+        """Test creating RunStepTaskAction without task_id."""
+        action = RunStepTaskAction(
+            id="action-123",
+            details=mock_step_details,
+            task_parameter_values={},
+        )
+
+        assert action.task_id is None
+        assert action._id == "action-123"
+
+    def test_start_with_task_id(self, mock_step_details, mock_session, mock_executor):
+        """Test start() includes DEADLINE_TASK_ID when task_id is provided."""
+        action = RunStepTaskAction(
+            id="action-123",
+            details=mock_step_details,
+            task_id="task-456",
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        mock_session.run_task.assert_called_once()
+        call_args = mock_session.run_task.call_args[1]
+
+        assert "os_env_vars" in call_args
+        env_vars = call_args["os_env_vars"]
+        assert env_vars["DEADLINE_SESSIONACTION_ID"] == "action-123"
+        assert env_vars["DEADLINE_TASK_ID"] == "task-456"
+
+    def test_start_without_task_id(self, mock_step_details, mock_session, mock_executor):
+        """Test start() excludes DEADLINE_TASK_ID when task_id is None."""
+        action = RunStepTaskAction(
+            id="action-123",
+            details=mock_step_details,
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        mock_session.run_task.assert_called_once()
+        call_args = mock_session.run_task.call_args[1]
+
+        assert "os_env_vars" in call_args
+        env_vars = call_args["os_env_vars"]
+        assert env_vars["DEADLINE_SESSIONACTION_ID"] == "action-123"
+        assert "DEADLINE_TASK_ID" not in env_vars


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

WorkerAgent needed to support task chunking workflows where task IDs are not available during session action run. The existing implementation required task IDs for all task run and attachment upload actions, preventing support for chunked steps.

### What was the solution? (How)

- Made `taskId` optional in `TaskRunAction` and `AttachmentUploadAction` TypedDict definitions
- Implemented dual path format support:
  - New format: `step_id/timestamp_session_action_id/` (when `MANIFEST_REPORTING_FEATURE` feature enabled + no task_id)
  - Old format: `step_id/task_id/timestamp_session_action_id/` (backward compatibility)
- Updated environment variable handling to conditionally set `DEADLINE_TASK_ID` only when task_id is present
- Modified session queue and action classes to handle optional task_id throughout the execution pipeline

### What is the impact of this change?

- Enables support for task chunking workflows in AWS Deadline Cloud
- Maintains backward compatibility with existing task-based workflows
- No breaking changes to existing API contracts or behavior when feature flag is disabled

### How was this change tested?

- Added comprehensive unit tests covering both optional and required task_id scenarios
- Created 5 new test files
- Tests validate correct path format selection, environment variable handling, and action creation
- Verified backward compatibility with existing task_id workflows

### Was this change documented?

No additional documentation required as this is an internal implementation change that maintains existing API compatibility.

### Is this a breaking change?

No - this change is backward compatible. Existing workflows continue to function unchanged when the feature flag is disabled or when task_id is provided.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*