### PR TITLE
chore(test): update mypy to 1.18

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -9,7 +9,7 @@ pytest-timeout == 2.4.*
 pytest-xdist == 3.8.*
 rich == 14.2.*
 types-python-dateutil ~= 2.9
-mypy >= 1.17, < 1.18
+mypy >= 1.17, < 1.19
 types-requests ~= 2.31; python_version < "3.10"
 types-requests ~= 2.32; python_version >= "3.10"
 ruff ~= 0.14.2

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -786,7 +786,7 @@ class TestSessionSyncAssetInputs:
                     {
                         "job_attachment_details": JobAttachmentDetails(
                             manifests=[],
-                            job_attachments_file_system="COPIED",
+                            job_attachments_file_system=JobAttachmentsFileSystem.COPIED,
                         )
                     }
                 ],
@@ -797,7 +797,7 @@ class TestSessionSyncAssetInputs:
                     {
                         "job_attachment_details": JobAttachmentDetails(
                             manifests=[],
-                            job_attachments_file_system="COPIED",
+                            job_attachments_file_system=JobAttachmentsFileSystem.COPIED,
                         )
                     },
                     {"step_dependencies": ["step-1"]},


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

dependabot update for mypy was failing

```
cmd [3] | mypy src test
test/unit/sessions/test_session.py:792: error: Argument
"job_attachments_file_system" to "JobAttachmentDetails" has incompatible type
"str"; expected "JobAttachmentsFileSystem"  [arg-type]
                                job_attachments_file_system="COPIED",
                                                            ^~~~~~~~
test/unit/sessions/test_session.py:803: error: Argument
"job_attachments_file_system" to "JobAttachmentDetails" has incompatible type
"str"; expected "JobAttachmentsFileSystem"  [arg-type]
                                job_attachments_file_system="COPIED",
                                                            ^~~~~~~~
Found 2 errors in 1 file (checked 179 source files)
```

### What was the solution? (How)

fix the linting issue

### What is the impact of this change?

works with newer deps!

### How was this change tested?

```
hatch run lint
hatch run test
```

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*