### PR TITLE
fix(experimental): not reporting manifests in progress updates

### DIFF
--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -1206,15 +1206,12 @@ class Session:
 
         if self._output_sync_target_action is not None:
             if OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS.get(action_status.state, None):
-                manifests_list = None
+                manifests_list = []
 
                 # Get job attachment details to access input manifests
                 job_attachment_details = self._job_attachment_details
 
                 if job_attachment_details:
-                    # Create a list of ManifestInfo objects with the same length as the input manifests list
-                    manifests_list = []
-
                     # For each input manifest, find the corresponding output manifest
                     for input_manifest in job_attachment_details.manifests:
                         asset_root = input_manifest.root_path
@@ -1359,12 +1356,6 @@ class Session:
         now: datetime,
         manifests: list[ManifestInfo] | None = None,
     ):
-        # avoid circular import
-        from .actions import RunStepTaskAction
-
-        if manifests is None and isinstance(current_action.definition, RunStepTaskAction):
-            manifests = []
-
         completed_status = OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS.get(
             action_status.state, None
         )
@@ -1423,8 +1414,18 @@ class Session:
         # Only report action update when it's not attachment upload for syncing job attachment outputs,
         # progress reporting is not supported by the output upload yet.
         if not self._output_sync_target_action:
-            # Only include manifests if feature flag is enabled
-            session_manifests = manifests if MANIFEST_REPORTING_FEATURE else None
+            # avoid circular import
+            from .actions import RunStepTaskAction
+
+            # Only include manifests for successfully completed RunStepTaskActions
+            session_manifests = None
+            if (
+                MANIFEST_REPORTING_FEATURE
+                and completed_status == "SUCCEEDED"
+                and isinstance(current_action.definition, RunStepTaskAction)
+            ):
+                # Always report empty list for successful task runs to differentiate from old workers
+                session_manifests = manifests if manifests is not None else []
 
             self._report_action_update(
                 SessionActionStatus(

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Generator, Iterable
 from concurrent.futures import wait
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from threading import Event, RLock
 from types import TracebackType
@@ -60,6 +60,9 @@ from deadline_worker_agent.sessions.actions import (
     EnterEnvironmentAction,
     ExitEnvironmentAction,
     RunStepTaskAction,
+)
+from deadline_worker_agent.sessions.actions.run_attachment_upload import (
+    AttachmentUploadAction as AttachmentUploadActionClass,
 )
 from deadline_worker_agent.sessions.job_entities import (
     EnvironmentDetails,
@@ -1437,7 +1440,7 @@ class TestSessionActionUpdatedImpl:
                 start_time=action_start_time,
                 completed_status="FAILED",
                 end_time=action_complete_time,
-                manifests=[],
+                manifests=None,
             )
         else:
             expected_action_update = SessionActionStatus(
@@ -1516,7 +1519,7 @@ class TestSessionActionUpdatedImpl:
                 start_time=action_start_time,
                 completed_status="FAILED",
                 end_time=action_complete_time,
-                manifests=[],
+                manifests=None,
             )
         else:
             expected_action_update = SessionActionStatus(
@@ -1908,7 +1911,7 @@ class TestSessionActionUpdatedImpl:
                 start_time=action_start_time,
                 completed_status="FAILED",
                 end_time=action_complete_time,
-                manifests=[],
+                manifests=None,
             )
         else:
             expected_action_update = SessionActionStatus(
@@ -2179,6 +2182,203 @@ class TestSessionActionUpdatedImpl:
 
         assert len(session._upload_manifest_list) == 1
         assert all(isinstance(item, UploadManifestInfo) for item in session._upload_manifest_list)
+
+    @pytest.mark.skipif(
+        not MANIFEST_REPORTING_FEATURE or not ASSET_SYNC_JOB_USER_FEATURE,
+        reason="This test only runs when both MANIFEST_REPORTING_FEATURE and ASSET_SYNC_JOB_USER_FEATURE are enabled",
+    )
+    def test_progress_update_excludes_manifests(
+        self,
+        session: Session,
+        mock_report_action_update: MagicMock,
+    ) -> None:
+        """Test that progress updates (RUNNING state) do not include manifests field"""
+        # GIVEN - A running task action with progress
+        action_id = "test-action-123"
+        step_id = "step-456"
+        task_id = "task-789"
+
+        current_action = CurrentAction(
+            definition=RunStepTaskAction(
+                details=StepDetails(
+                    step_template=StepTemplate(
+                        name="Test",
+                        script=StepScript(
+                            actions=StepActions(
+                                onRun=Action(
+                                    command=CommandString("echo"),
+                                    args=[ArgString("hello")],
+                                    cancelation=None,
+                                )
+                            )
+                        ),
+                    ),
+                    step_id=step_id,
+                ),
+                id=action_id,
+                task_id=task_id,
+                task_parameter_values=dict[str, ParameterValue](),
+            ),
+            start_time=datetime.now(tz=timezone.utc),
+        )
+        session._current_action = current_action
+
+        # Progress update (RUNNING state, no completed_status)
+        progress_action_status = ActionStatus(
+            state=ActionState.RUNNING, progress=50.0, status_message="Processing files..."
+        )
+
+        # WHEN - Progress update is reported
+        session._action_updated_impl(
+            action_status=progress_action_status,
+            now=datetime.now(tz=timezone.utc),
+        )
+
+        # THEN - No manifests field should be included
+        mock_report_action_update.assert_called_once()
+        call_args = mock_report_action_update.call_args[0][0]
+        assert isinstance(call_args, SessionActionStatus)
+        assert call_args.manifests is None  # Should be None for progress updates
+
+    @pytest.mark.skipif(
+        not MANIFEST_REPORTING_FEATURE or not ASSET_SYNC_JOB_USER_FEATURE,
+        reason="This test only runs when both MANIFEST_REPORTING_FEATURE and ASSET_SYNC_JOB_USER_FEATURE are enabled",
+    )
+    def test_failed_task_excludes_manifests(
+        self,
+        session: Session,
+        mock_report_action_update: MagicMock,
+    ) -> None:
+        """Test that failed task actions do not include manifests field"""
+        # GIVEN - A failed task action
+        action_id = "test-action-123"
+        step_id = "step-456"
+        task_id = "task-789"
+
+        current_action = CurrentAction(
+            definition=RunStepTaskAction(
+                details=StepDetails(
+                    step_template=StepTemplate(
+                        name="Test",
+                        script=StepScript(
+                            actions=StepActions(
+                                onRun=Action(
+                                    command=CommandString("echo"),
+                                    args=[ArgString("hello")],
+                                    cancelation=None,
+                                )
+                            )
+                        ),
+                    ),
+                    step_id=step_id,
+                ),
+                id=action_id,
+                task_id=task_id,
+                task_parameter_values=dict[str, ParameterValue](),
+            ),
+            start_time=datetime.now(tz=timezone.utc),
+        )
+        session._current_action = current_action
+
+        # Failed action status
+        failed_action_status = ActionStatus(state=ActionState.FAILED, fail_message="Task failed")
+
+        # WHEN - Failed action is reported
+        with patch.object(
+            session_mod,
+            "OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS",
+            {ActionState.FAILED: "FAILED"},
+        ):
+            session._action_updated_impl(
+                action_status=failed_action_status,
+                now=datetime.now(tz=timezone.utc),
+            )
+
+        # THEN - No manifests field should be included
+        mock_report_action_update.assert_called_once()
+        call_args = mock_report_action_update.call_args[0][0]
+        assert isinstance(call_args, SessionActionStatus)
+        assert call_args.manifests is None  # Should be None for failed actions
+
+    @pytest.mark.skipif(
+        not MANIFEST_REPORTING_FEATURE or not ASSET_SYNC_JOB_USER_FEATURE,
+        reason="This test only runs when both MANIFEST_REPORTING_FEATURE and ASSET_SYNC_JOB_USER_FEATURE are enabled",
+    )
+    def test_successful_task_without_job_attachments_includes_empty_manifests(
+        self,
+        session: Session,
+        mock_report_action_update: MagicMock,
+    ) -> None:
+        """Test that successful task actions without job attachments include empty manifests list"""
+        # GIVEN - A successful attachment upload action with no outputs
+        action_id = "test-action-123"
+        step_id = "step-456"
+        task_id = "task-789"
+
+        current_action = CurrentAction(
+            definition=RunStepTaskAction(
+                details=StepDetails(
+                    step_template=StepTemplate(
+                        name="Test",
+                        script=StepScript(
+                            actions=StepActions(
+                                onRun=Action(
+                                    command=CommandString("echo"),
+                                    args=[ArgString("hello")],
+                                    cancelation=None,
+                                )
+                            )
+                        ),
+                    ),
+                    step_id=step_id,
+                ),
+                id=action_id,
+                task_id=task_id,
+                task_parameter_values=dict[str, ParameterValue](),
+            ),
+            start_time=datetime.now(tz=timezone.utc),
+        )
+
+        # Mock the attachment upload completion scenario
+        # Create an attachment upload action as the current action
+        upload_action = CurrentAction(
+            definition=AttachmentUploadActionClass(
+                id=f"{current_action.definition.id}-upload",
+                session_id="test-session",
+                step_id=step_id,
+                task_id=task_id,
+                start_time=current_action.start_time.timestamp(),
+            ),
+            start_time=datetime.now(tz=timezone.utc),
+        )
+
+        session._current_action = upload_action  # Upload action is current
+        session._output_sync_target_action = current_action  # Original task action is target
+        session._job_attachment_details = None  # No job attachments
+        session._upload_manifest_list = []
+
+        # Successful action status for the upload action
+        success_action_status = ActionStatus(state=ActionState.SUCCESS, exit_code=0)
+
+        # WHEN - Upload action completes successfully
+        with (
+            patch.object(
+                session_mod,
+                "OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS",
+                {ActionState.SUCCESS: "SUCCEEDED"},
+            ),
+            patch.object(session, "_handle_action_update") as mock_handle_action_update,
+        ):
+            session._action_updated_impl(
+                action_status=success_action_status,
+                now=datetime.now(tz=timezone.utc),
+            )
+
+        # THEN - Empty manifests list should be passed to _handle_action_update
+        mock_handle_action_update.assert_called_once()
+        call_args = mock_handle_action_update.call_args[0]
+        manifests_arg = call_args[4]  # 5th argument is manifests
+        assert manifests_arg == []  # Should be empty list
 
 
 @pytest.mark.usefixtures("mock_openjd_session")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The WorkerAgent was incorrectly including the `manifests` field in UpdateWorkerSchedule API when reporting progress updates. This occurred because the code automatically initialized `manifests = []` for all RunStepTaskAction instances. Manifest reporting code is hidden under `MANIFEST_REPORTING_FEATURE` feature flag, so the issue is not customer-facing.

### What was the solution? (How)

1. Removed automatic manifest initialization (`manifests = []`) for all RunStepTaskAction instances in `_handle_action_update`
2. Changed manifest initialization in attachment upload completion from `manifests_list = None` to `manifests_list = []` to ensure empty list is reported for successful tasks without job attachments
3. Added proper conditional logic to only include manifests when:
   - `MANIFEST_REPORTING_FEATURE` is enabled
   - `completed_status == "SUCCEEDED"`
   - Action is a `RunStepTaskAction`

### What is the impact of this change?

The WorkerAgent now correctly differentiates between old workers (never report manifests) and new workers (always report empty list for successful task runs, even if no outputs). Progress updates and failed actions no longer incorrectly include the manifests field in API requests.

### How was this change tested?

Added three new unit tests:
- `test_progress_update_excludes_manifests` - Verifies progress updates don't include manifests
- `test_failed_task_excludes_manifests` - Verifies failed tasks don't include manifests  
- `test_successful_task_without_job_attachments_includes_empty_manifests` - Verifies successful tasks without attachments include empty list

Updated existing test expectations to expect `manifests=None` for failed actions instead of `manifests=[]`.

### Was this change documented?

No user-facing documentation changes required. This is an internal bug fix in the API request construction. Manifest reporting code is still under feature flag, so this PR doesn't introduce any no customer-facing changes.

### Is this a breaking change?

No. This fix ensures the worker agent correctly implements the intended behavior of the manifest reporting feature.