### PR TITLE
chore(e2e): Verify Windows Powershell file replacement successful

### DIFF
--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -14,6 +14,7 @@ import os
 import logging
 
 from e2e.conftest import DeadlineResources
+from e2e.utils import windows_replace_and_verify
 from deadline_test_fixtures import (
     Job,
     Farm,
@@ -125,12 +126,11 @@ class TestWindowsJobUserOverride:
     ) -> None:
         class_worker.stop_worker_service()
 
-        cmd_result = class_worker.send_command(
-            "(Get-Content -Path C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml -Raw) -replace '# windows_job_user = \"job-user\"', 'windows_job_user = \"config-override\"' | Set-Content -Path C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml"
-        )
-
-        assert cmd_result.exit_code == 0, (
-            f"Setting the job user override via CLI failed: {cmd_result}"
+        windows_replace_and_verify(
+            worker=class_worker,
+            file_path="C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml",
+            old_pattern='# windows_job_user = "job-user"',
+            new_pattern='windows_job_user = "config-override"',
         )
 
         class_worker.start_worker_service()
@@ -156,11 +156,12 @@ class TestWindowsJobUserOverride:
         assert job.task_run_status == TaskStatus.SUCCEEDED
 
         # reset config file
-        cmd_result = class_worker.send_command(
-            "(Get-Content -Path C:\\ProgramData\Amazon\\Deadline\\Config\\worker.toml -Raw) -replace 'windows_job_user = \"config-override\"', '# windows_job_user = \"job-user\"' | Set-Content -Path C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml"
+        windows_replace_and_verify(
+            worker=class_worker,
+            file_path="C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml",
+            old_pattern='windows_job_user = "config-override"',
+            new_pattern='# windows_job_user = "job-user"',
         )
-
-        assert cmd_result.exit_code == 0, f"Failed to reset config file: {cmd_result}"
 
     def test_installer_user_override(
         self,
@@ -224,11 +225,12 @@ class TestWindowsJobUserOverride:
         assert override_worker_agent_job.task_run_status == TaskStatus.SUCCEEDED
 
         # reset config file
-        cmd_result = class_worker.send_command(
-            "(Get-Content -Path C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml -Raw) -replace 'windows_job_user = \"installer-override\"', '# windows_job_user = \"job-user\"' | Set-Content -Path C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml"
+        windows_replace_and_verify(
+            worker=class_worker,
+            file_path="C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml",
+            old_pattern='windows_job_user = "installer-override"',
+            new_pattern='# windows_job_user = "job-user"',
         )
-
-        assert cmd_result.exit_code == 0, f"Failed to reset config file: {cmd_result}"
 
     def test_env_var_user_override(
         self,

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -504,3 +504,40 @@ def upload_directory_to_s3(s3_client: Any, local_dir: str, bucket: str, s3_prefi
 
             LOG.info(f"Uploading {file_path} to s3://{bucket}/{s3_key}")
             s3_client.upload_file(str(file_path), bucket, s3_key)
+
+
+def windows_replace_and_verify(
+    worker: EC2InstanceWorker,
+    file_path: str,
+    old_pattern: str,
+    new_pattern: str,
+) -> None:
+    """
+    Performs a PowerShell string replacement in a file and verifies it succeeded.
+
+    PowerShell's -replace operator returns exit code 0 even when no replacement occurs,
+    so this function adds verification to ensure the replacement actually happened.
+
+    Args:
+        worker: The EC2 worker instance to execute commands on
+        file_path: Windows path to the file to modify (e.g., "C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml")
+        old_pattern: Pattern to replace (regex pattern used in PowerShell -replace)
+        new_pattern: Replacement string
+
+    Raises:
+        AssertionError: If replacement command or verification fails
+    """
+    # Perform replacement
+    cmd_result = worker.send_command(
+        f"(Get-Content -Path {file_path} -Raw) -replace '{old_pattern}', '{new_pattern}' | Set-Content -Path {file_path}"
+    )
+    assert cmd_result.exit_code == 0, f"Replacement command failed: {cmd_result}"
+
+    # Verify the replacement actually happened - PowerShell's -replace silently
+    # returns the original string if the pattern isn't found
+    verify_result = worker.send_command(f"Get-Content {file_path}")
+    assert verify_result.exit_code == 0, f"Failed to read config file: {verify_result}"
+    assert new_pattern in verify_result.stdout, (
+        f"Config replacement failed - template format may have changed. "
+        f"Config contents:\n{verify_result.stdout}"
+    )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `test_config_file_user_override` test can fail with a misleading assertion error when the PowerShell `-replace` command doesn't find a match. The test expects `I am: config-override` but gets `I am: job-user`.

PowerShell's `-replace` operator silently returns the original string when the pattern isn't found - it doesn't throw an error or return a non-zero exit code. The existing assert `cmd_result.exit_code == 0` check only verifies the command ran, not that it actually modified anything.

Additionally, while the test fixtures use `$ErrorActionPreference = 'Stop'` for worker configuration commands (see `configure_worker_common`), this isn't applied to arbitrary `send_command` calls from tests. And even if it were, `-replace` not finding a match isn't a terminating error in PowerShell.

### What was the solution? (How)

Add a verification step after the replacement to confirm the config was actually modified. This provides a clear, actionable error message pointing to the actual problem rather than a downstream assertion failure about unexpected user output.

### What is the impact of this change?

This change adds a fail-fast verification to the `test_config_file_user_override` e2e test. If the config file replacement silently fails (e.g., due to template format changes), the test will now fail
immediately with a clear error message showing the actual config contents, rather than failing later with a confusing assertion about unexpected user output.

### How was this change tested?

I ran the e2e test:

```
===================================================================================================================== slowest 5 durations ======================================================================================================================
318.11s setup    test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_config_file_user_override
61.22s call     test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_config_file_user_override
8.22s teardown test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_config_file_user_override
=========================================================================================================== 1 passed, 1 warning in 387.60s (0:06:27) ===========================================================================================================
```

### Was this change documented?

No documentation needed - this is an internal test improvement.

### Is this a breaking change?

No. This only affects test behavior and does not change any production code or public APIs.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*