### PR TITLE
chore: Fixed scripts/assume_role_to_env.sh not functioning

### DIFF
--- a/scripts/assume_role_to_env.sh
+++ b/scripts/assume_role_to_env.sh
@@ -4,13 +4,13 @@
 if ! which jq 2>&1 > /dev/null
 then
     echo "ERROR: jq must be installed."
-    exit 1
+    return 1
 fi
 
 if test $# -lt 1
 then
     echo "Usage: $0 <IAM Role Arn>"
-    exit 1
+    return 1
 fi
 
 unset AWS_ACCESS_KEY_ID
@@ -18,13 +18,28 @@ unset AWS_SECRET_ACCESS_KEY
 unset AWS_SESSION_TOKEN
 
 ASSUME_ROLE=$(aws sts assume-role --role-arn "$1" --role-session-name WorkerAgentAssumeRole)
+export ASSUME_ROLE
+
 AWS_ACCESS_KEY_ID=$(printenv ASSUME_ROLE | jq -r '.Credentials''.AccessKeyId')
 AWS_SECRET_ACCESS_KEY=$(printenv ASSUME_ROLE | jq -r '.Credentials''.SecretAccessKey')
 AWS_SESSION_TOKEN=$(printenv ASSUME_ROLE | jq -r '.Credentials''.SessionToken')
 
-export ASSUME_ROLE
 export AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY
 export AWS_SESSION_TOKEN
 
 unset ASSUME_ROLE
+
+if [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
+    echo "ERROR: failed to set AWS_ACCESS_KEY_ID"
+    return 1
+fi
+if [[ -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+    echo "ERROR: failed to set AWS_SECRET_ACCESS_KEY"
+    return 1
+fi
+if [[ -z "$AWS_SESSION_TOKEN" ]]; then
+    echo "ERROR: failed to set AWS_SESSION_TOKEN"
+    return 1
+fi
+


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1. The script exits out of the shell on failure
2. The script was not actually setting any environment variables
3. If the script does not set the environment variables as expected, the failure is silent

### What was the solution? (How)

1. Changed `exit 1` to `return 1` to avoid exiting out of the shell which is necessary due to this script intending to be invoked with `source`
2. `export` `ASSUME_ROLE` before calls to `printenv ASSUME_ROLE` because otherwise `printenv` can't see `ASSUME_ROLE`
3. Check to make sure the desired environment variables are set at the end of the scripts run and print an error message and `return 1` if it did not.

### What is the impact of this change?

The script works as intended now.

### How was this change tested?

I ran it through the happy path and verified that it now worked as expected by echoing the environment variables it's supposed to set. I also forced it to error to verify that the error handling changes work.

### Was this change documented?

N/A

### Is this a breaking change?

No, this is a fixing change!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*