### PR TITLE
chore: cherry pick temporary pin virtualenv<21 to fix build

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -42,7 +42,7 @@ jobs:
     
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch "virtualenv<21"
 
     - name: Run Integration Tests
       run: hatch run integ-test

--- a/.github/workflows/mainline_e2e_canary.yml
+++ b/.github/workflows/mainline_e2e_canary.yml
@@ -20,7 +20,7 @@ jobs:
     
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch "virtualenv<21"
 
     - name: Run Integration Tests
       run: hatch run integ-test

--- a/.github/workflows/mainline_e2e_test.yml
+++ b/.github/workflows/mainline_e2e_test.yml
@@ -23,7 +23,7 @@ jobs:
     
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch "virtualenv<21"
 
     - name: Run Integration Tests
       run: hatch run integ-test

--- a/.github/workflows/release_e2e_canary.yml
+++ b/.github/workflows/release_e2e_canary.yml
@@ -20,7 +20,7 @@ jobs:
     
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch "virtualenv<21"
 
     - name: Run Integration Tests
       run: hatch run integ-test

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -148,7 +148,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "virtualenv<21"
 pip install --upgrade twine
 hatch -v run lint
 hatch run test

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -3,7 +3,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "virtualenv<21"
 
 if [ "$TEST_TYPE" ]
 then

--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -3,7 +3,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "virtualenv<21"
 
 if [ "$TEST_TYPE" ]
 then


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

virtualenv 21 was released which broke hatch commands. The release canaries will fail to run.

### What was the solution? (How)

Cherry pick https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/886 to bring the fix into the release canaries

### What is the impact of this change?

Release canaries work

### How was this change tested?

Ran `hatch build` with virtualenv<21

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*