### PR TITLE
test(fix): incorrect job user was being searched for

### DIFF
--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -228,7 +228,7 @@ class TestWindowsJobUserOverride:
         windows_replace_and_verify(
             worker=class_worker,
             file_path="C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml",
-            old_pattern='windows_job_user = "installer-override"',
+            old_pattern=f'windows_job_user = "{WINDOWS_JOB_USER}"',
             new_pattern='# windows_job_user = "job-user"',
         )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

mainline canaries were consistently failing:

```
=========================== short test summary info ============================
FAILED test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_installer_user_override
======= 1 failed, 46 passed, 17 skipped, 1 warning in 6181.92s (1:43:01) =======
```

```
>       windows_replace_and_verify(
            worker=class_worker,
            file_path="C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml",
            old_pattern='windows_job_user = "installer-override"',
            new_pattern='# windows_job_user = "job-user"',
        )
```
```
>       assert new_pattern in verify_result.stdout, (
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            f"Config replacement failed - template format may have changed. "
            f"Config contents:\n{verify_result.stdout}"
        )
E       AssertionError: Config replacement failed - template format may have changed. Config contents:
...
E       windows_job_user = "install-override"
```

Test is looking to replace `installer-override` but is set-up that the contents will be `install-override`.

### What was the solution? (How)

Use the constant defined at the top of the file

### What is the impact of this change?

Working canaries

### How was this change tested?

Canaries will test :)

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*