### PR TITLE
chore: add names to threads for debugging

### DIFF
--- a/src/deadline_worker_agent/aws_credentials/credentials_refresher.py
+++ b/src/deadline_worker_agent/aws_credentials/credentials_refresher.py
@@ -145,6 +145,7 @@ class AwsCredentialsRefresher:
             refresh_in = timedelta(minutes=1)
 
         self._timer = Timer(refresh_in.total_seconds(), self._refresh)
+        self._timer.name = f"AwsCredentialsRefresher({self._resource['resource']})"
         self._timer.start()
         _logger.info(
             AwsCredentialsLogEvent(

--- a/src/deadline_worker_agent/log_sync/cloudwatch.py
+++ b/src/deadline_worker_agent/log_sync/cloudwatch.py
@@ -419,6 +419,8 @@ class CloudWatchLogStreamThread(Thread):
         self._log_stream_name = log_stream_name
         self._stop_event = stop_event
         self._prev_request_times: Deque[float] = deque()
+        if "name" not in kwargs:  # pragma: no cover
+            kwargs["name"] = f"CloudWatchLogStreamThread({log_group_name}-{log_stream_name})"
 
         super().__init__(*args, **kwargs)
 

--- a/src/deadline_worker_agent/metrics.py
+++ b/src/deadline_worker_agent/metrics.py
@@ -206,4 +206,5 @@ class HostMetricsLogger:
             interval_s (float): The interval in seconds to print the host metrics at.
         """
         self._timer = Timer(self.interval_s, self.log_metrics)
+        self._timer.name = "HostMetricsLogger"
         self._timer.start()

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -233,7 +233,10 @@ class WorkerScheduler:
             If the value is None, then no local session logs will be written.
         """
         self._deadline = deadline
-        self._executor = ThreadPoolExecutor(max_workers=100)
+        self._executor = ThreadPoolExecutor(
+            max_workers=100,
+            thread_name_prefix="WorkerSchedulerSessions",
+        )
         self._sessions = SessionMap(cleanup_session_user_processes=cleanup_session_user_processes)
         self._wakeup = Event()
         self._shutdown = stop or Event()
@@ -487,6 +490,7 @@ class WorkerScheduler:
         # fast to get to transitioning to STOPPED state after this.
         timeout_event = Event()
         timer = Timer(interval=timeout.total_seconds(), function=timeout_event.set)
+        timer.name = "UpdateWorkerStoppingTimeout"
 
         try:
             update_worker(

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -221,7 +221,10 @@ class Session:
         self._job_details = job_details
         self._report_action_update = action_update_callback
         self._env = env
-        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=id,
+        )
         self._worker_manifest_properties_by_local_root: dict[str, WorkerManifestProperties] = {}
 
         def openjd_session_action_callback(session_id: str, action_status: ActionStatus) -> None:
@@ -418,8 +421,7 @@ class Session:
         This code will loop until Session.stop() is called from another thread.
         """
 
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            self._executor = executor
+        with self._executor:
             while not self._stop.wait(timeout=0.1):
                 # Start session action if needed
                 with (

--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -98,7 +98,10 @@ class Worker:
         self._deadline_client = deadline_client
         self._s3_client = s3_client
         self._logs_client = logs_client
-        self._executor = ThreadPoolExecutor(max_workers=3)
+        self._executor = ThreadPoolExecutor(
+            max_workers=3,
+            thread_name_prefix="Worker",
+        )
         self._farm_id = farm_id
         self._fleet_id = fleet_id
         self._worker_id = worker_id


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent uses Python threads, but does not assign names to them. This can make it more challenging to debug threading issues.

### What was the solution? (How)

Add names to threads.

### What is the impact of this change?

Threads be can more easily identified using tools like `py-spy` when debugging threading issues in the worker agent.

### How was this change tested?

Turned off `pytest-xdist` and ran the worker agent unit tests - which uncovers an issue where there is a `threading.Timer` being continuously created and blocking `pytest` from exiting. Then ran `py-spy --pid $(pgrep pytest)` to get:

```shtxt
Thread 22092 (idle): "MainThread"
    _shutdown (threading.py:1542)
Thread 23066 (idle): "HostMetricsLogger"
    wait (threading.py:363)
    wait (threading.py:659)
    run (threading.py:1342)
    _bootstrap_inner (threading.py:1043)
    _bootstrap (threading.py:1014)
```

As can be seen, the `HostMetricslogger` thread name is shown.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*