### PR TITLE
test: add e2e test to verify empty outputRelativeDirectories lead to no output

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -147,6 +147,12 @@ def deadline_resources() -> Generator[DeadlineResources, None, None]:
 
 
 @pytest.fixture(scope="session")
+def test_runner_identity() -> dict[str, str]:
+    sts_client = boto3.client("sts")
+    return sts_client.get_caller_identity()
+
+
+@pytest.fixture(scope="session")
 def worker_config(
     posix_job_user: PosixSessionUser,
     posix_env_override_job_user: PosixSessionUser,

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -3406,3 +3406,156 @@ with open(output_path, "w") as f:
             reference_dir_path=f"{os.path.dirname(__file__)}/job_attachment_bundle/complex_bundle/windows/correct_output",
             output_dir_path=output_root_path,
         )
+
+    def test_job_attachments_no_output_relative_directories(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        session_worker: EC2InstanceWorker,
+        test_runner_identity: dict[str, str],
+    ) -> None:
+        """
+        Tests that a job created with multiple manifests that have the same rootPath and both manifests have a file with the same path
+        results in the file from the second manifest taking precedence over the first manifest
+        """
+        # Get S3 settings from queue using boto3 directly
+        queue_info = deadline_client._real_client.get_queue(
+            farmId=deadline_resources.farm.id, queueId=deadline_resources.queue_a.id
+        )
+        s3_bucket = queue_info["jobAttachmentSettings"]["s3BucketName"]
+        s3_prefix = queue_info["jobAttachmentSettings"]["rootPrefix"]
+
+        # Create test files and calculate hashes
+        file1_content = str(time.time())
+        from xxhash import xxh3_128
+
+        file1_hash = xxh3_128(file1_content).hexdigest()
+
+        # Upload asset files to S3
+        s3 = boto3.client("s3")
+        s3.put_object(
+            Bucket=s3_bucket,
+            Key=f"{s3_prefix}/Data/{file1_hash}",
+            Body=file1_content,
+            ExpectedBucketOwner=test_runner_identity["Account"],
+        )
+
+        # Create manifests with collision (same path, different hashes)
+        manifest = {
+            "hashAlg": "xxh128",
+            "manifestVersion": "2023-03-03",
+            "paths": [
+                {
+                    "hash": file1_hash,
+                    "mtime": 1679079744833848,
+                    "path": "file.txt",
+                    "size": len(file1_content),
+                },
+            ],
+            "totalSize": len(file1_content),
+        }
+
+        # Upload manifests
+        s3.put_object(
+            Bucket=s3_bucket,
+            Key=f"{s3_prefix}/Manifests/manifest1hash",
+            Body=json.dumps(manifest),
+            ExpectedBucketOwner=test_runner_identity["Account"],
+        )
+
+        # Create and submit job using boto3 directly
+        template = {
+            "specificationVersion": "jobtemplate-2023-09",
+            "name": f"empty-outputRelativeDirectories-test-{os.environ['OPERATING_SYSTEM']}",
+            "parameterDefinitions": [
+                {
+                    "name": "AssetPath",
+                    "type": "PATH",
+                    "objectType": "DIRECTORY",
+                    "dataFlow": "INOUT",
+                    "description": "Path to input assets",
+                }
+            ],
+            "steps": [
+                {
+                    "name": "step1",
+                    "script": {
+                        "actions": {
+                            "onRun": (
+                                {
+                                    "command": "/bin/bash",
+                                    "args": [
+                                        "-c",
+                                        "; ".join(
+                                            [
+                                                "ls -lR",
+                                                "echo $(cat {{Param.AssetPath}}/file.txt)",
+                                                "echo 'Modifying existing file' >> {{Param.AssetPath}}/file.txt",
+                                                "echo $(cat {{Param.AssetPath}}/file.txt)",
+                                                "echo 'Create a new file' > {{Param.AssetPath}}/newfile.txt",
+                                                "ls -lR",
+                                                "echo {{Session.PathMappingRulesFile}}",
+                                                "cat {{Session.PathMappingRulesFile}}",
+                                            ]
+                                        ),
+                                    ],
+                                }
+                                if os.environ["OPERATING_SYSTEM"] == "linux"
+                                else {
+                                    "command": "cmd",
+                                    "args": [
+                                        "/c",
+                                        (
+                                            "dir /s & "
+                                            "type {{Param.AssetPath}}\\file.txt & "
+                                            "echo Modifying existing file >> {{Param.AssetPath}}\\file.txt & "
+                                            "type {{Param.AssetPath}}\\file.txt & "
+                                            "echo Create a new file > {{Param.AssetPath}}\\newfile.txt & "
+                                            "dir /s & "
+                                            "echo {{Session.PathMappingRulesFile}} & "
+                                            "type {{Session.PathMappingRulesFile}}"
+                                        ),
+                                    ],
+                                }
+                            ),
+                        }
+                    },
+                }
+            ],
+        }
+        attachments = {
+            "manifests": [
+                {
+                    # no outputRelativeDirectories
+                    "rootPath": "/test/assets",
+                    "rootPathFormat": "posix",
+                    "inputManifestPath": "manifest1hash",
+                    "inputManifestHash": "manifest1hash",
+                },
+            ]
+        }
+
+        job = Job.submit(
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            template=template,
+            priority=50,
+            attachments=attachments,
+            parameters={
+                "AssetPath": {"path": "/test/assets"},
+            },
+        )
+        job.wait_until_complete(client=deadline_client)
+        assert job.task_run_status == TaskStatus.SUCCEEDED
+
+        output_root_path = tempfile.mkdtemp(
+            dir=self.JOB_OUTPUT_PATH, prefix="no_output_relative_directories_empty_output"
+        )
+        output_path: dict[str, list[str]] = wait_for_job_output(
+            job=job,
+            deadline_client=deadline_client,
+            deadline_resources=deadline_resources,
+            output_root_path=output_root_path,
+        )
+        assert len(output_path) == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
ouputRelativeDirectories is an optional field in [ManifestProperties](https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ManifestProperties.html) as part of CreateJob API model. If not provided upon calling CreateJob, the value will be None. When the list is None, nothing gets recognize as upload for upload.

This can be easily overlooked, we should have a test to guard the expected behaviour.

### What was the solution? (How)
Add tests to guard the expected behaviour when `ouputRelativeDirectories` is None.

### What is the impact of this change?
Better test coverage.

### How was this change tested?
#### Verified both windows and linux tests pass.
```
test/e2e/test_job_submissions.py::TestJobSubmission::test_job_attachments_no_output_relative_directories
=================== 1 passed, 1 warning in 342.44s (0:05:42) ===================
```
#### Verified no job output

windows
```
 ~> deadline job download-output --job-id job-1bd1c08da4f94ec3a991d8e6c6fc9572
Downloading output from Job 'empty-outputRelativeDirectories-test-windows'
There are no output files available for download at this moment. Please verify that the Job/Step/Task you are trying to download output from has completed successfully.
```
linux
```
 ~> deadline job download-output --job-id job-c1fc3dee3df54c6f9f60a90cb7a00272
Downloading output from Job 'empty-outputRelativeDirectories-test-linux'
There are no output files available for download at this moment. Please verify that the Job/Step/Task you are trying to download output from has completed successfully.
```


### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*