### PR TITLE
test: increase max retries to allow more time for TestJobAttachments.test_worker_job_attachments_dep_data_flow_windows[True]

### DIFF
--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -608,14 +608,18 @@ if __name__ == "__main__":
             os.path.dirname(__file__), "job_attachment_bundle", "dep_data_flow", "windows_bundle"
         )
 
+        submit_start_time = time.perf_counter()
         job = submit_job_from_bundle(
             deadline_client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             bundle_path=job_bundle_path,
         )
+        LOG.info(f"Job {job.id} submitted in {time.perf_counter() - submit_start_time:.2f} seconds")
 
         job.wait_until_complete(client=deadline_client, max_retries=30)
+        LOG.info(f"Job {job.id} total in {time.perf_counter() - submit_start_time:.2f} seconds")
+
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
         # Validate S3 setup and manifest integrity

--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -615,7 +615,7 @@ if __name__ == "__main__":
             bundle_path=job_bundle_path,
         )
 
-        job.wait_until_complete(client=deadline_client)
+        job.wait_until_complete(client=deadline_client, max_retries=30)
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
         # Validate S3 setup and manifest integrity


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

```
FAILED test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_windows[True]
```

Test failure do to timeout setting wait for jobs to complete.

### What was the solution? (How)

Increase timeout and add log lines to break down the time taken for future debugging.

### What is the impact of this change?
- Better visibility
- Tests passing 🤞 


### How was this change tested?
```
Job job-1fabc7cdb4af4ef6a573f2346ad5aa39 submitted in 2.84 seconds
Job job-1fabc7cdb4af4ef6a573f2346ad5aa39 total in 115.11 seconds
```
```
============================= slowest 5 durations ==============================
368.80s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_windows[False]
347.62s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_windows[True]
260.58s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_windows[True]
125.44s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_windows[False]
6.48s teardown test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_windows[False]
================== 2 passed, 1 warning in 1111.57s (0:18:31) ===================

```

### Was this change documented?
N/A

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*