### PR TITLE
fix(experimental): job attachment output manifest upload uses current time to construct s3 parition

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -107,6 +107,7 @@ class AttachmentUploadAction(TypedDict):
     actionType: AttachmentUploadActionType
     stepId: str
     taskId: str
+    startTime: float
 
 
 class HostConfiguration(TypedDict):

--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -516,12 +516,14 @@ class SessionActionQueue:
                 action_definition = action_queue_entry.definition
                 step_id = action_definition["stepId"]
                 task_id = action_definition["taskId"]
+                start_time = action_definition["startTime"]
 
                 next_action = AttachmentUploadAction(
                     id=action_id,
                     session_id=self._session_id,
                     step_id=step_id,
                     task_id=task_id,
+                    start_time=start_time,
                 )
 
             elif action_type == "SYNC_INPUT_JOB_ATTACHMENTS":

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
@@ -52,6 +52,7 @@ class AttachmentUploadAction(OpenjdAction):
     _step_script: Optional[StepScript_2023_09]
     _step_id: str
     _task_id: str
+    _start_time: float
 
     def __init__(
         self,
@@ -60,6 +61,7 @@ class AttachmentUploadAction(OpenjdAction):
         session_id: str,
         step_id: str,
         task_id: str,
+        start_time: float,
     ) -> None:
         super(AttachmentUploadAction, self).__init__(
             id=id,
@@ -67,6 +69,7 @@ class AttachmentUploadAction(OpenjdAction):
         )
         self._step_id = step_id
         self._task_id = task_id
+        self._start_time = start_time
 
         self._logger = LoggerAdapter(OPENJD_LOG, extra={"session_id": session_id})
 
@@ -128,6 +131,7 @@ class AttachmentUploadAction(OpenjdAction):
             and self._id == other._id
             and self._step_id == other._step_id
             and self._task_id == other._task_id
+            and self._start_time == other._start_time
             and self._step_script == other._step_script
         )
 
@@ -184,6 +188,7 @@ class AttachmentUploadAction(OpenjdAction):
             task_parameter_values=dict[str, ParameterValue](),
             os_env_vars={
                 "DEADLINE_SESSIONACTION_ID": self._id,
+                "DEADLINE_SESSIONACTION_START_TIME": str(self._start_time),
                 "DEADLINE_STEP_ID": self._step_id,
                 "DEADLINE_TASK_ID": self._task_id,
                 "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -233,7 +233,7 @@ def upload_output_assets(
         step_id=os.environ["DEADLINE_STEP_ID"],
         task_id=os.environ["DEADLINE_TASK_ID"],
         session_action_id=os.environ["DEADLINE_SESSIONACTION_ID"],
-        time=time.time(),
+        time=float(os.environ["DEADLINE_SESSIONACTION_START_TIME"]),
     )
 
     # Create S3 settings from the provided URI

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -1277,6 +1277,7 @@ class Session:
                     actionType="SYNC_OUTPUT_JOB_ATTACHMENTS",
                     stepId=current_action.definition.step_id,
                     taskId=current_action.definition.task_id,
+                    startTime=current_action.start_time.timestamp(),
                 )
 
                 if not self._action_output_log_filter:

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -311,6 +311,7 @@ class TestSessionActionQueueDequeue:
                         actionType="SYNC_OUTPUT_JOB_ATTACHMENTS",
                         stepId="step-1",
                         taskId="task-1",
+                        startTime=1234567890.0,
                     ),
                 ),
                 AttachmentUploadAction(
@@ -318,6 +319,7 @@ class TestSessionActionQueueDequeue:
                     session_id="session-1234",
                     step_id="step-1",
                     task_id="task-1",
+                    start_time=1234567890.0,
                 ),
                 id="attachment upload action",
             ),
@@ -361,6 +363,7 @@ class TestSessionActionQueueDequeue:
             actionType="SYNC_OUTPUT_JOB_ATTACHMENTS",
             stepId="step-1",
             taskId="task-1",
+            startTime=1234567890.0,
         )
 
         # WHEN

--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -2,6 +2,7 @@
 
 import json
 import pytest
