### PR TITLE
fix(experimental): attachment uploads all as output when no output relative directories defined for a root

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -158,6 +158,7 @@ def snapshot(
         local_root_path = manifest_props.local_root_path
         output_relative_directories = manifest_props.local_output_relative_directories()
 
+        # Skip when output relative directories is None or []
         if not output_relative_directories:
             print(
                 f"No output directories specified for {manifest_props.root_path}, skipping upload"
@@ -173,6 +174,7 @@ def snapshot(
             # if the base is None, meaning all changes are output
             diff=root_path_to_base_manifest.get(manifest_props.root_path),
             # include patterns for output directories (with recursive wildcard)
+            # when the code reaches here, it's guaranteed output_relative_directories contains value
             include=[subdir + "/**" for subdir in output_relative_directories],
             name="output",
         )

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -156,7 +156,13 @@ def snapshot(
     # Process each worker manifest property
     for manifest_props in worker_manifest_properties:
         local_root_path = manifest_props.local_root_path
-        output_relative_directories = manifest_props.local_output_relative_directories() or []
+        output_relative_directories = manifest_props.local_output_relative_directories()
+
+        if not output_relative_directories:
+            print(
+                f"No output directories specified for {manifest_props.root_path}, skipping upload"
+            )
+            continue
 
         # Create a snapshot of the output files, comparing against the base manifest
         output_manifest: Optional[ManifestSnapshot] = _manifest_snapshot(

--- a/src/deadline_worker_agent/sessions/attachment_models.py
+++ b/src/deadline_worker_agent/sessions/attachment_models.py
@@ -88,7 +88,7 @@ class WorkerManifestProperties:
                                or None if no output directories are defined
         """
 
-        if not self.output_relative_directories:
+        if self.output_relative_directories is None:
             return None
 
         local_output_relative_directories: list[str] = []

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -3527,7 +3527,15 @@ with open(output_path, "w") as f:
             "manifests": [
                 {
                     # no outputRelativeDirectories
-                    "rootPath": "/test/assets",
+                    "rootPath": "/test/assets1",
+                    "rootPathFormat": "posix",
+                    "inputManifestPath": "manifest1hash",
+                    "inputManifestHash": "manifest1hash",
+                },
+                {
+                    # empty outputRelativeDirectories
+                    "outputRelativeDirectories": [],
+                    "rootPath": "/test/assets2",
                     "rootPathFormat": "posix",
                     "inputManifestPath": "manifest1hash",
                     "inputManifestHash": "manifest1hash",

--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -158,6 +158,69 @@ class TestAttachmentUpload:
         )
 
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload._manifest_snapshot")
+    def test_snapshot_mixed_output_directories(self, mock_manifest_snapshot: Mock):
+        # GIVEN
+        mock_worker_props1 = Mock()
+        mock_worker_props1.local_root_path = "/local/path1"
+        mock_worker_props1.root_path = "/source/path1"
+        mock_worker_props1.local_output_relative_directories.return_value = None
+        mock_worker_props1.output_relative_directories = None
+
+        mock_worker_props2 = Mock()
+        mock_worker_props2.local_root_path = "/local/path2"
+        mock_worker_props2.root_path = "/source/path2"
+        mock_worker_props2.local_output_relative_directories.return_value = ["output"]
+
+        mock_worker_props3 = Mock()
+        mock_worker_props3.local_root_path = "/local/path3"
+        mock_worker_props3.root_path = "/source/path3"
+        mock_worker_props3.local_output_relative_directories.return_value = []
+        mock_worker_props3.output_relative_directories = []
+
+        mock_worker_props4 = Mock()
+        mock_worker_props4.local_root_path = "/local/path4"
+        mock_worker_props4.root_path = "/source/path4"
+        mock_worker_props4.local_output_relative_directories.return_value = ["."]
+
+        mock_snapshot_result = Mock()
+        mock_snapshot_result.manifest = "/snapshot/manifest.json"
+        mock_manifest_snapshot.return_value = mock_snapshot_result
+
+        base_manifests = {
+            "/source/path1": None,
+            "/source/path2": "/base/manifest.json",
+            "/source/path3": None,
+            "/source/path4": None,
+        }
+
+        # WHEN
+        result = snapshot(
+            [mock_worker_props1, mock_worker_props2, mock_worker_props3, mock_worker_props4],
+            base_manifests,
+        )
+
+        # THEN
+        assert result == {
+            "/source/path2": "/snapshot/manifest.json",
+            "/source/path4": "/snapshot/manifest.json",
+        }
+        assert mock_manifest_snapshot.call_count == 2
+        mock_manifest_snapshot.assert_any_call(
+            root="/local/path2",
+            destination="manifest_snapshot",
+            diff="/base/manifest.json",
+            include=["output/**"],
+            name="output",
+        )
+        mock_manifest_snapshot.assert_any_call(
+            root="/local/path4",
+            destination="manifest_snapshot",
+            diff=None,
+            include=["./**"],
+            name="output",
+        )
+
+    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload._manifest_snapshot")
     def test_snapshot(self, mock_manifest_snapshot: Mock):
         # GIVEN
         mock_worker_props1 = Mock()

--- a/test/unit/sessions/test_attachment_models.py
+++ b/test/unit/sessions/test_attachment_models.py
@@ -635,7 +635,7 @@ class TestWorkerManifestProperties:
         result = worker_props.local_output_relative_directories()
 
         # THEN
-        assert result is None
+        assert result == []
 
     @pytest.mark.skipif(
         platform.system() == "Windows",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`ouputRelativeDirectories` is an optional field in `ManifestProperties` as part of `CreateJob` API model. If not provided upon calling CreateJob, the value will be None. Old Job Attachment code path identify output file under the output dir by iterating through ouputRelativeDirectories. When the list is None or empty, nothing gets recognize as upload for upload. This is the correct intended behaviour.

The new code path for `ASSET_SYNC_JOB_USER_FEATURE` treated the empty and None as uploading all, which is incorrect.

### What was the solution? (How)
Skip snapshot and upload when ouputRelativeDirectories is not specified.

### What is the impact of this change?
Correctly upload for specified output directories.

### How was this change tested?
1. Added and ran unit tests
2. Ran E2E tests

```
attachments:
  manifests:
  - rootPath: /test/assets1
    rootPathFormat: posix
    inputManifestPath: manifest1hash
    inputManifestHash: manifest1hash
  - rootPath: /test/assets2
    rootPathFormat: posix
    outputRelativeDirectories: []
    inputManifestPath: manifest1hash
    inputManifestHash: manifest1hash
  fileSystem: COPIED
```

Logs
```
2025/10/22 13:51:36-07:00 Output:2025/10/22 13:51:37-07:00 No output directories specified for /test/assets1, skipping upload
2025/10/22 13:51:37-07:00 No output directories specified for /test/assets2, skipping upload
```

### Was this change documented?
N/A

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*