### PR TITLE
chore: Compatibility fix to compensate for moving _hash_attachments into the Job Attachments code

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -13,7 +13,7 @@ from botocore.exceptions import ClientError
 
 from deadline.client.api import TelemetryClient
 from deadline.client import version as deadline_client_lib_version
-from deadline.job_attachments.progress_tracker import SummaryStatistics
+from deadline.job_attachments.upload import SummaryStatistics
 from openjd.model import version as openjd_model_version
 from openjd.sessions import version as openjd_sessions_version
 
@@ -984,3 +984,7 @@ def record_success_fail_telemetry_event(**decorator_kwargs: Any) -> Callable[[F]
         return cast(F, wrapper)
 
     return inner
+
+
+def hash_summary_telemetry_callback(hash_summary: SummaryStatistics):
+    _get_deadline_telemetry_client().record_hashing_summary(hash_summary)

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -42,6 +42,7 @@ from deadline_worker_agent.aws.deadline import (
     record_attachment_upload_latencies_telemetry_event,
     record_attachment_upload_telemetry_event,
     record_success_fail_telemetry_event,
+    hash_summary_telemetry_callback,
 )
 from deadline_worker_agent.sessions.attachment_models import (
     WorkerManifestProperties,
@@ -180,6 +181,8 @@ def snapshot(
             # when the code reaches here, it's guaranteed output_relative_directories contains value
             include=[glob.escape(subdir) + "/**" for subdir in output_relative_directories],
             name="output",
+            hash_cache_dir=config_file.get_cache_directory(),
+            telemetry_callback=hash_summary_telemetry_callback,
         )
 
         if output_manifest:

--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -1,4 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from deadline_worker_agent.aws.deadline import hash_summary_telemetry_callback
 
 import json
 import pytest
@@ -7,6 +8,7 @@ from unittest.mock import Mock, call, patch, mock_open
 from typing import Optional, Generator
 
 import deadline_worker_agent.sessions.actions.scripts.attachment_upload as attachment_upload_mod
+from deadline.client.config import config_file
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
 from deadline.job_attachments.progress_tracker import ProgressStatus, ProgressTracker
 from deadline.job_attachments.models import JobAttachmentS3Settings
@@ -212,6 +214,8 @@ class TestAttachmentUpload:
             diff="/base/manifest.json",
             include=["output/**"],
             name="output",
+            hash_cache_dir=config_file.get_cache_directory(),
+            telemetry_callback=hash_summary_telemetry_callback,
         )
         mock_manifest_snapshot.assert_any_call(
             root="/local/path4",
@@ -219,6 +223,8 @@ class TestAttachmentUpload:
             diff=None,
             include=["./**"],
             name="output",
+            hash_cache_dir=config_file.get_cache_directory(),
+            telemetry_callback=hash_summary_telemetry_callback,
         )
 
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload._manifest_snapshot")
@@ -255,6 +261,8 @@ class TestAttachmentUpload:
             diff="/base/manifest.json",
             include=["output/**"],
             name="output",
+            hash_cache_dir=config_file.get_cache_directory(),
+            telemetry_callback=hash_summary_telemetry_callback,
         )
         mock_manifest_snapshot.assert_any_call(
             root="/local/path2",
@@ -262,6 +270,8 @@ class TestAttachmentUpload:
             diff=None,
             include=["output/**"],
             name="output",
+            hash_cache_dir=config_file.get_cache_directory(),
+            telemetry_callback=hash_summary_telemetry_callback,
         )
 
     @patch("deadline_worker_agent.sessions.actions.scripts.attachment_upload._manifest_snapshot")
@@ -299,6 +309,8 @@ class TestAttachmentUpload:
                 "[[]data_][*]dir2[?]/**",  # Complex case with multiple special chars
             ],
             name="output",
+            hash_cache_dir=config_file.get_cache_directory(),
+            telemetry_callback=hash_summary_telemetry_callback,
         )
 
     @patch.dict(


### PR DESCRIPTION
NOTE: This should be merged at the same time as updating to the version of deadline-cloud (`deadline`) that releases this change: https://github.com/aws-deadline/deadline-cloud/pull/966

### What was the problem/requirement? (What/Why)

The worker agent calls a non-public function (`_manifest_snapshot`) in the client/job attachments code which had its signature changed as part of an effort to decouple job attachments and the rest of the client.

### What was the solution? (How)

Update calls to this function to use the new signature. This includes querying the config ourself to get the hash cache directory and providing a telemetry callback. Config querying and telemetry were previously done by a function called by the modified function, but are no longer as this is a library function and config and telemetry are application responsibilities.

### What is the impact of this change?

This will be used to fix compatibility with the `deadline` package when it is updated.

### How was this change tested?

I ran the unit tests and e2e tests.

### Was this change documented?

N/A

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*