### PR TITLE
feat: report output job attachment manifest locations to the service

### DIFF
--- a/docs/dev/worker_api_protocol.md
+++ b/docs/dev/worker_api_protocol.md
@@ -105,7 +105,13 @@ Workflow before proceeding.
             * The Session Action uses an Open Job Description version that the Worker Agent doesn't understand; or
             * Otherwise unable to be run by the Worker Agent (e.g. compatibility reasons, or failures
             in a `AssumeQueueRoleForWorker` request).
-        4. Any other updates as dictated by a Worker-Initiated Drain workflow.
+        4. Manifest information for `taskRun` Session Actions that have generated output manifests. The `manifests`
+        field contains an array of manifest objects that must have the same length and order as the 
+        `attachments/manifests` field in the job attachment details for job entity resource obtained from 
+        BatchGetJobEntity API. Each manifest object includes `outputManifestPath` and `outputManifestHash` 
+        properties indicating the location and hash of uploaded output manifest files. If a manifest had no 
+        outputs, the list should still contain an empty object without path and hash properties.
+        5. Any other updates as dictated by a Worker-Initiated Drain workflow.
     * Response: Success(200) cases:
         1. `assignedSessions` empty -> End any locally active Sessions that the worker is
         holding as active, and then loop.

--- a/src/deadline_worker_agent/feature_flag.py
+++ b/src/deadline_worker_agent/feature_flag.py
@@ -7,6 +7,3 @@ import os
 ASSET_SYNC_JOB_USER_FEATURE = (
     os.environ.get("ASSET_SYNC_JOB_USER_FEATURE", "false").lower() == "true"
 )
-
-# Feature flag for output manifest reporting
-MANIFEST_REPORTING_FEATURE = os.environ.get("MANIFEST_REPORTING_FEATURE", "false").lower() == "true"

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -69,7 +69,6 @@ from ..log_messages import (
     WorkerLogEvent,
     WorkerLogEventOp,
 )
-from ..feature_flag import MANIFEST_REPORTING_FEATURE
 from .log import LOGGER
 from .session_cleanup import SessionUserCleanupManager
 from .session_queue import SessionActionQueue, SessionActionStatus
@@ -609,8 +608,8 @@ class WorkerScheduler:
         if action_updated.end_time:
             updated_action["endedAt"] = action_updated.end_time
 
-        # Add manifest information if available and feature flag is enabled
-        if MANIFEST_REPORTING_FEATURE and action_updated.manifests is not None:
+        # Add manifest information if available
+        if action_updated.manifests is not None:
             updated_action["manifests"] = action_updated.manifests
 
         # Truncate message to max bytes allowed by UpdateWorkerSchedule API

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
@@ -25,7 +25,6 @@ from openjd.model.v2023_09 import (
 )
 from openjd.model import ParameterValue
 
-from ...feature_flag import MANIFEST_REPORTING_FEATURE
 from ...log_messages import SessionActionLogKind
 from ..attachment_models import WorkerManifestProperties
 from .openjd_action import OpenjdAction
@@ -188,7 +187,6 @@ class AttachmentUploadAction(OpenjdAction):
             "DEADLINE_SESSIONACTION_ID": self._id,
             "DEADLINE_SESSIONACTION_START_TIME": str(self._start_time),
             "DEADLINE_STEP_ID": self._step_id,
-            "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
         }
 
         if self._task_id is not None:

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -366,14 +366,9 @@ def upload_output_assets(
     return output_manifest_info_list
 
 
-def is_manifest_reporting_enabled() -> bool:
-    """Check if manifest reporting feature is enabled."""
-    return os.environ.get("MANIFEST_REPORTING_FEATURE", "false").lower() == "true"
-
-
 def should_use_task_chunking_format() -> bool:
     """Determine if task chunking format (without task_id) should be used."""
-    return is_manifest_reporting_enabled() and not os.environ.get("DEADLINE_TASK_ID")
+    return not os.environ.get("DEADLINE_TASK_ID")
 
 
 def build_s3_manifest_path() -> str:
@@ -464,11 +459,9 @@ def main(args=None):
         )
         latencies.upload_output_assets = time.perf_counter_ns() - start_t
 
