### PR TITLE
test: Bump timeout for Step-Step Dataflow test

### DIFF
--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -598,7 +598,7 @@ if __name__ == "__main__":
             job_parameters=job_parameters,
         )
 
-        job.wait_until_complete(client=deadline_client)
+        job.wait_until_complete(client=deadline_client, max_retries=42)
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
         # Validate S3 setup and manifest integrity


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have an E2E test that failed because the timeout was not long enough to account for auto-scaling fluctuations.

### What was the solution? (How)
Bump the timeout in question to 7 minutes (average test time + 5 minute grace period).

The default interval for `wait_until_complete` is 10 seconds, so 42 retries gives 7 minutes before timing out.

### What is the impact of this change?
Slightly more reliable E2E tests

### How was this change tested?
n/a

### Was this change documented?
n/a

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*