### PR TITLE
chore: worker agent construct telemetry client to avoid using cached client from deadline cloud lib

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -5,13 +5,13 @@ from time import sleep, monotonic
 from typing import Any, Callable, Dict, Optional, TypeVar, cast
 from threading import Event
 from dataclasses import asdict, dataclass
-from functools import wraps
+from functools import wraps, cache
 import random
 
 from botocore.retries.standard import RetryContext
 from botocore.exceptions import ClientError
 
-from deadline.client.api import get_telemetry_client, TelemetryClient
+from deadline.client.api import TelemetryClient
 from deadline.client import version as deadline_client_lib_version
 from deadline.job_attachments.progress_tracker import SummaryStatistics
 from openjd.model import version as openjd_model_version
@@ -38,8 +38,6 @@ from ...log_sync.cloudwatch import (
     LOG_CONFIG_OPTION_GROUP_NAME_KEY,
     LOG_CONFIG_OPTION_STREAM_NAME_KEY,
 )
-
-__cached_telemetry_client: Optional[TelemetryClient] = None
 
 _logger = logging.getLogger(__name__)
 
@@ -802,25 +800,22 @@ def update_worker_schedule(
     return response
 
 
+@cache
 def _get_deadline_telemetry_client() -> TelemetryClient:
     """Wrapper around the Deadline Client Library telemetry client, in order to set package-specific information"""
-    global __cached_telemetry_client
-    if not __cached_telemetry_client:
-        __cached_telemetry_client = get_telemetry_client(
-            "deadline-cloud-worker-agent", ".".join(version.split(".")[:3])
-        )
-        # Override service name to ensure consistency for all telemetry from worker agent
-        __cached_telemetry_client._system_metadata["service"] = "deadline-cloud-worker-agent"
-        __cached_telemetry_client.update_common_details(
-            {"openjd-sessions-version": ".".join(openjd_sessions_version.split(".")[:3])}
-        )
-        __cached_telemetry_client.update_common_details(
-            {"openjd-model-version": ".".join(openjd_model_version.split(".")[:3])}
-        )
-        __cached_telemetry_client.update_common_details(
-            {"deadline-cloud": ".".join(deadline_client_lib_version.split(".")[:3])}
-        )
-    return __cached_telemetry_client
+    client = TelemetryClient(
+        package_name="deadline-cloud-worker-agent", package_ver=".".join(version.split(".")[:3])
+    )
+    client.update_common_details(
+        {"openjd-sessions-version": ".".join(openjd_sessions_version.split(".")[:3])}
+    )
+    client.update_common_details(
+        {"openjd-model-version": ".".join(openjd_model_version.split(".")[:3])}
+    )
+    client.update_common_details(
+        {"deadline-cloud": ".".join(deadline_client_lib_version.split(".")[:3])}
+    )
+    return client
 
 
 def record_worker_start_telemetry_event(capabilities: Capabilities) -> None:

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -809,6 +809,8 @@ def _get_deadline_telemetry_client() -> TelemetryClient:
         __cached_telemetry_client = get_telemetry_client(
             "deadline-cloud-worker-agent", ".".join(version.split(".")[:3])
         )
+        # Override service name to ensure consistency for all telemetry from worker agent
+        __cached_telemetry_client._system_metadata["service"] = "deadline-cloud-worker-agent"
         __cached_telemetry_client.update_common_details(
             {"openjd-sessions-version": ".".join(openjd_sessions_version.split(".")[:3])}
         )

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -3,6 +3,7 @@
 
 from unittest.mock import patch, MagicMock
 import pytest
+from dataclasses import asdict
 
 import deadline_worker_agent.aws.deadline as deadline_mod
 from deadline_worker_agent.aws.deadline import (
@@ -11,6 +12,7 @@ from deadline_worker_agent.aws.deadline import (
     record_sync_inputs_telemetry_event,
     record_sync_outputs_telemetry_event,
     record_uncaught_exception_telemetry_event,
+    _get_deadline_telemetry_client,
 )
 from deadline_worker_agent.capabilities import Capabilities
 from deadline.job_attachments.progress_tracker import SummaryStatistics
@@ -142,22 +144,22 @@ def test_record_attachment_upload_telemetry_event():
         # GIVEN
         summary_stats1 = SummaryStatistics(
             total_time=5,
-            total_files=3,
-            total_bytes=300,
+            total_files=4,
+            total_bytes=400,
             processed_files=3,
             processed_bytes=300,
-            skipped_files=0,
-            skipped_bytes=0,
+            skipped_files=1,
+            skipped_bytes=100,
             transfer_rate=60,
         )
         summary_stats2 = SummaryStatistics(
             total_time=3,
-            total_files=2,
-            total_bytes=200,
+            total_files=3,
+            total_bytes=300,
             processed_files=2,
             processed_bytes=200,
-            skipped_files=0,
-            skipped_bytes=0,
+            skipped_files=1,
+            skipped_bytes=100,
             transfer_rate=66.67,
         )
         upload_summaries = [summary_stats1, summary_stats2]
@@ -172,12 +174,12 @@ def test_record_attachment_upload_telemetry_event():
     # Verify the aggregated summary is calculated correctly
     expected_aggregate = {
         "total_time": 8.0,  # 5 + 3
-        "total_files": 5,  # 3 + 2
-        "total_bytes": 500,  # 300 + 200
+        "total_files": 7,  # 4 + 3
+        "total_bytes": 700,  # 400 + 300
         "processed_files": 5,  # 3 + 2
         "processed_bytes": 500,  # 300 + 200
-        "skipped_files": 0,  # 0 + 0
-        "skipped_bytes": 0,  # 0 + 0
+        "skipped_files": 2,  # 1 + 1
+        "skipped_bytes": 200,  # 100 + 100
         "transfer_rate": 62.5,  # 500 / 8
     }
 
@@ -186,28 +188,7 @@ def test_record_attachment_upload_telemetry_event():
         event_details={
             "queue_id": "queue-test",
             "upload_summary": expected_aggregate,
-            "upload_summaries": [
-                {
-                    "total_time": 5,
-                    "total_files": 3,
-                    "total_bytes": 300,
-                    "processed_files": 3,
-                    "processed_bytes": 300,
-                    "skipped_files": 0,
-                    "skipped_bytes": 0,
-                    "transfer_rate": 60.0,
-                },
-                {
-                    "total_time": 3,
-                    "total_files": 2,
-                    "total_bytes": 200,
-                    "processed_files": 2,
-                    "processed_bytes": 200,
-                    "skipped_files": 0,
-                    "skipped_bytes": 0,
-                    "transfer_rate": 66.67,
-                },
-            ],
+            "upload_summaries": [asdict(summary_stats1), asdict(summary_stats2)],
         },
     )
 
@@ -281,3 +262,25 @@ def test_record_decorator_fails():
                 "is_success": False,
             },
         )
