### PR TITLE
chore: Update openjd-sessions to 0.10.6.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline >= 0.53.1,< 0.54",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.10.5",
+    "openjd-sessions == 0.10.6",
     "openjd-model >= 0.8.1, < 0.9",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

New release of OpenJD Sessions is ready to be used.

### What was the solution? (How)

Updated OpenJD Sessions dependency to new 0.10.6 release.

### What is the impact of this change?

Staying up to date with our deps.

### How was this change tested?

Ran `hatch run all:test` locally.

### Was this change documented?

No

### Is this a breaking change?

No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*