### PR TITLE
chore(test): cherry pick fix failing aws model override copy command (#871)

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -276,6 +276,8 @@ def worker_config(
             posix_env_override_job_user,
         ],
         windows_job_users=windows_job_users,
+        # TODO: Temporary workaround due to AWS CLI v2 upgrade causing canary failures when copying over AWS models for deadline
+        service_model_path=None,
     )
 
 

--- a/test/e2e/test_installer.py
+++ b/test/e2e/test_installer.py
@@ -73,6 +73,8 @@ class TestWindowsInstaller:
             allow_shutdown=False,
             start_service=False,
             fleet=deadline_resources.scaling_fleet,
+            # TODO: Temporary workaround due to AWS CLI v2 upgrade causing canary failures when copying over AWS models for deadline
+            service_model_path=None,
         )
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There are recent awcli changes that broke canaries worker setup step in windows

### What was the solution? (How)
Added a workaround due to AWS CLI v2 upgrade causing canary failures when copying over AWS models for deadline

### What is the impact of this change?
Stop windows canaries from failing during worker setup and get the tests run.

### How was this change tested?
Mainline E2E and canaries are already passing

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*