### PR TITLE
test: parameterize job names with asset sync configuration

### DIFF
--- a/test/e2e/job_attachment_bundle/output_only/template.yaml
+++ b/test/e2e/job_attachment_bundle/output_only/template.yaml
@@ -1,6 +1,6 @@
 
 specificationVersion: 'jobtemplate-2023-09'
-name: "Output Sync No Input Job"
+name: '{{Param.JobName}}'
 description: |
   This job bundle is for testing job attachments output sync with no input.
 
@@ -11,6 +11,9 @@ jobEnvironments:
     PYTHONUNBUFFERED: "True"
 
 parameterDefinitions:
+- name: JobName
+  type: STRING
+  default: "Output Sync No Input Job"
 - name: CommandRunner
   type: STRING
 - name: FilesPerTask

--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -67,6 +67,7 @@ class Asset:
 
 class TestJobAttachments:
     JOB_OUTPUT_PATH = os.path.join(os.getcwd(), "job_output")
+    ASSET_SYNC_JOB_USER_FEATURE = "ASSET_SYNC_JOB_USER_FEATURE"
 
     @pytest.mark.usefixtures("asset_sync_class_worker")
     @pytest.mark.parametrize(
@@ -81,6 +82,7 @@ class TestJobAttachments:
         submission_os: str,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
         tmp_path: pathlib.Path,
     ) -> None:
         # Test that submits a job that has storage profile and confirm that the final output path and content is as we expect
