### PR TITLE
test(debug): report when pytest is done in the e2e-test command

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -14,6 +14,7 @@ metadata = "hatch project metadata {args:}"
 e2e-test= [
   "python test/e2e/pre_test_cleanup.py",
   "pytest --session-timeout=6600 --no-cov test/e2e {args:}",
+  "echo pytest done",
 ]
 integ-test = "pytest --no-cov test/integ {args:}"
 typing = "mypy {args:src test}"


### PR DESCRIPTION
Grabbing more information about what's not exiting in the e2e runs.

Note: If any individual command fails in a hatch command, then it stops immediately and doesn't do the ones that come afterwards. So this won't change the outcome of the hatch command

```sh
# exit-test=["echo hello","false","echo $?"]
$ hatch run exit-test
cmd [1] | echo hello
hello
cmd [2] | false
$ echo $?
1
```
```sh
# exit-test=["echo hello","true","echo $?"]
$ hatch run exit-test
cmd [1] | echo hello
hello
cmd [2] | true
cmd [3] | echo $?
0
```

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*