### PR TITLE
test: add ability to output thread stack traces after e2e tests finish

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -128,3 +128,11 @@ hatch run e2e-test
 source .e2e_windows_infra.sh
 hatch run e2e-test
 ```
+
+#### Debugging Pytest Hanging
+
+Sometimes you may encounter an issue where the tests complete, but pytest hangs and does not exit.
+This could happen if the test code or the code-under-test creates a Python thread that does not exit.
+There are two pytest hooks `pytest_unconfigure` and `pytest_sessionfinish` that have been
+instrumented with debug tooling for this situation. To use this, set the `DEBUG_THREAD_STACKS`
+environment variable before running the end-to-end tests.

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,29 +1,30 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-import boto3
 import dataclasses
 import logging
 import os
-import pytest
-
-from dataclasses import dataclass, field, InitVar
-from typing import Callable, Generator, Type
+import sys
+import traceback
+from collections.abc import Generator
 from contextlib import contextmanager
+from dataclasses import InitVar, dataclass, field
+from typing import Callable, Type
 
+import boto3
+import pytest
 from deadline_test_fixtures import (
+    BootstrapResources,
     DeadlineWorker,
     DeadlineWorkerConfiguration,
     DockerContainerWorker,
+    EC2InstanceWorker,
+    Ec2Tag,
     Farm,
     Fleet,
-    Queue,
-    EC2InstanceWorker,
-    BootstrapResources,
-    PosixSessionUser,
     OperatingSystem,
-    Ec2Tag,
+    PosixSessionUser,
+    Queue,
 )
-import pytest
 
 LOG = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ class DeadlineResources:
 
 
 @pytest.fixture(scope="session")
-def deadline_resources() -> Generator[DeadlineResources, None, None]:
+def deadline_resources() -> DeadlineResources:
     """
     Gets Deadline resources required for running tests.
 
@@ -143,7 +144,7 @@ def deadline_resources() -> Generator[DeadlineResources, None, None]:
     response = sts_client.get_caller_identity()
     LOG.info("Running tests with credentials from: %s" % response.get("Arn"))
 
-    yield DeadlineResources(
+    return DeadlineResources(
         farm_id=farm_id,
         queue_a_id=queue_a_id,
         queue_b_id=queue_b_id,
@@ -501,3 +502,36 @@ def pytest_collection_modifyitems(items):
     sorted_list.extend(session_worker_tests)
 
     items[:] = sorted_list
+
+
+def _output_thread_stack_traces() -> None:
+    print("\n*** THREAD STACKTRACE - START ***\n", file=sys.stderr)
+
+    for threadId, stack in sys._current_frames().items():
+        print(f"\n{'=' * 60}", file=sys.stderr)
+        print(f"ThreadID: {threadId}", file=sys.stderr)
+        print(f"{'=' * 60}", file=sys.stderr)
+
+        for filename, lineno, name, line in traceback.extract_stack(stack):
+            print(f'File: "{filename}", line {lineno}, in {name}', file=sys.stderr)
+            if line:
+                print(f"  {line.strip()}", file=sys.stderr)
+        print("", file=sys.stderr)
+
+    print("\n*** THREAD STACKTRACE - END ***\n", file=sys.stderr)
+
+
+def pytest_unconfigure(config):
+    """Pytest hook that runs at the end of the test session to output thread stack traces."""
+    if not os.getenv("DEBUG_THREAD_STACKS"):
+        return
+
+    _output_thread_stack_traces()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Pytest hook that runs at the end of the test session to output thread stack traces."""
+    if not os.getenv("DEBUG_THREAD_STACKS"):
+        return
+
+    _output_thread_stack_traces()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent end-to-end tests sometimes hang and the `pytest` process does not exit. The last output from the process is the pytest summary, for example:

```txt
=========== 44 passed, 18 skipped, 2 warnings in 5492.08s (1:31:32) ============
```

It has proven difficult to reproduce this issue, so we would like to instrument some debugging code to help confirm our current hypothesis which is that a non-daemon Python thread is left running. The CPython interpreter will not exit the process until all non-daemon Threads have exited ([docs](https://docs.python.org/3/library/threading.html#thread-objects)):

>   A thread can be flagged as a “daemon thread”. The significance of this flag is that the entire Python program exits when only daemon threads are left.

### What was the solution? (How)

Add two pytest hooks:

*   (`pytest_unconfigure` / [docs](https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_unconfigure)):
    >   Called before test process is exited.
*   (`pytest_sessionfinish` / [docs](https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_sessionfinish)):
    >   Called after whole test run finished, right before returning the exit status to the system.

These hooks checks for an environment variable (`DEBUG_THREAD_STACKS`) and if set, it will output a stack trace for all threads.

We use two hooks to catch threads at different points in the test life-cycle. Once when the session is ending and once before the program is exiting. I suspect that having both hooks will be beneficial to get snapshots of the thread stack traces at each point in the pytest lifecycle. The `pytest_sessionfinish` runs earlier in the life-cycle before the pytest test summary report is output. The `pytest_unconfigure` hook seems to happen later in the life-cycle.

### What is the impact of this change?

This debugging flag can be used to identify what Python threads are running and their stack traces to help identify runaway threads.

### How was this change tested?

Created a temporary no-op test an ran it:

<details>
<summary>Example run:</summary>

```sh
cmd [1] | pytest --no-cov test/e2e -k test_noop
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.13.5, pytest-8.4.2, pluggy-1.6.0
rootdir: /local/home/usiskin/bea/bealine-clients/wa_e2e_thread_stack_debug
configfile: pyproject.toml
plugins: xdist-3.8.0, cov-7.0.0, deadline-cloud-test-fixtures-0.18.7, flaky-3.8.1, timeout-2.4.0
collected 80 items / 79 deselected / 1 selected