-        # Check if manifest reporting feature is enabled via environment variable
-        if is_manifest_reporting_enabled():
-            # ja_upload: is a key word that is detected in the worker agent log filter
-            # We're printing the manifest info to the logs so that we can re-load it as a manifest info in the worker agent process
-            print(f"ja_upload: {json.dumps([asdict(info) for info in manifest_infos])}")
+        # ja_upload: is a key word that is detected in the worker agent log filter
+        # We're printing the manifest info to the logs so that we can re-load it as a manifest info in the worker agent process
+        print(f"ja_upload: {json.dumps([asdict(info) for info in manifest_infos])}")
 
     # Always record latencies telemetry regardless of whether upload occurred
     total = time.perf_counter_ns() - total_start_time

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -35,7 +35,6 @@ from deadline_worker_agent.api_models import (
 )
 from deadline_worker_agent.feature_flag import (
     ASSET_SYNC_JOB_USER_FEATURE,
-    MANIFEST_REPORTING_FEATURE,
 )
 
 if TYPE_CHECKING:
@@ -1140,7 +1139,7 @@ class Session:
             self.add_local_manifest_path(
                 local_root_path=value["root"], manifest_path=value["manifest"]
             )
-        if MANIFEST_REPORTING_FEATURE and message_type == ActionOutputMessageKind.JA_UPLOAD:
+        if message_type == ActionOutputMessageKind.JA_UPLOAD:
             try:
                 manifest_list_data = json.loads(value)
                 self._upload_manifest_list = [
@@ -1429,10 +1428,8 @@ class Session:
 
             # Only include manifests for successfully completed RunStepTaskActions
             session_manifests = None
-            if (
-                MANIFEST_REPORTING_FEATURE
-                and completed_status == "SUCCEEDED"
-                and isinstance(current_action.definition, RunStepTaskAction)
+            if completed_status == "SUCCEEDED" and isinstance(
+                current_action.definition, RunStepTaskAction
             ):
                 # Always report empty list for successful task runs to differentiate from old workers
                 session_manifests = manifests if manifests is not None else []

--- a/test/unit/scheduler/test_manifest_in_scheduler.py
+++ b/test/unit/scheduler/test_manifest_in_scheduler.py
@@ -1,20 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from datetime import datetime, timezone
 
 from deadline_worker_agent.scheduler.scheduler import WorkerScheduler
 from deadline_worker_agent.scheduler.session_action_status import SessionActionStatus
 from deadline_worker_agent.api_models import ManifestInfo
-from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
 from openjd.sessions import ActionStatus, ActionState
 
 
-@pytest.mark.skipif(
-    not MANIFEST_REPORTING_FEATURE,
-    reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
-)
 class TestSchedulerManifests:
     @pytest.fixture
     def scheduler(self):
@@ -56,33 +51,6 @@ class TestSchedulerManifests:
         # Assert
         assert "manifests" in result
         assert result["manifests"] == manifests
-
-    @patch("deadline_worker_agent.scheduler.scheduler.MANIFEST_REPORTING_FEATURE", False)
-    def test_updated_action_to_boto_excludes_manifests_when_feature_disabled(self, scheduler):
-        # Arrange
-        now = datetime.now(timezone.utc)
-        action_status = ActionStatus(state=ActionState.SUCCESS)
-        manifests = [
-            ManifestInfo(
-                outputManifestPath="s3://bucket/Manifests/key1",
-                outputManifestHash="hash1",
-            ),
-        ]
-
-        action_updated = SessionActionStatus(
-            id="test_action_id",
-            status=action_status,
-            start_time=now,
-            end_time=now,
-            completed_status="SUCCEEDED",
-            manifests=manifests,
-        )
-
-        # Act
-        result = scheduler._updated_action_to_boto(action_updated)
-
-        # Assert
-        assert "manifests" not in result
 
     def test_updated_action_to_boto_excludes_manifests_when_none(self, scheduler):
         # Arrange

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -9,7 +9,6 @@ from unittest.mock import ANY, MagicMock, Mock, call, patch
 import logging
 
 from deadline_worker_agent.api_models import ManifestInfo
-from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
 
 from openjd.sessions import (
     ActionState,
@@ -708,10 +707,6 @@ class TestSchedulerSync:
         else:
             assert status_as_boto.get("processExitCode", "FAIL") == expected_result
 
-    @pytest.mark.skipif(
-        not MANIFEST_REPORTING_FEATURE,
-        reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
-    )
     def test_updated_action_to_boto_with_empty_manifests(self, scheduler: WorkerScheduler) -> None:
         # GIVEN
         manifests = [

--- a/test/unit/sessions/actions/test_attachment_upload_path_format.py
+++ b/test/unit/sessions/actions/test_attachment_upload_path_format.py
@@ -73,7 +73,7 @@ class TestAttachmentUploadPathFormat:
     )
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.decode_manifest")
     @patch("builtins.open")
-    def test_old_format_when_feature_disabled(
+    def test_old_format_when_task_id_present(
         self,
         mock_open,
         mock_decode_manifest,
@@ -83,52 +83,7 @@ class TestAttachmentUploadPathFormat:
         mock_worker_manifest_properties,
         mock_root_path_to_output_manifest,
     ):
-        """Test that old format is used when MANIFEST_REPORTING_FEATURE=false."""
-        # Arrange
-        mock_env_vars["MANIFEST_REPORTING_FEATURE"] = "false"
-        mock_s3_settings.partial_session_action_manifest_prefix.return_value = "test/path"
-        mock_s3_settings.from_s3_root_uri.return_value = MagicMock()
-
-        mock_uploader = MagicMock()
-        mock_uploader_class.return_value = mock_uploader
-        mock_uploader.upload_assets.return_value = ("key", "data")
-
-        mock_decode_manifest.return_value = MagicMock()
-        mock_open.return_value.__enter__.return_value.read.return_value = "{}"
-
-        with patch.dict(os.environ, mock_env_vars):
-            # Act
-            upload_output_assets(
-                "s3://bucket/root",
-                mock_worker_manifest_properties,
-                mock_root_path_to_output_manifest,
-            )
-
-            # Assert: Should call old format method with task_id
-            mock_s3_settings.partial_session_action_manifest_prefix.assert_called_once()
-            call_args = mock_s3_settings.partial_session_action_manifest_prefix.call_args[1]
-            assert "task_id" in call_args
-            assert call_args["task_id"] == "task-def"
-
-    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.S3AssetUploader")
-    @patch(
-        "deadline_worker_agent.sessions.actions.scripts.attachment_upload.JobAttachmentS3Settings"
-    )
-    @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload.decode_manifest")
-    @patch("builtins.open")
-    def test_old_format_when_feature_enabled_but_task_id_present(
-        self,
-        mock_open,
-        mock_decode_manifest,
-        mock_s3_settings,
-        mock_uploader_class,
-        mock_env_vars,
-        mock_worker_manifest_properties,
-        mock_root_path_to_output_manifest,
-    ):
-        """Test that old format is used when MANIFEST_REPORTING_FEATURE=true but task_id is present."""
-        # Arrange
-        mock_env_vars["MANIFEST_REPORTING_FEATURE"] = "true"
+        """Test that old format is used when task_id is present."""
         # Keep task_id present
         mock_s3_settings.partial_session_action_manifest_prefix.return_value = "test/path"
         mock_s3_settings.from_s3_root_uri.return_value = MagicMock()
@@ -170,9 +125,7 @@ class TestAttachmentUploadPathFormat:
         mock_worker_manifest_properties,
         mock_root_path_to_output_manifest,
     ):
-        """Test that new format is used when MANIFEST_REPORTING_FEATURE=true."""
-        # Arrange
-        mock_env_vars["MANIFEST_REPORTING_FEATURE"] = "true"
+        """Test that new format is used."""
         # Remove task_id to simulate new format
         del mock_env_vars["DEADLINE_TASK_ID"]
 
@@ -220,7 +173,7 @@ class TestAttachmentUploadPathFormat:
         mock_root_path_to_output_manifest,
     ):
         """Test that old format is used by default when feature flag not set."""
-        # Arrange: No MANIFEST_REPORTING_FEATURE in environment
+        # Arrange
         mock_s3_settings.partial_session_action_manifest_prefix.return_value = "test/path"
         mock_s3_settings.from_s3_root_uri.return_value = MagicMock()
 

--- a/test/unit/sessions/actions/test_run_attachment_upload.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload.py
@@ -12,7 +12,6 @@ import pytest
 
 import deadline_worker_agent.sessions.actions as actions_module
 from deadline_worker_agent.sessions.job_entities.job_details import JobDetails
-from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
 from openjd.sessions import SessionUser
 from openjd.model import ParameterValue
 from openjd.model.v2023_09 import (
@@ -175,7 +174,6 @@ class TestStart:
                 "DEADLINE_STEP_ID": step_id,
                 "DEADLINE_TASK_ID": task_id,
                 "DEADLINE_SESSIONACTION_START_TIME": "1234567890.0",
-                "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,
         )
@@ -242,7 +240,6 @@ class TestStart:
                 "DEADLINE_STEP_ID": step_id,
                 "DEADLINE_TASK_ID": task_id,
                 "DEADLINE_SESSIONACTION_START_TIME": "1234567890.0",
-                "MANIFEST_REPORTING_FEATURE": str(MANIFEST_REPORTING_FEATURE),
             },
             log_task_banner=False,
         )

