### PR TITLE
fix(experimental): skip manifest reporting without job attachments

### DIFF
--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -1206,12 +1206,13 @@ class Session:
 
         if self._output_sync_target_action is not None:
             if OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS.get(action_status.state, None):
-                manifests_list = []
+                manifests_list = None
 
                 # Get job attachment details to access input manifests
                 job_attachment_details = self._job_attachment_details
 
                 if job_attachment_details:
+                    manifests_list = []
                     # For each input manifest, find the corresponding output manifest
                     for input_manifest in job_attachment_details.manifests:
                         asset_root = input_manifest.root_path

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -2276,45 +2276,27 @@ class TestSessionActionUpdatedImpl:
         assert call_args.manifests is None  # Should be None for failed actions
 
     @pytest.mark.parametrize("manifest_reporting_enabled", [True, False])
-    def test_successful_task_manifest_reporting_based_on_feature_flag(
+    def test_successful_task_without_job_attachments_includes_none_manifests(
         self,
         session: Session,
         mock_report_action_update: MagicMock,
         manifest_reporting_enabled: bool,
     ) -> None:
-        """Test that manifests are included/excluded based on MANIFEST_REPORTING_FEATURE flag"""
-        action_id = "test-action-123"
-        step_id = "step-456"
-        task_id = "task-789"
+        """Test that manifests are None when job attachments are not used in output sync flow"""
+        # Set up a mock output sync action
+        mocked_upload_action = MagicMock()
+        # Set up a mock output sync target action
+        output_sync_target_action = MagicMock()
 
-        current_action = CurrentAction(
-            definition=RunStepTaskAction(
-                details=StepDetails(
-                    step_template=StepTemplate(
-                        name="Test",
-                        script=StepScript(
-                            actions=StepActions(
-                                onRun=Action(
-                                    command=CommandString("echo"),
-                                    args=[ArgString("hello")],
-                                    cancelation=None,
-                                )
-                            )
-                        ),
-                    ),
-                    step_id=step_id,
-                ),
-                id=action_id,
-                task_id=task_id,
-                task_parameter_values=dict[str, ParameterValue](),
-            ),
-            start_time=datetime.now(tz=timezone.utc),
-        )
-        session._current_action = current_action
+        session._current_action = mocked_upload_action
+        session._output_sync_target_action = output_sync_target_action
+        # Explicitly set job_attachment_details to None to simulate no job attachments
+        session._job_attachment_details = None
 
-        success_action_status = ActionStatus(state=ActionState.SUCCESS, exit_code=0)
+        # WHEN - Call with a completed action status
+        completed_action_status = ActionStatus(state=ActionState.SUCCESS)
+        action_complete_time = datetime.now()
 
-        # WHEN - Action completes successfully with feature flag set
         with (
             patch(
                 "deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE",
@@ -2325,23 +2307,21 @@ class TestSessionActionUpdatedImpl:
                 "OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS",
                 {ActionState.SUCCESS: "SUCCEEDED"},
             ),
+            patch.object(session, "_handle_action_update") as mocked_handle_action_upload,
         ):
-            session._handle_action_update(
-                is_unsuccessful=False,
-                action_status=success_action_status,
-                current_action=current_action,
-                now=datetime.now(tz=timezone.utc),
-                manifests=[],
+            session._action_updated_impl(
+                action_status=completed_action_status,
+                now=action_complete_time,
             )
 
-        # THEN - Verify manifests field based on feature flag
-        mock_report_action_update.assert_called_once()
-        call_args = mock_report_action_update.call_args[0][0]
-        assert isinstance(call_args, SessionActionStatus)
-        if manifest_reporting_enabled:
-            assert call_args.manifests == []
-        else:
-            assert call_args.manifests is None
+        # THEN - manifests_list should be None when job attachments are not used
+        mocked_handle_action_upload.assert_called_once_with(
+            False,
+            completed_action_status,
+            output_sync_target_action,
+            action_complete_time,
+            None,  # manifests_list should be None when job attachments are not used
+        )
 
 
 @pytest.mark.usefixtures("mock_openjd_session")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The manifests field was being set to an empty list `[]` even when job attachments are not used. Manifests should be `None` when job attachments are not used. This way, session action manifests would match the job's manifests, which would not be an empty list if job attachments are not used at all.

### What was the solution? (How)

- Initialize `manifests_list` to `None` instead of an empty list
- Only set `manifests_list = []` inside the `if job_attachment_details:` block when job attachments are actually used
- This ensures manifests is `None` when job attachments are not configured, and `[]` when they are configured but have no output

### What is the impact of this change?

- When job attachments are NOT used: `manifests = None` 
- When job attachments ARE used: `manifests = []` (then populated with manifest info)

### How was this change tested?

- Added new test `test_successful_task_without_job_attachments_includes_none_manifests` to verify manifests is `None` when `job_attachment_details` is `None`
- Existing tests continue to pass, covering the case where job attachments are used
- Removed artificial test that didn't match real code flow

### Was this change documented?

No documentation changes needed - this is an internal implementation detail.

### Is this a breaking change?

No - this is a bug fix that makes the behavior match the intended design.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*