### PR TITLE
ci: add changelog section for performance improvements

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -22,4 +22,11 @@
         {% endfor %}
     {% endif %}
 
+    {% if "performance improvements" in release["elements"] %}
+### Performance Improvements
+        {% for commit in release["elements"]["performance improvements"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
 {% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,7 @@ patch_tags = [
   "feat",
   "fix",
   "refactor",
+  "perf",
 ]
 
 [tool.semantic_release.publish]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There is no section in the release process' git history -> changelog template for performance improvements

### What was the solution? (How)

Added a section to the changelog template for performance improvements - similar to aws-deadline/deadline-cloud#870. Also add `perf` commits to the `patch_tags` setting of `python-semantic-release` so that they are considered as part of bumping a version for release.

### What is the impact of this change?

Developers can use `perf: ...` [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to communicate performance improvements when changelogs are automatically generated as part of the release

### How was this change tested?

1.  Set my local `mainline` branch to this commit
2. Added example commits using the `perf: ...` commit summary message
3. Ran:
    ```
    hatch run release:deps
    hatch run release:bump
    ```
4.  confirmed that rendered `CHANGELOG.md` contained the expected "Performance Improvements" section correctly

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*