### PR TITLE
chore(test): fix failing aws model override copy command

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -276,6 +276,8 @@ def worker_config(
             posix_env_override_job_user,
         ],
         windows_job_users=windows_job_users,
+        # TODO: Temporary workaround due to AWS CLI v2 upgrade causing canary failures when copying over AWS models for deadline
+        service_model_path=None,
     )
 
 

--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -73,6 +73,8 @@ class TestWindowsInstaller:
             allow_shutdown=False,
             start_service=False,
             fleet=deadline_resources.scaling_fleet,
+            # TODO: Temporary workaround due to AWS CLI v2 upgrade causing canary failures when copying over AWS models for deadline
+            service_model_path=None,
         )
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Windows release canary is failing due to a Copy command failing when trying to install the `deadline` service model file onto the Worker host

### What was the solution? (How)
Do not install the service model file onto the Worker host, we do not need it for now.

### What is the impact of this change?
Canaries are passing again

### How was this change tested?
This will be tested using the Mainline canary workflows on this repo

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*