### PR TITLE
feat: add telemetry event on what filesystem is used

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -835,7 +835,7 @@ def record_uncaught_exception_telemetry_event(exception_type: str) -> None:
     )
 
 
-def record_asset_sync_filesystem_event(queue_id: str, file_system: str) -> None:
+def _record_asset_sync_filesystem_event(queue_id: str, file_system: str) -> None:
     """Calls the telemetry client to record what filesystem was used"""
     details: Dict[str, Any] = {"queue_id": queue_id, "filesystem": file_system}
     _get_deadline_telemetry_client().record_event(

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -835,11 +835,11 @@ def record_uncaught_exception_telemetry_event(exception_type: str) -> None:
     )
 
 
-def _record_asset_sync_filesystem_event(queue_id: str, file_system: str) -> None:
+def _record_attachment_download_filesystem_event(queue_id: str, file_system: str) -> None:
     """Calls the telemetry client to record what filesystem was used"""
     details: Dict[str, Any] = {"queue_id": queue_id, "filesystem": file_system}
     _get_deadline_telemetry_client().record_event(
-        event_type="com.amazon.rum.deadline.worker_agent.sync_inputs_filesystem",
+        event_type="com.amazon.rum.deadline.worker_agent.attachment_download_filesystem",
         event_details=details,
     )
 

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -835,6 +835,15 @@ def record_uncaught_exception_telemetry_event(exception_type: str) -> None:
     )
 
 
+def record_asset_sync_filesystem_event(queue_id: str, file_system: str) -> None:
+    """Calls the telemetry client to record what filesystem was used"""
+    details: Dict[str, Any] = {"queue_id": queue_id, "filesystem": file_system}
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.sync_inputs_filesystem",
+        event_details=details,
+    )
+
+
 def record_sync_inputs_telemetry_event(queue_id: str, summary: SummaryStatistics) -> None:
     """Calls the telemetry client to record an event capturing the sync-inputs summary."""
     details: Dict[str, Any] = asdict(summary)

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -29,6 +29,7 @@ from deadline.job_attachments.os_file_permission import (
     WindowsPermissionEnum,
 )
 from deadline.job_attachments._utils import _get_unique_dest_dir_name
+from deadline_worker_agent.aws.deadline import record_asset_sync_filesystem_event
 
 from openjd.sessions import (
     LOG as OPENJD_LOG,
@@ -232,6 +233,9 @@ class AttachmentDownloadAction(OpenjdAction):
             manifests=manifest_properties_list,
             fileSystem=session._job_attachment_details.job_attachments_file_system,
         )
+
+        # emit telemetry event on what fileSystem we are using
+        record_asset_sync_filesystem_event(session._queue_id, attachments.fileSystem)
 
         storage_profiles_path_mapping_rules_dict: dict[str, str] = {
             str(rule.source_path): str(rule.destination_path)

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -29,7 +29,7 @@ from deadline.job_attachments.os_file_permission import (
     WindowsPermissionEnum,
 )
 from deadline.job_attachments._utils import _get_unique_dest_dir_name
-from deadline_worker_agent.aws.deadline import record_asset_sync_filesystem_event
+from deadline_worker_agent.aws.deadline import _record_asset_sync_filesystem_event
 
 from openjd.sessions import (
     LOG as OPENJD_LOG,
@@ -235,7 +235,7 @@ class AttachmentDownloadAction(OpenjdAction):
         )
 
         # emit telemetry event on what fileSystem we are using
-        record_asset_sync_filesystem_event(session._queue_id, attachments.fileSystem)
+        _record_asset_sync_filesystem_event(session._queue_id, attachments.fileSystem)
 
         storage_profiles_path_mapping_rules_dict: dict[str, str] = {
             str(rule.source_path): str(rule.destination_path)

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -29,7 +29,7 @@ from deadline.job_attachments.os_file_permission import (
     WindowsPermissionEnum,
 )
 from deadline.job_attachments._utils import _get_unique_dest_dir_name
-from deadline_worker_agent.aws.deadline import _record_asset_sync_filesystem_event
+from deadline_worker_agent.aws.deadline import _record_attachment_download_filesystem_event
 
 from openjd.sessions import (
     LOG as OPENJD_LOG,
@@ -235,7 +235,7 @@ class AttachmentDownloadAction(OpenjdAction):
         )
 
         # emit telemetry event on what fileSystem we are using
-        _record_asset_sync_filesystem_event(session._queue_id, attachments.fileSystem)
+        _record_attachment_download_filesystem_event(session._queue_id, attachments.fileSystem)
 
         storage_profiles_path_mapping_rules_dict: dict[str, str] = {
             str(rule.source_path): str(rule.destination_path)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

we would like to have stats on the usage of COPIED vs VIRTUAL for filesystem

### What was the solution? (How)

added a telemetry event when we are syncing the filesystem that emits whether the session is using COPIED vs VIRTUAL

### What is the impact of this change?

we will have data on usage of COPIED vs VIRTUAL

### How was this change tested?

tested submitting jobs using both COPIED and VIRTUAL  to an SMF that used this change via host configuration script. Verified that I saw the expected telemetry events being created in our backend.

### Was this change documented?

### Is this a breaking change?

no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*