### PR TITLE
fix(experimental): sync output not logging file processing information

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -110,6 +110,7 @@ def merge(worker_manifest_properties: list[WorkerManifestProperties]) -> dict[st
             # directory to put the generated merged manifests
             destination=manifest_path,
             name="merge",
+            print_function_callback=print,
         )
 
         if root_path_to_local_manifest.get(manifest_props.root_path) is not None:
@@ -177,6 +178,7 @@ def snapshot(
             # when the code reaches here, it's guaranteed output_relative_directories contains value
             include=[subdir + "/**" for subdir in output_relative_directories],
             name="output",
+            print_function_callback=print,
         )
 
         if output_manifest:

--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -155,6 +155,7 @@ class TestAttachmentUpload:
             manifest_files=["/path/to/manifest.json"],
             destination="manifest_merge",
             name="merge",
+            print_function_callback=print,
         )
 
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload._manifest_snapshot")
@@ -211,6 +212,7 @@ class TestAttachmentUpload:
             diff="/base/manifest.json",
             include=["output/**"],
             name="output",
+            print_function_callback=print,
         )
         mock_manifest_snapshot.assert_any_call(
             root="/local/path4",
@@ -218,6 +220,7 @@ class TestAttachmentUpload:
             diff=None,
             include=["./**"],
             name="output",
+            print_function_callback=print,
         )
 
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload._manifest_snapshot")
@@ -254,6 +257,7 @@ class TestAttachmentUpload:
             diff="/base/manifest.json",
             include=["output/**"],
             name="output",
+            print_function_callback=print,
         )
         mock_manifest_snapshot.assert_any_call(
             root="/local/path2",
@@ -261,6 +265,7 @@ class TestAttachmentUpload:
             diff=None,
             include=["output/**"],
             name="output",
+            print_function_callback=print,
         )
 
     @patch.dict(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A recent change in deadline client lib started to require `print_function_callback` to be passed in for logging. Without this change, WA stopped logging file processing information for attachment upload.

### What was the solution? (How)
Pass in the `print_function_callback`.

### What is the impact of this change?
Improved visibility into session logs for easier debugging

### How was this change tested?
- unit tests
- e2e test

```
2025/10/30 15:41:27-07:00 ==============================================
2025/10/30 15:41:27-07:00 --------- Job Attachments Upload for Task
2025/10/30 15:41:27-07:00 ==============================================
2025/10/30 15:41:27-07:00 ----------------------------------------------
2025/10/30 15:41:27-07:00 Phase: Setup
2025/10/30 15:41:27-07:00 ----------------------------------------------
2025/10/30 15:41:27-07:00 Writing embedded files for Task to disk.
2025/10/30 15:41:27-07:00 Mapping: Task.File.WorkerManifestProperties -> /sessions/session-8fb1466ea0824fcf83ac2bf0a26e95cc13sq5z4f/embedded_filesmyuhy5aa/tmpn9ci78pt
2025/10/30 15:41:27-07:00 Wrote: WorkerManifestProperties -> /sessions/session-8fb1466ea0824fcf83ac2bf0a26e95cc13sq5z4f/embedded_filesmyuhy5aa/tmpn9ci78pt
2025/10/30 15:41:27-07:00 ----------------------------------------------
2025/10/30 15:41:27-07:00 Phase: Running action
2025/10/30 15:41:27-07:00 ----------------------------------------------
2025/10/30 15:41:27-07:00 Running command sudo -u job-user -i setsid -w /sessions/session-8fb1466ea0824fcf83ac2bf0a26e95cc13sq5z4f/tmp96phmp5u.sh
2025/10/30 15:41:27-07:00 Command started as pid: 26122
2025/10/30 15:41:27-07:00 Output:
2025/10/30 15:41:28-07:00 Manifest generated at manifest_merge/merge-27d5e523d926d138c3187515a2616a41-2025-10-30T22-41-28.manifest
2025/10/30 15:41:28-07:00 Found difference at: 4812a07820244f978b8ff5d2482dcf47/files/output_file, Status: FileStatus.NEW
2025/10/30 15:41:28-07:00 Hashing Attachments
2025/10/30 15:41:29-07:00 Hashing Summary:
2025/10/30 15:41:29-07:00     Processed 1 file totaling 37 B.
2025/10/30 15:41:29-07:00     Skipped re-processing 0 files totaling 0 B.
2025/10/30 15:41:29-07:00     Total processing time of 0.01671 seconds at 2.21 KB/s.
2025/10/30 15:41:29-07:00  
2025/10/30 15:41:29-07:00 Manifest generated at manifest_snapshot/output-5d3d81e2a6a21fc20946b37d2436812c-2025-10-30T22-41-28.manifest
2025/10/30 15:41:29-07:00 ja_snapshot: {"root": "/tmp/storageprofiletest/dest", "manifest": "manifest_snapshot/output-5d3d81e2a6a21fc20946b37d2436812c-2025-10-30T22-41-28.manifest"}
2025/10/30 15:41:29-07:00  
2025/10/30 15:41:29-07:00 Starting upload...
2025/10/30 15:41:29-07:00 Uploaded assets from /tmp/storageprofiletest/dest, to s3://XXXXXX/Deadline/Manifests/farm-XXX/queue-XXX/job-9705189cd9aa40f3a98fb7d1b56426a5/step-42df87985bc74e4f85bde21c5b9e0238/task-42df87985bc74e4f85bde21c5b9e0238-0/2025-10-30T22:41:27.599679Z_sessionaction-8fb1466ea0824fcf83ac2bf0a26e95cc-1/71532871ba76c9fe966559e8d414a9a6_output, hashed data d287be994ec7c8ff26844ae224bbd5cb
2025/10/30 15:41:29-07:00 Finished after 0.5 seconds
2025/10/30 15:41:29-07:00 Process pid 26122 exited with code: 0 (unsigned) / 0x0 (hex)
```

### Was this change documented?
N/A

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*