### PR TITLE
test: add mock for snicaddr

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -14,5 +14,5 @@ types-requests ~= 2.31; python_version < "3.10"
 types-requests ~= 2.32; python_version >= "3.10"
 ruff ~= 0.14.10
 twine ~= 6.2
-types-psutil ~= 7.1
+types-psutil ~= 7.2
 types-PyYAML == 6.0.*

--- a/test/unit/startup/test_host_properties.py
+++ b/test/unit/startup/test_host_properties.py
@@ -1,14 +1,23 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from socket import AddressFamily
-from typing import Generator, NamedTuple
+from typing import Generator, NamedTuple, Optional
 from unittest.mock import MagicMock, patch
 
-from psutil._common import snicaddr
 from pytest import fixture, mark, param
 
 from deadline_worker_agent.api_models import IpAddresses
 from deadline_worker_agent.startup import host_properties as host_properties_mod
+
+
+class MockNetworkAddress(NamedTuple):
+    """Mock network address structure matching psutil's snicaddr"""
+
+    address: str
+    family: AddressFamily
+    broadcast: Optional[str]
+    netmask: str
+    ptp: Optional[str]
 
 
 @fixture
@@ -133,10 +142,10 @@ class TestGetIpAddresses:
         net_if_addrs: dict[str, list[DetectedAddress]],
     ) -> Generator[MagicMock, None, None]:
         with patch.object(host_properties_mod.psutil, "net_if_addrs") as mock_psutil_net_if_addrs:
-            return_value: dict[str, list[snicaddr]] = {}
+            return_value: dict[str, list[MockNetworkAddress]] = {}
             for nic, addresses in net_if_addrs.items():
                 return_value[nic] = [
-                    snicaddr(
+                    MockNetworkAddress(
                         address=address.address,
                         family=address.family,
                         # These are ignored


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We were importing a private module `snicaddr` from `psutils._common`. In 7.2 this was moved from `psutils._common` to `psutils._ntuples` which is now causing failures with the test.

https://github.com/giampaolo/psutil/blob/6130c19da2d01383befa0dfca2371a792f8881af/psutil/_ntuples.py#L65

```
Checking dependencies
cmd [1] | ruff check .
All checks passed!
cmd [2] | ruff format --check .
187 files already formatted
cmd [3] | mypy src test
test/unit/startup/test_host_properties.py:7: error: Module "psutil._common" has
no attribute "snicaddr"  [attr-defined]
    from psutil._common import snicaddr
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 185 source files)
```

### What was the solution? (How)
We shouldn't be importing private modules. I have changed the test to use a mock.

### What is the impact of this change?
Tests pass. No longer depending on a private module.

### How was this change tested?
`hatch run lint`
`hatch run test`

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*