--- a/test/unit/sessions/test_attachment_upload_status.py
+++ b/test/unit/sessions/test_attachment_upload_status.py
@@ -8,7 +8,6 @@ import pytest
 from openjd.sessions import ActionState, ActionStatus
 
 from deadline_worker_agent.api_models import ManifestInfo
-from deadline_worker_agent.feature_flag import MANIFEST_REPORTING_FEATURE
 from deadline_worker_agent.scheduler.session_action_status import SessionActionStatus
 
 
@@ -37,10 +36,6 @@ def action_complete_time() -> datetime:
     return datetime(2023, 1, 2, 3, 4, 5)
 
 
-@pytest.mark.skipif(
-    not MANIFEST_REPORTING_FEATURE,
-    reason="Only relevant when MANIFEST_REPORTING_FEATURE is enabled",
-)
 class TestAttachmentUploadHandling:
     """Test the handling of attachment upload completion"""
 

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -71,7 +71,6 @@ from deadline_worker_agent.log_messages import (
 from deadline.job_attachments.models import (
     Attachments,
     JobAttachmentsFileSystem,
-    JobAttachmentS3Settings,
     JobAttachmentsFileSystem,
     UploadManifestInfo,
 )
@@ -985,63 +984,6 @@ class TestSessionSyncAssetOutputs:
 
         return current_action
 
-    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", False)
-    def test_sync_asset_outputs_without_manifest_reporting(
-        self,
-        action_id: str,
-        queue_id: str,
-        step_id: str,
-        task_id: str,
-        action_start_time: datetime,
-        session: Session,
-        job_attachment_details: JobAttachmentDetails,
-        mock_asset_sync: MagicMock,
-        mock_telemetry_event_for_sync_outputs: MagicMock,
-    ):
-        """
-        Tests that session's '_sync_asset_outputs' calls Job Attachment's method 'sync_outputs' correctly
-        when MANIFEST_REPORTING_FEATURE is disabled.
-        """
-        # GIVEN
-        current_action = self._setup_sync_asset_outputs_test(
-            action_id,
-            step_id,
-            task_id,
-            action_start_time,
-            session,
-            job_attachment_details,
-            mock_asset_sync,
-        )
-
-        # WHEN
-        session._sync_asset_outputs(current_action=current_action)  # type: ignore
-
-        # THEN
-        mock_asset_sync.sync_outputs.assert_called_once_with(
-            s3_settings=JobAttachmentS3Settings(
-                rootPrefix="job_attachments",
-                s3BucketName="job_attachments_bucket",
-            ),
-            attachments=Attachments(
-                manifests=ANY,
-                fileSystem=JobAttachmentsFileSystem.COPIED,
-            ),
-            queue_id=queue_id,
-            job_id=ANY,
-            step_id=step_id,
-            task_id=task_id,
-            session_action_id=action_id,
-            start_time=ANY,
-            session_dir=ANY,
-            storage_profiles_path_mapping_rules={},
-            on_uploading_files=ANY,
-        )
-        mock_asset_sync.sync_outputs_with_manifests.assert_not_called()
-        mock_telemetry_event_for_sync_outputs.assert_called_once_with(
-            queue_id,
-            SummaryStatistics(),
-        )
-
 
 class TestSessionInnerRun:
     """Test cases for Session._run()"""
@@ -1386,7 +1328,6 @@ class TestSessionActionUpdatedImpl:
         with patch("deadline_worker_agent.sessions.session.OPENJD_LOG") as mock_log:
             yield mock_log
 
-    @pytest.mark.parametrize("manifest_feature", [True, False])
     def test_failed_enter_env(
         self,
         action_id: str,
@@ -1396,7 +1337,6 @@ class TestSessionActionUpdatedImpl:
         action_complete_time: datetime,
         failed_action_status: ActionStatus,
         mock_report_action_update: MagicMock,
-        manifest_feature: bool,
     ) -> None:
         """Tests that if a environment enter action fails (the Open Job Description action), that the action
         failure is returned, and that any pending actions other than ENV_EXITS are marked as
@@ -1427,27 +1367,17 @@ class TestSessionActionUpdatedImpl:
         expected_next_action_message = failed_action_status.fail_message or (
             f"Previous action failed: {current_action.definition.id}"
         )
-        if manifest_feature:
-            expected_action_update = SessionActionStatus(
-                id=action_id,
-                status=failed_action_status,
-                start_time=action_start_time,
-                completed_status="FAILED",
-                end_time=action_complete_time,
-                manifests=None,
-            )
-        else:
-            expected_action_update = SessionActionStatus(
-                id=action_id,
-                status=failed_action_status,
-                start_time=action_start_time,
-                completed_status="FAILED",
-                end_time=action_complete_time,
-            )
+        expected_action_update = SessionActionStatus(
+            id=action_id,
+            status=failed_action_status,
+            start_time=action_start_time,
+            completed_status="FAILED",
+            end_time=action_complete_time,
+            manifests=None,
+        )
 
         with (
             patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs,
-            patch.object(session_mod, "MANIFEST_REPORTING_FEATURE", manifest_feature),
         ):
             # WHEN
             future = session._action_updated_impl(
@@ -1466,7 +1396,6 @@ class TestSessionActionUpdatedImpl:
         mock_sync_asset_outputs.assert_not_called()
         assert session._current_action is None, "Current session action emptied"
 
-    @pytest.mark.parametrize("manifest_feature", [True, False])
     def test_failed_task_run(
         self,
         action_id: str,
@@ -1478,7 +1407,6 @@ class TestSessionActionUpdatedImpl:
         action_complete_time: datetime,
         failed_action_status: ActionStatus,
         mock_report_action_update: MagicMock,
-        manifest_feature: bool,
     ) -> None:
         """Tests that if a task run fails (the Open Job Description action), that job attachment output
         sync is not performed, the action failure is returned, and that any pending actions are
@@ -1511,27 +1439,17 @@ class TestSessionActionUpdatedImpl:
         expected_next_action_message = failed_action_status.fail_message or (
             f"Previous action failed: {current_action.definition.id}"
         )
-        if manifest_feature:
-            expected_action_update = SessionActionStatus(
-                id=action_id,
-                status=failed_action_status,
-                start_time=action_start_time,
-                completed_status="FAILED",
-                end_time=action_complete_time,
-                manifests=None,
-            )
-        else:
-            expected_action_update = SessionActionStatus(
-                id=action_id,
-                status=failed_action_status,
-                start_time=action_start_time,
-                completed_status="FAILED",
-                end_time=action_complete_time,
-            )
+        expected_action_update = SessionActionStatus(
+            id=action_id,
+            status=failed_action_status,
+            start_time=action_start_time,
+            completed_status="FAILED",
+            end_time=action_complete_time,
+            manifests=None,
+        )
 
         with (
             patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs,
-            patch.object(session_mod, "MANIFEST_REPORTING_FEATURE", manifest_feature),
         ):
             # WHEN
             future = session._action_updated_impl(
@@ -1550,7 +1468,6 @@ class TestSessionActionUpdatedImpl:
         assert session._current_action is None, "Current session action emptied"
         mock_sync_asset_outputs.assert_not_called()
 
-    @pytest.mark.parametrize("manifest_feature", [True, False])
     @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", False)
     def test_success_task_run(
         self,
@@ -1563,7 +1480,6 @@ class TestSessionActionUpdatedImpl:
         success_action_status: ActionStatus,
         task_id: str,
         mock_report_action_update: MagicMock,
-        manifest_feature: bool,
     ) -> None:
         """Tests that if a task run succeeds (the Open Job Description action), that job attachment output
         sync is performed, and AFTER that, the action success is returned."""
@@ -1593,23 +1509,14 @@ class TestSessionActionUpdatedImpl:
         session._current_action = current_action
         queue_cancel_all: MagicMock = session_action_queue.cancel_all
 
-        if manifest_feature:
-            expected_action_update = SessionActionStatus(
-                id=action_id,
-                status=success_action_status,
-                start_time=action_start_time,
-                completed_status="SUCCEEDED",
-                end_time=action_complete_time,
-                manifests=[],
-            )
-        else:
-            expected_action_update = SessionActionStatus(
-                id=action_id,
-                status=success_action_status,
-                start_time=action_start_time,
-                completed_status="SUCCEEDED",
-                end_time=action_complete_time,
-            )
+        expected_action_update = SessionActionStatus(
+            id=action_id,
+            status=success_action_status,
+            start_time=action_start_time,
+            completed_status="SUCCEEDED",
+            end_time=action_complete_time,
+            manifests=[],
+        )
 
         def mock_now(*arg, **kwarg) -> datetime:
             return action_complete_time
@@ -1617,7 +1524,6 @@ class TestSessionActionUpdatedImpl:
         with (
             patch.object(session_mod, "datetime") as mock_datetime,
             patch.object(session, "_sync_asset_outputs") as mock_sync_asset_outputs,
-            patch.object(session_mod, "MANIFEST_REPORTING_FEATURE", manifest_feature),
         ):
             mock_datetime.now.side_effect = mock_now
 
@@ -1716,7 +1622,6 @@ class TestSessionActionUpdatedImpl:
             )
         )
 