@@ -169,10 +171,17 @@ class TestJobAttachments:
             "inputManifestHash": test_disambiguator,
         }
 
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+        job_name = f"{asset_sync_feature}_StorageProfilePathMappingJob"
+
         # Create and submit job using boto3 directly
         template = {
             "specificationVersion": "jobtemplate-2023-09",
-            "name": "StorageProfilePathMappingJob",
+            "name": job_name,
             "parameterDefinitions": [
                 {
                     "name": "DataDir",
@@ -302,6 +311,7 @@ if __name__ == "__main__":
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
         asset_sync_class_worker: EC2InstanceWorker,
         append_string_script: str,
     ) -> None:
@@ -317,13 +327,21 @@ if __name__ == "__main__":
             {"name": "StringToAppend", "value": test_run_uuid},
             {"name": "DataDir", "value": job_bundle_path},
         ]
+
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+        job_name = f"{asset_sync_feature}_AppendStringJob"
+
         try:
             with open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file:
                 template_file.write(
                     json.dumps(
                         {
                             "specificationVersion": "jobtemplate-2023-09",
-                            "name": "AppendStringJob",
+                            "name": job_name,
                             "parameterDefinitions": [
                                 {
                                     "name": "DataDir",
@@ -434,6 +452,7 @@ if __name__ == "__main__":
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
         asset_sync_class_worker: EC2InstanceWorker,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
     ) -> None:
         # Tests that if a job has no job output files in the output directory, the job does not fail. This tests prevents regressions in the output code
 
@@ -454,11 +473,20 @@ if __name__ == "__main__":
                     },
                 ]
 
+                asset_sync_feature = (
+                    asset_sync_worker_config.worker_env_var.get(
+                        self.ASSET_SYNC_JOB_USER_FEATURE, "False"
+                    )
+                    if asset_sync_worker_config.worker_env_var
+                    else "False"
+                )
+                job_name = f"{asset_sync_feature}_NoOutputJob"
+
                 template_file.write(
                     json.dumps(
                         {
                             "specificationVersion": "jobtemplate-2023-09",
-                            "name": "NoOutputJob",
+                            "name": job_name,
                             "parameterDefinitions": [
                                 {
                                     "name": "OutputFilePath",
@@ -542,17 +570,23 @@ if __name__ == "__main__":
         job_bundle_path: str = os.path.join(
             os.path.dirname(__file__), "job_attachment_bundle", "dep_data_flow", "linux_bundle"
         )
-        if asset_sync_worker_config.worker_env_var:
-            job_parameters: List[Dict[str, str]] = [
-                {
-                    "name": "AssetSync",
-                    "value": asset_sync_worker_config.worker_env_var.get(
-                        "ASSET_SYNC_JOB_USER_FEATURE", "False"
-                    ),
-                },
-            ]
-        else:
-            job_parameters = []
+
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+
+        job_parameters: List[Dict[str, str]] = [
+            {
+                "name": "JobName",
+                "value": f"{asset_sync_feature}_Step-Step Dataflow Linux_{file_system}",
+            },
+            {
+                "name": "AssetSync",
+                "value": asset_sync_feature,
+            },
+        ]
 
         job = submit_job_from_bundle(
             deadline_client=deadline_client,
@@ -609,12 +643,26 @@ if __name__ == "__main__":
             os.path.dirname(__file__), "job_attachment_bundle", "dep_data_flow", "windows_bundle"
         )
 
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+
+        job_parameters: List[Dict[str, str]] = [
+            {
+                "name": "JobName",
+                "value": f"{asset_sync_feature}_Step-Step Dataflow Win",
+            },
+        ]
+
         submit_start_time = time.perf_counter()
         job = submit_job_from_bundle(
             deadline_client=deadline_client,
             farm=deadline_resources.farm,
             queue=deadline_resources.queue_a,
             bundle_path=job_bundle_path,
+            job_parameters=job_parameters,
         )
         LOG.info(f"Job {job.id} submitted in {time.perf_counter() - submit_start_time:.2f} seconds")
 
@@ -656,6 +704,7 @@ if __name__ == "__main__":
         deadline_resources: DeadlineResources,
         asset_sync_class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
     ) -> None:
         # Test that when submitting a job with job attachments to a queue with a role that cannot read the S3 bucket, the worker will fail the job attachments sync
 
@@ -672,13 +721,20 @@ if __name__ == "__main__":
             else '''set /p input=<"{{Param.DataDir}}\\files\\test_input_file"\n powershell -Command "echo ($env:input+\'hi\') | Out-File -encoding utf8 {{Param.DataDir}}\\output_file -NoNewLine"'''
         )
 
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+        job_name = f"{asset_sync_feature}_JobAttachmentToNonValidRoleQueue"
+
         try:
             with open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file:
                 template_file.write(
                     json.dumps(
                         {
                             "specificationVersion": "jobtemplate-2023-09",
-                            "name": "JobAttachmentToNonValidRoleQueue",
+                            "name": job_name,
                             "parameterDefinitions": [
                                 {
                                     "name": "DataDir",
@@ -783,7 +839,7 @@ if __name__ == "__main__":
     @pytest.mark.parametrize(
         "hash_string_script",
         [
-            (
+            pytest.param(
                 "#!/usr/bin/env bash\n\n"
                 "folder_path={{Param.DataDir}}/files\n"
                 'combined_contents=""\n'
@@ -804,7 +860,8 @@ if __name__ == "__main__":
                 "}\n"
                 "$sha256 = [System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($combinedContent))\n"
                 '$hashString = [System.BitConverter]::ToString($sha256).Replace("-", "").ToLower()\n'
-                "Set-Content -Path $OutputFile -Value $hashString -NoNewLine"
+                "Set-Content -Path $OutputFile -Value $hashString -NoNewLine",
+                id="hash_script",
             )
         ],
     )
@@ -813,6 +870,7 @@ if __name__ == "__main__":
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
         asset_sync_class_worker: EC2InstanceWorker,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
         hash_string_script: str,
         tmp_path: pathlib.Path,
     ) -> None:
@@ -850,12 +908,20 @@ if __name__ == "__main__":
         job_parameters: List[Dict[str, str]] = [
             {"name": "DataDir", "value": job_bundle_path},
         ]
+
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+        job_name = f"{asset_sync_feature}_AssetsSync"
+
         with open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file:
             template_file.write(
                 json.dumps(
                     {
                         "specificationVersion": "jobtemplate-2023-09",
-                        "name": "AssetsSync",
+                        "name": job_name,
                         "parameterDefinitions": [
                             {
                                 "name": "DataDir",
@@ -979,6 +1045,7 @@ if __name__ == "__main__":
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
         asset_sync_class_worker: EC2InstanceWorker,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
         tmp_path: pathlib.Path,
     ) -> None:
         # Test that submits a job that has step step dependencies and confirm that the final output is as we expect
@@ -1012,13 +1079,21 @@ if __name__ == "__main__":
             if os.environ["OPERATING_SYSTEM"] == "linux"
             else '''set /p input=<"{{Param.DataDir}}\\files\\step_one_output"\n powershell -Command "echo ($env:input+\'Hello\') | Out-File -encoding utf8 {{Param.DataDir}}\\files\\output_file -NoNewLine"'''
         )
+
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+        job_name = f"{asset_sync_feature}_StepDependencyJob"
+
         # Create a template that uses step-step dependencies, appending the word "Hello" to the input file once in each step
         with open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file:
             template_file.write(
                 json.dumps(
                     {
                         "specificationVersion": "jobtemplate-2023-09",
-                        "name": "StepDependencyJob",
+                        "name": job_name,
                         "parameterDefinitions": [
                             {
                                 "name": "DataDir",
@@ -1146,6 +1221,7 @@ if __name__ == "__main__":
         deadline_resources: DeadlineResources,
         asset_sync_class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
         tmp_path: pathlib.Path,
     ) -> None:
         # Submits a job with input job attachments, deleting the input files from the Job Attadchments bucket before the job starts, and verifying the job syncInputAttachments step fails
@@ -1165,6 +1241,14 @@ if __name__ == "__main__":
         ]
 
         queue_to_use = deadline_resources.queue_a
+
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+        job_name = f"{asset_sync_feature}_JobAttachmentThatGetsDeleted"
+
         with open(
             os.path.join(job_bundle_path, "parameter_values.json"), "w+"
         ) as parameter_values_file:
@@ -1183,7 +1267,7 @@ if __name__ == "__main__":
                 json.dumps(
                     {
                         "specificationVersion": "jobtemplate-2023-09",
-                        "name": "JobAttachmentThatGetsDeleted",
+                        "name": job_name,
                         "parameterDefinitions": [
                             {
                                 "name": "DataDir",
@@ -1340,7 +1424,7 @@ if __name__ == "__main__":
         # Submit another job and verify that the worker still works properly and finishes the job
 
         sleep_job = submit_sleep_job(
-            "Test Success Sleep Job after syncInputJobAttachments fail",
+            f"{asset_sync_feature}_Success Sleep Job after syncInputJobAttachments fail",
             deadline_client,
             deadline_resources.farm,
             queue_to_use,
@@ -1355,6 +1439,7 @@ if __name__ == "__main__":
         deadline_resources,
         asset_sync_class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
         tmp_path: pathlib.Path,
     ) -> None:
         """
@@ -1376,6 +1461,13 @@ with open(output_path, "w") as f:
 
         os.makedirs(job_bundle_path, exist_ok=True)
 
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+        job_name = f"{asset_sync_feature}_Test Job with Job Attachments and Embedded Files"
+
         # Create input file for job attachments
         input_file = os.path.join(job_bundle_path, "input.txt")
         with open(input_file, "w") as f:
@@ -1390,7 +1482,7 @@ with open(output_path, "w") as f:
                 json.dumps(
                     {
                         "specificationVersion": "jobtemplate-2023-09",
-                        "name": "Test Job with Job Attachments and Embedded Files",
+                        "name": job_name,
                         "parameterDefinitions": [
                             {
                                 "name": "DataDir",
@@ -1524,10 +1616,17 @@ with open(output_path, "w") as f:
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
         asset_sync_class_worker: EC2InstanceWorker,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
     ) -> None:
         """Test output-only job attachments with small files on both Windows and Linux"""
         job_bundle_path: str = os.path.join(
             os.path.dirname(__file__), "job_attachment_bundle", "output_only"
+        )
+
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
         )
 
         # Use smaller parameters for E2E testing to avoid long-running test
@@ -1540,6 +1639,7 @@ with open(output_path, "w") as f:
             bundle_path=job_bundle_path,
             max_retries_per_task=0,
             job_parameters=[
+                {"name": "JobName", "value": f"{asset_sync_feature}_Output Sync No Input Job"},
                 {"name": "FilesPerTask", "value": "1"},
                 {"name": "Tasks", "value": "1-5"},
                 {"name": "FileSize", "value": "50"},
@@ -1576,6 +1676,7 @@ with open(output_path, "w") as f:
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
         asset_sync_class_worker: EC2InstanceWorker,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
     ) -> None:
         """
         Test job submission using the Create Job API with a complex job attachment bundle.
@@ -1592,6 +1693,12 @@ with open(output_path, "w") as f:
         )
         os.makedirs(name=self.JOB_OUTPUT_PATH, exist_ok=True)
 
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+
         # Create Job API
         job = submit_job_from_create_job_API(
             deadline_client=deadline_client,
@@ -1600,6 +1707,7 @@ with open(output_path, "w") as f:
             queue=deadline_resources.queue_a,
             debug_snapshot_dir=job_bundle_path,
             storage_profile=True,
+            job_name=f"{asset_sync_feature}_Complex Manifest Test",
         )
 
         job.wait_until_complete(client=deadline_client)
@@ -1638,6 +1746,7 @@ with open(output_path, "w") as f:
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
         asset_sync_class_worker: EC2InstanceWorker,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
     ) -> None:
         """
         Test job submission using the Create Job API with a complex job attachment bundle.
@@ -1653,6 +1762,12 @@ with open(output_path, "w") as f:
         )
         os.makedirs(name=self.JOB_OUTPUT_PATH, exist_ok=True)
 
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+
         # Create Job API
         submit_start_time = time.perf_counter()
         job = submit_job_from_create_job_API(
@@ -1662,6 +1777,7 @@ with open(output_path, "w") as f:
             queue=deadline_resources.queue_a,
             debug_snapshot_dir=job_bundle_path,
             storage_profile=False,
+            job_name=f"{asset_sync_feature}_Complex Manifest Test",
         )
 
         LOG.info(f"Job {job.id} submitted in {time.perf_counter() - submit_start_time:.2f} seconds")
@@ -1699,6 +1815,7 @@ with open(output_path, "w") as f:
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
         asset_sync_class_worker: EC2InstanceWorker,
+        asset_sync_worker_config: DeadlineWorkerConfiguration,
         test_runner_identity: dict[str, str],
     ) -> None:
         """
@@ -1742,6 +1859,13 @@ with open(output_path, "w") as f:
             "totalSize": len(file1_content),
         }
 
+        asset_sync_feature = (
+            asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
+            if asset_sync_worker_config.worker_env_var
+            else "False"
+        )
+        job_name = f"{asset_sync_feature}_empty-outputRelativeDirectories-test-{os.environ['OPERATING_SYSTEM']}"
+
         # Upload manifests
         s3.put_object(
             Bucket=s3_bucket,
@@ -1753,7 +1877,7 @@ with open(output_path, "w") as f:
         # Create and submit job using boto3 directly
         template = {
             "specificationVersion": "jobtemplate-2023-09",
-            "name": f"empty-outputRelativeDirectories-test-{os.environ['OPERATING_SYSTEM']}",
+            "name": job_name,
             "parameterDefinitions": [
                 {
                     "name": "AssetPath",

--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -176,7 +176,7 @@ class TestJobAttachments:
             if asset_sync_worker_config.worker_env_var
             else "False"
         )
-        job_name = f"{asset_sync_feature}_StorageProfilePathMappingJob"
+        job_name = f"StorageProfilePathMappingJob[asset_sync_feature={asset_sync_feature}]"
 
         # Create and submit job using boto3 directly
         template = {
@@ -333,7 +333,7 @@ if __name__ == "__main__":
             if asset_sync_worker_config.worker_env_var
             else "False"
         )
-        job_name = f"{asset_sync_feature}_AppendStringJob"
+        job_name = f"AppendStringJob[asset_sync_feature={asset_sync_feature}]"
 
         try:
             with open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file:
@@ -480,7 +480,7 @@ if __name__ == "__main__":
                     if asset_sync_worker_config.worker_env_var
                     else "False"
                 )
-                job_name = f"{asset_sync_feature}_NoOutputJob"
+                job_name = f"NoOutputJob[asset_sync_feature={asset_sync_feature}]"
 
                 template_file.write(
                     json.dumps(
@@ -580,7 +580,7 @@ if __name__ == "__main__":
         job_parameters: List[Dict[str, str]] = [
             {
                 "name": "JobName",
-                "value": f"{asset_sync_feature}_Step-Step Dataflow Linux_{file_system}",
+                "value": f"Step-Step Dataflow Linux_{file_system}[asset_sync_feature={asset_sync_feature}]",
             },
             {
                 "name": "AssetSync",
@@ -652,7 +652,7 @@ if __name__ == "__main__":
         job_parameters: List[Dict[str, str]] = [
             {
                 "name": "JobName",
-                "value": f"{asset_sync_feature}_Step-Step Dataflow Win",
+                "value": f"Step-Step Dataflow Win[asset_sync_feature={asset_sync_feature}]",
             },
         ]
 
@@ -726,7 +726,7 @@ if __name__ == "__main__":
             if asset_sync_worker_config.worker_env_var
             else "False"
         )
-        job_name = f"{asset_sync_feature}_JobAttachmentToNonValidRoleQueue"
+        job_name = f"JobAttachmentToNonValidRoleQueue[asset_sync_feature={asset_sync_feature}]"
 
         try:
             with open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file:
@@ -914,7 +914,7 @@ if __name__ == "__main__":
             if asset_sync_worker_config.worker_env_var
             else "False"
         )
-        job_name = f"{asset_sync_feature}_AssetsSync"
+        job_name = f"AssetsSync[asset_sync_feature={asset_sync_feature}]"
 
         with open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file:
             template_file.write(
@@ -1085,7 +1085,7 @@ if __name__ == "__main__":
             if asset_sync_worker_config.worker_env_var
             else "False"
         )
-        job_name = f"{asset_sync_feature}_StepDependencyJob"
+        job_name = f"StepDependencyJob[asset_sync_feature={asset_sync_feature}]"
 
         # Create a template that uses step-step dependencies, appending the word "Hello" to the input file once in each step
         with open(os.path.join(job_bundle_path, "template.json"), "w+") as template_file:
@@ -1247,7 +1247,7 @@ if __name__ == "__main__":
             if asset_sync_worker_config.worker_env_var
             else "False"
         )
-        job_name = f"{asset_sync_feature}_JobAttachmentThatGetsDeleted"
+        job_name = f"JobAttachmentThatGetsDeleted[asset_sync_feature={asset_sync_feature}]"
 
         with open(
             os.path.join(job_bundle_path, "parameter_values.json"), "w+"
@@ -1424,7 +1424,7 @@ if __name__ == "__main__":
         # Submit another job and verify that the worker still works properly and finishes the job
 
         sleep_job = submit_sleep_job(
-            f"{asset_sync_feature}_Success Sleep Job after syncInputJobAttachments fail",
+            f"Success Sleep Job after syncInputJobAttachments fail[asset_sync_feature={asset_sync_feature}]",
             deadline_client,
             deadline_resources.farm,
             queue_to_use,
@@ -1466,7 +1466,7 @@ with open(output_path, "w") as f:
             if asset_sync_worker_config.worker_env_var
             else "False"
         )
-        job_name = f"{asset_sync_feature}_Test Job with Job Attachments and Embedded Files"
+        job_name = f"JA and Embedded Files[asset_sync_feature={asset_sync_feature}]"
 
         # Create input file for job attachments
         input_file = os.path.join(job_bundle_path, "input.txt")
@@ -1639,7 +1639,10 @@ with open(output_path, "w") as f:
             bundle_path=job_bundle_path,
             max_retries_per_task=0,
             job_parameters=[
-                {"name": "JobName", "value": f"{asset_sync_feature}_Output Sync No Input Job"},
+                {
+                    "name": "JobName",
+                    "value": f"Output Sync No Input Job[asset_sync_feature={asset_sync_feature}]",
+                },
                 {"name": "FilesPerTask", "value": "1"},
                 {"name": "Tasks", "value": "1-5"},
                 {"name": "FileSize", "value": "50"},
@@ -1707,7 +1710,7 @@ with open(output_path, "w") as f:
             queue=deadline_resources.queue_a,
             debug_snapshot_dir=job_bundle_path,
             storage_profile=True,
-            job_name=f"{asset_sync_feature}_Complex Manifest Test",
+            job_name=f"Complex Manifest Test[asset_sync_feature={asset_sync_feature}]",
         )
 
         job.wait_until_complete(client=deadline_client)
@@ -1777,7 +1780,7 @@ with open(output_path, "w") as f:
             queue=deadline_resources.queue_a,
             debug_snapshot_dir=job_bundle_path,
             storage_profile=False,
-            job_name=f"{asset_sync_feature}_Complex Manifest Test",
+            job_name=f"Complex Manifest Test[asset_sync_feature={asset_sync_feature}]",
         )
 
         LOG.info(f"Job {job.id} submitted in {time.perf_counter() - submit_start_time:.2f} seconds")
@@ -1864,7 +1867,7 @@ with open(output_path, "w") as f:
             if asset_sync_worker_config.worker_env_var
             else "False"
         )
-        job_name = f"{asset_sync_feature}_empty-outputRelativeDirectories-test-{os.environ['OPERATING_SYSTEM']}"
+        job_name = f"empty-outputRelativeDirectories-test-{os.environ['OPERATING_SYSTEM']}[asset_sync_feature={asset_sync_feature}]"
 
         # Upload manifests
         s3.put_object(

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -395,6 +395,7 @@ def submit_job_from_create_job_API(
     queue: Queue,
     debug_snapshot_dir: str,
     storage_profile: bool = False,
+    job_name: Optional[str] = None,
 ) -> Job:
     """Submit a job using the Deadline create job API.
 
@@ -446,6 +447,10 @@ def submit_job_from_create_job_API(
     # Load parameters file
     with open(f"{debug_snapshot_dir}/parameters_param.json", "r") as f:
         parameters = json.load(f)
+
+    # Override job name if provided
+    if job_name is not None:
+        parameters["JobName"] = {"string": job_name}
 
     create_job_kwargs = {
         "farmId": farm.id,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
E2E test jobs were using generic, hard-coded names that made it difficult to identify which specific test case or configuration was being tested when looking at job execution logs or debugging test failures. This lack of descriptive naming hindered troubleshooting and test result analysis.

### What was the solution? (How)
- Added dynamic job naming that includes the asset sync feature flag value (e.g., "True_StorageProfilePathMappingJob" or "False_AppendStringJob")
- Extracted asset sync feature configuration into a reusable pattern across all test methods
- Made job template names parameterizable by adding JobName parameter definitions

### What is the impact of this change
- Better visibility and debuggability via DCM.
- Help to gather job data for analysis.

### How was this change tested?

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*