### PR TITLE
chore(deps): update deadline from deadline >= 0.50,< 0.54 to deadline >= 0.53.1,< 0.54

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.34.75",
-    "deadline >= 0.50,< 0.54",
+    "deadline >= 0.53.1,< 0.54",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
     "openjd-sessions == 0.10.4",
     "openjd-model >= 0.8.1, < 0.9",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
attachment upload requires a change from deadline `0.53.1`

https://github.com/aws-deadline/deadline-cloud/pull/886

### What was the solution? (How)
bump the deadline version

### What is the impact of this change?
attachment upload is able to use the updated deadline

### How was this change tested?
`hatch run fmt && hatch run lint && hatch run test`

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*