### PR TITLE
test: shutdown s3transfer TransferManager instances to join threads keeping process open

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -4,14 +4,23 @@ import dataclasses
 import logging
 import os
 import sys
+import threading
 import traceback
 from collections.abc import Generator
+from configparser import ConfigParser
 from contextlib import contextmanager
 from dataclasses import InitVar, dataclass, field
 from typing import Callable, Type
 
 import boto3
 import pytest
+from botocore.client import BaseClient
+from deadline.client.api import (
+    get_boto3_client,
+    get_queue_user_boto3_session,
+)
+from deadline.client.config import set_setting as set_deadline_setting
+from deadline.job_attachments._aws.aws_clients import get_s3_client, get_s3_transfer_manager
 from deadline_test_fixtures import (
     BootstrapResources,
     DeadlineWorker,
@@ -87,8 +96,34 @@ class DeadlineResources:
         object.__setattr__(self, "queue_a_job_storage_profile_id", job_storage_profile_id)
 
 
+def _shutdown_s3_transfer_manager(
+    s3_client: BaseClient,
+    desc: str,
+) -> None:
+    """
+    The s3transfer.manager.TransferManager maintains concurrent.futures.Exeuctor instance (by
+    default a ThreadPoolExecutor) which needs to be shut down. The deadline library maintains an
+    lru_cache mapping s3 client -> TransferManager, so these instances are long-lived for the life
+    of the Python process.
+
+    This helper method will obtain the TransferManager instance mapped to a s3 client instance and
+    shut it down.
+
+    Parameters:
+        s3_client: The boto3 s3 client instance to use to lookup the TransferManager instance
+        desc: A description for the shutdown context
+    """
+    num_threads_before = threading.active_count()
+    s3_transfer_manager = get_s3_transfer_manager(s3_client)
+    LOG.info(f"Shutting down S3 Transfer Manager: {desc}")
+    s3_transfer_manager.shutdown()
+    num_threads_after = threading.active_count()
+    num_threads_joined = num_threads_before - num_threads_after
+    LOG.info(f"Shut down S3 Transfer Manager: {desc} (num threads joined: {num_threads_joined})")
+
+
 @pytest.fixture(scope="session")
-def deadline_resources() -> DeadlineResources:
+def deadline_resources() -> Generator[DeadlineResources, None, None]:
     """
     Gets Deadline resources required for running tests.
 
@@ -144,7 +179,7 @@ def deadline_resources() -> DeadlineResources:
     response = sts_client.get_caller_identity()
     LOG.info("Running tests with credentials from: %s" % response.get("Arn"))
 
-    return DeadlineResources(
+    yield DeadlineResources(
         farm_id=farm_id,
         queue_a_id=queue_a_id,
         queue_b_id=queue_b_id,
@@ -157,6 +192,47 @@ def deadline_resources() -> DeadlineResources:
         windows_job_storage_profile_id=windows_job_storage_profile_id,
         fleet_storage_profile_id=fleet_storage_profile_id,
         windows_fleet_storage_profile_id=windows_fleet_storage_profile_id,
+    )
+
+    # HACK: Cleanup the s3transfer.manager.TransferManager instances that are held in lru_cache.
+    # Each one maintains a concurrent.futures.ThreadPoolExecutor instance which contains a pool
+    # of threads. This must be explicitly shutdown since the threads are non-daemon and will keep
+    # the Python process open.
+    config = ConfigParser()
+    set_deadline_setting("defaults.farm_id", farm_id, config)
+    deadline = get_boto3_client("deadline", config=config)
+
+    # For job attachment upload, deadline Python library assumes the role of the queue like below to
+    # create a s3 boto client. Only the queues below use the deadline Python library to submit jobs
+    queues_to_shutdown = (
+        ("queue_a", queue_a_id),
+        ("non_valid_role_queue_id", non_valid_role_queue_id),
+    )
+    for queue_label, queue_id in queues_to_shutdown:
+        set_deadline_setting("defaults.queue_id", queue_id, config)
+        queue = deadline.get_queue(
+            farmId=farm_id,
+            queueId=queue_id,
+        )
+        queue_role_session = get_queue_user_boto3_session(
+            deadline=deadline,
+            config=config,
+            farm_id=farm_id,
+            queue_id=queue_id,
+            queue_display_name=queue["displayName"],
+        )
+        queue_s3_client = get_s3_client(queue_role_session)
+        _shutdown_s3_transfer_manager(
+            s3_client=queue_s3_client,
+            desc=f"for queue {queue_label} ({queue_id})",
+        )
+
+    # The wait_for_job_output function in e2e.utils does not provide a session, so the default
+    # s3 client is used like below
+    default_s3_client = get_s3_client()
+    _shutdown_s3_transfer_manager(
+        s3_client=default_s3_client,
+        desc="for the default s3 client",
     )
 
 

--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -1240,7 +1240,7 @@ if __name__ == "__main__":
             {"name": "DataDir", "value": job_bundle_path},
         ]
 
-        queue_to_use = deadline_resources.queue_a
+        queue_a = deadline_resources.queue_a
 
         asset_sync_feature = (
             asset_sync_worker_config.worker_env_var.get(self.ASSET_SYNC_JOB_USER_FEATURE, "False")
@@ -1297,7 +1297,7 @@ if __name__ == "__main__":
 
         config = configparser.ConfigParser()
         set_setting("defaults.farm_id", deadline_resources.farm.id, config)
-        set_setting("defaults.queue_id", queue_to_use.id, config)
+        set_setting("defaults.queue_id", queue_a.id, config)
         job_id: Optional[str] = api.create_job_from_job_bundle(
             job_bundle_path,
             job_parameters,
@@ -1311,7 +1311,7 @@ if __name__ == "__main__":
         job_details = Job.get_job_details(
             client=deadline_client,
             farm=deadline_resources.farm,
-            queue=queue_to_use,
+            queue=queue_a,
             job_id=job_id,
         )
 
@@ -1330,7 +1330,7 @@ if __name__ == "__main__":
         # Find the input manifest
         queue_job_attachment_settings: dict[str, Any] = deadline_client.get_queue(
             farmId=deadline_resources.farm.id,
-            queueId=queue_to_use.id,
+            queueId=queue_a.id,
         )["jobAttachmentSettings"]
 
         job_attachments_bucket_name: str = queue_job_attachment_settings["s3BucketName"]
@@ -1367,7 +1367,7 @@ if __name__ == "__main__":
         deadline_client.update_job(
             farmId=deadline_resources.farm.id,
             jobId=job_id,
-            queueId=queue_to_use.id,
+            queueId=queue_a.id,
             targetTaskRunStatus="READY",
         )
 
@@ -1427,7 +1427,7 @@ if __name__ == "__main__":
             f"Success Sleep Job after syncInputJobAttachments fail[asset_sync_feature={asset_sync_feature}]",
             deadline_client,
             deadline_resources.farm,
-            queue_to_use,
+            queue_a,
         )
 
         sleep_job.wait_until_complete(client=deadline_client)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Continuation of #820

>   The worker agent end-to-end tests sometimes hang and the `pytest` process does not exit. The last output from the process is the pytest summary, for example:
>   
>   ```txt
>   =========== 44 passed, 18 skipped, 2 warnings in 5492.08s (1:31:32) ============
>   ```

After encountering another occurrence where pytest did not exit with the thread stack trace debug output, I made the following discovery. There are 12 threads with the same stack trace

```txt
File: "/root/.pyenv/versions/3.11.14/lib/python3.11/threading.py", line 1002, in _bootstrap
  self._bootstrap_inner()
File: "/root/.pyenv/versions/3.11.14/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
  self.run()
File: "/root/.pyenv/versions/3.11.14/lib/python3.11/threading.py", line 982, in run
  self._target(*self._args, **self._kwargs)
File: "/root/.pyenv/versions/3.11.14/lib/python3.11/concurrent/futures/thread.py", line 81, in _worker
  work_item = work_queue.get(block=True)
```

These appear to be threads that belong to a `concurrent.futures.ThreadPoolExecutor`([source](https://github.com/python/cpython/blob/3.11/Lib/concurrent/futures/thread.py#L81)) blocked waiting for work. After some code diving, I think I may have figured out where the thread pool is being created.

1.  The `deadline.job_attachments` python package has a [`get_s3_transfer manager` function](https://github.com/aws-deadline/deadline-cloud/blob/8f5f29bfc71eac1ccd595a2e26714c067957c587/src/deadline/job_attachments/_aws/aws_clients.py#L106-L108) which [uses `boto3.s3.transfer.create_transfer_manager`](https://github.com/aws-deadline/deadline-cloud/blob/8f5f29bfc71eac1ccd595a2e26714c067957c587/src/deadline/job_attachments/_aws/aws_clients.py#L12).
2.  The `boto3.s3.transfer.create_transfer_manager` [instantiates a `s3transfer.manager.TransferManager` class](https://github.com/boto/boto3/blob/759c68d48613bd931702de6f135e51ae355173f9/boto3/s3/transfer.py#L230)
3.  The `s3transfer.manager.TransferManager` class [docstring](https://github.com/boto/s3transfer/blob/1461069ce3cd9bd57b45a027cd9505d93f5deb9d/s3transfer/manager.py#L232C58-L243) states that it uses a `ThreadPoolExecutor`

The `s3transfer.manager.TransferManager` class can be used as a context manager ([code](https://github.com/boto/s3transfer/blob/1461069ce3cd9bd57b45a027cd9505d93f5deb9d/s3transfer/manager.py#L613-L628)) and has a [`shutdown()` method](https://github.com/boto/s3transfer/blob/1461069ce3cd9bd57b45a027cd9505d93f5deb9d/s3transfer/manager.py#L630-L645) which appears to shutdown the executors ([code](https://github.com/boto/s3transfer/blob/1461069ce3cd9bd57b45a027cd9505d93f5deb9d/s3transfer/manager.py#L666-L669)).

### What was the solution? (How)

In the long term, we will need to make a changes to `deadline.job_attachments` to provide means to shutdown the transfer managers properly. Currently, the `get_s3_transfer_manager` class is wrapped with `functools.lru_cache`, and getting access to them as a consumer of the library requires using private APIs.

For now to prevent automated tests from getting stuck not exiting, I'm adding some cleanup code that uses the necessary private APIs of `deadline` to get a reference to the `TransferManager` class and shut it down when the tests are cleaning up. I've instrumented this in the `deadline_resources` fixture teardown since the cleanup code requires access to the queue IDs that the tests submitted jobs to using the `deadline` Python APIs.

### What is the impact of this change?

There is less chance of pytest hanging due to un-joined threads. The thread stack traces do not indicate how the thread pools were created, but I identified these cases of un-joiend thread pools that should help reduce the problem.

### How was this change tested?

Ran the e2e tests locally and confirmed they succeeded

### Was this change documented?

*   Code comments were added
*   aws-deadline/deadline-cloud#928 &mdash; created an upstream issue

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*