+
+
+def test_get_deadline_telemetry_client_sets_service_name():
+    """
+    Tests that _get_deadline_telemetry_client() sets the service name in system metadata
+    to ensure consistency for all telemetry from worker agent.
+    """
+    # Clear the cached client to ensure fresh initialization
+    deadline_mod.__cached_telemetry_client = None
+
+    mock_telemetry_client = MagicMock()
+    mock_telemetry_client._system_metadata = {}
+
+    with patch("deadline_worker_agent.aws.deadline.get_telemetry_client") as mock_get_client:
+        mock_get_client.return_value = mock_telemetry_client
+
+        # WHEN
+        client = _get_deadline_telemetry_client()
+
+        # THEN
+        assert client is mock_telemetry_client
+        assert mock_telemetry_client._system_metadata["service"] == "deadline-cloud-worker-agent"

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -266,21 +266,23 @@ def test_record_decorator_fails():
 
 def test_get_deadline_telemetry_client_sets_service_name():
     """
-    Tests that _get_deadline_telemetry_client() sets the service name in system metadata
-    to ensure consistency for all telemetry from worker agent.
+    Tests that _get_deadline_telemetry_client() creates a TelemetryClient with the correct
+    service name by directly constructing the client.
     """
-    # Clear the cached client to ensure fresh initialization
-    deadline_mod.__cached_telemetry_client = None
+    # Clear the cache to ensure fresh initialization
+    _get_deadline_telemetry_client.cache_clear()
 
     mock_telemetry_client = MagicMock()
-    mock_telemetry_client._system_metadata = {}
 