+from pathlib import Path
 from unittest.mock import Mock, patch, mock_open
 
 from deadline_worker_agent.sessions.actions.scripts.attachment_upload import (
@@ -172,8 +173,10 @@ class TestAttachmentUpload:
             "DEADLINE_STEP_ID": "step-abc",
             "DEADLINE_TASK_ID": "task-def",
             "DEADLINE_SESSIONACTION_ID": "action-ghi",
+            "DEADLINE_SESSIONACTION_START_TIME": "1234567890.0",
         },
     )
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.config_file")
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.S3AssetUploader")
     @patch(
         "deadline_worker_agent.sessions.actions.scripts.attachment_upload.JobAttachmentS3Settings"
@@ -181,7 +184,7 @@ class TestAttachmentUpload:
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.decode_manifest")
     @patch("builtins.open", new_callable=mock_open, read_data='{"files": []}')
     def test_upload_output_assets(
-        self, mock_file, mock_decode, mock_s3_settings, mock_uploader_class
+        self, mock_file, mock_decode, mock_s3_settings, mock_uploader_class, mock_config_file
     ):
         # GIVEN
         mock_worker_props = Mock()
@@ -197,7 +200,9 @@ class TestAttachmentUpload:
         mock_s3_settings_instance = Mock()
         mock_s3_settings.from_s3_root_uri.return_value = mock_s3_settings_instance
         mock_s3_settings_instance.to_s3_root_uri.return_value = "s3://bucket/path"
+        mock_s3_settings.partial_session_action_manifest_prefix.return_value = "session/path"
 
+        mock_config_file.get_cache_directory.return_value = "/cache/dir"
         mock_decode.return_value = {"files": []}
 
         root_to_manifest = {"/source/path": "/output/manifest.json"}
@@ -208,7 +213,16 @@ class TestAttachmentUpload:
         # THEN
         assert len(result) == 1
         assert result[0].source_path == "/source/path"
-        mock_uploader.upload_assets.assert_called_once()
+        mock_uploader.upload_assets.assert_called_once_with(
+            job_attachment_settings=mock_s3_settings_instance,
+            manifest={"files": []},
+            partial_manifest_prefix="session/path",
+            manifest_file_name="hash123_output",
+            manifest_metadata={"Metadata": {"key": "value"}},
+            source_root=Path("/source/path"),
+            asset_root=Path("/local/path"),
+            s3_check_cache_dir="/cache/dir",
+        )
 
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.upload_output_assets")
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.snapshot")

--- a/test/unit/sessions/actions/test_run_attachment_upload.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload.py
@@ -79,7 +79,11 @@ def action(
     task_id: str,
 ) -> actions_module.AttachmentUploadAction:
     return actions_module.AttachmentUploadAction(
-        id=action_id, session_id="session-1234", step_id=step_id, task_id=task_id
+        id=action_id,
+        session_id="session-1234",
+        step_id=step_id,
+        task_id=task_id,
+        start_time=1234567890.0,
     )
 
 
@@ -170,6 +174,7 @@ class TestStart:
                 "DEADLINE_SESSIONACTION_ID": action_id,
                 "DEADLINE_STEP_ID": step_id,
                 "DEADLINE_TASK_ID": task_id,
+                "DEADLINE_SESSIONACTION_START_TIME": "1234567890.0",
                 "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,
@@ -236,6 +241,7 @@ class TestStart:
                 "DEADLINE_SESSIONACTION_ID": action_id,
                 "DEADLINE_STEP_ID": step_id,
                 "DEADLINE_TASK_ID": task_id,
+                "DEADLINE_SESSIONACTION_START_TIME": "1234567890.0",
                 "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1710,6 +1710,7 @@ class TestSessionActionUpdatedImpl:
                 actionType="SYNC_OUTPUT_JOB_ATTACHMENTS",
                 stepId=step_id,
                 taskId=task_id,
+                startTime=action_start_time.timestamp(),
             )
         )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Job attachment output manifest s3 prefix contains timestamp for session action. Current implementation uses timestamp from action start time. ASSET_SYNC_JOB_USER_FEATURE uses `time.time()` at the time of upload. This introduced a inconsistency. 

### What was the solution? (How)
Pass the task run session action start time to upload script and use it to construct s3 prefix.

### What is the impact of this change?
Keep backward consistency.

### How was this change tested?
- unit tests, e2e tests
- verify in s3, `"startedAt": "2025-10-10T19:37:45.568000+00:00",` vs `2025-10-10T19:37:45.568967Z`

```
{
            "sessionActionId": "sessionaction-92d6051fc5be4563bc8be773a574a60f-2",
            "status": "SUCCEEDED",
            "startedAt": "2025-10-10T19:37:45.568000+00:00",
            "endedAt": "2025-10-10T19:37:47.379000+00:00",
            "progressPercent": 100.0,
            "definition": {
                "taskRun": {
                    "taskId": "task-48391dfff9b540228ddda148a224ac80-0",
                    "stepId": "step-48391dfff9b540228ddda148a224ac80"
                }
            }
        },
```

```
job-a4d7bb60fd4f455e9b4b290666931fe3/step-48391dfff9b540228ddda148a224ac80/task-48391dfff9b540228ddda148a224ac80-0/2025-10-10T19:37:45.568967Z_sessionaction-92d6051fc5be4563bc8be773a574a60f-2/63ebdd1d87c005687f99d2489ff4c18f_output
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*