### PR TITLE
test: fix hard-coded job attachment root prefix failing dev e2e tests

### DIFF
--- a/test/e2e/s3_validation_utils.py
+++ b/test/e2e/s3_validation_utils.py
@@ -68,6 +68,7 @@ def validate_s3_job_output_manifest(
 
     # Extract S3 configuration
     s3_bucket = queue_details.jobAttachmentSettings.s3BucketName
+    root_prefix = queue_details.jobAttachmentSettings.rootPrefix
 
     for manifest_properties in job_details.attachments.manifests:
         root_path = manifest_properties.rootPath
@@ -78,7 +79,7 @@ def validate_s3_job_output_manifest(
 
         for step in steps:
             step_id = step["stepId"]
-            manifest_prefix = f"rootPrefix/Manifests/{farm_id}/{queue_id}/{job.id}/{step_id}"
+            manifest_prefix = f"{root_prefix}/Manifests/{farm_id}/{queue_id}/{job.id}/{step_id}"
 
             try:
                 manifest_keys = _get_tasks_manifests_keys_from_s3(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Developers following `DEVELOPMENT.md` workflow to run the worker agent e2e tests using the `validate_s3_job_output_manifest` function in `test/e2e/s3_validation_utils.py` would fail.

This is because the `validate_s3_job_output_manifest` function assumes that the queue's job attachment root prefix was `rootPrefix`:

https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/84bb52d7c193a2e3fc72c712fb2fda25ae93e3f5/test/e2e/s3_validation_utils.py#L81

 but the CloudFormation template provided for development e2e testing configures the root prefix as `Deadline`:

https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/84bb52d7c193a2e3fc72c712fb2fda25ae93e3f5/scripts/e2e_testing_infrastructure.yaml#L679

There was a previous attempt to fix this in #757, but the solution was not general.

### What was the solution? (How)

Switch to using the root prefix configured on the queue as suggested in

https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/757/files#r2412278759

### What is the impact of this change?

The tests now use the job attachment S3 root prefix configured on the queue and do not assume a hard-coded prefix. Developers running the e2e tests will no longer see failures when running the tests.

### How was this change tested?

Ran the e2e tests which passed successfully

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*