### PR TITLE
test(debug): add e2e pytest session timeout for 1h50m (6600s)

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -13,7 +13,7 @@ version = "hatch version"
 metadata = "hatch project metadata {args:}"
 e2e-test= [
   "python test/e2e/pre_test_cleanup.py",
-  "pytest --no-cov test/e2e {args:}",
+  "pytest --session-timeout=6600 --no-cov test/e2e {args:}",
 ]
 integ-test = "pytest --no-cov test/integ {args:}"
 typing = "mypy {args:src test}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

canary.sh is sometimes not exiting after 2hrs even though the tests are reported as all passed, so it seems like something in our tests is hanging.

### What was the solution? (How)

To help understand what might be happening, I've added a session timeout of 1h50m since the canaries timeout after 2hrs, but successful runs take ~1h30m.

```
Interrupt test run and dump stacks of all threads after a test times out:
...
  --session-timeout=SECONDS
                        Timeout in seconds for entire session.  Default is None which
                        means no timeout. Timeout is checked between tests, and will not interrupt a
                        test
                        in progress.
```

### What is the impact of this change?

🤞 we get a stacktrace of where it's freezing

### How was this change tested?

Locally ran pytest for unit-tests and confirmed that the session timeout syntax works

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*