-    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
     @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_success_task_run_attachment_upload_with_no_output_manifest(
         self,
@@ -1761,7 +1666,6 @@ class TestSessionActionUpdatedImpl:
             expected_manifest_list,
         )
 
-    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
     @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_success_task_run_attachment_upload_with_manifest(
         self,
@@ -1849,7 +1753,6 @@ class TestSessionActionUpdatedImpl:
             expected_manifest_list,
         )
 
-    @pytest.mark.parametrize("manifest_feature", [True, False])
     @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", False)
     def test_success_task_run_fail_output_sync(
         self,
@@ -1862,7 +1765,6 @@ class TestSessionActionUpdatedImpl:
         success_action_status: ActionStatus,
         task_id: str,
         mock_report_action_update: MagicMock,
-        manifest_feature: bool,
     ) -> None:
         """Tests that if a task run succeeds (the Open Job Description action), but the job attachment output
         sync fails, the action failure is returned, and any pending actions are marked as
@@ -1898,23 +1800,14 @@ class TestSessionActionUpdatedImpl:
             state=ActionState.FAILED,
             fail_message=f"Failed to sync job output attachments for {current_action.definition.id}: {sync_outputs_exception_msg}",
         )
-        if manifest_feature:
-            expected_action_update = SessionActionStatus(
-                id=action_id,
-                status=expected_fail_action_status,
-                start_time=action_start_time,
-                completed_status="FAILED",
-                end_time=action_complete_time,
-                manifests=None,
-            )
-        else:
-            expected_action_update = SessionActionStatus(
-                id=action_id,
-                status=expected_fail_action_status,
-                start_time=action_start_time,
-                completed_status="FAILED",
-                end_time=action_complete_time,
-            )
+        expected_action_update = SessionActionStatus(
+            id=action_id,
+            status=expected_fail_action_status,
+            start_time=action_start_time,
+            completed_status="FAILED",
+            end_time=action_complete_time,
+            manifests=None,
+        )
 
         def mock_now(*arg, **kwarg) -> datetime:
             return action_complete_time
@@ -1924,7 +1817,6 @@ class TestSessionActionUpdatedImpl:
             patch.object(
                 session, "_sync_asset_outputs", side_effect=sync_outputs_exception
             ) as mock_sync_asset_outputs,
-            patch.object(session_mod, "MANIFEST_REPORTING_FEATURE", manifest_feature),
         ):
             mock_datetime.now.side_effect = mock_now
 
@@ -2127,7 +2019,6 @@ class TestSessionActionUpdatedImpl:
         # Verify output sync target action was cleared
         assert session._output_sync_target_action is None
 
-    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
     def test_action_output_capture_filter_ja_upload_callback_invalid(
         self,
         session: Session,
@@ -2147,7 +2038,6 @@ class TestSessionActionUpdatedImpl:
 
         assert session._upload_manifest_list == []
 
-    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
     def test_action_output_capture_filter_ja_upload_callback_valid(
         self,
         session: Session,
@@ -2163,7 +2053,6 @@ class TestSessionActionUpdatedImpl:
         assert len(session._upload_manifest_list) == 1
         assert all(isinstance(item, UploadManifestInfo) for item in session._upload_manifest_list)
 
-    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
     @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_progress_update_excludes_manifests(
         self,
@@ -2218,7 +2107,6 @@ class TestSessionActionUpdatedImpl:
         assert isinstance(call_args, SessionActionStatus)
         assert call_args.manifests is None  # Should be None for progress updates
 
-    @patch("deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE", True)
     @patch("deadline_worker_agent.sessions.session.ASSET_SYNC_JOB_USER_FEATURE", True)
     def test_failed_task_excludes_manifests(
         self,
@@ -2276,12 +2164,10 @@ class TestSessionActionUpdatedImpl:
         assert isinstance(call_args, SessionActionStatus)
         assert call_args.manifests is None  # Should be None for failed actions
 
-    @pytest.mark.parametrize("manifest_reporting_enabled", [True, False])
     def test_successful_task_without_job_attachments_includes_none_manifests(
         self,
         session: Session,
         mock_report_action_update: MagicMock,
-        manifest_reporting_enabled: bool,
     ) -> None:
         """Test that manifests are None when job attachments are not used in output sync flow"""
         # Set up a mock output sync action
@@ -2299,10 +2185,6 @@ class TestSessionActionUpdatedImpl:
         action_complete_time = datetime.now()
 
         with (
-            patch(
-                "deadline_worker_agent.sessions.session.MANIFEST_REPORTING_FEATURE",
-                manifest_reporting_enabled,
-            ),
             patch.object(
                 session_mod,
                 "OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The MANIFEST_REPORTING_FEATURE flag should now be enabled by default. We don't have to set MANIFEST_REPORTING_FEATURE flag to True but can instead remove all the guardrails related to it. The functionality should now be always available (when another flag ASSET_SYNC_JOB_USER_FEATURE is also enabled). 

### What was the solution? (How)

Removed the MANIFEST_REPORTING_FEATURE flag from feature_flag.py and cleaned up all related code paths in the scheduler, session management, and attachment upload functionality.

### What is the impact of this change?

- Manifest reporting is now enabled by default
- Simplified codebase by removing 226 lines of unused code
- Eliminated feature flag complexity around manifest reporting
- Reduced maintenance burden by removing dead code paths
- Cleaned up test suite by removing tests for removed functionality

### How was this change tested?

Existing test suite should continue to pass with the removal of the feature flag code and its associated tests.

### Was this change documented?

No documentation changes required as this removes internal feature flag code that was not part of the public API.

### Is this a breaking change?

No, this is not a breaking change as it removes internal feature flag code that was not part of the public interface.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*