### PR TITLE
feat(experimental): add progress reporting and low transfer rate check to sync input attachments

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
@@ -3,21 +3,49 @@
 #! /usr/bin/env python3
 import argparse
 import json
+import sys
 import time
 import os
 import boto3
+import boto3.session
 from typing import Dict, List
 
 from deadline.job_attachments.download import download_files_from_manifests
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
 from deadline.job_attachments.asset_manifests import BaseAssetManifest
 from deadline.job_attachments.models import JobAttachmentS3Settings
-from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+from deadline.job_attachments.progress_tracker import (
+    DownloadSummaryStatistics,
+    ProgressReportMetadata,
+)
 from deadline_worker_agent.sessions.attachment_models import WorkerManifestProperties
 from deadline_worker_agent.aws.deadline import (
     record_sync_inputs_fail_telemetry_event,
     record_sync_inputs_telemetry_event,
 )
+
+
+# During a SYNC_INPUT_JOB_ATTACHMENTS session action, the transfer rate is periodically reported through
+# a callback function. If a transfer rate lower than LOW_TRANSFER_RATE_THRESHOLD is observed in a series
+# for LOW_TRANSFER_COUNT_THRESHOLD times, it is considered concerning or potentially stalled, and the
+# session action is canceled.
+LOW_TRANSFER_RATE_THRESHOLD = 10 * 10**3  # 10 KB/s÷
+LOW_TRANSFER_COUNT_THRESHOLD = (
+    60  # Each progress report takes 1 sec at the longest, so 60 reports amount to 1 min in total.
+)
+
+
+def _seconds_to_minutes_str(seconds: int) -> str:
+    minutes = seconds // 60
+    remaining_seconds = seconds % 60
+    if minutes > 0 and remaining_seconds > 0:
+        return f"{minutes} minute{'s' if minutes != 1 else ''} {remaining_seconds} second{'s' if remaining_seconds != 1 else ''}"
+    elif minutes > 0:
+        return f"{minutes} minute{'s' if minutes != 1 else ''}"
+    elif remaining_seconds == 0:
+        return "0 seconds"
+    else:
+        return f"{remaining_seconds} second{'s' if remaining_seconds != 1 else ''}"
 
 
 def load_worker_manifest_properties(worker_properties_file: str) -> List[WorkerManifestProperties]:
@@ -94,11 +122,46 @@ def perform_download(
         Exception: Any exception that occurs during download (after recording telemetry)
     """
     try:
+        low_transfer_count = 0
+
+        def progress_handler(job_attachments_download_status: ProgressReportMetadata) -> bool:
+            """
+            Callback for Job Attachments' download_files_from_manifests() to track the download progress.
+            Returns True if the operation should continue as normal or False to cancel.
+            """
+            # Check the transfer rate from the progress report. It monitors for a series of
+            # alarmingly low transfer rates, and if the count exceeds the specified threshold,
+            # cancels the download and fails the current (SYNC_INPUT_JOB_ATTACHMENTS) action.
+            nonlocal low_transfer_count
+            transfer_rate = job_attachments_download_status.transferRate
+
+            if transfer_rate < LOW_TRANSFER_RATE_THRESHOLD:
+                low_transfer_count += 1
+            else:
+                low_transfer_count = 0
+            if low_transfer_count >= LOW_TRANSFER_COUNT_THRESHOLD:
+                fail_message = (
+                    f"Input syncing failed due to successive low transfer rates (< {LOW_TRANSFER_RATE_THRESHOLD / 1000} KB/s). "
+                    f"The transfer rate was below the threshold for the last {_seconds_to_minutes_str(LOW_TRANSFER_COUNT_THRESHOLD)}."
+                )
+                print(f"openjd_fail: {fail_message}", flush=True)
+                record_sync_inputs_fail_telemetry_event(
+                    queue_id=queue_id,
+                    failure_reason=f"Insufficient download speed: {fail_message}",
+                )
+                return False
+
+            print(f"openjd_progress: {job_attachments_download_status.progress}")
+            print(f"openjd_status: {job_attachments_download_status.progressMessage}")
+            sys.stdout.flush()
+            return True
+
         download_summary_statistics = download_files_from_manifests(
             s3_bucket=s3_settings.s3BucketName,
             manifests_by_root=manifests_by_root,
             cas_prefix=s3_settings.full_cas_prefix(),
             session=boto3.session.Session(),
+            on_downloading_files=progress_handler,
         )
 
         # Record successful download telemetry

--- a/test/unit/sessions/actions/scripts/test_attachment_download.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_download.py
@@ -4,18 +4,26 @@ import json
 import os
 import tempfile
 from unittest.mock import Mock, patch, mock_open, ANY
+from typing import Generator
 import pytest
 
+from deadline.job_attachments.progress_tracker import (
+    DownloadSummaryStatistics,
+    ProgressReportMetadata,
+    ProgressStatus,
+)
 from deadline.job_attachments.models import ManifestProperties, PathFormat, JobAttachmentS3Settings
 from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import AssetManifest
 from deadline_worker_agent.sessions.attachment_models import WorkerManifestProperties
 
 # Import the functions we want to test
+import deadline_worker_agent.sessions.actions.scripts.attachment_download as attachment_download_mod
 from deadline_worker_agent.sessions.actions.scripts.attachment_download import (
     load_worker_manifest_properties,
     build_merged_manifests_by_root,
     perform_download,
     main,
+    _seconds_to_minutes_str,
 )
 
 
@@ -263,22 +271,31 @@ class TestBuildMergedManifestsByRoot:
 class TestPerformDownload:
     """Test cases for perform_download function."""
 
-    @patch(
-        "deadline_worker_agent.sessions.actions.scripts.attachment_download.download_files_from_manifests"
-    )
-    @patch(
-        "deadline_worker_agent.sessions.actions.scripts.attachment_download.record_sync_inputs_telemetry_event"
-    )
-    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_download.boto3")
-    def test_perform_download_success(
-        self, mock_boto3, mock_success_telemetry, mock_download_files
-    ):
+    @pytest.fixture(autouse=True)
+    def mock_boto3(self) -> Generator[Mock, None, None]:
+        """Mock boto3 session for testing."""
+        with patch.object(attachment_download_mod, "boto3") as m:
+            yield m
+
+    @pytest.fixture(autouse=True)
+    def mock_download_files(self) -> Generator[Mock, None, None]:
+        with patch.object(attachment_download_mod, "download_files_from_manifests") as m:
+            yield m
+
+    @pytest.fixture(autouse=True)
+    def mock_success_telemetry(self) -> Generator[Mock, None, None]:
+        with patch.object(attachment_download_mod, "record_sync_inputs_telemetry_event") as m:
+            yield m
+
+    @pytest.fixture(autouse=True)
+    def mock_fail_telemetry(self) -> Generator[Mock, None, None]:
+        with patch.object(attachment_download_mod, "record_sync_inputs_fail_telemetry_event") as m:
+            yield m
+
+    def test_perform_download_success(self, mock_success_telemetry, mock_download_files):
         """Test successful download with telemetry recording."""
         # GIVEN
         from deadline.job_attachments.progress_tracker import SummaryStatistics
-
-        mock_session = Mock()
-        mock_boto3.session.Session.return_value = mock_session
 
         mock_download_summary = Mock()
         mock_summary_stats = SummaryStatistics(
@@ -304,18 +321,9 @@ class TestPerformDownload:
         mock_download_files.assert_called_once()
         mock_success_telemetry.assert_called_once_with("test-queue", mock_summary_stats)
 
-    @patch(
-        "deadline_worker_agent.sessions.actions.scripts.attachment_download.download_files_from_manifests"
-    )
-    @patch(
-        "deadline_worker_agent.sessions.actions.scripts.attachment_download.record_sync_inputs_fail_telemetry_event"
-    )
-    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_download.boto3")
-    def test_perform_download_failure(self, mock_boto3, mock_fail_telemetry, mock_download_files):
+    def test_perform_download_failure(self, mock_fail_telemetry, mock_download_files):
         """Test download failure with telemetry recording."""
         # GIVEN
-        mock_session = Mock()
-        mock_boto3.session.Session.return_value = mock_session
         mock_download_files.side_effect = Exception("Download failed")
 
         s3_settings = JobAttachmentS3Settings.from_s3_root_uri("s3://test-bucket/test-prefix")
@@ -327,6 +335,96 @@ class TestPerformDownload:
         mock_fail_telemetry.assert_called_once_with(
             queue_id="test-queue",
             failure_reason="Error downloading files: Download failed",
+        )
+
+    def test_progress_reporting(
+        self,
+        mock_download_files: Mock,
+        capsys: pytest.CaptureFixture,
+    ):
+        """
+        Tests that attachment_download reports progress and status
+        """
+        # GIVEN
+        s3_settings = JobAttachmentS3Settings.from_s3_root_uri("s3://test-bucket/test-prefix")
+
+        # Mock out the Job Attachment's download_files_from_manifests function to
+        # report progress
+        def fake_download_files_from_manifests(on_downloading_files, *args, **kwargs):
+            for i in range(10):
+                on_downloading_files(
+                    ProgressReportMetadata(
+                        status=ProgressStatus.DOWNLOAD_IN_PROGRESS,
+                        progress=i * 10,
+                        transferRate=10 * 10**9,
+                        progressMessage=f"test: {i}",
+                    )
+                )
+            return DownloadSummaryStatistics()
+
+        mock_download_files.side_effect = fake_download_files_from_manifests
+
+        # WHEN
+        perform_download(
+            s3_settings=s3_settings,
+            manifests_by_root={},
+            queue_id="test-queue",
+        )
+
+        # THEN
+        stdout = capsys.readouterr().out
+        for msg in [f"openjd_progress: {i * 10}" for i in range(10)]:
+            assert msg in stdout
+        for msg in [f"openjd_status: test: {i}" for i in range(10)]:
+            assert msg in stdout
+
+    def test_cancellation_by_low_transfer_rate(
+        self,
+        mock_fail_telemetry: Mock,
+        mock_download_files: Mock,
+        capsys: pytest.CaptureFixture,
+    ):
+        """
+        Tests that the session is canceled if it observes a series of alarmingly low transfer rates.
+        """
+        # GIVEN
+        s3_settings = JobAttachmentS3Settings.from_s3_root_uri("s3://test-bucket/test-prefix")
+
+        # Mock out the Job Attachment's download_files_from_manifests function to
+        # report multiple consecutive low transfer rates (lower than the threshold) via callback function.
+        def fake_download_files_from_manifests(on_downloading_files, *args, **kwargs):
+            low_transfer_rate_report = ProgressReportMetadata(
+                status=ProgressStatus.DOWNLOAD_IN_PROGRESS,
+                progress=0.0,
+                transferRate=(10 * 10**3) / 2,
+                progressMessage="",
+            )
+            for _ in range(60):
+                on_downloading_files(low_transfer_rate_report)
+
+            return DownloadSummaryStatistics()
+
+        mock_download_files.side_effect = fake_download_files_from_manifests
+
+        # WHEN
+        perform_download(
+            s3_settings=s3_settings,
+            manifests_by_root={},
+            queue_id="test-queue",
+        )
+
+        # THEN
+        assert (
+            "openjd_fail: Input syncing failed due to successive low transfer rates (< 10.0 KB/s). "
+            "The transfer rate was below the threshold for the last 1 minute."
+        ) in capsys.readouterr().out
+        mock_fail_telemetry.assert_called_once_with(
+            queue_id="test-queue",
+            failure_reason=(
+                "Insufficient download speed: "
+                "Input syncing failed due to successive low transfer rates (< 10.0 KB/s). "
+                "The transfer rate was below the threshold for the last 1 minute."
+            ),
         )
 
 
@@ -434,3 +532,21 @@ class TestMainFunction:
             mock_manifests,
             "queue-unknown",
         )
+
+
+@pytest.mark.parametrize(
+    "seconds, expected_str",
+    [
+        (0, "0 seconds"),
+        (1, "1 second"),
+        (30, "30 seconds"),
+        (60, "1 minute"),
+        (61, "1 minute 1 second"),
+        (90, "1 minute 30 seconds"),
+        (120, "2 minutes"),
+        (121, "2 minutes 1 second"),
+        (150, "2 minutes 30 seconds"),
+    ],
+)
+def test_seconds_to_minutes_str(seconds: int, expected_str: str):
+    assert _seconds_to_minutes_str(seconds) == expected_str


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The asset sync as job user feature is missing the following features for the sync input attachments session action that exist in the current implementation:
- Progress reporting for input syncing
- Low transfer rate checks that fail the session action if transfer rate is low

### What was the solution? (How)
Add the above features into the asset sync as user's sync input attachment implementation, copying the code from the original implementation added in https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/143

https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/e286e75c9ccde69cbbfbc513a0ba9a116c7de067/src/deadline_worker_agent/sessions/session.py#L979-L1018

### What is the impact of this change?
When the `ASSET_SYNC_JOB_USER_FEATURE=true` environment variable is set to true, the sync input attachments session action will now have progress reporting and low transfer rate checks like the current implementation.

### How was this change tested?
- Added unit tests
- Manual testing with job submissions + CMF fleet (see screenshots below)

### Was this change documented?
No

### Is this a breaking change?
No

### Manual Testing Results

#### Low Transfer Rate Check

_Note: I manually modified the transfer rate constants in the file to force the failure code path_

<img width="2860" height="1594" alt="image" src="https://github.com/user-attachments/assets/03084901-c43b-40aa-9992-b8794ed62ed5" />


<details><summary>Session action logs (EXPAND ME)</summary>

```
2025/10/07 14:13:04-07:00 ==============================================
2025/10/07 14:13:04-07:00 --------- Job Attachments Download for Job
2025/10/07 14:13:04-07:00 ==============================================
2025/10/07 14:13:04-07:00 True: [<CloudWatchHandler (NOTSET)>, <FileHandler /var/log/amazon/deadline/queue-a781fa7ac9f3401bb0341f2f95867d17/session-99d1de782e664da88159654f8fc4fc76.log (NOTSET)>]
2025/10/07 14:13:04-07:00 Creating local manifest file: /sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/manifests/d6f5222ffc6d3eaf474292953285562e_job
2025/10/07 14:13:04-07:00 ----------------------------------------------
2025/10/07 14:13:04-07:00 Phase: Setup
2025/10/07 14:13:04-07:00 ----------------------------------------------
2025/10/07 14:13:04-07:00 Writing embedded files for Task to disk.
2025/10/07 14:13:04-07:00 Mapping: Task.File.AttachmentDownload -> /sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/embedded_filespit8cii5/tmpr5jg1b6t
2025/10/07 14:13:04-07:00 Mapping: Task.File.WorkerManifestProperties -> /sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/embedded_filespit8cii5/tmpis8kianr
2025/10/07 14:13:04-07:00 Wrote: AttachmentDownload -> /sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/embedded_filespit8cii5/tmpr5jg1b6t
2025/10/07 14:13:04-07:00 Wrote: WorkerManifestProperties -> /sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/embedded_filespit8cii5/tmpis8kianr
2025/10/07 14:13:04-07:00 ----------------------------------------------
2025/10/07 14:13:04-07:00 Phase: Running action
2025/10/07 14:13:04-07:00 ----------------------------------------------
2025/10/07 14:13:04-07:00 Running command /sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/tmpzd3pyagy.sh
2025/10/07 14:13:04-07:00 Command started as pid: 30712
2025/10/07 14:13:04-07:00 Output:
2025/10/07 14:13:06-07:00 args.worker_properties is /sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/embedded_filespit8cii5/tmpis8kianr
2025/10/07 14:13:06-07:00  
2025/10/07 14:13:06-07:00 Starting download...
2025/10/07 14:13:06-07:00 openjd_progress: 1.9
2025/10/07 14:13:06-07:00 openjd_status: Downloaded 400.82 MB / 21.47 GB of 2 files (Transfer rate: 400.82 MB/s)
2025/10/07 14:13:07-07:00 openjd_progress: 3.7
2025/10/07 14:13:07-07:00 openjd_status: Downloaded 804.26 MB / 21.47 GB of 2 files (Transfer rate: 403.44 MB/s)
2025/10/07 14:13:08-07:00 openjd_progress: 5.6
2025/10/07 14:13:08-07:00 openjd_status: Downloaded 1.21 GB / 21.47 GB of 2 files (Transfer rate: 407.9 MB/s)
2025/10/07 14:13:09-07:00 openjd_progress: 7.6
2025/10/07 14:13:09-07:00 openjd_status: Downloaded 1.63 GB / 21.47 GB of 2 files (Transfer rate: 413.66 MB/s)
2025/10/07 14:13:10-07:00 openjd_progress: 9.4
2025/10/07 14:13:10-07:00 openjd_status: Downloaded 2.02 GB / 21.47 GB of 2 files (Transfer rate: 390.07 MB/s)
2025/10/07 14:13:11-07:00 openjd_progress: 11.2
2025/10/07 14:13:11-07:00 openjd_status: Downloaded 2.42 GB / 21.47 GB of 2 files (Transfer rate: 399.77 MB/s)
2025/10/07 14:13:12-07:00 openjd_progress: 13.2
2025/10/07 14:13:12-07:00 openjd_status: Downloaded 2.83 GB / 21.47 GB of 2 files (Transfer rate: 418.91 MB/s)
2025/10/07 14:13:13-07:00 openjd_progress: 15.1
2025/10/07 14:13:13-07:00 openjd_status: Downloaded 3.24 GB / 21.47 GB of 2 files (Transfer rate: 408.42 MB/s)
2025/10/07 14:13:14-07:00 openjd_progress: 17.0
2025/10/07 14:13:14-07:00 openjd_status: Downloaded 3.65 GB / 21.47 GB of 2 files (Transfer rate: 403.7 MB/s)
2025/10/07 14:13:15-07:00 openjd_fail: Input syncing failed due to successive low transfer rates (< 10000000.0 KB/s). The transfer rate was below the threshold for the last 10 seconds.
2025/10/07 14:13:15-07:00 Traceback (most recent call last):
2025/10/07 14:13:15-07:00   File "/home/jericht/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/4zLt7-Hx/deadline-cloud-worker-agent/lib/python3.11/site-packages/deadline/job_attachments/download.py", line 536, in download_file
2025/10/07 14:13:15-07:00     future.result()
2025/10/07 14:13:15-07:00   File "/home/jericht/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/4zLt7-Hx/deadline-cloud-worker-agent/lib/python3.11/site-packages/s3transfer/futures.py", line 111, in result
2025/10/07 14:13:15-07:00     return self._coordinator.result()
2025/10/07 14:13:15-07:00            ^^^^^^^^^^^^^^^^^^^^^^^^^^
2025/10/07 14:13:15-07:00   File "/home/jericht/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/4zLt7-Hx/deadline-cloud-worker-agent/lib/python3.11/site-packages/s3transfer/futures.py", line 287, in result
2025/10/07 14:13:15-07:00     raise self._exception
2025/10/07 14:13:15-07:00 concurrent.futures._base.CancelledError
2025/10/07 14:13:15-07:00  
2025/10/07 14:13:15-07:00 During handling of the above exception, another exception occurred:
2025/10/07 14:13:15-07:00  
2025/10/07 14:13:15-07:00 Traceback (most recent call last):
2025/10/07 14:13:15-07:00   File "/sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/embedded_filespit8cii5/tmpr5jg1b6t", line 224, in <module>
2025/10/07 14:13:15-07:00     main()
2025/10/07 14:13:15-07:00   File "/sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/embedded_filespit8cii5/tmpr5jg1b6t", line 215, in main
2025/10/07 14:13:15-07:00     perform_download(
2025/10/07 14:13:15-07:00   File "/sessions/session-99d1de782e664da88159654f8fc4fc763wmodc0b/embedded_filespit8cii5/tmpr5jg1b6t", line 160, in perform_download
2025/10/07 14:13:15-07:00     download_summary_statistics = download_files_from_manifests(
2025/10/07 14:13:15-07:00                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025/10/07 14:13:15-07:00   File "/home/jericht/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/4zLt7-Hx/deadline-cloud-worker-agent/lib/python3.11/site-packages/deadline/job_attachments/download.py", line 858, in download_files_from_manifests
2025/10/07 14:13:15-07:00     downloaded_files_paths = _download_files_parallel(
2025/10/07 14:13:15-07:00                              ^^^^^^^^^^^^^^^^^^^^^^^^^
2025/10/07 14:13:15-07:00   File "/home/jericht/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/4zLt7-Hx/deadline-cloud-worker-agent/lib/python3.11/site-packages/deadline/job_attachments/download.py", line 650, in _download_files_parallel
2025/10/07 14:13:15-07:00     (file_bytes, local_file_name) = future.result()
2025/10/07 14:13:15-07:00                                     ^^^^^^^^^^^^^^^
2025/10/07 14:13:15-07:00   File "/local/home/jericht/.local/share/mise/installs/python/3.11.7/lib/python3.11/concurrent/futures/_base.py", line 449, in result
2025/10/07 14:13:15-07:00     return self.__get_result()
2025/10/07 14:13:15-07:00            ^^^^^^^^^^^^^^^^^^^
2025/10/07 14:13:15-07:00   File "/local/home/jericht/.local/share/mise/installs/python/3.11.7/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
2025/10/07 14:13:15-07:00     raise self._exception
2025/10/07 14:13:15-07:00   File "/local/home/jericht/.local/share/mise/installs/python/3.11.7/lib/python3.11/concurrent/futures/thread.py", line 58, in run
2025/10/07 14:13:15-07:00     result = self.fn(*self.args, **self.kwargs)
2025/10/07 14:13:15-07:00              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025/10/07 14:13:15-07:00   File "/home/jericht/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/4zLt7-Hx/deadline-cloud-worker-agent/lib/python3.11/site-packages/deadline/job_attachments/download.py", line 539, in download_file
2025/10/07 14:13:15-07:00     raise AssetSyncCancelledError("File download cancelled.")
2025/10/07 14:13:15-07:00 deadline.job_attachments.exceptions.AssetSyncCancelledError: File download cancelled.
2025/10/07 14:13:15-07:00 Process pid 30712 exited with code: 1 (unsigned) / 0x1 (hex)
```

</details>

#### Progress Reporting

<img width="1430" height="797" alt="image" src="https://github.com/user-attachments/assets/7fb75fd8-a5a9-4535-b76e-78523f74bee7" />

<details><summary>Session action logs (EXPAND ME)</summary>

```
2025/10/07 14:34:12-07:00 ==============================================
2025/10/07 14:34:12-07:00 --------- Job Attachments Download for Job
2025/10/07 14:34:12-07:00 ==============================================
2025/10/07 14:34:12-07:00 Creating local manifest file: /sessions/session-395df88a7d4d4c2d9911385ea00d4b81ev_zckqq/manifests/d6f5222ffc6d3eaf474292953285562e_job
2025/10/07 14:34:12-07:00 ----------------------------------------------
2025/10/07 14:34:12-07:00 Phase: Setup
2025/10/07 14:34:12-07:00 ----------------------------------------------
2025/10/07 14:34:12-07:00 Writing embedded files for Task to disk.
2025/10/07 14:34:12-07:00 Mapping: Task.File.AttachmentDownload -> /sessions/session-395df88a7d4d4c2d9911385ea00d4b81ev_zckqq/embedded_filesnispdos2/tmp_49uy3gy
2025/10/07 14:34:12-07:00 Mapping: Task.File.WorkerManifestProperties -> /sessions/session-395df88a7d4d4c2d9911385ea00d4b81ev_zckqq/embedded_filesnispdos2/tmpzd85kwjo
2025/10/07 14:34:12-07:00 Wrote: AttachmentDownload -> /sessions/session-395df88a7d4d4c2d9911385ea00d4b81ev_zckqq/embedded_filesnispdos2/tmp_49uy3gy
2025/10/07 14:34:12-07:00 Wrote: WorkerManifestProperties -> /sessions/session-395df88a7d4d4c2d9911385ea00d4b81ev_zckqq/embedded_filesnispdos2/tmpzd85kwjo
2025/10/07 14:34:12-07:00 ----------------------------------------------
2025/10/07 14:34:12-07:00 Phase: Running action
2025/10/07 14:34:12-07:00 ----------------------------------------------
2025/10/07 14:34:12-07:00 Running command /sessions/session-395df88a7d4d4c2d9911385ea00d4b81ev_zckqq/tmpoxc32lum.sh
2025/10/07 14:34:12-07:00 Command started as pid: 17639
2025/10/07 14:34:12-07:00 Output:
2025/10/07 14:34:14-07:00 args.worker_properties is /sessions/session-395df88a7d4d4c2d9911385ea00d4b81ev_zckqq/embedded_filesnispdos2/tmpzd85kwjo
2025/10/07 14:34:14-07:00  
2025/10/07 14:34:14-07:00 Starting download...
2025/10/07 14:34:14-07:00 openjd_progress: 1.7
2025/10/07 14:34:14-07:00 openjd_status: Downloaded 364.12 MB / 21.47 GB of 2 files (Transfer rate: 364.12 MB/s)
2025/10/07 14:34:15-07:00 openjd_progress: 3.7
2025/10/07 14:34:15-07:00 openjd_status: Downloaded 785.12 MB / 21.47 GB of 2 files (Transfer rate: 421.0 MB/s)
2025/10/07 14:34:16-07:00 openjd_progress: 5.7
2025/10/07 14:34:16-07:00 openjd_status: Downloaded 1.23 GB / 21.47 GB of 2 files (Transfer rate: 449.31 MB/s)
2025/10/07 14:34:17-07:00 openjd_progress: 7.8
2025/10/07 14:34:17-07:00 openjd_status: Downloaded 1.67 GB / 21.47 GB of 2 files (Transfer rate: 436.21 MB/s)
2025/10/07 14:34:18-07:00 openjd_progress: 9.8
2025/10/07 14:34:18-07:00 openjd_status: Downloaded 2.1 GB / 21.47 GB of 2 files (Transfer rate: 432.54 MB/s)
2025/10/07 14:34:19-07:00 openjd_progress: 11.8
2025/10/07 14:34:19-07:00 openjd_status: Downloaded 2.54 GB / 21.47 GB of 2 files (Transfer rate: 433.06 MB/s)
2025/10/07 14:34:20-07:00 openjd_progress: 13.9
2025/10/07 14:34:20-07:00 openjd_status: Downloaded 2.99 GB / 21.47 GB of 2 files (Transfer rate: 449.58 MB/s)
2025/10/07 14:34:21-07:00 openjd_progress: 16.0
2025/10/07 14:34:21-07:00 openjd_status: Downloaded 3.43 GB / 21.47 GB of 2 files (Transfer rate: 446.69 MB/s)
2025/10/07 14:34:22-07:00 openjd_progress: 18.0
2025/10/07 14:34:22-07:00 openjd_status: Downloaded 3.87 GB / 21.47 GB of 2 files (Transfer rate: 438.83 MB/s)
2025/10/07 14:34:23-07:00 openjd_progress: 20.1
2025/10/07 14:34:23-07:00 openjd_status: Downloaded 4.31 GB / 21.47 GB of 2 files (Transfer rate: 441.97 MB/s)
2025/10/07 14:34:24-07:00 openjd_progress: 22.1
2025/10/07 14:34:24-07:00 openjd_status: Downloaded 4.76 GB / 21.47 GB of 2 files (Transfer rate: 441.97 MB/s)
2025/10/07 14:34:25-07:00 openjd_progress: 24.2
2025/10/07 14:34:25-07:00 openjd_status: Downloaded 5.21 GB / 21.47 GB of 2 files (Transfer rate: 450.63 MB/s)
2025/10/07 14:34:26-07:00 openjd_progress: 26.3
2025/10/07 14:34:26-07:00 openjd_status: Downloaded 5.65 GB / 21.47 GB of 2 files (Transfer rate: 442.76 MB/s)
2025/10/07 14:34:27-07:00 openjd_progress: 28.4
2025/10/07 14:34:27-07:00 openjd_status: Downloaded 6.09 GB / 21.47 GB of 2 files (Transfer rate: 439.62 MB/s)
2025/10/07 14:34:28-07:00 openjd_progress: 30.5
2025/10/07 14:34:28-07:00 openjd_status: Downloaded 6.54 GB / 21.47 GB of 2 files (Transfer rate: 452.2 MB/s)
2025/10/07 14:34:29-07:00 openjd_progress: 32.6
2025/10/07 14:34:29-07:00 openjd_status: Downloaded 6.99 GB / 21.47 GB of 2 files (Transfer rate: 450.36 MB/s)
2025/10/07 14:34:30-07:00 openjd_progress: 34.6
2025/10/07 14:34:30-07:00 openjd_status: Downloaded 7.43 GB / 21.47 GB of 2 files (Transfer rate: 438.57 MB/s)
2025/10/07 14:34:31-07:00 openjd_progress: 36.6
2025/10/07 14:34:31-07:00 openjd_status: Downloaded 7.86 GB / 21.47 GB of 2 files (Transfer rate: 431.23 MB/s)
2025/10/07 14:34:32-07:00 openjd_progress: 38.1
2025/10/07 14:34:32-07:00 openjd_status: Downloaded 8.19 GB / 21.47 GB of 2 files (Transfer rate: 324.53 MB/s)
2025/10/07 14:34:33-07:00 openjd_progress: 39.4
2025/10/07 14:34:33-07:00 openjd_status: Downloaded 8.46 GB / 21.47 GB of 2 files (Transfer rate: 274.73 MB/s)
2025/10/07 14:34:34-07:00 openjd_progress: 40.6
2025/10/07 14:34:34-07:00 openjd_status: Downloaded 8.73 GB / 21.47 GB of 2 files (Transfer rate: 268.17 MB/s)
2025/10/07 14:34:35-07:00 openjd_progress: 41.9
2025/10/07 14:34:35-07:00 openjd_status: Downloaded 9.0 GB / 21.47 GB of 2 files (Transfer rate: 270.79 MB/s)
2025/10/07 14:34:36-07:00 openjd_progress: 43.2
2025/10/07 14:34:36-07:00 openjd_status: Downloaded 9.27 GB / 21.47 GB of 2 files (Transfer rate: 269.48 MB/s)
2025/10/07 14:34:37-07:00 openjd_progress: 44.4
2025/10/07 14:34:37-07:00 openjd_status: Downloaded 9.54 GB / 21.47 GB of 2 files (Transfer rate: 272.89 MB/s)
2025/10/07 14:34:38-07:00 openjd_progress: 45.7
2025/10/07 14:34:38-07:00 openjd_status: Downloaded 9.81 GB / 21.47 GB of 2 files (Transfer rate: 268.17 MB/s)
2025/10/07 14:34:39-07:00 openjd_progress: 46.9
2025/10/07 14:34:39-07:00 openjd_status: Downloaded 10.08 GB / 21.47 GB of 2 files (Transfer rate: 269.67 MB/s)
2025/10/07 14:34:40-07:00 openjd_progress: 48.2
2025/10/07 14:34:40-07:00 openjd_status: Downloaded 10.35 GB / 21.47 GB of 2 files (Transfer rate: 269.48 MB/s)
2025/10/07 14:34:41-07:00 openjd_progress: 49.4
2025/10/07 14:34:41-07:00 openjd_status: Downloaded 10.62 GB / 21.47 GB of 2 files (Transfer rate: 257.31 MB/s)
2025/10/07 14:34:42-07:00 openjd_progress: 50.8
2025/10/07 14:34:42-07:00 openjd_status: Downloaded 10.9 GB / 21.47 GB of 2 files (Transfer rate: 284.16 MB/s)
2025/10/07 14:34:43-07:00 openjd_progress: 52.0
2025/10/07 14:34:43-07:00 openjd_status: Downloaded 11.17 GB / 21.47 GB of 2 files (Transfer rate: 268.44 MB/s)
2025/10/07 14:34:44-07:00 openjd_progress: 53.3
2025/10/07 14:34:44-07:00 openjd_status: Downloaded 11.44 GB / 21.47 GB of 2 files (Transfer rate: 272.37 MB/s)
2025/10/07 14:34:45-07:00 openjd_progress: 54.5
2025/10/07 14:34:45-07:00 openjd_status: Downloaded 11.71 GB / 21.47 GB of 2 files (Transfer rate: 270.79 MB/s)
2025/10/07 14:34:46-07:00 openjd_progress: 55.8
2025/10/07 14:34:46-07:00 openjd_status: Downloaded 11.98 GB / 21.47 GB of 2 files (Transfer rate: 268.17 MB/s)
2025/10/07 14:34:47-07:00 openjd_progress: 57.1
2025/10/07 14:34:47-07:00 openjd_status: Downloaded 12.25 GB / 21.47 GB of 2 files (Transfer rate: 274.46 MB/s)
2025/10/07 14:34:48-07:00 openjd_progress: 58.3
2025/10/07 14:34:48-07:00 openjd_status: Downloaded 12.52 GB / 21.47 GB of 2 files (Transfer rate: 269.75 MB/s)
2025/10/07 14:34:49-07:00 openjd_progress: 59.6
2025/10/07 14:34:49-07:00 openjd_status: Downloaded 12.79 GB / 21.47 GB of 2 files (Transfer rate: 270.01 MB/s)
2025/10/07 14:34:50-07:00 openjd_progress: 60.9
2025/10/07 14:34:50-07:00 openjd_status: Downloaded 13.07 GB / 21.47 GB of 2 files (Transfer rate: 276.04 MB/s)
2025/10/07 14:34:51-07:00 openjd_progress: 62.1
2025/10/07 14:34:51-07:00 openjd_status: Downloaded 13.34 GB / 21.47 GB of 2 files (Transfer rate: 270.01 MB/s)
2025/10/07 14:34:52-07:00 openjd_progress: 63.4
2025/10/07 14:34:52-07:00 openjd_status: Downloaded 13.61 GB / 21.47 GB of 2 files (Transfer rate: 266.56 MB/s)
2025/10/07 14:34:53-07:00 openjd_progress: 64.6
2025/10/07 14:34:53-07:00 openjd_status: Downloaded 13.88 GB / 21.47 GB of 2 files (Transfer rate: 273.15 MB/s)
2025/10/07 14:34:54-07:00 openjd_progress: 65.9
2025/10/07 14:34:54-07:00 openjd_status: Downloaded 14.16 GB / 21.47 GB of 2 files (Transfer rate: 272.63 MB/s)
2025/10/07 14:34:55-07:00 openjd_progress: 66.8
2025/10/07 14:34:55-07:00 openjd_status: Downloaded 14.36 GB / 21.47 GB of 2 files (Transfer rate: 199.75 MB/s)
2025/10/07 14:34:56-07:00 openjd_progress: 68.1
2025/10/07 14:34:56-07:00 openjd_status: Downloaded 14.62 GB / 21.47 GB of 2 files (Transfer rate: 265.03 MB/s)
2025/10/07 14:34:57-07:00 openjd_progress: 69.5
2025/10/07 14:34:57-07:00 openjd_status: Downloaded 14.93 GB / 21.47 GB of 2 files (Transfer rate: 311.43 MB/s)
2025/10/07 14:34:58-07:00 openjd_progress: 70.8
2025/10/07 14:34:58-07:00 openjd_status: Downloaded 15.2 GB / 21.47 GB of 2 files (Transfer rate: 271.58 MB/s)
2025/10/07 14:34:59-07:00 openjd_progress: 72.1
2025/10/07 14:34:59-07:00 openjd_status: Downloaded 15.47 GB / 21.47 GB of 2 files (Transfer rate: 269.48 MB/s)
2025/10/07 14:35:00-07:00 openjd_progress: 73.3
2025/10/07 14:35:00-07:00 openjd_status: Downloaded 15.74 GB / 21.47 GB of 2 files (Transfer rate: 262.66 MB/s)
2025/10/07 14:35:01-07:00 openjd_progress: 74.6
2025/10/07 14:35:01-07:00 openjd_status: Downloaded 16.01 GB / 21.47 GB of 2 files (Transfer rate: 273.68 MB/s)
2025/10/07 14:35:02-07:00 openjd_progress: 75.9
2025/10/07 14:35:02-07:00 openjd_status: Downloaded 16.29 GB / 21.47 GB of 2 files (Transfer rate: 278.4 MB/s)
2025/10/07 14:35:03-07:00 openjd_progress: 77.1
2025/10/07 14:35:03-07:00 openjd_status: Downloaded 16.57 GB / 21.47 GB of 2 files (Transfer rate: 270.45 MB/s)
2025/10/07 14:35:04-07:00 openjd_progress: 78.4
2025/10/07 14:35:04-07:00 openjd_status: Downloaded 16.84 GB / 21.47 GB of 2 files (Transfer rate: 272.37 MB/s)
2025/10/07 14:35:05-07:00 openjd_progress: 79.7
2025/10/07 14:35:05-07:00 openjd_status: Downloaded 17.11 GB / 21.47 GB of 2 files (Transfer rate: 270.53 MB/s)
2025/10/07 14:35:06-07:00 openjd_progress: 80.9
2025/10/07 14:35:06-07:00 openjd_status: Downloaded 17.38 GB / 21.47 GB of 2 files (Transfer rate: 270.79 MB/s)
2025/10/07 14:35:07-07:00 openjd_progress: 82.2
2025/10/07 14:35:07-07:00 openjd_status: Downloaded 17.65 GB / 21.47 GB of 2 files (Transfer rate: 272.37 MB/s)
2025/10/07 14:35:08-07:00 openjd_progress: 83.5
2025/10/07 14:35:08-07:00 openjd_status: Downloaded 17.92 GB / 21.47 GB of 2 files (Transfer rate: 270.27 MB/s)
2025/10/07 14:35:09-07:00 openjd_progress: 84.7
2025/10/07 14:35:09-07:00 openjd_status: Downloaded 18.19 GB / 21.47 GB of 2 files (Transfer rate: 272.11 MB/s)
2025/10/07 14:35:10-07:00 openjd_progress: 86.0
2025/10/07 14:35:10-07:00 openjd_status: Downloaded 18.46 GB / 21.47 GB of 2 files (Transfer rate: 270.01 MB/s)
2025/10/07 14:35:11-07:00 openjd_progress: 87.2
2025/10/07 14:35:11-07:00 openjd_status: Downloaded 18.73 GB / 21.47 GB of 2 files (Transfer rate: 265.55 MB/s)
2025/10/07 14:35:12-07:00 openjd_progress: 88.5
2025/10/07 14:35:12-07:00 openjd_status: Downloaded 19.0 GB / 21.47 GB of 2 files (Transfer rate: 271.58 MB/s)
2025/10/07 14:35:13-07:00 openjd_progress: 89.7
2025/10/07 14:35:13-07:00 openjd_status: Downloaded 19.27 GB / 21.47 GB of 2 files (Transfer rate: 268.44 MB/s)
2025/10/07 14:35:14-07:00 openjd_progress: 90.4
2025/10/07 14:35:14-07:00 openjd_status: Downloaded 19.41 GB / 21.47 GB of 2 files (Transfer rate: 274.48 MB/s)
2025/10/07 14:35:15-07:00 openjd_progress: 91.6
2025/10/07 14:35:15-07:00 openjd_status: Downloaded 19.68 GB / 21.47 GB of 2 files (Transfer rate: 266.04 MB/s)
2025/10/07 14:35:16-07:00 openjd_progress: 92.9
2025/10/07 14:35:16-07:00 openjd_status: Downloaded 19.95 GB / 21.47 GB of 2 files (Transfer rate: 268.37 MB/s)
2025/10/07 14:35:17-07:00 openjd_progress: 94.2
2025/10/07 14:35:17-07:00 openjd_status: Downloaded 20.22 GB / 21.47 GB of 2 files (Transfer rate: 270.01 MB/s)
2025/10/07 14:35:18-07:00 openjd_progress: 95.4
2025/10/07 14:35:18-07:00 openjd_status: Downloaded 20.49 GB / 21.47 GB of 2 files (Transfer rate: 270.79 MB/s)
2025/10/07 14:35:19-07:00 openjd_progress: 96.6
2025/10/07 14:35:19-07:00 openjd_status: Downloaded 20.75 GB / 21.47 GB of 2 files (Transfer rate: 259.52 MB/s)
2025/10/07 14:35:20-07:00 openjd_progress: 97.9
2025/10/07 14:35:20-07:00 openjd_status: Downloaded 21.03 GB / 21.47 GB of 2 files (Transfer rate: 277.35 MB/s)
2025/10/07 14:35:21-07:00 openjd_progress: 99.2
2025/10/07 14:35:21-07:00 openjd_status: Downloaded 21.3 GB / 21.47 GB of 2 files (Transfer rate: 268.96 MB/s)
2025/10/07 14:35:22-07:00 openjd_progress: 100.0
2025/10/07 14:35:22-07:00 openjd_status: Downloaded 21.47 GB / 21.47 GB of 2 files (Transfer rate: 228.87 MB/s)
2025/10/07 14:35:22-07:00 openjd_progress: 100.0
2025/10/07 14:35:22-07:00 openjd_status: Downloaded 21.47 GB / 21.47 GB of 2 files (Transfer rate: 0 B/s)
2025/10/07 14:35:22-07:00 Finished downloading after 68.8755264020001 seconds
2025/10/07 14:35:22-07:00 Process pid 17639 exited with code: 0 (unsigned) / 0x0 (hex)
```

</details>

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*