### PR TITLE
chore(experimental): add telemetry for attachment_download

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -2,9 +2,10 @@
 
 import logging
 from time import sleep, monotonic
-from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
+from typing import Any, Callable, Dict, Optional, TypeVar, cast
 from threading import Event
 from dataclasses import asdict, dataclass
+from functools import wraps
 import random
 
 from botocore.retries.standard import RetryContext
@@ -869,19 +870,51 @@ def record_sync_inputs_fail_telemetry_event(
     )
 
 
-def record_success_fail_telemetry_event(**decorator_kwargs: Dict[str, Any]) -> Callable[..., F]:
+def record_attachment_download_telemetry_event(queue_id: str, summary: SummaryStatistics) -> None:
+    """Calls the telemetry client to record an event capturing the attachment download summary."""
+    details: Dict[str, Any] = asdict(summary)
+    details["queue_id"] = queue_id
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.attachment_download_summary",
+        event_details=details,
+    )
+
+
+def record_attachment_download_fail_telemetry_event(
+    queue_id: str,
+    failure_reason: str,
+) -> None:
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.attachment_download_failure",
+        event_details={
+            "queue_id": queue_id,
+            "failure_reason": failure_reason,
+        },
+    )
+
+
+def record_attachment_download_latencies_telemetry_event(
+    queue_id: str,
+    latencies: Dict[str, Any],
+) -> None:
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.attachment_download_latencies",
+        event_details={
+            "queue_id": queue_id,
+            "latencies": latencies,
+        },
+    )
+
+
+def record_success_fail_telemetry_event(**decorator_kwargs: Any) -> Callable[[F], F]:
     """
     Decorator to try catch a function. Sends a success / fail telemetry event.
     :param ** Python variable arguments. See https://docs.python.org/3/glossary.html#term-parameter
     """
 
     def inner(function: F) -> F:
-        def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
-            """
-            Wrapper to actually try-catch
-            :param * Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter
-            :param ** Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter
-            """
+        @wraps(function)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             success: bool = True
             try:
                 return function(*args, **kwargs)

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
@@ -2,13 +2,15 @@
 
 #! /usr/bin/env python3
 import argparse
+import dataclasses
+import functools
 import json
 import sys
 import time
 import os
 import boto3
 import boto3.session
-from typing import Dict, List
+from typing import cast, Any, Callable, Dict, List, TypeVar
 
 from deadline.job_attachments.download import download_files_from_manifests
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
@@ -20,10 +22,13 @@ from deadline.job_attachments.progress_tracker import (
 )
 from deadline_worker_agent.sessions.attachment_models import WorkerManifestProperties
 from deadline_worker_agent.aws.deadline import (
-    record_sync_inputs_fail_telemetry_event,
-    record_sync_inputs_telemetry_event,
+    record_attachment_download_fail_telemetry_event,
+    record_attachment_download_latencies_telemetry_event,
+    record_attachment_download_telemetry_event,
+    record_success_fail_telemetry_event,
 )
 
+_queue_id = os.environ.get("DEADLINE_QUEUE_ID", "queue-unknown")  # Just for telemetry
 
 # During a SYNC_INPUT_JOB_ATTACHMENTS session action, the transfer rate is periodically reported through
 # a callback function. If a transfer rate lower than LOW_TRANSFER_RATE_THRESHOLD is observed in a series
@@ -33,6 +38,26 @@ LOW_TRANSFER_RATE_THRESHOLD = 10 * 10**3  # 10 KB/s÷
 LOW_TRANSFER_COUNT_THRESHOLD = (
     60  # Each progress report takes 1 sec at the longest, so 60 reports amount to 1 min in total.
 )
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def failure_telemetry(function: F) -> F:
+    """Decorator to record failure telemetry on a function"""
+
+    @functools.wraps(function)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return function(*args, **kwargs)
+        except Exception as e:
+            record_attachment_download_fail_telemetry_event(
+                queue_id=_queue_id,
+                failure_reason=f"{function.__name__}: {type(e).__name__}",
+            )
+            raise e
+
+    return cast(F, wrapper)
 
 
 def _seconds_to_minutes_str(seconds: int) -> str:
