### PR TITLE
chore(experimental): add metrics for attachment_upload

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -906,6 +906,32 @@ def record_attachment_download_latencies_telemetry_event(
     )
 
 
+def record_attachment_upload_fail_telemetry_event(
+    queue_id: str,
+    failure_reason: str,
+) -> None:
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.attachment_upload_failure",
+        event_details={
+            "queue_id": queue_id,
+            "failure_reason": failure_reason,
+        },
+    )
+
+
+def record_attachment_upload_latencies_telemetry_event(
+    queue_id: str,
+    latencies: Dict[str, Any],
+) -> None:
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.attachment_upload_latencies",
+        event_details={
+            "queue_id": queue_id,
+            "latencies": latencies,
+        },
+    )
+
+
 def record_success_fail_telemetry_event(**decorator_kwargs: Any) -> Callable[[F], F]:
     """
     Decorator to try catch a function. Sends a success / fail telemetry event.

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -13,11 +13,13 @@ to handle job output file uploads after task completion.
 
 #! /usr/bin/env python3
 import argparse
+import dataclasses
+import functools
 import sys
 import time
 import os
 import json
-from typing import Optional
+from typing import cast, Any, Callable, Optional, TypeVar
 from pathlib import Path
 from dataclasses import asdict
 
@@ -32,11 +34,49 @@ from deadline.job_attachments.models import (
     JobAttachmentS3Settings,
     UploadManifestInfo,
 )
+from deadline_worker_agent.aws.deadline import (
+    record_attachment_upload_fail_telemetry_event,
+    record_attachment_upload_latencies_telemetry_event,
+    record_success_fail_telemetry_event,
+)
 from deadline_worker_agent.sessions.attachment_models import (
     WorkerManifestProperties,
 )
 
+_queue_id = os.environ.get("DEADLINE_QUEUE_ID", "queue-unknown")  # Just for telemetry
 
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def failure_telemetry(function: F) -> F:
+    """Decorator to record failure telemetry on a function"""
+
+    @functools.wraps(function)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return function(*args, **kwargs)
+        except Exception as e:
+            record_attachment_upload_fail_telemetry_event(
+                queue_id=_queue_id,
+                failure_reason=f"{function.__name__}: {type(e).__name__}",
+            )
+            raise e
+
+    return cast(F, wrapper)
+
+
+@dataclasses.dataclass
+class AttachmentUploadLatences:
+    """Stores metrics for function latencies in this script"""
+
+    merge: int = 0
+    snapshot: int = 0
+    parse_worker_manifest_properties: int = 0
+    upload_output_assets: int = 0
+    total: int = 0
+
+
+@failure_telemetry
 def merge(worker_manifest_properties: list[WorkerManifestProperties]) -> dict[str, Optional[str]]:
     """
     Merge multiple manifest files for each worker manifest property.
