### PR TITLE
chore: improve client telemetry attachment upload and download event details

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -881,8 +881,10 @@ def record_sync_inputs_fail_telemetry_event(
 
 def record_attachment_download_telemetry_event(queue_id: str, summary: SummaryStatistics) -> None:
     """Calls the telemetry client to record an event capturing the attachment download summary."""
-    details: Dict[str, Any] = asdict(summary)
-    details["queue_id"] = queue_id
+    details = {
+        "queue_id": queue_id,
+        "download_summary": asdict(summary),
+    }
     _get_deadline_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.worker_agent.attachment_download_summary",
         event_details=details,
@@ -918,17 +920,15 @@ def record_attachment_download_latencies_telemetry_event(
 def record_attachment_upload_telemetry_event(
     queue_id: str,
     upload_summaries: list[SummaryStatistics],
-    manifest_total_files: int,
-    manifest_total_bytes: int,
 ) -> None:
     """Calls the telemetry client to record an event capturing the attachment_upload summary."""
+    aggregate_summary = SummaryStatistics()
+    [aggregate_summary.aggregate(summary) for summary in upload_summaries]
+
     details = {
         "queue_id": queue_id,
+        "upload_summary": asdict(aggregate_summary),
         "upload_summaries": [asdict(summary) for summary in upload_summaries],
-        "manifest_summary": {
-            "total_files": manifest_total_files,
-            "total_bytes": manifest_total_bytes,
-        },
     }
     _get_deadline_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.worker_agent.attachment_upload_summary",

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -291,8 +291,6 @@ def upload_output_assets(
     asset_uploader: S3AssetUploader = S3AssetUploader()
     output_manifest_info_list = []
 
-    all_manifests_total_files = 0
-    all_manifests_total_bytes = 0
     all_upload_summaries = []
 
     # Process each worker manifest property for upload
@@ -310,9 +308,7 @@ def upload_output_assets(
                 continue
 
             total_file_count = len(output_manifest.paths)
-            all_manifests_total_files += total_file_count
             total_file_size = sum([path.size for path in output_manifest.paths])
-            all_manifests_total_bytes += total_file_size
 
             print(
                 f"Found {total_file_count} file{'' if total_file_count == 1 else 's'}"
@@ -359,8 +355,6 @@ def upload_output_assets(
     record_attachment_upload_telemetry_event(
         queue_id=_queue_id,
         upload_summaries=all_upload_summaries,
-        manifest_total_bytes=all_manifests_total_bytes,
-        manifest_total_files=all_manifests_total_files,
     )
 
     return output_manifest_info_list

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -130,6 +130,88 @@ def test_record_sync_outputs_telemetry_event():
     )
 
 
+def test_record_attachment_upload_telemetry_event():
+    """
+    Tests that when record_attachment_upload_telemetry_event() is called, the correct
+    event type and details are passed to the telemetry client's record_event() method.
+    """
+    mock_telemetry_client = MagicMock()
+
+    with patch.object(deadline_mod, "_get_deadline_telemetry_client") as mock_get_telemetry_client:
+        mock_get_telemetry_client.return_value = mock_telemetry_client
+        # GIVEN
+        summary_stats1 = SummaryStatistics(
+            total_time=5,
+            total_files=3,
+            total_bytes=300,
+            processed_files=3,
+            processed_bytes=300,
+            skipped_files=0,
+            skipped_bytes=0,
+            transfer_rate=60,
+        )
+        summary_stats2 = SummaryStatistics(
+            total_time=3,
+            total_files=2,
+            total_bytes=200,
+            processed_files=2,
+            processed_bytes=200,
+            skipped_files=0,
+            skipped_bytes=0,
+            transfer_rate=66.67,
+        )
+        upload_summaries = [summary_stats1, summary_stats2]
+
+        # WHEN
+        deadline_mod.record_attachment_upload_telemetry_event(
+            queue_id="queue-test",
+            upload_summaries=upload_summaries,
+        )
+
+    # THEN
+    # Verify the aggregated summary is calculated correctly
+    expected_aggregate = {
+        "total_time": 8.0,  # 5 + 3
+        "total_files": 5,  # 3 + 2
+        "total_bytes": 500,  # 300 + 200
+        "processed_files": 5,  # 3 + 2
+        "processed_bytes": 500,  # 300 + 200
+        "skipped_files": 0,  # 0 + 0
+        "skipped_bytes": 0,  # 0 + 0
+        "transfer_rate": 62.5,  # 500 / 8
+    }
+
+    mock_telemetry_client.record_event.assert_called_with(
+        event_type="com.amazon.rum.deadline.worker_agent.attachment_upload_summary",
+        event_details={
+            "queue_id": "queue-test",
+            "upload_summary": expected_aggregate,
+            "upload_summaries": [
+                {
+                    "total_time": 5,
+                    "total_files": 3,
+                    "total_bytes": 300,
+                    "processed_files": 3,
+                    "processed_bytes": 300,
+                    "skipped_files": 0,
+                    "skipped_bytes": 0,
+                    "transfer_rate": 60.0,
+                },
+                {
+                    "total_time": 3,
+                    "total_files": 2,
+                    "total_bytes": 200,
+                    "processed_files": 2,
+                    "processed_bytes": 200,
+                    "skipped_files": 0,
+                    "skipped_bytes": 0,
+                    "transfer_rate": 66.67,
+                },
+            ],
+        },
+    )
+
+
 def test_record_uncaught_exception_telemetry_event():
     """
     Tests that when record_uncaught_exception_telemetry_event() is called, the correct

--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -465,8 +465,6 @@ class TestAttachmentUpload:
                 progress_tracker_stub.get_summary_statistics(),
                 progress_tracker_stub.get_summary_statistics(),
             ],
-            manifest_total_bytes=expected_total_bytes,
-            manifest_total_files=expected_total_files,
         )
 
         # Verify print statements


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The attachment upload and download telemetry events needed improved data structure and consistency. The previous 
implementation had inconsistent event details formatting between upload and download events, and the upload event was tracking redundant manifest totals that could be derived from the summary statistics.

### What was the solution? (How)
- **Standardized telemetry event structure**: Both upload and download events now use a consistent nested structure with queue_id and summary data as separate fields
- **Simplified upload telemetry**: Removed redundant manifest_total_files and manifest_total_bytes parameters from 
record_attachment_upload_telemetry_event()
- **Added aggregate summary**: Upload events now include an aggregated summary calculated from all individual upload summaries
- **Updated event details format**: 
  • Download events: {"queue_id": "...", "download_summary": {...}}
  • Upload events: {"queue_id": "...", "upload_summary": {...}, "upload_summaries": [...]}

### What is the impact of this change?
- Improved telemetry data consistency and structure for better analytics
- Reduced code complexity by removing redundant parameter tracking
- Enhanced observability with aggregated upload statistics
- Better alignment between upload and download telemetry event formats

### How was this change tested?
- unit tests
- e2e tests
```
============================= slowest 5 durations ==============================
229.99s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[False-linux]
209.19s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[True-linux]
194.11s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_job_submission_many_small_files_download_does_not_cancel
141.67s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_create_job_API_call_linux[True]
133.06s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_linux[True-VIRTUAL]
============ 27 passed, 6 skipped, 1 warning in 2157.96s (0:35:57) =============
```

```
"event_details": {
    "queue_id": "queue-XXX",
    "download_summary": {
        "total_time": 0.29764252799998303,
        "total_files": 2,
        "total_bytes": 36,
        "processed_files": 2,
        "processed_bytes": 36,
        "skipped_files": 0,
        "skipped_bytes": 0,
        "transfer_rate": 120.9504577249191
    }
```

*There are some issue with the statistics themselves, which is not in scope for the PR*
```
"event_details": {
    "queue_id": "queue-XXX",
    "upload_summary": {
        "total_time": 0.0,
        "total_files": 3,
        "total_bytes": 1612,
        "processed_files": 0,
        "processed_bytes": 0,
        "skipped_files": 3,
        "skipped_bytes": 1612,
        "transfer_rate": 0.0
    },
    "upload_summaries": [{
        "total_time": 0.0,
        "total_files": 2,
        "total_bytes": 1602,
        "processed_files": 0,
        "processed_bytes": 0,
        "skipped_files": 2,
        "skipped_bytes": 1602,
        "transfer_rate": 0.0
    }, {
        "total_time": 0.0,
        "total_files": 1,
        "total_bytes": 10,
        "processed_files": 0,
        "processed_bytes": 0,
        "skipped_files": 1,
        "skipped_bytes": 10,
        "transfer_rate": 0.0
    }]
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*