@@ -48,6 +73,17 @@ def _seconds_to_minutes_str(seconds: int) -> str:
         return f"{remaining_seconds} second{'s' if remaining_seconds != 1 else ''}"
 
 
+@dataclasses.dataclass
+class AttachmentDownloadLatencies:
+    """Stores metrics for function latencies in this script"""
+
+    load_worker_manifest_properties: int = 0
+    build_merged_manifests_by_root: int = 0
+    perform_download: int = 0
+    total: int = 0
+
+
+@failure_telemetry
 def load_worker_manifest_properties(worker_properties_file: str) -> List[WorkerManifestProperties]:
     """
     Load and parse worker manifest properties from a JSON file.
@@ -72,6 +108,7 @@ def load_worker_manifest_properties(worker_properties_file: str) -> List[WorkerM
     return [WorkerManifestProperties.from_dict(item) for item in worker_manifest_properties_data]
 
 
+@failure_telemetry
 def build_merged_manifests_by_root(
     worker_manifest_properties: List[WorkerManifestProperties],
 ) -> Dict[str, BaseAssetManifest]:
@@ -102,10 +139,10 @@ def build_merged_manifests_by_root(
     return manifests_by_root
 
 
+@failure_telemetry
 def perform_download(
     s3_settings: JobAttachmentS3Settings,
     manifests_by_root: Dict[str, BaseAssetManifest],
-    queue_id: str,
 ) -> DownloadSummaryStatistics:
     """
     Perform the actual download of files from S3 using the provided manifests.