@@ -85,6 +125,7 @@ def merge(worker_manifest_properties: list[WorkerManifestProperties]) -> dict[st
     return root_path_to_local_manifest
 
 
+@failure_telemetry
 def snapshot(
     worker_manifest_properties: list[WorkerManifestProperties],
     root_path_to_base_manifest: dict[str, Optional[str]],
@@ -142,6 +183,7 @@ def snapshot(
     return root_path_to_output_manifest
 
 
+@failure_telemetry
 def parse_worker_manifest_properties(file_path: str) -> list[WorkerManifestProperties]:
     """
     Parse WorkerManifestProperties from a JSON file.
@@ -199,6 +241,7 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
+@failure_telemetry
 def upload_output_assets(
     s3_uri: str,
     worker_manifest_properties: list[WorkerManifestProperties],
@@ -285,6 +328,7 @@ def upload_output_assets(
     return output_manifest_info_list
 
 
+@record_success_fail_telemetry_event(metric_name="attachment_upload")
 def main(args=None):
     """
     Main entry point for the attachment upload script.
@@ -299,7 +343,8 @@ def main(args=None):
     Args:
         args: Optional list of command line arguments. If None, uses sys.argv[1:]
     """
-    start_time = time.perf_counter()
+    total_start_time = time.perf_counter_ns()
+    latencies = AttachmentUploadLatences()
 
     # Use command line arguments if not provided
     if args is None:
@@ -308,16 +353,22 @@ def main(args=None):
     parsed_args = parse_args(args)
 
     # Load and parse worker manifest properties configuration
+    start_t = time.perf_counter_ns()
     worker_manifest_properties = parse_worker_manifest_properties(parsed_args.worker_properties)
+    latencies.parse_worker_manifest_properties = time.perf_counter_ns() - start_t
 
     # Step 1: Merge input manifests to create base manifests for comparison
+    start_t = time.perf_counter_ns()
     root_path_to_base_manifest = merge(worker_manifest_properties=worker_manifest_properties)
+    latencies.merge = time.perf_counter_ns() - start_t
 
     # Step 2: Create snapshots of output files by comparing against base manifests
+    start_t = time.perf_counter_ns()
     root_path_to_output_manifest = snapshot(
         worker_manifest_properties=worker_manifest_properties,
         root_path_to_base_manifest=root_path_to_base_manifest,
     )
+    latencies.snapshot = time.perf_counter_ns() - start_t
 
     # Step 3: Upload assets if there are any changes to upload
     if not root_path_to_output_manifest:
@@ -325,11 +376,13 @@ def main(args=None):
 
     else:
         print("\nStarting upload...")
+        start_t = time.perf_counter_ns()
         manifest_infos = upload_output_assets(
             s3_uri=parsed_args.s3_uri,
             worker_manifest_properties=worker_manifest_properties,
             root_path_to_output_manifest=root_path_to_output_manifest,
         )
+        latencies.upload_output_assets = time.perf_counter_ns() - start_t
 
         # Check if manifest reporting feature is enabled via environment variable
         manifest_reporting_enabled = (
@@ -341,8 +394,15 @@ def main(args=None):
             # We're printing the manifest info to the logs so that we can re-load it as a manifest info in the worker agent process
             print(f"ja_upload: {json.dumps([asdict(info) for info in manifest_infos])}")
 
-        total = time.perf_counter() - start_time
-        print(f"Finished uploading after {total} seconds")
+    # Always record latencies telemetry regardless of whether upload occurred
+    total = time.perf_counter_ns() - total_start_time
+    print(f"Finished after {round(total * 10**-9, 2)} seconds")
+    latencies.total = total
+
+    record_attachment_upload_latencies_telemetry_event(
+        queue_id=_queue_id,
+        latencies=dataclasses.asdict(latencies),
+    )
 
 
 if __name__ == "__main__":

--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from pathlib import Path
 from unittest.mock import Mock, patch, mock_open
+from typing import Optional
 
 from deadline_worker_agent.sessions.actions.scripts.attachment_upload import (
     parse_args,
@@ -13,6 +14,7 @@ from deadline_worker_agent.sessions.actions.scripts.attachment_upload import (
     upload_output_assets,
     main,
 )
+import deadline_worker_agent.sessions.actions.scripts.attachment_upload as attachment_upload_mod
 
 
 class TestAttachmentUpload:
@@ -286,3 +288,140 @@ class TestAttachmentUpload:
             worker_manifest_properties=[mock_worker_props],
             root_path_to_base_manifest={"/source/path": "/base/manifest.json"},
         )
+
+
+class TestTelemetry:
+    """Test cases for telemetry functionality."""
+
+    @patch.object(attachment_upload_mod, "record_attachment_upload_fail_telemetry_event")
+    @patch("builtins.open", side_effect=FileNotFoundError("File not found"))
+    def test_failure_telemetry_decorator_on_parse_worker_manifest_properties(
+        self, mock_open: Mock, mock_fail_telemetry: Mock
+    ):
+        """Test that @failure_telemetry decorator records failures for parse_worker_manifest_properties."""
+        with pytest.raises(ValueError):
+            # WHEN
+            parse_worker_manifest_properties("/nonexistent/file.json")
+
+        # THEN
+        mock_fail_telemetry.assert_called_once_with(
+            queue_id="queue-unknown",
+            failure_reason="parse_worker_manifest_properties: ValueError",
+        )
+
+    @patch.object(attachment_upload_mod, "record_attachment_upload_fail_telemetry_event")
+    @patch.object(attachment_upload_mod, "_manifest_merge")
+    def test_failure_telemetry_decorator_on_merge(
+        self, mock_manifest_merge: Mock, mock_fail_telemetry: Mock
+    ):
+        """Test that @failure_telemetry decorator records failures for merge function."""
+        # GIVEN
+        mock_manifest_merge.side_effect = Exception("Merge failed")
+
+        with pytest.raises(Exception, match="Merge failed"):
+            # WHEN
+            merge([Mock()])
+
+        # THEN
+        mock_fail_telemetry.assert_called_once_with(
+            queue_id="queue-unknown",
+            failure_reason="merge: Exception",
+        )
+
+    @patch.object(attachment_upload_mod, "record_attachment_upload_fail_telemetry_event")
+    @patch.object(attachment_upload_mod, "_manifest_snapshot")
+    def test_failure_telemetry_decorator_on_snapshot(
+        self, mock_manifest_snapshot: Mock, mock_fail_telemetry: Mock
+    ):
+        """Test that @failure_telemetry decorator records failures for snapshot function."""
+        # GIVEN
+        mock_worker_manifest_properties = Mock()
+        mock_worker_manifest_properties.local_output_relative_directories.return_value = ["test"]
+        mock_manifest_snapshot.side_effect = Exception("Snapshot failed")
+
+        with pytest.raises(Exception, match="Snapshot failed"):
+            # WHEN
+            snapshot([mock_worker_manifest_properties], Mock())
+
+        # THEN
+        mock_fail_telemetry.assert_called_once_with(
+            queue_id="queue-unknown",
+            failure_reason="snapshot: Exception",
+        )
+
+    @patch.object(
+        attachment_upload_mod.JobAttachmentS3Settings, "partial_session_action_manifest_prefix"
+    )
+    @patch.object(attachment_upload_mod, "record_attachment_upload_fail_telemetry_event")
+    def test_failure_telemetry_decorator_on_upload_output_assets(
+        self,
+        mock_fail_telemetry: Mock,
+        mock_partial_session_action_manifest_prefix: Mock,
+    ):
+        """Test that @failure_telemetry decorator records failures for upload_output_assets function."""
+        # GIVEN
+        with (
+            # Force a KeyError failure by clearing the environment variables
+            # which the function uses to get DEADLINE_FARM_ID, etc.
+            patch.dict(attachment_upload_mod.os.environ, {}),
+            pytest.raises(KeyError),
+        ):
+            # WHEN
+            upload_output_assets(Mock(), [Mock()], Mock())
+
+        # THEN
+        mock_fail_telemetry.assert_called_once_with(
+            queue_id="queue-unknown",
+            failure_reason="upload_output_assets: KeyError",
+        )
+
+    @pytest.mark.parametrize(
+        argnames=["root_path_to_output_manifest"],
+        argvalues=[[{"test": "value"}], [{}]],
+        ids=["with output", "no output"],
+    )
+    @patch.dict(
+        attachment_upload_mod.os.environ,
+        {
+            "DEADLINE_FARM_ID": "DEADLINE_FARM_ID",
+            "DEADLINE_QUEUE_ID": "DEADLINE_QUEUE_ID",
+            "DEADLINE_JOB_ID": "DEADLINE_JOB_ID",
+            "DEADLINE_STEP_ID": "DEADLINE_STEP_ID",
+            "DEADLINE_TASK_ID": "DEADLINE_TASK_ID",
+            "DEADLINE_SESSIONACTION_ID": "DEADLINE_SESSIONACTION_ID",
+            "DEADLINE_SESSIONACTION_START_TIME": "123.456",
+        },
+    )  # Mock the environment variables
+    @patch.object(attachment_upload_mod, "record_attachment_upload_latencies_telemetry_event")
+    @patch.object(attachment_upload_mod, "snapshot")
+    @patch.object(attachment_upload_mod, "merge")
+    @patch.object(attachment_upload_mod, "parse_worker_manifest_properties")
+    def test_latencies_telemetry(
+        self,
+        mock_parse: Mock,
+        mock_merge: Mock,
+        mock_snapshot: Mock,
+        mock_latencies_telemetry: Mock,
+        root_path_to_output_manifest: Optional[Mock],
+    ):
+        """Test that latencies telemetry is recorded whether output is uploaded or not"""
+        # GIVEN
+        mock_snapshot.return_value = root_path_to_output_manifest
+        args = ["-s3", "s3://test-bucket/path", "-wp", "/path/to/worker.json"]
+
+        # WHEN
+        main(args)
+
+        # THEN
+        mock_latencies_telemetry.assert_called_once()
+        call_args = mock_latencies_telemetry.call_args
+        assert call_args[1]["queue_id"] == "queue-unknown"
+        assert "latencies" in call_args[1]
+
+        # Verify latencies structure
+        latencies = call_args[1]["latencies"]
+        assert "merge" in latencies
+        assert "snapshot" in latencies
+        assert "parse_worker_manifest_properties" in latencies
+        assert "upload_output_assets" in latencies
+        assert "total" in latencies


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need metrics for attachment_upload, the experimental implementation for syncing assets as the job user

### What was the solution? (How)
Add metrics for success/fail, detailed error reasons, and latencies

### What is the impact of this change?
We have above metrics

### How was this change tested?
- Added unit tests
- Manually calling the CLI to invoke each telemetry event

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*