### PR TITLE
test: mock feature flags in tests

### DIFF
--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -44,10 +44,6 @@ from deadline_worker_agent.api_models import (
     AttachmentUploadAction,
     ManifestInfo,
 )
-from deadline_worker_agent.feature_flag import (
-    ASSET_SYNC_JOB_USER_FEATURE,
-    MANIFEST_REPORTING_FEATURE,
-)
 from deadline_worker_agent.sessions import Session
 import deadline_worker_agent.sessions.session as session_mod
 from deadline_worker_agent.sessions.session import (
@@ -61,9 +57,7 @@ from deadline_worker_agent.sessions.actions import (
     ExitEnvironmentAction,
     RunStepTaskAction,
 )
-from deadline_worker_agent.sessions.actions.run_attachment_upload import (
-    AttachmentUploadAction as AttachmentUploadActionClass,
-)
+
 from deadline_worker_agent.sessions.job_entities import (
     EnvironmentDetails,
     JobAttachmentDetails,
@@ -990,10 +984,7 @@ class TestSessionSyncAssetOutputs:
 
         return current_action
 
-    @pytest.mark.skipif(
-        MANIFEST_REPORTING_FEATURE,
-        reason="Only relevant when MANIFEST_REPORTING_FEATURE is not enabled",
-    )
+    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", False)
     def test_sync_asset_outputs_without_manifest_reporting(
         self,
         action_id: str,
@@ -1394,6 +1385,7 @@ class TestSessionActionUpdatedImpl:
         with patch("deadline_worker_agent.sessions.session.OPENJD_LOG") as mock_log:
             yield mock_log
 
+    @pytest.mark.parametrize("manifest_feature", [True, False])
     def test_failed_enter_env(
         self,
         action_id: str,
@@ -1403,6 +1395,7 @@ class TestSessionActionUpdatedImpl:
         action_complete_time: datetime,
         failed_action_status: ActionStatus,
         mock_report_action_update: MagicMock,
+        manifest_feature: bool,
     ) -> None:
         """Tests that if a environment enter action fails (the Open Job Description action), that the action
         failure is returned, and that any pending actions other than ENV_EXITS are marked as
@@ -1433,7 +1426,7 @@ class TestSessionActionUpdatedImpl:
         expected_next_action_message = failed_action_status.fail_message or (
             f"Previous action failed: {current_action.definition.id}"
         )
-        if MANIFEST_REPORTING_FEATURE:
+        if manifest_feature:
             expected_action_update = SessionActionStatus(
                 id=action_id,
                 status=failed_action_status,
@@ -1451,7 +1444,10 @@ class TestSessionActionUpdatedImpl:
                 end_time=action_complete_time,
             )
 
-        with patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs:
+        with (
+            patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs,
+            patch.object(session_mod, "MANIFEST_REPORTING_FEATURE", manifest_feature),
+        ):
             # WHEN
             future = session._action_updated_impl(
                 action_status=failed_action_status,
@@ -1469,6 +1465,7 @@ class TestSessionActionUpdatedImpl:
         mock_sync_asset_outputs.assert_not_called()
         assert session._current_action is None, "Current session action emptied"
 
+    @pytest.mark.parametrize("manifest_feature", [True, False])
     def test_failed_task_run(
         self,
         action_id: str,
@@ -1480,6 +1477,7 @@ class TestSessionActionUpdatedImpl:
         action_complete_time: datetime,
         failed_action_status: ActionStatus,
         mock_report_action_update: MagicMock,
+        manifest_feature: bool,
     ) -> None:
         """Tests that if a task run fails (the Open Job Description action), that job attachment output
         sync is not performed, the action failure is returned, and that any pending actions are
@@ -1512,7 +1510,7 @@ class TestSessionActionUpdatedImpl:
         expected_next_action_message = failed_action_status.fail_message or (
             f"Previous action failed: {current_action.definition.id}"
         )
-        if MANIFEST_REPORTING_FEATURE:
+        if manifest_feature:
             expected_action_update = SessionActionStatus(
                 id=action_id,
                 status=failed_action_status,
@@ -1530,7 +1528,10 @@ class TestSessionActionUpdatedImpl:
                 end_time=action_complete_time,
             )
 
-        with patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs:
+        with (
+            patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs,
+            patch.object(session_mod, "MANIFEST_REPORTING_FEATURE", manifest_feature),
+        ):
             # WHEN
             future = session._action_updated_impl(
                 action_status=failed_action_status,
@@ -1548,10 +1549,8 @@ class TestSessionActionUpdatedImpl:
         assert session._current_action is None, "Current session action emptied"
         mock_sync_asset_outputs.assert_not_called()
 
-    @pytest.mark.skipif(
-        ASSET_SYNC_JOB_USER_FEATURE,
-        reason="This test will be removed after releasing the asset sync job user feature",
-    )
+    @pytest.mark.parametrize("manifest_feature", [True, False])
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", False)
     def test_success_task_run(
         self,
         action_id: str,
@@ -1563,6 +1562,7 @@ class TestSessionActionUpdatedImpl:
         success_action_status: ActionStatus,
         task_id: str,
         mock_report_action_update: MagicMock,
+        manifest_feature: bool,
     ) -> None:
         """Tests that if a task run succeeds (the Open Job Description action), that job attachment output
         sync is performed, and AFTER that, the action success is returned."""
@@ -1592,7 +1592,7 @@ class TestSessionActionUpdatedImpl:
         session._current_action = current_action
         queue_cancel_all: MagicMock = session_action_queue.cancel_all
 
-        if MANIFEST_REPORTING_FEATURE:
+        if manifest_feature:
             expected_action_update = SessionActionStatus(
                 id=action_id,
                 status=success_action_status,
@@ -1616,6 +1616,7 @@ class TestSessionActionUpdatedImpl:
         with (
             patch.object(session_mod, "datetime") as mock_datetime,
             patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs,
+            patch.object(session_mod, "MANIFEST_REPORTING_FEATURE", manifest_feature),
         ):
             mock_datetime.now.side_effect = mock_now
 
@@ -1640,10 +1641,7 @@ class TestSessionActionUpdatedImpl:
         assert session._current_action is None, "Current session action emptied"
         mock_sync_asset_outputs.assert_called_once_with(current_action=current_action)
 
-    @pytest.mark.skipif(
-        not ASSET_SYNC_JOB_USER_FEATURE,
-        reason="This test will be run unconditionally after releasing the asset sync job user featuer",
-    )
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_success_task_run_attachment_upload(
         self,
         action_id: str,
@@ -1717,10 +1715,8 @@ class TestSessionActionUpdatedImpl:
             )
         )
 
-    @pytest.mark.skipif(
-        not ASSET_SYNC_JOB_USER_FEATURE or not MANIFEST_REPORTING_FEATURE,
-        reason="This test should be skipped if either feature is not implemented",
-    )
+    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_success_task_run_attachment_upload_with_no_output_manifest(
         self,
         session: Session,
@@ -1764,10 +1760,8 @@ class TestSessionActionUpdatedImpl:
             expected_manifest_list,
         )
 
-    @pytest.mark.skipif(
-        not ASSET_SYNC_JOB_USER_FEATURE or not MANIFEST_REPORTING_FEATURE,
-        reason="This test should be skipped if either feature is not implemented",
-    )
+    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_success_task_run_attachment_upload_with_manifest(
         self,
         session: Session,
@@ -1854,10 +1848,8 @@ class TestSessionActionUpdatedImpl:
             expected_manifest_list,
         )
 
-    @pytest.mark.skipif(
-        ASSET_SYNC_JOB_USER_FEATURE,
-        reason="This test will be re-written before releasing the asset sync job user feature",
-    )
+    @pytest.mark.parametrize("manifest_feature", [True, False])
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", False)
     def test_success_task_run_fail_output_sync(
         self,
         action_id: str,
@@ -1869,6 +1861,7 @@ class TestSessionActionUpdatedImpl:
         success_action_status: ActionStatus,
         task_id: str,
         mock_report_action_update: MagicMock,
+        manifest_feature: bool,
     ) -> None:
         """Tests that if a task run succeeds (the Open Job Description action), but the job attachment output
         sync fails, the action failure is returned, and any pending actions are marked as
@@ -1904,7 +1897,7 @@ class TestSessionActionUpdatedImpl:
             state=ActionState.FAILED,
             fail_message=f"Failed to sync job output attachments for {current_action.definition.id}: {sync_outputs_exception_msg}",
         )
-        if MANIFEST_REPORTING_FEATURE:
+        if manifest_feature:
             expected_action_update = SessionActionStatus(
                 id=action_id,
                 status=expected_fail_action_status,
@@ -1930,6 +1923,7 @@ class TestSessionActionUpdatedImpl:
             patch.object(
                 session, "_sync_asset_outputs", side_effect=sync_outputs_exception
             ) as mock_sync_asset_outputs,
+            patch.object(session_mod, "MANIFEST_REPORTING_FEATURE", manifest_feature),
         ):
             mock_datetime.now.side_effect = mock_now
 
@@ -1950,10 +1944,7 @@ class TestSessionActionUpdatedImpl:
         assert session._current_action is None, "Current session action emptied"
         mock_sync_asset_outputs.assert_called_once_with(current_action=current_action)
 
-    @pytest.mark.skipif(
-        ASSET_SYNC_JOB_USER_FEATURE,
-        reason="This test will be re-written before releasing the asset sync job user feature",
-    )
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", False)
     def test_logs_succeeded(
         self,
         action_complete_time: datetime,
@@ -2033,10 +2024,7 @@ class TestSessionActionUpdatedImpl:
         assert mock_mod_logger.info.call_args.args[0].status == "CANCELED"
         assert mock_mod_logger.info.call_args.args[0].action_id == current_action.definition.id
 
-    @pytest.mark.skipif(
-        not ASSET_SYNC_JOB_USER_FEATURE,
-        reason="This test only runs when ASSET_SYNC_JOB_USER_FEATURE is enabled",
-    )
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_action_output_capture_filter_integration_on_output_sync_creation(
         self,
         action_id: str,
@@ -2098,10 +2086,7 @@ class TestSessionActionUpdatedImpl:
         assert session._output_sync_target_action == current_action
         assert session._current_action is None
 
-    @pytest.mark.skipif(
-        not ASSET_SYNC_JOB_USER_FEATURE,
-        reason="This test only runs when ASSET_SYNC_JOB_USER_FEATURE is enabled",
-    )
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_action_output_filter_removed_on_output_sync_completion(
         self,
         session: Session,
@@ -2141,10 +2126,7 @@ class TestSessionActionUpdatedImpl:
         # Verify output sync target action was cleared
         assert session._output_sync_target_action is None
 
-    @pytest.mark.skipif(
-        not MANIFEST_REPORTING_FEATURE,
-        reason="This test only runs when MANIFEST_REPORTING_FEATURE is enabled",
-    )
+    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
     def test_action_output_capture_filter_ja_upload_callback_invalid(
         self,
         session: Session,
@@ -2164,10 +2146,7 @@ class TestSessionActionUpdatedImpl:
 
         assert session._upload_manifest_list == []
 
-    @pytest.mark.skipif(
-        not MANIFEST_REPORTING_FEATURE,
-        reason="This test only runs when MANIFEST_REPORTING_FEATURE is enabled",
-    )
+    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
     def test_action_output_capture_filter_ja_upload_callback_valid(
         self,
         session: Session,
@@ -2183,10 +2162,8 @@ class TestSessionActionUpdatedImpl:
         assert len(session._upload_manifest_list) == 1
         assert all(isinstance(item, UploadManifestInfo) for item in session._upload_manifest_list)
 
-    @pytest.mark.skipif(
-        not MANIFEST_REPORTING_FEATURE or not ASSET_SYNC_JOB_USER_FEATURE,
-        reason="This test only runs when both MANIFEST_REPORTING_FEATURE and ASSET_SYNC_JOB_USER_FEATURE are enabled",
-    )
+    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_progress_update_excludes_manifests(
         self,
         session: Session,
@@ -2240,10 +2217,8 @@ class TestSessionActionUpdatedImpl:
         assert isinstance(call_args, SessionActionStatus)
         assert call_args.manifests is None  # Should be None for progress updates
 
-    @pytest.mark.skipif(
-        not MANIFEST_REPORTING_FEATURE or not ASSET_SYNC_JOB_USER_FEATURE,
-        reason="This test only runs when both MANIFEST_REPORTING_FEATURE and ASSET_SYNC_JOB_USER_FEATURE are enabled",
-    )
+    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
+    @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_failed_task_excludes_manifests(
         self,
         session: Session,
@@ -2300,17 +2275,14 @@ class TestSessionActionUpdatedImpl:
         assert isinstance(call_args, SessionActionStatus)
         assert call_args.manifests is None  # Should be None for failed actions
 
-    @pytest.mark.skipif(
-        not MANIFEST_REPORTING_FEATURE or not ASSET_SYNC_JOB_USER_FEATURE,
-        reason="This test only runs when both MANIFEST_REPORTING_FEATURE and ASSET_SYNC_JOB_USER_FEATURE are enabled",
-    )
-    def test_successful_task_without_job_attachments_includes_empty_manifests(
+    @pytest.mark.parametrize("manifest_reporting_enabled", [True, False])
+    def test_successful_task_manifest_reporting_based_on_feature_flag(
         self,
         session: Session,
         mock_report_action_update: MagicMock,
+        manifest_reporting_enabled: bool,
     ) -> None:
-        """Test that successful task actions without job attachments include empty manifests list"""
-        # GIVEN - A successful attachment upload action with no outputs
+        """Test that manifests are included/excluded based on MANIFEST_REPORTING_FEATURE flag"""
         action_id = "test-action-123"
         step_id = "step-456"
         task_id = "task-789"
@@ -2338,47 +2310,38 @@ class TestSessionActionUpdatedImpl:
             ),
             start_time=datetime.now(tz=timezone.utc),
         )
+        session._current_action = current_action
 
-        # Mock the attachment upload completion scenario
-        # Create an attachment upload action as the current action
-        upload_action = CurrentAction(
-            definition=AttachmentUploadActionClass(
-                id=f"{current_action.definition.id}-upload",
-                session_id="test-session",
-                step_id=step_id,
-                task_id=task_id,
-                start_time=current_action.start_time.timestamp(),
-            ),
-            start_time=datetime.now(tz=timezone.utc),
-        )
-
-        session._current_action = upload_action  # Upload action is current
-        session._output_sync_target_action = current_action  # Original task action is target
-        session._job_attachment_details = None  # No job attachments
-        session._upload_manifest_list = []
-
-        # Successful action status for the upload action
         success_action_status = ActionStatus(state=ActionState.SUCCESS, exit_code=0)
 
-        # WHEN - Upload action completes successfully
+        # WHEN - Action completes successfully with feature flag set
         with (
+            patch(
+                "deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE",
+                manifest_reporting_enabled,
+            ),
             patch.object(
                 session_mod,
                 "OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS",
                 {ActionState.SUCCESS: "SUCCEEDED"},
             ),
-            patch.object(session, "_handle_action_update") as mock_handle_action_update,
         ):
-            session._action_updated_impl(
+            session._handle_action_update(
+                is_unsuccessful=False,
                 action_status=success_action_status,
+                current_action=current_action,
                 now=datetime.now(tz=timezone.utc),
+                manifests=[],
             )
 
-        # THEN - Empty manifests list should be passed to _handle_action_update
-        mock_handle_action_update.assert_called_once()
-        call_args = mock_handle_action_update.call_args[0]
-        manifests_arg = call_args[4]  # 5th argument is manifests
-        assert manifests_arg == []  # Should be empty list
+        # THEN - Verify manifests field based on feature flag
+        mock_report_action_update.assert_called_once()
+        call_args = mock_report_action_update.call_args[0][0]
+        assert isinstance(call_args, SessionActionStatus)
+        if manifest_reporting_enabled:
+            assert call_args.manifests == []
+        else:
+            assert call_args.manifests is None
 
 
 @pytest.mark.usefixtures("mock_openjd_session")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Tests were being skipped in CI/CD when feature flags (environment variables) were not set. This meant that feature-flagged functionality was not being tested in our continuous integration pipeline, creating a gap in test coverage.

### What was the solution? (How)

Implemented mock feature flag functionality to ensure tests run regardless of environment variable state. This allows CI/CD to execute all tests while maintaining the ability to conditionally test feature-flagged code.

### What is the impact of this change?

- Ensures complete test coverage in CI/CD pipeline
- Maintains feature flag testing capabilities
- Improves confidence in feature-flagged code quality
- No impact on production feature flag behavior

### How was this change tested?

- Verified tests are not skipped anymore
- Confirmed mock flags properly simulate both enabled/disabled states
- Existing feature flag tests continue to pass

### Was this change documented?

No documentation changes needed.

### Is this a breaking change?

No, this is a non-breaking change that improves test coverage without modifying existing functionality.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*