### PR TITLE
feat: pass host AWS_ENDPOINT_URL env variables to job attachment sync actions

### DIFF
--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -1191,6 +1192,16 @@ class Session:
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
+        # Forward any AWS endpoint URL overrides from the host environment so that
+        # customers can direct S3 (or other service) traffic to custom endpoints.
+        endpoint_overrides = {
+            k: v for k, v in os.environ.items() if k.startswith("AWS_ENDPOINT_URL")
+        }
+        if endpoint_overrides:
+            if os_env_vars is None:
+                os_env_vars = {}
+            os_env_vars.update(endpoint_overrides)
+
         self._session._run_task_without_session_env(
             step_script=step_script,
             task_parameter_values=task_parameter_values,

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -189,6 +189,13 @@ def logs_client() -> MagicMock:
 
 
 @pytest.fixture(autouse=True)
+def clear_aws_endpoint_url_env_vars(monkeypatch: pytest.MonkeyPatch):
+    for key in list(os.environ):
+        if key.startswith("AWS_ENDPOINT_URL"):
+            monkeypatch.delenv(key)
+
+
+@pytest.fixture(autouse=True)
 def patch_windows_session_user_validate():
     with patch.object(WindowsSessionUser, "_validate_username_password"):
         yield

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -2524,3 +2524,51 @@ class TestRunAttachmentSyncTask:
             )
 
         assert exc_info.value is expected_exception
+
+    def test_forwards_aws_endpoint_url_overrides(
+        self,
+        session: Session,
+        mock_openjd_session: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Tests that AWS_ENDPOINT_URL* env vars from the host are forwarded."""
+        # GIVEN
+        monkeypatch.setenv("AWS_ENDPOINT_URL_S3", "https://custom-s3-endpoint")
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "https://custom-global-endpoint")
+        monkeypatch.setenv("UNRELATED_VAR", "should-not-appear")
+        step_script_model = MagicMock()
+
+        # WHEN
+        session._run_attachment_sync_task(
+            step_script=step_script_model,
+            task_parameter_values={},
+            os_env_vars={"DEADLINE_QUEUE_ID": "queue-1"},
+        )
+
+        # THEN
+        call_kwargs = mock_openjd_session._run_task_without_session_env.call_args[1]
+        assert call_kwargs["os_env_vars"]["AWS_ENDPOINT_URL_S3"] == "https://custom-s3-endpoint"
+        assert call_kwargs["os_env_vars"]["AWS_ENDPOINT_URL"] == "https://custom-global-endpoint"
+        assert call_kwargs["os_env_vars"]["DEADLINE_QUEUE_ID"] == "queue-1"
+        assert "UNRELATED_VAR" not in call_kwargs["os_env_vars"]
+
+    def test_forwards_aws_endpoint_url_overrides_when_no_env_vars(
+        self,
+        session: Session,
+        mock_openjd_session: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Tests that AWS_ENDPOINT_URL* env vars are forwarded even when os_env_vars is None."""
+        # GIVEN
+        monkeypatch.setenv("AWS_ENDPOINT_URL_S3", "https://custom-s3-endpoint")
+        step_script_model = MagicMock()
+
+        # WHEN
+        session._run_attachment_sync_task(
+            step_script=step_script_model,
+            task_parameter_values={},
+        )
+
+        # THEN
+        call_kwargs = mock_openjd_session._run_task_without_session_env.call_args[1]
+        assert call_kwargs["os_env_vars"]["AWS_ENDPOINT_URL_S3"] == "https://custom-s3-endpoint"


### PR DESCRIPTION
Fixes #882 

### What was the problem/requirement? (What/Why)

With the new "sync as job user" feature, users are unable to pass along any endpoint url overrides to the sync action since it explicitly disregards the session env.

### What was the solution? (How)

Allowlist `AWS_ENDPOINT_URL` env variables so that they're passed along.

### What is the impact of this change?

Users should be able to set these endpoint overrides on their worker host and have them work in the job attachment sync action.

### How was this change tested?

Added some tests, but need to test manually

### Was this change documented?

This might be something we want to document for users. Not currently sure the best location.

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*