@@ -117,72 +154,59 @@ def perform_download(
 
     Returns:
         DownloadSummaryStatistics object containing download results
-
-    Raises:
-        Exception: Any exception that occurs during download (after recording telemetry)
     """
-    try:
-        low_transfer_count = 0
+    low_transfer_count = 0
 
-        def progress_handler(job_attachments_download_status: ProgressReportMetadata) -> bool:
-            """
-            Callback for Job Attachments' download_files_from_manifests() to track the download progress.
-            Returns True if the operation should continue as normal or False to cancel.
-            """
-            # Check the transfer rate from the progress report. It monitors for a series of
-            # alarmingly low transfer rates, and if the count exceeds the specified threshold,
-            # cancels the download and fails the current (SYNC_INPUT_JOB_ATTACHMENTS) action.
-            nonlocal low_transfer_count
-            transfer_rate = job_attachments_download_status.transferRate
+    def progress_handler(job_attachments_download_status: ProgressReportMetadata) -> bool:
+        """
+        Callback for Job Attachments' download_files_from_manifests() to track the download progress.
+        Returns True if the operation should continue as normal or False to cancel.
+        """
+        # Check the transfer rate from the progress report. It monitors for a series of
+        # alarmingly low transfer rates, and if the count exceeds the specified threshold,
+        # cancels the download and fails the current (SYNC_INPUT_JOB_ATTACHMENTS) action.
+        nonlocal low_transfer_count
+        transfer_rate = job_attachments_download_status.transferRate
 
-            if transfer_rate < LOW_TRANSFER_RATE_THRESHOLD:
-                low_transfer_count += 1
-            else:
-                low_transfer_count = 0
-            if low_transfer_count >= LOW_TRANSFER_COUNT_THRESHOLD:
-                fail_message = (
-                    f"Input syncing failed due to successive low transfer rates (< {LOW_TRANSFER_RATE_THRESHOLD / 1000} KB/s). "
-                    f"The transfer rate was below the threshold for the last {_seconds_to_minutes_str(LOW_TRANSFER_COUNT_THRESHOLD)}."
-                )
-                print(f"openjd_fail: {fail_message}", flush=True)
-                record_sync_inputs_fail_telemetry_event(
-                    queue_id=queue_id,
-                    failure_reason=f"Insufficient download speed: {fail_message}",
-                )
-                return False
+        if transfer_rate < LOW_TRANSFER_RATE_THRESHOLD:
+            low_transfer_count += 1
+        else:
+            low_transfer_count = 0
+        if low_transfer_count >= LOW_TRANSFER_COUNT_THRESHOLD:
+            fail_message = (
+                f"Input syncing failed due to successive low transfer rates (< {LOW_TRANSFER_RATE_THRESHOLD / 1000} KB/s). "
+                f"The transfer rate was below the threshold for the last {_seconds_to_minutes_str(LOW_TRANSFER_COUNT_THRESHOLD)}."
+            )
+            print(f"openjd_fail: {fail_message}", flush=True)
+            record_attachment_download_fail_telemetry_event(
+                queue_id=_queue_id,
+                failure_reason=f"Insufficient download speed: {fail_message}",
+            )
+            return False
 
-            print(f"openjd_progress: {job_attachments_download_status.progress}")
-            print(f"openjd_status: {job_attachments_download_status.progressMessage}")
-            sys.stdout.flush()
-            return True
+        print(f"openjd_progress: {job_attachments_download_status.progress}")
+        print(f"openjd_status: {job_attachments_download_status.progressMessage}")
+        sys.stdout.flush()
+        return True
 
-        download_summary_statistics = download_files_from_manifests(
-            s3_bucket=s3_settings.s3BucketName,
-            manifests_by_root=manifests_by_root,
-            cas_prefix=s3_settings.full_cas_prefix(),
-            session=boto3.session.Session(),
-            on_downloading_files=progress_handler,
-        )
-
-        # Record successful download telemetry
-        record_sync_inputs_telemetry_event(
-            queue_id, download_summary_statistics.convert_to_summary_statistics()
-        )
-
-        return download_summary_statistics
-
-    except Exception as exc:
-        # Record failure telemetry
-        record_sync_inputs_fail_telemetry_event(
-            queue_id=queue_id,
-            failure_reason=f"Error downloading files: {exc}",
-        )
-        raise
+    download_summary_statistics = download_files_from_manifests(
+        s3_bucket=s3_settings.s3BucketName,
+        manifests_by_root=manifests_by_root,
+        cas_prefix=s3_settings.full_cas_prefix(),
+        session=boto3.session.Session(),
+        on_downloading_files=progress_handler,
+    )
+    record_attachment_download_telemetry_event(
+        queue_id=_queue_id,
+        summary=download_summary_statistics.convert_to_summary_statistics(),
+    )
+    return download_summary_statistics
 
 
+@record_success_fail_telemetry_event(metric_name="attachment_download")
 def main() -> None:
     """Main function to handle command line execution."""
-    start_time = time.perf_counter()
+    total_start_time = time.perf_counter_ns()
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-s3", "--s3-uri", type=str, help="S3 root URI", required=True)
@@ -196,20 +220,32 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    worker_manifest_properties = load_worker_manifest_properties(args.worker_properties)
+    latencies = AttachmentDownloadLatencies()
 
+    start_t = time.perf_counter_ns()
+    worker_manifest_properties = load_worker_manifest_properties(args.worker_properties)
+    latencies.load_worker_manifest_properties = time.perf_counter_ns() - start_t
+
+    start_t = time.perf_counter_ns()
     manifests_by_root = build_merged_manifests_by_root(worker_manifest_properties)
+    latencies.build_merged_manifests_by_root = time.perf_counter_ns() - start_t
 
     print("\nStarting download...")
 
     s3_settings = JobAttachmentS3Settings.from_s3_root_uri(args.s3_uri)
 
-    perform_download(
-        s3_settings, manifests_by_root, os.environ.get("DEADLINE_QUEUE_ID", "queue-unknown")
-    )
+    start_t = time.perf_counter_ns()
+    perform_download(s3_settings, manifests_by_root)
+    latencies.perform_download = time.perf_counter_ns() - start_t
 
-    total = time.perf_counter() - start_time
-    print(f"Finished downloading after {total} seconds")
+    total = time.perf_counter_ns() - total_start_time
+    latencies.total = total
+    print(f"Finished downloading after {round(total * 10**-9, 2)} seconds")
+
+    record_attachment_download_latencies_telemetry_event(
+        queue_id=_queue_id,
+        latencies=dataclasses.asdict(latencies),
+    )
 
 
 if __name__ == "__main__":

--- a/test/unit/sessions/actions/scripts/test_attachment_download.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_download.py
@@ -11,6 +11,7 @@ from deadline.job_attachments.progress_tracker import (
     DownloadSummaryStatistics,
     ProgressReportMetadata,
     ProgressStatus,
+    SummaryStatistics,
 )
 from deadline.job_attachments.models import ManifestProperties, PathFormat, JobAttachmentS3Settings
 from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import AssetManifest
@@ -284,12 +285,16 @@ class TestPerformDownload:
 
     @pytest.fixture(autouse=True)
     def mock_success_telemetry(self) -> Generator[Mock, None, None]:
-        with patch.object(attachment_download_mod, "record_sync_inputs_telemetry_event") as m:
+        with patch.object(
+            attachment_download_mod, "record_attachment_download_telemetry_event"
+        ) as m:
             yield m
 
     @pytest.fixture(autouse=True)
     def mock_fail_telemetry(self) -> Generator[Mock, None, None]:
-        with patch.object(attachment_download_mod, "record_sync_inputs_fail_telemetry_event") as m:
+        with patch.object(
+            attachment_download_mod, "record_attachment_download_fail_telemetry_event"
+        ) as m:
             yield m
 
     def test_perform_download_success(self, mock_success_telemetry, mock_download_files):
@@ -314,12 +319,14 @@ class TestPerformDownload:
         s3_settings = JobAttachmentS3Settings.from_s3_root_uri("s3://test-bucket/test-prefix")
 
         # WHEN
-        result = perform_download(s3_settings, {}, "test-queue")
+        result = perform_download(s3_settings, {})
 
         # THEN
         assert result == mock_download_summary
         mock_download_files.assert_called_once()
-        mock_success_telemetry.assert_called_once_with("test-queue", mock_summary_stats)
+        mock_success_telemetry.assert_called_once_with(
+            queue_id="queue-unknown", summary=mock_summary_stats
+        )
 
     def test_perform_download_failure(self, mock_fail_telemetry, mock_download_files):
         """Test download failure with telemetry recording."""
@@ -330,11 +337,11 @@ class TestPerformDownload:
 
         # WHEN/THEN
         with pytest.raises(Exception, match="Download failed"):
-            perform_download(s3_settings, {}, "test-queue")
+            perform_download(s3_settings, {})
 
         mock_fail_telemetry.assert_called_once_with(
-            queue_id="test-queue",
-            failure_reason="Error downloading files: Download failed",
+            queue_id="queue-unknown",
+            failure_reason="perform_download: Exception",
         )
 
     def test_progress_reporting(
@@ -368,7 +375,6 @@ class TestPerformDownload:
         perform_download(
             s3_settings=s3_settings,
             manifests_by_root={},
-            queue_id="test-queue",
         )
 
         # THEN
@@ -410,7 +416,6 @@ class TestPerformDownload:
         perform_download(
             s3_settings=s3_settings,
             manifests_by_root={},
-            queue_id="test-queue",
         )
 
         # THEN
@@ -419,7 +424,7 @@ class TestPerformDownload:
             "The transfer rate was below the threshold for the last 1 minute."
         ) in capsys.readouterr().out
         mock_fail_telemetry.assert_called_once_with(
-            queue_id="test-queue",
+            queue_id="queue-unknown",
             failure_reason=(
                 "Insufficient download speed: "
                 "Input syncing failed due to successive low transfer rates (< 10.0 KB/s). "
@@ -479,7 +484,6 @@ class TestMainFunction:
         mock_perform_download.assert_called_once_with(
             ANY,  # s3_settings - we'll verify the bucket name separately
             mock_manifests,
-            "test-queue-id",
         )
         # Verify S3 settings bucket name
         call_args = mock_perform_download.call_args
@@ -530,7 +534,6 @@ class TestMainFunction:
         mock_perform_download.assert_called_once_with(
             ANY,  # s3_settings
             mock_manifests,
-            "queue-unknown",
         )
 
 
@@ -550,3 +553,160 @@ class TestMainFunction:
 )
 def test_seconds_to_minutes_str(seconds: int, expected_str: str):
     assert _seconds_to_minutes_str(seconds) == expected_str
+
+
+class TestTelemetry:
+    """Test cases for telemetry functionality."""
+
+    @patch.object(attachment_download_mod, "record_attachment_download_fail_telemetry_event")
+    def test_failure_telemetry_decorator_on_load_worker_properties(self, mock_fail_telemetry: Mock):
+        """Test that @failure_telemetry decorator records failures for load_worker_manifest_properties."""
+        # WHEN
+        with pytest.raises(FileNotFoundError):
+            load_worker_manifest_properties("/nonexistent/file.json")
+
+        # THEN
+        mock_fail_telemetry.assert_called_once_with(
+            queue_id="queue-unknown",
+            failure_reason="load_worker_manifest_properties: FileNotFoundError",
+        )
+
+    @patch.object(attachment_download_mod, "record_attachment_download_fail_telemetry_event")
+    def test_failure_telemetry_decorator_on_build_manifests(self, mock_fail_telemetry: Mock):
+        """Test that @failure_telemetry decorator records failures for build_merged_manifests_by_root."""
+        # GIVEN
+        worker_prop = WorkerManifestProperties(
+            manifest_properties=Mock(),
+            local_root_path="/local/test",
+            local_manifest_paths=["/manifest.json"],
+            local_input_manifest_path="/manifest.json",
+        )
+
+        # WHEN
+        with (
+            pytest.raises(FileNotFoundError),
+            patch("builtins.open", side_effect=FileNotFoundError("Manifest not found")),
+        ):
+            build_merged_manifests_by_root([worker_prop])
+
+        # THEN
+        mock_fail_telemetry.assert_called_once_with(
+            queue_id="queue-unknown",
+            failure_reason="build_merged_manifests_by_root: FileNotFoundError",
+        )
+
+    @patch.object(attachment_download_mod, "record_attachment_download_fail_telemetry_event")
+    @patch.object(attachment_download_mod, "download_files_from_manifests")
+    def test_failure_telemetry_decorator_on_perform_download(
+        self, mock_download_files_from_manifests: Mock, mock_fail_telemetry: Mock
+    ):
+        """Test that @failure_telemetry decorator records failures for perform_download."""
+        # GIVEN
+        mock_download_files_from_manifests.side_effect = Exception("S3 error")
+        s3_settings = JobAttachmentS3Settings.from_s3_root_uri("s3://test-bucket/prefix")
+
+        # WHEN
+        with pytest.raises(Exception, match="S3 error") as raised_exc:
+            perform_download(s3_settings, {})
+
+        # THEN
+        assert raised_exc.value is mock_download_files_from_manifests.side_effect
+        mock_fail_telemetry.assert_called_once_with(
+            queue_id="queue-unknown", failure_reason="perform_download: Exception"
+        )
+
+    @patch.object(attachment_download_mod, "record_attachment_download_latencies_telemetry_event")
+    @patch.object(attachment_download_mod, "perform_download")
+    @patch.object(attachment_download_mod, "build_merged_manifests_by_root")
+    @patch.object(attachment_download_mod, "load_worker_manifest_properties")
+    @patch.object(attachment_download_mod.argparse.ArgumentParser, "parse_args")
+    @patch.object(attachment_download_mod, "_queue_id", "test-queue-123")
+    def test_latencies_telemetry_on_success(
+        self,
+        mock_parse_args: Mock,
+        mock_load: Mock,
+        mock_build: Mock,
+        mock_download: Mock,
+        mock_latencies_telemetry: Mock,
+    ):
+        """Test that latencies telemetry is recorded on successful completion."""
+        # GIVEN
+        mock_parse_args.return_value.s3_uri = "s3://test-bucket/test-object"
+
+        # WHEN
+        main()
+
+        # THEN
+        mock_latencies_telemetry.assert_called_once()
+        call_args = mock_latencies_telemetry.call_args
+        assert call_args[1]["queue_id"] == "test-queue-123"
+        assert "latencies" in call_args[1]
+
+        # Verify latencies structure
+        latencies = call_args[1]["latencies"]
+        assert "load_worker_manifest_properties" in latencies
+        assert "build_merged_manifests_by_root" in latencies
+        assert "perform_download" in latencies
+        assert "total" in latencies
+
+    @patch.object(attachment_download_mod, "record_attachment_download_fail_telemetry_event")
+    @patch.object(attachment_download_mod, "download_files_from_manifests")
+    def test_low_transfer_rate_telemetry(self, mock_download: Mock, mock_fail_telemetry: Mock):
+        """Test that low transfer rate triggers failure telemetry."""
+        # GIVEN
+        s3_settings = JobAttachmentS3Settings.from_s3_root_uri("s3://test-bucket/prefix")
+
+        def mock_download_with_low_rate(on_downloading_files, *args, **kwargs):
+            # Simulate 60 consecutive low transfer rate reports
+            low_rate_progress = ProgressReportMetadata(
+                status=ProgressStatus.DOWNLOAD_IN_PROGRESS,
+                progress=0.0,
+                transferRate=1,
+                progressMessage="Low rate",
+            )
+            for _ in range(60):
+                should_continue = on_downloading_files(low_rate_progress)
+                if not should_continue:
+                    break
+            return DownloadSummaryStatistics()
+
+        mock_download.side_effect = mock_download_with_low_rate
+
+        # WHEN
+        perform_download(s3_settings, {})
+
+        # THEN
+        mock_fail_telemetry.assert_called_once()
+        call_args = mock_fail_telemetry.call_args
+        assert call_args[1]["queue_id"] == "queue-unknown"
+        assert "Insufficient download speed" in call_args[1]["failure_reason"]
+
+    @patch.object(attachment_download_mod, "record_attachment_download_telemetry_event")
+    @patch.object(attachment_download_mod, "download_files_from_manifests")
+    def test_success_download_telemetry(self, mock_download: Mock, mock_success_telemetry: Mock):
+        """Test that successful download records telemetry with summary statistics."""
+        # GIVEN
+        mock_summary = SummaryStatistics(
+            total_time=2.5,
+            total_files=5,
+            total_bytes=2048,
+            processed_files=5,
+            processed_bytes=2048,
+            skipped_files=0,
+            skipped_bytes=0,
+            transfer_rate=819.2,
+        )
+
+        mock_download_result = Mock()
+        mock_download_result.convert_to_summary_statistics.return_value = mock_summary
+        mock_download.return_value = mock_download_result
+
+        s3_settings = JobAttachmentS3Settings.from_s3_root_uri("s3://test-bucket/prefix")
+
+        # WHEN
+        perform_download(s3_settings, {})
+
+        # THEN
+        mock_success_telemetry.assert_called_once_with(
+            queue_id="queue-unknown", summary=mock_summary
+        )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to record the following telemetry events when downloading input attachments:
- Success/fail
- Latency of each step in the operation
- Error reason (i.e. the function) when a failure happens

### What was the solution? (How)
Add above metrics

### What is the impact of this change?
We have the above metrics

### How was this change tested?
- Unit tests updated
- Manual CLI testing with debug logging enabled to show telemetry events (see below)

### Was this change documented?
N/A

### Is this a breaking change?
No

### Manual CLI Testing

I enabled DEBUG logging and ran `main` with different setups to cause scenarios that would emit the various telemetry events

Success/fail
```
deadline.client.api._telemetry - DEBUG - Sending telemetry data: {'BatchId': '156dd633-344c-4dd3-8290-794c595f8c35', 'RumEvents': [{'details': '{"is_success": true, "deadline-cloud-version": "0.52.1", "openjd-sessions-version": "0.10.4", "openjd-model-version": "0.8.4", "deadline-cloud": "0.52.1", "accountId": "162923712518", "usage_mode": "CLI"}', 'id': 'dea743a6-24be-442a-a845-78c64be8c863', 'metadata': '{"service": "deadline-cloud-worker-agent", "version": "0.28.14", "python_version": "3.11.7", "osName": "Linux", "osVersion": "5.10.244-220.965.amzn2int.x86_64"}', 'timestamp': 1759961058, 'type': 'com.amazon.rum.deadline.worker_agent.attachment_download'}], 'UserDetails': {'sessionId': 'a5393821-84e4-4113-85ac-f670a7ba29c3', 'userId': '1fd4f0c8-c8df-4914-9162-d2daa4a2488f'}}
```

Download summary (mocked download - no actual download)
```
deadline.client.api._telemetry - DEBUG - Sending telemetry data: {'BatchId': '27866ce5-a8d4-4557-a86d-87d24ab1464c', 'RumEvents': [{'details': '{"total_time": 6.689995643682778e-06, "total_files": 0, "total_bytes": 0, "processed_files": 0, "processed_bytes": 0, "skipped_files": 0, "skipped_bytes": 0, "transfer_rate": 0.0, "queue_id": "test-queue-123", "deadline-cloud-version": "0.52.1", "openjd-sessions-version": "0.10.4", "openjd-model-version": "0.8.4", "deadline-cloud": "0.52.1", "accountId": "162923712518", "usage_mode": "CLI"}', 'id': '963737f0-2dfd-4b9a-ad7a-eb4cc8e6733a', 'metadata': '{"service": "deadline-cloud-worker-agent", "version": "0.28.14", "python_version": "3.11.7", "osName": "Linux", "osVersion": "5.10.244-220.965.amzn2int.x86_64"}', 'timestamp': 1759961059, 'type': 'com.amazon.rum.deadline.worker_agent.attachment_download_summary'}], 'UserDetails': {'sessionId': 'c2a435ac-9e89-47bb-9aeb-ef4d5ad91951', 'userId': '1fd4f0c8-c8df-4914-9162-d2daa4a2488f'}}
```

Latencies
```
deadline.client.api._telemetry - DEBUG - Sending telemetry data: {'BatchId': 'f57e7b03-c4cf-4977-92fb-6e89a77f5f46', 'RumEvents': [{'details': '{"queue_id": "test-queue-123", "latencies": {"load_worker_manifest_properties": 96855, "build_merged_manifests_by_root": 27982, "perform_download": 121255533, "total": 122026438}, "deadline-cloud-version": "0.52.1", "openjd-sessions-version": "0.10.4", "openjd-model-version": "0.8.4", "deadline-cloud": "0.52.1", "accountId": "162923712518", "usage_mode": "CLI"}', 'id': '639501f1-a7d9-437a-8287-6b9e040c1c56', 'metadata': '{"service": "deadline-cloud-worker-agent", "version": "0.28.14", "python_version": "3.11.7", "osName": "Linux", "osVersion": "5.10.244-220.965.amzn2int.x86_64"}', 'timestamp': 1759961058, 'type': 'com.amazon.rum.deadline.worker_agent.attachment_download_latencies'}], 'UserDetails': {'sessionId': 'a5393821-84e4-4113-85ac-f670a7ba29c3', 'userId': '1fd4f0c8-c8df-4914-9162-d2daa4a2488f'}}
```

Insufficient transfer rate
```
deadline.client.api._telemetry - DEBUG - Sending telemetry data: {'BatchId': '739f58ff-3c1b-441d-bbbb-8b2b12647fb2', 'RumEvents': [{'details': '{"queue_id": "test-queue-123", "failure_reason": "Insufficient download speed: Input syncing failed due to successive low transfer rates (< 10.0 KB/s). The transfer rate was below the threshold for the last 1 minute.", "deadline-cloud-version": "0.52.1", "openjd-sessions-version": "0.10.4", "openjd-model-version": "0.8.4", "deadline-cloud": "0.52.1", "accountId": "162923712518", "usage_mode": "CLI"}', 'id': '3cd9c8b0-29a2-4839-b48d-786329dfe679', 'metadata': '{"service": "deadline-cloud-worker-agent", "version": "0.28.14", "python_version": "3.11.7", "osName": "Linux", "osVersion": "5.10.244-220.965.amzn2int.x86_64"}', 'timestamp': 1759961419, 'type': 'com.amazon.rum.deadline.worker_agent.attachment_download_failure'}], 'UserDetails': {'sessionId': 'e04014f9-6793-4365-9434-04aaa363c731', 'userId': '1fd4f0c8-c8df-4914-9162-d2daa4a2488f'}}
```

Failure - load_worker_manifest_properties
```
deadline.client.api._telemetry - DEBUG - Sending telemetry data: {'BatchId': '5de3c56e-859e-4dfe-8b84-f76eb0e2bfa7', 'RumEvents': [{'details': '{"queue_id": "test-queue-123", "failure_reason": "load_worker_manifest_properties: JSONDecodeError", "deadline-cloud-version": "0.52.1", "openjd-sessions-version": "0.10.4", "openjd-model-version": "0.8.4", "deadline-cloud": "0.52.1", "accountId": "162923712518", "usage_mode": "CLI"}', 'id': 'c2a83076-904a-4fc4-b70f-7eb08079dbff', 'metadata': '{"service": "deadline-cloud-worker-agent", "version": "0.28.14", "python_version": "3.11.7", "osName": "Linux", "osVersion": "5.10.244-220.965.amzn2int.x86_64"}', 'timestamp': 1759960146, 'type': 'com.amazon.rum.deadline.worker_agent.attachment_download_failure'}], 'UserDetails': {'sessionId': '80f6d464-8bbc-4dba-ab02-15b2eeec0b6f', 'userId': '1fd4f0c8-c8df-4914-9162-d2daa4a2488f'}}
```

Failure - build_merged_manifests_by_root
```
deadline.client.api._telemetry - DEBUG - Sending telemetry data: {'BatchId': 'b7c4bd41-9fcf-4dd5-b6f4-d47cd27c5f4d', 'RumEvents': [{'details': '{"queue_id": "test-queue-123", "failure_reason": "build_merged_manifests_by_root: ManifestDecodeValidationError", "deadline-cloud-version": "0.52.1", "openjd-sessions-version": "0.10.4", "openjd-model-version": "0.8.4", "deadline-cloud": "0.52.1", "accountId": "162923712518", "usage_mode": "CLI"}', 'id': 'e7cdb00c-ec0d-4109-ac8c-e11e19e0840f', 'metadata': '{"service": "deadline-cloud-worker-agent", "version": "0.28.14", "python_version": "3.11.7", "osName": "Linux", "osVersion": "5.10.244-220.965.amzn2int.x86_64"}', 'timestamp': 1759960147, 'type': 'com.amazon.rum.deadline.worker_agent.attachment_download_failure'}], 'UserDetails': {'sessionId': '73d07546-1a72-4eee-951b-5290386d1327', 'userId': '1fd4f0c8-c8df-4914-9162-d2daa4a2488f'}}
```

Failure - perform_download
```
deadline.client.api._telemetry - DEBUG - Sending telemetry data: {'BatchId': 'f96364b1-2bab-42af-831e-879169e8cd0a', 'RumEvents': [{'details': '{"queue_id": "test-queue-123", "failure_reason": "perform_download: JobAttachmentsS3ClientError", "deadline-cloud-version": "0.52.1", "openjd-sessions-version": "0.10.4", "openjd-model-version": "0.8.4", "deadline-cloud": "0.52.1", "accountId": "162923712518", "usage_mode": "CLI"}', 'id': '63377a76-8f79-4d74-9fdc-8b88fe2a4390', 'metadata': '{"service": "deadline-cloud-worker-agent", "version": "0.28.14", "python_version": "3.11.7", "osName": "Linux", "osVersion": "5.10.244-220.965.amzn2int.x86_64"}', 'timestamp': 1759960149, 'type': 'com.amazon.rum.deadline.worker_agent.attachment_download_failure'}], 'UserDetails': {'sessionId': 'f9dd64c8-7597-4936-9359-4bbe0fdddfb2', 'userId': '1fd4f0c8-c8df-4914-9162-d2daa4a2488f'}}
```


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*