### PR TITLE
test: remove xfail for test_worker_create_job_API_call_windows and extend retry for test_worker_create_job_API_call_windows

### DIFF
--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -605,13 +605,6 @@ if __name__ == "__main__":
         asset_sync_class_worker: EC2InstanceWorker,
         asset_sync_worker_config: DeadlineWorkerConfiguration,
     ) -> None:
-        # Mark as xfail when ASSET_SYNC_JOB_USER_FEATURE is True
-        if (
-            asset_sync_worker_config.worker_env_var
-            and asset_sync_worker_config.worker_env_var.get("ASSET_SYNC_JOB_USER_FEATURE") == "True"
-        ):
-            pytest.xfail("Expected to fail when ASSET_SYNC_JOB_USER_FEATURE is True")
-
         job_bundle_path: str = os.path.join(
             os.path.dirname(__file__), "job_attachment_bundle", "dep_data_flow", "windows_bundle"
         )
@@ -1661,6 +1654,7 @@ with open(output_path, "w") as f:
         os.makedirs(name=self.JOB_OUTPUT_PATH, exist_ok=True)
 
         # Create Job API
+        submit_start_time = time.perf_counter()
         job = submit_job_from_create_job_API(
             deadline_client=deadline_client,
             deadline_resources=deadline_resources,
@@ -1670,7 +1664,10 @@ with open(output_path, "w") as f:
             storage_profile=False,
         )
 
-        job.wait_until_complete(client=deadline_client)
+        LOG.info(f"Job {job.id} submitted in {time.perf_counter() - submit_start_time:.2f} seconds")
+        job.wait_until_complete(client=deadline_client, max_retries=30)
+        LOG.info(f"Job {job.id} total in {time.perf_counter() - submit_start_time:.2f} seconds")
+
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
         # Validate S3 setup and manifest integrity


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
### Mainline Test Run 1

```
=========================== short test summary info ============================
FAILED test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_windows[True]
FAILED test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_create_job_API_call_windows[True]
!!!!!!!!!!!!!!!!!!!!! session-timeout: 6600.0 sec exceeded !!!!!!!!!!!!!!!!!!!!!
====== 2 failed, 39 passed, 13 skipped, 25 warnings in 6615.78s (1:50:15) ======
```

### Mainline Test Run 2 (after extend timeout for test_worker_job_attachments_dep_data_flow_windows)
Extend timeout worked (https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/806).

```
=========================== short test summary info ============================
FAILED test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_create_job_API_call_windows[True]
!!!!!!!!!!!!!!!!!!!!! session-timeout: 6600.0 sec exceeded !!!!!!!!!!!!!!!!!!!!!
====== 1 failed, 41 passed, 17 skipped, 26 warnings in 6762.27s (1:52:42) ======
```

That's why xfail (https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/807) still didn't fix mainline E2E tests, it's xfailing a test that's already passing.

### Mainline Test Run 3 (after xfail test_worker_job_attachments_dep_data_flow_windows)
```
=========================== short test summary info ============================
FAILED test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_create_job_API_call_windows[True]
!!!!!!!!!!!!!!!!!!!!! session-timeout: 6600.0 sec exceeded !!!!!!!!!!!!!!!!!!!!!
= 1 failed, 48 passed, 21 skipped, 1 xfailed, 26 warnings in 6660.88s (1:51:00) =
```

`test_worker_create_job_API_call_windows[True]` actually succeeded in 00:03:41.

```
Complex Manifest Test
100% (8/8)
Succeeded
00:03:41
```

### What was the solution? (How)
Extend the timeout and added log lines to gather more information.

### What is the impact of this change?
Fix CI test failures.

### How was this change tested?
```
[2025-11-07 13:20:03,541] [test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_create_job_API_call_windows[True]] Matches: ['root_1/data_dir2/Step2-2-34-5.out', 'root_1/data_dir2/Step2-2.10.out', 'root_1/data_dir2/Step2-2.11.out', 'root_1/data_dir2/Step2.out', 'root_1/data_dir2/Step2-2.8.out', 'root_1/data_dir2/Step2-2-4.out', 'root_1/data_dir2/Step2-2.9.out', 'root_1/data_dir2/Step2-2-3.out', 'root_1/data_dir1/Step1.out', 'root_1/data_dir1/Step1-2.8.out', 'root_1/data_dir1/Step1-2-4.out', 'root_1/data_dir1/Step1-2.9.out', 'root_1/data_dir1/Step1-2-34-5.out', 'root_1/data_dir1/Step1-2-3.out', 'root_1/data_dir1/Step1-2.10.out', 'root_1/data_dir1/Step1-2.11.out', 'root_0/files_out/output_file'], Mismatches: [], Errors: []
PASSED                                                                   [ 50%]
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*