### PR TITLE
test(experimental): parametrize ASSET_SYNC_JOB_USER_FEATURE for job attachments e2e tests

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -9,7 +9,6 @@ import pytest
 from dataclasses import dataclass, field, InitVar
 from typing import Callable, Generator, Type
 from contextlib import contextmanager
-from typing import Dict
 
 from deadline_test_fixtures import (
     DeadlineWorker,
@@ -25,7 +24,6 @@ from deadline_test_fixtures import (
     Ec2Tag,
 )
 import pytest
-from deadline_worker_agent.feature_flag import ASSET_SYNC_JOB_USER_FEATURE
 
 LOG = logging.getLogger(__name__)
 
@@ -192,9 +190,6 @@ def worker_config(
     Returns:
         DeadlineWorkerConfiguration: Configuration for use by DeadlineWorker.
     """
-    worker_env_var: Dict[str, str] = {
-        "ASSET_SYNC_JOB_USER_FEATURE": str(ASSET_SYNC_JOB_USER_FEATURE),
-    }
 
     return dataclasses.replace(
         worker_config,
@@ -204,7 +199,6 @@ def worker_config(
             posix_env_override_job_user,
         ],
         windows_job_users=windows_job_users,
-        worker_env_var=worker_env_var,
     )
 
 
@@ -237,6 +231,7 @@ def asset_sync_worker_config(
     """
     asset_sync_feature = request.param
     worker_env_var = {
+        **dict(worker_config.worker_env_var or {}),
         "ASSET_SYNC_JOB_USER_FEATURE": str(asset_sync_feature),
     }
     LOG.info(f"worker_env_var: {worker_env_var}")
@@ -499,11 +494,10 @@ def pytest_collection_modifyitems(items):
             sorted_list.remove(item)
             session_worker_tests.append(item)
 
-    # Run asset sync class worker tests first, then session worker tests
-    # This ensures
+    # Run asset sync class worker tests first, then session worker tests. This ensures
     # 1. job attachments tests are run by one asset sync worker at a time
-    # 2. only one session worker is active at a time
     sorted_list.extend(asset_sync_class_worker_tests)
+    # 2. only one session worker is active at a time
     sorted_list.extend(session_worker_tests)
 
     items[:] = sorted_list

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -220,6 +220,51 @@ def session_worker(
     stop_worker(request, worker)
 
 
+@pytest.fixture(scope="class", params=[True, False])
+def asset_sync_worker_config(
+    request: pytest.FixtureRequest,
+    posix_job_user: PosixSessionUser,
+    posix_env_override_job_user: PosixSessionUser,
+    posix_config_override_job_user: PosixSessionUser,
+    worker_config: DeadlineWorkerConfiguration,
+    windows_job_users: list[str],
+) -> DeadlineWorkerConfiguration:
+    """
+    Parametrized worker configuration fixture that tests ASSET_SYNC_JOB_USER_FEATURE with both True and False values.
+
+    This fixture ensures the environment variable is set before worker initialization,
+    allowing proper testing of the asset sync feature flag behavior.
+    """
+    asset_sync_feature = request.param
+    worker_env_var = {
+        "ASSET_SYNC_JOB_USER_FEATURE": str(asset_sync_feature),
+    }
+    LOG.info(f"worker_env_var: {worker_env_var}")
+
+    return dataclasses.replace(
+        worker_config,
+        job_users=[
+            posix_job_user,
+            posix_config_override_job_user,
+            posix_env_override_job_user,
+        ],
+        windows_job_users=windows_job_users,
+        worker_env_var=worker_env_var,
+    )
+
+
+@pytest.fixture(scope="class")
+def asset_sync_class_worker(
+    request: pytest.FixtureRequest,
+    asset_sync_worker_config: DeadlineWorkerConfiguration,
+    ec2_worker_type: Type[EC2InstanceWorker],
+) -> Generator[DeadlineWorker, None, None]:
+    with create_worker(asset_sync_worker_config, ec2_worker_type, request) as worker:
+        yield worker
+
+    stop_worker(request, worker)
+
+
 @pytest.fixture(scope="class")
 def class_worker(
     request: pytest.FixtureRequest,
@@ -432,10 +477,33 @@ def operating_system() -> OperatingSystem:
 
 def pytest_collection_modifyitems(items):
     sorted_list = list(items)
+    session_worker_tests = []
+    asset_sync_class_worker_tests = []
+
     for item in items:
-        # Run session scoped tests last to prevent Worker conflicts with class and function scoped tests.
-        if "session_worker" in item.fixturenames:
+        # Check for conflicting fixture usage
+        has_session_worker = "session_worker" in item.fixturenames
+        has_asset_sync_class_worker = "asset_sync_class_worker" in item.fixturenames
+
+        if has_session_worker and has_asset_sync_class_worker:
+            raise ValueError(
+                f"Test {item.nodeid} requests both 'session_worker' and 'asset_sync_class_worker' fixtures. "
+                "This would create conflicting workers. Use only one session worker fixture per test."
+            )
+
+        # Separate session worker tests into two groups to prevent worker conflicts
+        if has_asset_sync_class_worker:
             sorted_list.remove(item)
-            sorted_list.append(item)
+            asset_sync_class_worker_tests.append(item)
+        elif has_session_worker:
+            sorted_list.remove(item)
+            session_worker_tests.append(item)
+
+    # Run asset sync class worker tests first, then session worker tests
+    # This ensures
+    # 1. job attachments tests are run by one asset sync worker at a time
+    # 2. only one session worker is active at a time
+    sorted_list.extend(asset_sync_class_worker_tests)
+    sorted_list.extend(session_worker_tests)
 
     items[:] = sorted_list

--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -536,17 +536,17 @@ if __name__ == "__main__":
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
         asset_sync_class_worker: EC2InstanceWorker,
-        worker_config: DeadlineWorkerConfiguration,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
         file_system: str,
     ) -> None:
         job_bundle_path: str = os.path.join(
             os.path.dirname(__file__), "job_attachment_bundle", "dep_data_flow", "linux_bundle"
         )
-        if worker_config.worker_env_var:
+        if asset_sync_worker_config.worker_env_var:
             job_parameters: List[Dict[str, str]] = [
                 {
                     "name": "AssetSync",
-                    "value": worker_config.worker_env_var.get(
+                    "value": asset_sync_worker_config.worker_env_var.get(
                         "ASSET_SYNC_JOB_USER_FEATURE", "False"
                     ),
                 },

--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -68,7 +68,7 @@ class Asset:
 class TestJobAttachments:
     JOB_OUTPUT_PATH = os.path.join(os.getcwd(), "job_output")
 
-    @pytest.mark.usefixtures("session_worker")
+    @pytest.mark.usefixtures("asset_sync_class_worker")
     @pytest.mark.parametrize(
         "submission_os",
         [
@@ -302,7 +302,7 @@ if __name__ == "__main__":
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
         append_string_script: str,
     ) -> None:
         # Verify that the worker uses the correct job attachment configuration, and writes the output to the correct location
@@ -433,7 +433,7 @@ if __name__ == "__main__":
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
     ) -> None:
         # Tests that if a job has no job output files in the output directory, the job does not fail. This tests prevents regressions in the output code
 
@@ -535,7 +535,7 @@ if __name__ == "__main__":
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
         worker_config: DeadlineWorkerConfiguration,
         file_system: str,
     ) -> None:
@@ -602,7 +602,7 @@ if __name__ == "__main__":
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
     ) -> None:
         job_bundle_path: str = os.path.join(
             os.path.dirname(__file__), "job_attachment_bundle", "dep_data_flow", "windows_bundle"
@@ -649,7 +649,7 @@ if __name__ == "__main__":
     def test_worker_fails_job_attachment_sync_when_non_valid_queue_role(
         self,
         deadline_resources: DeadlineResources,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
     ) -> None:
         # Test that when submitting a job with job attachments to a queue with a role that cannot read the S3 bucket, the worker will fail the job attachments sync
@@ -807,7 +807,7 @@ if __name__ == "__main__":
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
         hash_string_script: str,
         tmp_path: pathlib.Path,
     ) -> None:
@@ -973,7 +973,7 @@ if __name__ == "__main__":
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
         tmp_path: pathlib.Path,
     ) -> None:
         # Test that submits a job that has step step dependencies and confirm that the final output is as we expect
@@ -1139,7 +1139,7 @@ if __name__ == "__main__":
     def test_worker_fails_job_attachment_sync_when_file_does_not_exist_in_bucket(
         self,
         deadline_resources: DeadlineResources,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
         tmp_path: pathlib.Path,
     ) -> None:
@@ -1325,9 +1325,9 @@ if __name__ == "__main__":
 
         # Make sure the worker is still running and not crashed after this
         get_worker_response: dict[str, Any] = deadline_client.get_worker(
-            farmId=session_worker.configuration.farm_id,
-            fleetId=session_worker.configuration.fleet.id,
-            workerId=session_worker.worker_id,
+            farmId=asset_sync_class_worker.configuration.farm_id,
+            fleetId=asset_sync_class_worker.configuration.fleet.id,
+            workerId=asset_sync_class_worker.worker_id,
         )
 
         assert get_worker_response["status"] in ["STARTED", "RUNNING", "IDLE"]
@@ -1348,7 +1348,7 @@ if __name__ == "__main__":
     def test_job_submission_asset_sync_behaviour_expected_without_errors(
         self,
         deadline_resources,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
         tmp_path: pathlib.Path,
     ) -> None:
@@ -1518,7 +1518,7 @@ with open(output_path, "w") as f:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
     ) -> None:
         """Test output-only job attachments with small files on both Windows and Linux"""
         job_bundle_path: str = os.path.join(
@@ -1570,7 +1570,7 @@ with open(output_path, "w") as f:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
     ) -> None:
         """
         Test job submission using the Create Job API with a complex job attachment bundle.
@@ -1632,7 +1632,7 @@ with open(output_path, "w") as f:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
     ) -> None:
         """
         Test job submission using the Create Job API with a complex job attachment bundle.
@@ -1689,7 +1689,7 @@ with open(output_path, "w") as f:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        session_worker: EC2InstanceWorker,
+        asset_sync_class_worker: EC2InstanceWorker,
         test_runner_identity: dict[str, str],
     ) -> None:
         """


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to guard the experimental asset sync run as job user feature via E2E tests, making sure there is no regression.

### What was the solution? (How)
Parametrize ASSET_SYNC_JOB_USER_FEATURE for e2e tests that uses job attachments
- Add asset_sync_worker_config fixture with parametrized feature flag
- Add asset_sync_session_worker fixture using parametrized config, ensure feature flag is set before worker initialization
- Replace all session_worker usage with asset_sync_session_worker for test cases use job attachment

### What is the impact of this change?
All tests that involve job attachments will be run as part of CI/CD to catch regressions.

### How was this change tested?
#### Linux
```
============================= slowest 5 durations ==============================
275.47s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[True-linux]
251.02s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[False-linux]
154.59s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_create_job_API_call_linux[True]
139.02s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_linux[True-VIRTUAL]
129.34s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_linux[False-VIRTUAL]
============ 26 passed, 6 skipped, 1 warning in 1968.11s (0:32:48) =============
```
#### Windows

```
============================= slowest 5 durations ==============================
357.16s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[False-linux]
336.34s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[True-linux]
222.18s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_create_job_API_call_windows[True]
207.39s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_windows[True]
132.09s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_create_job_API_call_windows[False]
============ 24 passed, 8 skipped, 1 warning in 2214.19s (0:36:54) =============
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*