### PR TITLE
test: add dependency to enforce deployment order in e2e testing infrastructure

### DIFF
--- a/scripts/e2e_testing_infrastructure.yaml
+++ b/scripts/e2e_testing_infrastructure.yaml
@@ -831,6 +831,14 @@ Resources:
             VCpuCount:
               Min: 2
               Max: 4
+    DependsOn:
+      # When adding storage profile to a fleet,
+      # all queues associated with the fleet need to be updated to allow it first.
+      # The order has to be reversed when removing the storage profile from fleet.
+      - MainQueue
+      - SecondaryQueue
+      - JobsRunAsAgentUserQueue
+      - NonValidRoleQueue
 
   LinuxAutoScalingFleetx86:
     Type: AWS::Deadline::Fleet
@@ -874,6 +882,14 @@ Resources:
             VCpuCount:
               Min: 2
               Max: 4
+    DependsOn:
+      # When adding storage profile to a fleet,
+      # all queues associated with the fleet need to be updated to allow it first.
+      # The order has to be reversed when removing the storage profile from fleet.
+      - MainQueue
+      - SecondaryQueue
+      - JobsRunAsAgentUserQueue
+      - NonValidRoleQueue
 
   WindowsAutoScalingFleetx86:
     Type: AWS::Deadline::Fleet


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Deployment could fail due to the order for storage profile update.

```
Resource handler returned message: "StorageProfile sp-XXX not allowed in queue queue-XXX (Service: Deadline, Status Code: 400, Request ID: 39eb73af-9ada-4edf-bbb0-6ad344f01041) (SDK Attempt Count: 1)" (RequestToken: 5f4dc636-2385-8879-0789-0cf0bb2a2297, HandlerErrorCode: InvalidRequest)
```

### What was the solution? (How)
For adding SP to a Fleet with QFAs, which is addressed by this PR
1. Make sure the SP is added to `AllowedStorageProfileIds` for all Queues the Fleet is associated with
2. Update the Fleet to add `StorageProfileId`

For removing SP from a Fleet with QFAs
1. Update the Fleet to remove `StorageProfileId`
2. Remove the SP From `AllowedStorageProfileIds` in all Queues that associated with the Fleet.

### What is the impact of this change?
Fix the deployment failure.

### How was this change tested?
`scripts/deploy_e2e_testing_infrastructure.sh`

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*