### PR TITLE
chore(deps): update openjd-sessions-for-python to 0.10.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline >= 0.54.0,< 0.55",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.10.6",
+    "openjd-sessions == 0.10.7",
     "openjd-model >= 0.8.1, < 0.10",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from concurrent.futures import Executor
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING, cast
 
 from openjd.model import TaskParameterSet
 
@@ -10,6 +10,8 @@ from ...log_messages import SessionActionLogKind
 from .openjd_action import OpenjdAction
 
 if TYPE_CHECKING:
+    from openjd.model.v2023_09 import StepScript
+
     from ..job_entities import StepDetails
     from ..session import Session
 
@@ -77,8 +79,9 @@ class RunStepTaskAction(OpenjdAction):
         if self.task_id is not None:
             env_vars["DEADLINE_TASK_ID"] = self.task_id
 
+        # The service resolves step template syntax sugar, so script is always present.
         session.run_task(
-            step_script=self._details.step_template.script,
+            step_script=cast("StepScript", self._details.step_template.script),
             task_parameter_values=self._task_parameter_values,
             os_env_vars=env_vars,
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

New openjd-sessions release that added FEATURE_BUNDLE_1 support. StepScript is now optional on submission, but is always resolved on the worker host. Linting was failing due to it appearing optional

### What was the solution? (How)

show that it's not optional

### What is the impact of this change?

linting passes

### How was this change tested?

```
hatch run test && hatch run lint
```

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*