### PR TITLE
fix: small files in syncInputJobAttachment causes sync cancel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.34.75",
-    "deadline >= 0.53.1,< 0.54",
+    "deadline >= 0.54.0,< 0.55",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
     "openjd-sessions == 0.10.6",
     "openjd-model >= 0.8.1, < 0.9",

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_download.py
@@ -156,6 +156,7 @@ def perform_download(
         DownloadSummaryStatistics object containing download results
     """
     low_transfer_count = 0
+    last_processed_files = 0
 
     def progress_handler(job_attachments_download_status: ProgressReportMetadata) -> bool:
         """
@@ -165,8 +166,14 @@ def perform_download(
         # Check the transfer rate from the progress report. It monitors for a series of
         # alarmingly low transfer rates, and if the count exceeds the specified threshold,
         # cancels the download and fails the current (SYNC_INPUT_JOB_ATTACHMENTS) action.
-        nonlocal low_transfer_count
+        nonlocal low_transfer_count, last_processed_files
         transfer_rate = job_attachments_download_status.transferRate
+
+        # File completion acts as heartbeat to prevent false positive of low transfer rate
+        # due to files with small sizes < ~50bytes
+        if job_attachments_download_status.processedFiles > last_processed_files:
+            low_transfer_count = 0
+        last_processed_files = job_attachments_download_status.processedFiles
 
         if transfer_rate < LOW_TRANSFER_RATE_THRESHOLD:
             low_transfer_count += 1

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -940,6 +940,7 @@ class Session:
             return
 
         low_transfer_count = 0
+        last_processed_files = 0
 
         def progress_handler(job_attachments_download_status: ProgressReportMetadata) -> bool:
             """
@@ -949,8 +950,14 @@ class Session:
             # Check the transfer rate from the progress report. It monitors for a series of
             # alarmingly low transfer rates, and if the count exceeds the specified threshold,
             # cancels the download and fails the current (SYNC_INPUT_JOB_ATTACHMENTS) action.
-            nonlocal low_transfer_count
+            nonlocal low_transfer_count, last_processed_files
             transfer_rate = job_attachments_download_status.transferRate
+
+            # File completion acts as heartbeat to prevent false positive of low transfer rate
+            # due to files with small sizes < ~50bytes
+            if job_attachments_download_status.processedFiles > last_processed_files:
+                low_transfer_count = 0
+            last_processed_files = job_attachments_download_status.processedFiles
 
             if transfer_rate < LOW_TRANSFER_RATE_THRESHOLD:
                 low_transfer_count += 1

--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -297,6 +297,194 @@ if __name__ == "__main__":
         finally:
             os.remove(output_file_path)
 
+    def test_job_submission_many_small_files_download_does_not_cancel(
+        self,
+        deadline_resources: DeadlineResources,
+        session_worker: EC2InstanceWorker,
+        deadline_client: DeadlineClient,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """
+        Test that downloading many small files does not trigger false positive cancellation
+        due to overhead being included in transfer rate calculation.
+
+        This test demonstrates the bug where many tiny files (1 byte each) with high
+        per-file overhead results in misleadingly low transfer rates that cause job cancellation.
+        """
+
+        # Create job bundle with many small input files
+        job_bundle_path = os.path.join(tmp_path, "small_files_job_bundle")
+        os.makedirs(job_bundle_path, exist_ok=True)
+
+        num_files = 3000  # ~minimum files needed to cause lost transfer rate bug
+        file_size = 1
+
+        LOG.info(f"Creating {num_files} small files ({file_size} byte each) in job bundle...")
+        # Optimize file creation for speed
+        content = "x"  # 1 byte content - reuse the same content
+        for i in range(num_files):
+            small_file_path = os.path.join(job_bundle_path, f"tiny_file_{i:04d}.txt")
+            with open(small_file_path, "w") as f:
+                f.write(content)
+        LOG.info(f"Finished creating {num_files} files")
+
+        # Create simple job template that just echoes completion
+        # The key is that job attachments will download all the small files
+        with open(os.path.join(job_bundle_path, "template.json"), "w") as template_file:
+            template_file.write(
+                json.dumps(
+                    {
+                        "specificationVersion": "jobtemplate-2023-09",
+                        "name": "Many Small Files Transfer Rate Test",
+                        "description": "Test job that downloads many small files to verify transfer rate calculation doesn't cause false cancellation",
+                        "parameterDefinitions": [
+                            {
+                                "name": "DataDir",
+                                "type": "PATH",
+                                "dataFlow": "IN",
+                            },
+                        ],
+                        "steps": [
+                            {
+                                "hostRequirements": {
+                                    "attributes": [
+                                        {
+                                            "name": "attr.worker.os.family",
+                                            "allOf": [os.environ["OPERATING_SYSTEM"]],
+                                        }
+                                    ]
+                                },
+                                "name": "ProcessSmallFiles",
+                                "script": {
+                                    "actions": {
+                                        "onRun": (
+                                            {
+                                                "command": "echo",
+                                                "args": [
+                                                    "Small files download test completed successfully"
+                                                ],
+                                            }
+                                            if os.environ["OPERATING_SYSTEM"] == "linux"
+                                            else {
+                                                "command": "powershell",
+                                                "args": [
+                                                    '"Small files download test completed successfully"'
+                                                ],
+                                            }
+                                        ),
+                                    },
+                                },
+                            },
+                        ],
+                    }
+                )
+            )
+
+        # Set up job parameters
+        job_parameters = [
+            {"name": "DataDir", "value": job_bundle_path},
+        ]
+
+        # Configure deadline client
+        config = configparser.ConfigParser()
+        set_setting("defaults.farm_id", deadline_resources.farm.id, config)
+        set_setting("defaults.queue_id", deadline_resources.queue_a.id, config)
+
+        # Submit job using the job bundle (this will create job attachments for all small files)
+        LOG.info(f"Submitting job with {num_files} small files as job attachments...")
+        job_id = api.create_job_from_job_bundle(
+            job_bundle_path,
+            job_parameters,
+            priority=98,
+            config=config,
+            queue_parameter_definitions=[],
+        )
+        assert job_id is not None
+
+        # Get job details and create Job object
+        job_details = Job.get_job_details(
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            job_id=job_id,
+        )
+        job = Job(
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            template={},
+            **job_details,
+        )
+
+        LOG.info(f"Submitted job {job.id} with {num_files} small files ({file_size} byte each)")
+        job.wait_until_complete(client=deadline_client, max_retries=30)
+        LOG.info(f"Job completed with status: {job.task_run_status}")
+
+        # Check if job failed due to transfer rate issues
+        if job.task_run_status == TaskStatus.FAILED:
+            LOG.info("Job failed - checking for transfer rate cancellation...")
+
+            # Get session details to find the failure reason
+            sessions = deadline_client.list_sessions(
+                farmId=job.farm.id, queueId=job.queue.id, jobId=job.id
+            ).get("sessions", [])
+
+            for session in sessions:
+                session_actions = deadline_client.list_session_actions(
+                    farmId=job.farm.id,
+                    queueId=job.queue.id,
+                    jobId=job.id,
+                    sessionId=session["sessionId"],
+                ).get("sessionActions", [])
+
+                for action in session_actions:
+                    # Look specifically for syncInputJobAttachments failures
+                    if "syncInputJobAttachments" in action.get("definition", {}):
+                        if action.get("status") == "FAILED":
+                            # Get detailed session action info to find the transfer rate error message
+                            try:
+                                detailed_action = deadline_client.get_session_action(
+                                    farmId=job.farm.id,
+                                    queueId=job.queue.id,
+                                    jobId=job.id,
+                                    sessionActionId=action["sessionActionId"],
+                                )
+
+                                # Debug: Print all available fields in detailed_action
+                                LOG.info(
+                                    f"FAILED syncInputJobAttachments - Full detailed_action: {detailed_action}"
+                                )
+
+                                # Get the progress message which contains the actual error
+                                progress_message = detailed_action.get("progressMessage", "")
+
+                                if progress_message:
+                                    LOG.info(f"TRANSFER RATE ERROR: {progress_message}")
+                                    pytest.fail(
+                                        f"Job cancelled due to transfer rate error: {progress_message}"
+                                    )
+                                else:
+                                    pytest.fail(
+                                        "Job cancelled due to false low transfer rates (syncInputJobAttachments failed)"
+                                    )
+
+                            except Exception:
+                                # Still count as transfer rate failure since syncInputJobAttachments failed
+                                pytest.fail(
+                                    "Job cancelled due to false low transfer rates (syncInputJobAttachments failed)"
+                                )
+
+                            return  # Exit after handling the first syncInputJobAttachments failure
+
+            # If we get here, no syncInputJobAttachments failures were found
+            pytest.fail(f"Job failed for unexpected reason. Status: {job.task_run_status}")
+
+        elif job.task_run_status == TaskStatus.SUCCEEDED:
+            LOG.info("Job completed successfully - no false cancellation occurred")
+
+        else:
+            # Unexpected status (CANCELED, etc.)
+            pytest.fail(f"Job ended with unexpected status: {job.task_run_status}")
+
     @pytest.mark.parametrize(
         "append_string_script",
         [
@@ -980,7 +1168,7 @@ if __name__ == "__main__":
             job_bundle_path,
             job_parameters,
             priority=99,
-            max_retries_per_task=2,
+            max_retries_per_task=0,
             config=config,
             queue_parameter_definitions=[],
         )

--- a/test/unit/sessions/actions/scripts/test_attachment_download.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_download.py
@@ -373,6 +373,7 @@ class TestPerformDownload:
                         progress=i * 10,
                         transferRate=10 * 10**9,
                         progressMessage=f"test: {i}",
+                        processedFiles=0,
                     )
                 )
             return DownloadSummaryStatistics()
@@ -412,6 +413,7 @@ class TestPerformDownload:
                 progress=0.0,
                 transferRate=(10 * 10**3) / 2,
                 progressMessage="",
+                processedFiles=0,
             )
             for _ in range(60):
                 on_downloading_files(low_transfer_rate_report)
@@ -671,6 +673,7 @@ class TestTelemetry:
                 progress=0.0,
                 transferRate=1,
                 progressMessage="Low rate",
+                processedFiles=0,
             )
             for _ in range(60):
                 should_continue = on_downloading_files(low_rate_progress)

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -873,6 +873,7 @@ class TestSessionSyncAssetInputs:
                 progress=0.0,
                 transferRate=LOW_TRANSFER_RATE_THRESHOLD / 2,
                 progressMessage="",
+                processedFiles=0,
             )
             for _ in range(LOW_TRANSFER_COUNT_THRESHOLD):
                 on_downloading_files(low_transfer_rate_report)


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/478

### What was the problem/requirement? (What/Why)


When submitting any job to a CMF with worker agent installed, with thousands (10000 as tested) of small 1 byte input files, after the job starts, the syncInputJobAttachments step will fail most of the time, with an error message "Input Syncing failed due to successive low transfer rates"

```
2025/11/03 16:37:43-08:00 ==============================================2025/11/03 16:37:43-08:00 --------- Job Attachments Download for Job2025/11/03 16:37:43-08:00 ==============================================
2025/11/03 16:37:43-08:00 Syncing inputs using Job Attachments
2025/11/03 16:37:44-08:00 Downloaded 555 B / 3.56 KB of 3001 files (Transfer rate: 0 B/s)2025/11/03 
16:37:47-08:00 Downloaded 911 B / 3.56 KB of 3001 files (Transfer rate: 150 B/s)
2025/11/03 16:37:49-08:00 Downloaded 1.27 KB / 3.56 KB of 3001 files (Transfer rate: 144 B/s)
2025/11/03 16:37:52-08:00 Downloaded 1.62 KB / 3.56 KB of 3001 files (Transfer rate: 128 B/s)
2025/11/03 16:37:55-08:00 Downloaded 1.98 KB / 3.56 KB of 3001 files (Transfer rate: 141 B/s)
2025/11/03 16:37:57-08:00 Downloaded 2.33 KB / 3.56 KB of 3001 files (Transfer rate: 125 B/s)

FAILS
```

Some math:
Given tiny files of 1 byte, transfer speed is negligible for file contents. However, overhead of api calls to S3 overshadow actual latency of file transfer.

-> Given average transfer rates of 150 - 200B/s = 150 - 200 files / second
-> threshold of 10KB/s = 10,000B/s
-> needs all files to be above 50 - 60 bytes/file to not be cancelled in a false positive fashion

Low transfer rates increment `low_transfer_count` counter, with 60 consecutive counts leading to failure.
Therefore possible for many consecutive tiny files to cause errors.

### What was the solution? (How)

(Change required in both deadline-cloud and deadline-cloud-worker-agent)
Added extra checks to reset `low_transfer_count` counter when files complete, acting as a heartbeat; many tiny files that are downloaded by the worker agent will now indicate progress, ignoring the false positive case.

Note, change would not mask over the original intent of cancelling due to low transfer rates. Given `LOW_TRANSFER_RATE_THRESHOLD` of 10kb/s and `LOW_TRANSFER_COUNT_THRESHOLD`, files above ~600kb will still lead to low transfer rate failure if has low transfer rates. 

### What is the impact of this change?

Job submissions with attachments that have many tiny files will no longer cause a false positive failure of low transfer rates

### How was this change tested?
Added E2E Test for specific bug.
Before change:
```
FAILED test/e2e/test_job_submissions.py::TestJobSubmission::test_job_submission_many_small_files_download_does_not_cancel - Failed: Job cancelled due to transfer rate error: Input syncing failed due to successive low transfer rates (< 10.0 KB/s). The transfer rate was below the threshold for the last 1 minute.
```
After Change
```
184.55s setup    test/e2e/test_job_submissions.py::TestJobSubmission::test_job_submission_many_small_files_download_does_not_cancel
57.67s call     test/e2e/test_job_submissions.py::TestJobSubmission::test_job_submission_many_small_files_download_does_not_cancel
6.01s teardown test/e2e/test_job_submissions.py::TestJobSubmission::test_job_submission_many_small_files_download_does_not_cancel
================================================================================== 1 passed, 1 warning in 248.27s (0:04:08) ===================================================================================
```

Ran Unit Tests:
```
================================================================================================= slowest 5 durations =================================================================================================
5.12s call     test/unit/sessions/actions/scripts/test_attachment_download.py::TestBuildMergedManifestsByRoot::test_build_merged_manifests_by_root_manifest_file_not_found
1.01s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[spot-shutdown-1-min]
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_asg_termination
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[spot-shutdown-15-sec]
0.47s call     test/unit/sessions/actions/scripts/test_attachment_download.py::TestTelemetry::test_latencies_telemetry_on_success
=================================================================================== 2718 passed, 53 skipped, 15 warnings in 19.80s ====================================================================================
```
### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*