### PR TITLE
fix(experimental): job attachment upload failures when session environment changes python search path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline >= 0.50,< 0.54",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions >= 0.10.4",
+    "openjd-sessions == 0.10.5",
     "openjd-model >= 0.8.1, < 0.9",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline >= 0.50,< 0.54",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.10.4",
+    "openjd-sessions >= 0.10.4",
     "openjd-model >= 0.8.1, < 0.9",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -349,7 +349,7 @@ class AttachmentDownloadAction(OpenjdAction):
             # Successfully launched VFS, running a echo step with openjd
             # for the session to proceed to the next action
             # LINUX and VIRTUAL only
-            session.run_task(
+            session._run_attachment_sync_task(
                 step_script=StepScript_2023_09(
                     actions=StepActions_2023_09(
                         onRun=Action_2023_09(
@@ -367,7 +367,7 @@ class AttachmentDownloadAction(OpenjdAction):
                 worker_manifest_properties_list=download_manifest_properties_list,
             )
             assert self._step_script is not None
-            session.run_task(
+            session._run_attachment_sync_task(
                 step_script=self._step_script,
                 task_parameter_values=dict[str, ParameterValue](),
                 os_env_vars={

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
@@ -194,7 +194,7 @@ class AttachmentUploadAction(OpenjdAction):
         if self._task_id is not None:
             env_vars["DEADLINE_TASK_ID"] = self._task_id
 
-        session.run_task(
+        session._run_attachment_sync_task(
             step_script=self._step_script,
             task_parameter_values=dict[str, ParameterValue](),
             os_env_vars=env_vars,

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -1523,25 +1523,27 @@ class Session:
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
-        # Avoid circular import
-        from .actions import AttachmentDownloadAction, AttachmentUploadAction
+        self._session.run_task(
+            step_script=step_script,
+            task_parameter_values=task_parameter_values,
+            os_env_vars=os_env_vars,
+            log_task_banner=log_task_banner,
+        )
 
-        if self._current_action is not None and isinstance(
-            self._current_action.definition, (AttachmentDownloadAction, AttachmentUploadAction)
-        ):
-            self._session._run_task_without_session_env(
-                step_script=step_script,
-                task_parameter_values=task_parameter_values,
-                os_env_vars=os_env_vars,
-                log_task_banner=log_task_banner,
-            )
-        else:
-            self._session.run_task(
-                step_script=step_script,
-                task_parameter_values=task_parameter_values,
-                os_env_vars=os_env_vars,
-                log_task_banner=log_task_banner,
-            )
+    def _run_attachment_sync_task(
+        self,
+        *,
+        step_script: StepScriptModel,
+        task_parameter_values: TaskParameterSet,
+        os_env_vars: Optional[dict[str, str]] = None,
+        log_task_banner: bool = True,
+    ) -> None:
+        self._session._run_task_without_session_env(
+            step_script=step_script,
+            task_parameter_values=task_parameter_values,
+            os_env_vars=os_env_vars,
+            log_task_banner=log_task_banner,
+        )
 
     def stop(
         self,

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -1523,12 +1523,25 @@ class Session:
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
-        self._session.run_task(
-            step_script=step_script,
-            task_parameter_values=task_parameter_values,
-            os_env_vars=os_env_vars,
-            log_task_banner=log_task_banner,
-        )
+        # Avoid circular import
+        from .actions import AttachmentDownloadAction, AttachmentUploadAction
+
+        if self._current_action is not None and isinstance(
+            self._current_action.definition, (AttachmentDownloadAction, AttachmentUploadAction)
+        ):
+            self._session._run_task_without_session_env(
+                step_script=step_script,
+                task_parameter_values=task_parameter_values,
+                os_env_vars=os_env_vars,
+                log_task_banner=log_task_banner,
+            )
+        else:
+            self._session.run_task(
+                step_script=step_script,
+                task_parameter_values=task_parameter_values,
+                os_env_vars=os_env_vars,
+                log_task_banner=log_task_banner,
+            )
 
     def stop(
         self,

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -238,7 +238,7 @@ class TestStart:
         assert len(action._step_script.embeddedFiles) == 1
         assert action._step_script.embeddedFiles[0].name == "WorkerManifestProperties"
 
-        session.run_task.assert_called_once_with(
+        session._run_attachment_sync_task.assert_called_once_with(
             step_script=action._step_script,
             task_parameter_values=dict[str, ParameterValue](),
             os_env_vars={

--- a/test/unit/sessions/actions/test_run_attachment_upload.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload.py
@@ -167,7 +167,7 @@ class TestStart:
         assert embedded_file.name == "WorkerManifestProperties"
         assert embedded_file.type == EmbeddedFileTypes_2023_09.TEXT
 
-        session.run_task.assert_called_once_with(
+        session._run_attachment_sync_task.assert_called_once_with(
             step_script=action._step_script,
             task_parameter_values=dict[str, ParameterValue](),
             os_env_vars={
@@ -234,7 +234,7 @@ class TestStart:
         assert len(embedded_data) == 1
         assert embedded_data[0]["root_path"] == "/test/path"
 
-        session.run_task.assert_called_once_with(
+        session._run_attachment_sync_task.assert_called_once_with(
             step_script=action._step_script,
             task_parameter_values=dict[str, ParameterValue](),
             os_env_vars={

--- a/test/unit/sessions/actions/test_run_attachment_upload_optional_task_id.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload_optional_task_id.py
@@ -10,7 +10,7 @@ from deadline_worker_agent.sessions.attachment_models import WorkerManifestPrope
 @pytest.fixture
 def mock_session():
     session = Mock()
-    session.run_task = Mock()
+    session._run_attachment_sync_task = Mock()
 
     # Mock the worker manifest properties
     mock_worker_props = Mock(spec=WorkerManifestProperties)
@@ -70,8 +70,8 @@ class TestAttachmentUploadActionOptionalTaskId:
 
         action.start(session=mock_session, executor=mock_executor)
 
-        mock_session.run_task.assert_called_once()
-        call_args = mock_session.run_task.call_args[1]
+        mock_session._run_attachment_sync_task.assert_called_once()
+        call_args = mock_session._run_attachment_sync_task.call_args[1]
 
         assert "os_env_vars" in call_args
         env_vars = call_args["os_env_vars"]
@@ -91,8 +91,8 @@ class TestAttachmentUploadActionOptionalTaskId:
 
         action.start(session=mock_session, executor=mock_executor)
 
-        mock_session.run_task.assert_called_once()
-        call_args = mock_session.run_task.call_args[1]
+        mock_session._run_attachment_sync_task.assert_called_once()
+        call_args = mock_session._run_attachment_sync_task.call_args[1]
 
         assert "os_env_vars" in call_args
         env_vars = call_args["os_env_vars"]

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -3115,3 +3115,67 @@ class TestSessionWorkerManifestProperties:
             "/first/manifest.json",
             "/second/manifest.json",
         ]
+
+
+class TestRunAttachmentSyncTask:
+    """Test cases for Session._run_attachment_sync_task()
+
+    This method is a thin wrapper around _run_task_without_session_env, so we only test
+    that it correctly delegates to the underlying method with the right parameters.
+    """
+
+    @pytest.mark.parametrize(
+        "os_env_vars,log_task_banner",
+        [
+            (None, True),
+            ({"ENV_VAR1": "value1", "ENV_VAR2": "value2"}, True),
+            (None, False),
+            ({"ENV_VAR1": "value1"}, False),
+        ],
+        ids=["defaults", "with_env_vars", "no_banner", "all_params"],
+    )
+    def test_delegates_to_run_task_without_session_env(
+        self,
+        session: Session,
+        mock_openjd_session: MagicMock,
+        os_env_vars: dict[str, str] | None,
+        log_task_banner: bool,
+    ) -> None:
+        """Tests that _run_attachment_sync_task correctly delegates to _run_task_without_session_env."""
+        # GIVEN
+        step_script_model = MagicMock()
+
+        # WHEN
+        session._run_attachment_sync_task(
+            step_script=step_script_model,
+            task_parameter_values=dict[str, ParameterValue](),
+            os_env_vars=os_env_vars,
+            log_task_banner=log_task_banner,
+        )
+
+        # THEN
+        mock_openjd_session._run_task_without_session_env.assert_called_once_with(
+            step_script=step_script_model,
+            task_parameter_values=dict[str, ParameterValue](),
+            os_env_vars=os_env_vars,
+            log_task_banner=log_task_banner,
+        )
+
+    def test_propagates_exception_from_openjd_session(
+        self,
+        session: Session,
+        mock_openjd_session: MagicMock,
+    ) -> None:
+        """Tests that exceptions from the underlying Open Job Description session are propagated."""
+        # GIVEN
+        expected_exception = RuntimeError("Task execution failed")
+        mock_openjd_session._run_task_without_session_env.side_effect = expected_exception
+
+        # WHEN / THEN
+        with pytest.raises(RuntimeError) as exc_info:
+            session._run_attachment_sync_task(
+                step_script=MagicMock(),
+                task_parameter_values={},
+            )
+
+        assert exc_info.value is expected_exception


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
OpenJD env setup could change path variable, and caused the worker agent asset sync task run to fail due to mismatch dependency versions. 

### What was the solution? (How)
Adopt a new function that prevent persisted env setup from session, allow sync OpenJD tasks to run within its dependency closure.

### What is the impact of this change?
Decouple WA dependencies from potential Python library bundled in which could be an old version and incompatible.

### How was this change tested?
#### E2E test
```
============================= slowest 5 durations ==============================
307.67s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[False-linux]
191.86s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[True-linux]
156.10s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_linux[True-VIRTUAL]
156.08s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_linux[True-COPIED]
130.27s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_linux[False-VIRTUAL]
============ 26 passed, 6 skipped, 1 warning in 1953.10s (0:32:33) =============
```

#### Tested via host config for C4D jobs 
```
2025/11/06 17:13:31-08:00 ==============================================
2025/11/06 17:13:31-08:00 --------- Job Attachments Upload for Task
2025/11/06 17:13:31-08:00 ==============================================
2025/11/06 17:13:31-08:00 in _run_attachment_sync_task, running _run_task_without_session_env
2025/11/06 17:13:31-08:00 ----------------------------------------------
2025/11/06 17:13:31-08:00 Phase: Setup
2025/11/06 17:13:31-08:00 ----------------------------------------------
2025/11/06 17:13:31-08:00 Writing embedded files for Task to disk.
2025/11/06 17:13:31-08:00 Mapping: Task.File.WorkerManifestProperties -> /sessions/session-bbe91c74c4a14b01ac0e73ca7b44d20bq_4h1s6x/embedded_files8_2uegd5/tmpzabbrcaz
2025/11/06 17:13:31-08:00 Wrote: WorkerManifestProperties -> /sessions/session-bbe91c74c4a14b01ac0e73ca7b44d20bq_4h1s6x/embedded_files8_2uegd5/tmpzabbrcaz
2025/11/06 17:13:31-08:00 ----------------------------------------------
2025/11/06 17:13:31-08:00 Phase: Running action
2025/11/06 17:13:31-08:00 ----------------------------------------------
2025/11/06 17:13:31-08:00 Running command sudo -u job-user -i setsid -w /sessions/session-bbe91c74c4a14b01ac0e73ca7b44d20bq_4h1s6x/tmpzffu9_u9.sh
2025/11/06 17:13:32-08:00 Command started as pid: 3393
2025/11/06 17:13:32-08:00 Output:
2025/11/06 17:13:33-08:00 Manifest generated at manifest_merge/merge-69782b531ae6c634de2994ca86dd0bed-2025-11-07T01-13-32.manifest
2025/11/06 17:13:33-08:00 Found difference at: output/render_0_0001.png, Status: FileStatus.NEW
2025/11/06 17:13:33-08:00 Hashing Attachments
2025/11/06 17:13:33-08:00 Hashing Summary:
2025/11/06 17:13:33-08:00     Processed 1 file totaling 13.94 KB.
2025/11/06 17:13:33-08:00     Skipped re-processing 0 files totaling 0 B.
2025/11/06 17:13:33-08:00     Total processing time of 0.0297 seconds at 469.13 KB/s.
2025/11/06 17:13:33-08:00  
2025/11/06 17:13:33-08:00 Manifest generated at manifest_snapshot/output-7cdb81876ef87950a2bc3ba9dae51d82-2025-11-07T01-13-33.manifest
2025/11/06 17:13:33-08:00 ja_snapshot: {"root": "/sessions/session-bbe91c74c4a14b01ac0e73ca7b44d20bq_4h1s6x/assetroot-49ae3f1b54363665841b", "manifest": "manifest_snapshot/output-7cdb81876ef87950a2bc3ba9dae51d82-2025-11-07T01-13-33.manifest"}
2025/11/06 17:13:33-08:00  
2025/11/06 17:13:33-08:00 Starting upload...
2025/11/06 17:13:33-08:00 Uploaded assets from /sessions/session-bbe91c74c4a14b01ac0e73ca7b44d20bq_4h1s6x/assetroot-49ae3f1b54363665841b, to s3://yuanbian-test-ja-bucket/AssetSyncTesting/Manifests/farm-c98c915a1c104f2ba14b4621ff2bdac0/queue-e6e771bf4ec74350a3a10079a87baa55/job-a8fc9d669cb045378a367136c77be205/step-3d1bc582a38a43e8a13bd0e2ce7a2665/task-3d1bc582a38a43e8a13bd0e2ce7a2665-0/2025-11-07T01:13:28.649240Z_sessionaction-bbe91c74c4a14b01ac0e73ca7b44d20b-3/69782b531ae6c634de2994ca86dd0bed_output, hashed data 205a9b9307c69ca03b5fac177786ac86
2025/11/06 17:13:33-08:00 Finished after 0.95 seconds
2025/11/06 17:13:34-08:00 Process pid 3393 exited with code: 0 (unsigned) / 0x0 (hex)
2025/11/06 17:13:31-08:00 ==============================================
2025/11/06 17:13:31-08:00 --------- Job Attachments Upload for Task
2025/11/06 17:13:31-08:00 ==============================================
2025/11/06 17:13:31-08:00 in _run_attachment_sync_task, running _run_task_without_session_env
2025/11/06 17:13:31-08:00 ----------------------------------------------
2025/11/06 17:13:31-08:00 Phase: Setup
2025/11/06 17:13:31-08:00 ----------------------------------------------
2025/11/06 17:13:31-08:00 Writing embedded files for Task to disk.
2025/11/06 17:13:31-08:00 Mapping: Task.File.WorkerManifestProperties -> /sessions/session-bbe91c74c4a14b01ac0e73ca7b44d20bq_4h1s6x/embedded_files8_2uegd5/tmpzabbrcaz
2025/11/06 17:13:31-08:00 Wrote: WorkerManifestProperties -> /sessions/session-bbe91c74c4a14b01ac0e73ca7b44d20bq_4h1s6x/embedded_files8_2uegd5/tmpzabbrcaz
2025/11/06 17:13:31-08:00 ----------------------------------------------
2025/11/06 17:13:31-08:00 Phase: Running action
2025/11/06 17:13:31-08:00 ----------------------------------------------
2025/11/06 17:13:31-08:00 Running command sudo -u job-user -i setsid -w /sessions/session-bbe91c74c4a14b01ac0e73ca7b44d20bq_4h1s6x/tmpzffu9_u9.sh
2025/11/06 17:13:32-08:00 Command started as pid: 3393
2025/11/06 17:13:32-08:00 Output:
2025/11/06 17:13:33-08:00 Manifest generated at manifest_merge/merge-69782b531ae6c634de2994ca86dd0bed-2025-11-07T01-13-32.manifest
2025/11/06 17:13:33-08:00 Found difference at: output/render_0_0001.png, Status: FileStatus.NEW
2025/11/06 17:13:33-08:00 Hashing Attachments
2025/11/06 17:13:33-08:00 Hashing Summary:
2025/11/06 17:13:33-08:00     Processed 1 file totaling 13.94 KB.
2025/11/06 17:13:33-08:00     Skipped re-processing 0 files totaling 0 B.
2025/11/06 17:13:33-08:00     Total processing time of 0.0297 seconds at 469.13 KB/s.
2025/11/06 17:13:33-08:00  
2025/11/06 17:13:33-08:00 Manifest generated at manifest_snapshot/output-7cdb81876ef87950a2bc3ba9dae51d82-2025-11-07T01-13-33.manifest
2025/11/06 17:13:33-08:00 ja_snapshot: {"root": "/sessions/session-bbe91c74c4a14b01ac0e73ca7b44d20bq_4h1s6x/assetroot-49ae3f1b54363665841b", "manifest": "manifest_snapshot/output-7cdb81876ef87950a2bc3ba9dae51d82-2025-11-07T01-13-33.manifest"}
2025/11/06 17:13:33-08:00  
2025/11/06 17:13:33-08:00 Starting upload...
2025/11/06 17:13:33-08:00 Uploaded assets from XXX to XXX
2025/11/06 17:13:33-08:00 Finished after 0.95 seconds
2025/11/06 17:13:34-08:00 Process pid 3393 exited with code: 0 (unsigned) / 0x0 (hex)
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*