### PR TITLE
revert: Revert "test(debug): add e2e pytest session timeout for 1h50m (6600s) (#793)"

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -13,7 +13,7 @@ version = "hatch version"
 metadata = "hatch project metadata {args:}"
 e2e-test= [
   "python test/e2e/pre_test_cleanup.py",
-  "pytest --session-timeout=6600 --no-cov test/e2e {args:}",
+  "pytest --no-cov test/e2e {args:}",
   "echo pytest done",
 ]
 integ-test = "pytest --no-cov test/integ {args:}"


### PR DESCRIPTION
This reverts commit 9367655a0ae35ce6ccb0b292a3a6e322cacec989.

### What was the problem/requirement? (What/Why)

There were cases where the CodeBuild project timeout gets exceeded a long time after the test suite passes. Initially the team thought this was a CodeBuild bug where the project hangs. It was determined that something in our pytest code is causing the process to not exit. 

We added this pytest session timeout to debug that problem but we no longer need it. Windows tests are failing due to hitting this timeout.

### What was the solution? (How)

Removing this timeout.

### What is the impact of this change?

Windows tests can proceed further.

### How was this change tested?

`hatch run fmt && hatch run lint && hatch run test`

### Was this change documented?
N/A

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*