### PR TITLE
test: increased test_cap_kill_not_inherited_by_running_jobs timeout (#838)

### DIFF
--- a/test/e2e/test_cap_kill.py
+++ b/test/e2e/test_cap_kill.py
@@ -102,7 +102,7 @@ def test_cap_kill_not_inherited_by_running_jobs(
                                     "term",
                                     str(sleep_job_in_bg_pid),
                                 ],
-                                "timeout": 1,  # Times out in 1 second
+                                "timeout": 5,  # Times out in 5 seconds
                                 "cancelation": {
                                     "mode": "NOTIFY_THEN_TERMINATE",
                                     "notifyPeriodInSeconds": 1,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We've been getting failures in the canary workflow due to this timeout being too short.  

### What was the solution? (How)

Cherry picking the already merged commit from mainline to the release branch.
Original PR: https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/838

### What is the impact of this change?

Mitigates failed canary workflows. 

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*