### PR TITLE
test: increase task retry for low transfer rate termination

### DIFF
--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -914,7 +914,7 @@ if __name__ == "__main__":
             job_bundle_path,
             job_parameters,
             priority=99,
-            max_retries_per_task=0,
+            max_retries_per_task=2,
             config=config,
             queue_parameter_definitions=[],
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have this known issue https://github.com/aws-deadline/deadline-cloud/issues/478 that caused test to fail in CI.

```
2025/11/13 05:29:54-08:00 openjd_status: Downloaded 7.95 KB / 9.93 KB of 2501 files (Transfer rate: 127 B/s)
2025/11/13 05:29:56-08:00 openjd_fail: Input syncing failed due to successive low transfer rates (< 10.0 KB/s). The transfer rate was below the threshold for the last 1 minute.
2025/11/13 05:30:05-08:00 Traceback (most recent call last):
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline\job_attachments\download.py", line 563, in download_file
2025/11/13 05:30:05-08:00     future.result()
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\s3transfer\futures.py", line 111, in result
2025/11/13 05:30:05-08:00     return self._coordinator.result()
2025/11/13 05:30:05-08:00            ^^^^^^^^^^^^^^^^^^^^^^^^^^
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\s3transfer\futures.py", line 287, in result
2025/11/13 05:30:05-08:00     raise self._exception
2025/11/13 05:30:05-08:00 concurrent.futures._base.CancelledError
2025/11/13 05:30:05-08:00  
2025/11/13 05:30:05-08:00 During handling of the above exception, another exception occurred:
2025/11/13 05:30:05-08:00  
2025/11/13 05:30:05-08:00 Traceback (most recent call last):
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\sessions\actions\scripts\attachment_download.py", line 252, in <module>
2025/11/13 05:30:05-08:00     main()
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\aws\deadline\__init__.py", line 970, in wrapper
2025/11/13 05:30:05-08:00     raise e
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\aws\deadline\__init__.py", line 967, in wrapper
2025/11/13 05:30:05-08:00     return function(*args, **kwargs)
2025/11/13 05:30:05-08:00            ^^^^^^^^^^^^^^^^^^^^^^^^^
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\sessions\actions\scripts\attachment_download.py", line 238, in main
2025/11/13 05:30:05-08:00     perform_download(s3_settings, manifests_by_root)
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\sessions\actions\scripts\attachment_download.py", line 58, in wrapper
2025/11/13 05:30:05-08:00     raise e
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\sessions\actions\scripts\attachment_download.py", line 52, in wrapper
2025/11/13 05:30:05-08:00     return function(*args, **kwargs)
2025/11/13 05:30:05-08:00            ^^^^^^^^^^^^^^^^^^^^^^^^^
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline_worker_agent\sessions\actions\scripts\attachment_download.py", line 192, in perform_download
2025/11/13 05:30:05-08:00     download_summary_statistics = download_files_from_manifests(
2025/11/13 05:30:05-08:00                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline\job_attachments\download.py", line 921, in download_files_from_manifests
2025/11/13 05:30:05-08:00     downloaded_files_paths = _download_files_parallel(
2025/11/13 05:30:05-08:00                              ^^^^^^^^^^^^^^^^^^^^^^^^^
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline\job_attachments\download.py", line 677, in _download_files_parallel
2025/11/13 05:30:05-08:00     (file_bytes, local_file_name) = future.result()
2025/11/13 05:30:05-08:00                                     ^^^^^^^^^^^^^^^
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\concurrent\futures\_base.py", line 449, in result
2025/11/13 05:30:05-08:00     return self.__get_result()
2025/11/13 05:30:05-08:00            ^^^^^^^^^^^^^^^^^^^
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\concurrent\futures\_base.py", line 401, in __get_result
2025/11/13 05:30:05-08:00     raise self._exception
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\concurrent\futures\thread.py", line 59, in run
2025/11/13 05:30:05-08:00     result = self.fn(*self.args, **self.kwargs)
2025/11/13 05:30:05-08:00              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025/11/13 05:30:05-08:00   File "C:\Program Files\Python312\Lib\site-packages\deadline\job_attachments\download.py", line 566, in download_file
2025/11/13 05:30:05-08:00     raise AssetSyncCancelledError("File download cancelled.")
2025/11/13 05:30:05-08:00 deadline.job_attachments.exceptions.AssetSyncCancelledError: File download cancelled.
2025/11/13 05:30:06-08:00 Process pid 4800 exited with code: 1 (unsigned) / 0x1 (hex)
```

### What was the solution? (How)
While we have this PR https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/805 to properly fix it, it's pending a deadline release. Adding retries for now for CI until the test is merged. 

### What is the impact of this change?
Make CI happy until https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/805 is in place.

### How was this change tested?
The test always pass locally, more tests to be validated in CI.

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*