### PR TITLE
ci: update mainline e2e canary schedule to run every 3h

### DIFF
--- a/.github/workflows/mainline_e2e_canary.yml
+++ b/.github/workflows/mainline_e2e_canary.yml
@@ -2,14 +2,12 @@ name: Mainline Canary
 
 on:
   schedule:
-    - cron: '0 */2 * * *'
     - cron: '0 */3 * * *'
   workflow_dispatch:
 
 jobs:
   IntegrationTests:
     name: Integration Tests
-    if: github.event.schedule == '0 */2 * * *' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -29,7 +27,6 @@ jobs:
       
   MainlineLinuxE2ECanary:
     name: Mainline Linux Canary
-    if: github.event.schedule == '0 */2 * * *' || github.event_name == 'workflow_dispatch'
     permissions:
       id-token: write
       contents: read
@@ -45,7 +42,6 @@ jobs:
 
   MainlineWindowsE2ECanary:
     name: Mainline Windows Canary
-    if: github.event.schedule == '0 */3 * * *' || github.event_name == 'workflow_dispatch'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/mainline_e2e_canary.yml
+++ b/.github/workflows/mainline_e2e_canary.yml
@@ -3,11 +3,13 @@ name: Mainline Canary
 on:
   schedule:
     - cron: '0 */2 * * *'
+    - cron: '0 */3 * * *'
   workflow_dispatch:
 
 jobs:
   IntegrationTests:
     name: Integration Tests
+    if: github.event.schedule == '0 */2 * * *' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -27,6 +29,7 @@ jobs:
       
   MainlineLinuxE2ECanary:
     name: Mainline Linux Canary
+    if: github.event.schedule == '0 */2 * * *' || github.event_name == 'workflow_dispatch'
     permissions:
       id-token: write
       contents: read
@@ -42,6 +45,7 @@ jobs:
 
   MainlineWindowsE2ECanary:
     name: Mainline Windows Canary
+    if: github.event.schedule == '0 */3 * * *' || github.event_name == 'workflow_dispatch'
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Windows mainline e2e canary takes more than 2h to run due to a recent test coverage increase.

### What was the solution? (How)
As we're extending CodeBuild timeout, reduce the frequency to every 3h for windows test run.

### What is the impact of this change?
MainlineWindowsE2ECanary run every 3h in CI.

### How was this change tested?
n/a - will be tested in CI

### Was this change documented?
n/a

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*