### PR TITLE
feat: add DEADLINE_STEP_ID to task run env vars

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -70,7 +70,10 @@ class RunStepTaskAction(OpenjdAction):
         executor : Executor
             An executor for running futures
         """
-        env_vars = {"DEADLINE_SESSIONACTION_ID": self._id}
+        env_vars = {
+            "DEADLINE_STEP_ID": self._details.step_id,
+            "DEADLINE_SESSIONACTION_ID": self._id,
+        }
         if self.task_id is not None:
             env_vars["DEADLINE_TASK_ID"] = self.task_id
 

--- a/test/unit/sessions/actions/test_run_step_task.py
+++ b/test/unit/sessions/actions/test_run_step_task.py
@@ -70,8 +70,9 @@ class TestRunStepTaskAction:
 
         assert "os_env_vars" in call_args
         env_vars = call_args["os_env_vars"]
-        assert env_vars["DEADLINE_SESSIONACTION_ID"] == "action-123"
+        assert env_vars["DEADLINE_STEP_ID"] == "step-123"
         assert env_vars["DEADLINE_TASK_ID"] == "task-456"
+        assert env_vars["DEADLINE_SESSIONACTION_ID"] == "action-123"
 
     def test_start_without_task_id(self, mock_step_details, mock_session, mock_executor):
         """Test start() excludes DEADLINE_TASK_ID when task_id is None."""
@@ -88,5 +89,6 @@ class TestRunStepTaskAction:
 
         assert "os_env_vars" in call_args
         env_vars = call_args["os_env_vars"]
+        assert env_vars["DEADLINE_STEP_ID"] == "step-123"
         assert env_vars["DEADLINE_SESSIONACTION_ID"] == "action-123"
         assert "DEADLINE_TASK_ID" not in env_vars

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -2738,6 +2738,7 @@ class TestSessionStartAction:
     def test_run_action_with_env_variables(
         self,
         session: Session,
+        step_id: str,
         run_step_task_action: RunStepTaskAction,
         mock_mod_logger: MagicMock,
     ) -> None:
@@ -2765,6 +2766,7 @@ class TestSessionStartAction:
         session_run_task.call_args.kwargs["os_env_vars"] == {
             "DEADLINE_SESSIONACTION_ID": run_step_task_action.id,
             "DEADLINE_TASK_ID": run_step_task_action.task_id,
+            "DEADLINE_STEP_ID": step_id,
         }
 
     def test_enter_env_action_called_with_env_variables(


### PR DESCRIPTION
Fixes #679 

### What was the problem/requirement? (What/Why)

We expose all the relevant ids except the step id in the task run environment!

ref: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/build-job-bundle.html

### What was the solution? (How)

Add it!

### What is the impact of this change?

You can now reference `DEADLINE_STEP_ID` in your tasks

### How was this change tested?

```
hatch run test
```

### Was this change documented?

Filed an docs request to update the service documentation

### Is this a breaking change?

Nope!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*