### PR TITLE
fix(e2e): Use flexible regex pattern for capabilities test

### DIFF
--- a/test/e2e/test_cap_kill.py
+++ b/test/e2e/test_cap_kill.py
@@ -226,13 +226,13 @@ def test_worker_subprocesses_have_no_capabilities(
     job.assert_single_task_log_contains(
         deadline_client=deadline_client,
         logs_client=logs_client,
-        expected_pattern=re.escape("Current: =\n"),
+        expected_pattern=r"Current: =\s*\n",
     )
 
     job.assert_single_task_log_contains(
         deadline_client=deadline_client,
         logs_client=logs_client,
-        expected_pattern=re.escape("Ambient set =\n"),
+        expected_pattern=r"Ambient set =\s*\n",
     )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`re.escape("Current: =\n")` creates a pattern that matches the exact literal string `"Current: =\n" - it escapes any regex special characters so nothing is interpreted as a regex metacharacter.

The problem is CloudWatch log batching can introduce variable whitespace when joining log events. So sometimes the actual log output might have extra spaces or different whitespace between = and the newline. This can lead to flaky test results.

By switching to `r"Current: =\s*\n"`, the `\s*` allows zero or more whitespace characters between = and the newline, making the pattern flexible enough to match regardless of how CloudWatch formatted the log output.

### What was the solution? (How)

Changed the assertion patterns from literal string matching `re.escape("Current: =\n")` to flexible regex patterns `r"Current: =\s*\n"` that allow whitespace variations between the = and the newline character. This applies to both the "Current:" and "Ambient set" capability checks.

### What is the impact of this change?

The e2e test `test_worker_subprocesses_have_no_capabilities` will be more resilient to CloudWatch log formatting variations, reducing flaky test failures.

### How was this change tested?

I ran the e2e test using the instructions in this package.

### Was this change documented?

No documentation changes required - this is an internal test fix.

### Is this a breaking change?

No. This only affects e2e test assertions and does not change any production code or public APIs.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*