### PR TITLE
test: increased test_cap_kill_not_inherited_by_running_jobs timeout

### DIFF
--- a/test/e2e/test_cap_kill.py
+++ b/test/e2e/test_cap_kill.py
@@ -102,7 +102,7 @@ def test_cap_kill_not_inherited_by_running_jobs(
                                     "term",
                                     str(sleep_job_in_bg_pid),
                                 ],
-                                "timeout": 1,  # Times out in 1 second
+                                "timeout": 5,  # Times out in 5 seconds
                                 "cancelation": {
                                     "mode": "NOTIFY_THEN_TERMINATE",
                                     "notifyPeriodInSeconds": 1,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We're seeing some actions fail as a result of this test timing out. 

Example: https://github.com/aws-deadline/deadline-cloud-worker-agent/actions/runs/19832538864/job/56821921561 

### What was the solution? (How)

Increased the timeout of the command.

### What is the impact of this change?

Fewer inconsistent tests.

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*