test/e2e/test_noop.py::test_noop PASSED                                                                                                                                                                                             [100%]
*** THREAD STACKTRACE - START ***


============================================================
ThreadID: 139747944843072
============================================================
File: "/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/bin/pytest", line 10, in <module>
  sys.exit(console_main())
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/_pytest/config/__init__.py", line 201, in console_main
  code = main()
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/_pytest/config/__init__.py", line 175, in main
  ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_hooks.py", line 512, in __call__
  return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
  return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
  res = hook_impl.function(*args)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/_pytest/main.py", line 336, in pytest_cmdline_main
  return wrap_session(config, _main)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/_pytest/main.py", line 324, in wrap_session
  config.hook.pytest_sessionfinish(
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_hooks.py", line 512, in __call__
  return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
  return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
  res = hook_impl.function(*args)
File: "/local/home/usiskin/bea/bealine-clients/wa_e2e_thread_stack_debug/test/e2e/conftest.py", line 537, in pytest_sessionfinish
  _output_thread_stack_traces()
File: "/local/home/usiskin/bea/bealine-clients/wa_e2e_thread_stack_debug/test/e2e/conftest.py", line 515, in _output_thread_stack_traces
  for filename, lineno, name, line in traceback.extract_stack(stack):


*** THREAD STACKTRACE - END ***



============================================================================================================ warnings summary =============================================================================================================
../../../.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/xdist/plugin.py:289
  /local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/xdist/plugin.py:289: DeprecationWarning: The --looponfail command line argument and looponfailroots config variable are deprecated.
  The loop-on-fail feature will be removed in pytest-xdist 4.0.
    config.issue_config_time_warning(warning, 2)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================== slowest 5 durations ===========================================================================================================

(3 durations < 0.005s hidden.  Use -vv to show these durations.)
=============================================================================================== 1 passed, 79 deselected, 1 warning in 0.16s ===============================================================================================

*** THREAD STACKTRACE - START ***


============================================================
ThreadID: 139747944843072
============================================================
File: "/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/bin/pytest", line 10, in <module>
  sys.exit(console_main())
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/_pytest/config/__init__.py", line 201, in console_main
  code = main()
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/_pytest/config/__init__.py", line 175, in main
  ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_hooks.py", line 512, in __call__
  return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
  return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
  res = hook_impl.function(*args)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/_pytest/main.py", line 336, in pytest_cmdline_main
  return wrap_session(config, _main)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/_pytest/main.py", line 331, in wrap_session
  config._ensure_unconfigure()
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/_pytest/config/__init__.py", line 1126, in _ensure_unconfigure
  self.hook.pytest_unconfigure(config=self)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_hooks.py", line 512, in __call__
  return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
  return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
File: "/local/home/usiskin/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/5SQRcFyR/deadline-cloud-worker-agent/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
  res = hook_impl.function(*args)
File: "/local/home/usiskin/bea/bealine-clients/wa_e2e_thread_stack_debug/test/e2e/conftest.py", line 529, in pytest_unconfigure
  _output_thread_stack_traces()
File: "/local/home/usiskin/bea/bealine-clients/wa_e2e_thread_stack_debug/test/e2e/conftest.py", line 515, in _output_thread_stack_traces
  for filename, lineno, name, line in traceback.extract_stack(stack):


*** THREAD STACKTRACE - END ***

cmd [2] | echo pytest done
pytest done
```
</details>

### Was this change documented?

Yes, I have updated `DEVELOPMENT.md` to document this new debug tooling.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*