-    with patch("deadline_worker_agent.aws.deadline.get_telemetry_client") as mock_get_client:
-        mock_get_client.return_value = mock_telemetry_client
+    with patch("deadline_worker_agent.aws.deadline.TelemetryClient") as mock_telemetry_constructor:
+        mock_telemetry_constructor.return_value = mock_telemetry_client
 
         # WHEN
         client = _get_deadline_telemetry_client()
 
         # THEN
         assert client is mock_telemetry_client
-        assert mock_telemetry_client._system_metadata["service"] == "deadline-cloud-worker-agent"
+        mock_telemetry_constructor.assert_called_once_with(
+            package_name="deadline-cloud-worker-agent",
+            package_ver=".".join(deadline_mod.version.split(".")[:3]),
+        )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The telemetry client needed to have a consistent service name across all telemetry events from the worker agent to ensure proper categorization and filtering in telemetry systems. The use of cached telemetry client from deadline client lib lead to wrong service name. As a result, upload metric missing while download works fine.

#### Upload Summary Event
```
{
  "event_timestamp": 1767827667000,
  "event_type": "com.amazon.rum.deadline.worker_agent.attachment_upload_summary",
  "event_id": "",
  "event_version": "1.0.0",
  "log_stream": "2026-01-07T16",
  "application_id": "",
  "metadata": {
    "version": "0.54.0",
    "osName": "Linux",
    "osVersion": "",
    "domain": "*.amazonaws.com",
    "service": "deadline-cloud-library", // ← UPLOAD: deadline-cloud-library
    "python_version": "3.9.25",
    "countryCode": "US",
    "subdivisionCode": "OR"
  },
  "user_details": {
    "userId": "",
    "sessionId": ""
  },
  "event_details": {
    "queue_id": "queue-",
    "upload_summary": {
      "total_time": 0.0,
      "total_files": 3,
      "total_bytes": 1612,
      "processed_files": 0,
      "processed_bytes": 0,
      "skipped_files": 3,
      "skipped_bytes": 1612,
      "transfer_rate": 0.0
    },
    "upload_summaries": [...],
    "accountId": "",
    "openjd-sessions-version": "0.10.6",
    "openjd-model-version": "0.8.7",
    "deadline-cloud": "0.54.0",
    "usage_mode": "CLI"
  }
}
```

#### Download Summary Event
```
{
  "event_timestamp": 1767827667000,
  "event_type": "com.amazon.rum.deadline.worker_agent.attachment_download_summary",
  "event_id": "",
  "event_version": "1.0.0",
  "log_stream": "2026-01-07T16",
  "application_id": "",
  "metadata": {
    "version": "0.28.14",
    "osName": "Linux",
    "domain": "*.amazonaws.com",
    "service": "deadline-cloud-worker-agent", // ← DOWNLOAD: deadline-cloud-worker-agent
    "python_version": "3.9.25",
    "countryCode": "US",
    "subdivisionCode": "OR"
  },
  "user_details": {
    "userId": "",
    "sessionId": ""
  },
  "event_details": {
    "queue_id": "queue-",
    "download_summary": {
      "total_time": 0.21266557500007366,
      "total_files": 2,
      "total_bytes": 28,
      "processed_files": 2,
      "processed_bytes": 28,
      "skipped_files": 0,
      "skipped_bytes": 0,
      "transfer_rate": 131.66211785800454
    },
    "deadline-cloud-version": "0.54.0",
    "openjd-sessions-version": "0.10.6",
    "openjd-model-version": "0.8.7",
    "deadline-cloud": "0.54.0",
    "accountId": "",
    "usage_mode": "CLI"
  }
}
```

Key Difference:
• **Upload**: metadata.service = "deadline-cloud-library"
• **Download**: metadata.service = "deadline-cloud-worker-agent"



### What was the solution? (How)
Directly construct TelemetryClient directly to avoid using cached client from buggy `get_telemetry_client`.

### What is the impact of this change?
All telemetry events from the worker agent will now have a consistent service identifier, improving telemetry data organization and making it easier to filter and analyze worker agent specific metrics.

### How was this change tested?
- unit test pass
- e2e test pass 

```
============================= slowest 5 durations ==============================
234.62s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[True-linux]
233.78s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_job_submission_many_small_files_download_does_not_cancel
156.82s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_linux[True-COPIED]
155.96s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_create_job_API_call_linux[True]
121.45s call     test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachments_dep_data_flow_linux[True-VIRTUAL]
============ 14 passed, 3 skipped, 1 warning in 1320.45s (0:22:00) =============
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*