### PR TITLE
fix(installer,windows): SIDs with no LSA rights fail the install on non-english locales

### DIFF
--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -723,7 +723,7 @@ def get_effective_user_rights(user: str) -> set[str]:
             try:
                 account_rights = win32security.LsaEnumerateAccountRights(policy_handle, sid)
             except pywintypes.error as e:
-                if e.strerror == "The system cannot find the file specified.":
+                if e.winerror == winerror.ERROR_FILE_NOT_FOUND:
                     # Account is not directly assigned any rights
                     continue
                 else:

--- a/test/unit/install/test_windows_installer.py
+++ b/test/unit/install/test_windows_installer.py
@@ -17,6 +17,7 @@ from deadline_worker_agent import installer as installer_mod
 from deadline_worker_agent.installer import ParsedCommandLineArguments, win_installer, install
 from deadline_worker_agent.windows.win_service import WorkerAgentWindowsService
 
+import pywintypes
 import win32con
 import win32netcon
 import win32profile
@@ -996,3 +997,24 @@ class TestProvisionDirectories:
             agent_user_permission=None,
             users_group_permission=FileSystemPermissionEnum.LIST_DIRECTORY_AND_READ,
         )
+
+
+class TestGetEffectiveUserRights:
+    """Tests for get_effective_user_rights"""
+
+    @patch.object(win_installer, "win32api")
+    @patch.object(win_installer, "win32security")
+    @patch.object(win_installer, "win32net")
+    def test_skips_sid_with_no_rights(self, mock_win32net, mock_win32security, mock_win32api):
+        """SID with no assigned rights (ERROR_FILE_NOT_FOUND) properly returns an empty set"""
+        mock_win32security.LookupAccountName.return_value = (Mock(), None, None)
+        mock_win32net.NetUserGetLocalGroups.return_value = []
+        mock_win32security.LsaEnumerateAccountRights.side_effect = pywintypes.error(
+            winerror.ERROR_FILE_NOT_FOUND,
+            "LsaEnumerateAccountRights",
+            "Le fichier spécifié est introuvable.",
+        )
+
+        result = win_installer.get_effective_user_rights("testuser")
+
+        assert result == set()


### PR DESCRIPTION
Fixes #885

### What was the problem/requirement? (What/Why)

When determining if we should ignore a specific error

```
pywintypes.error: (2, 'LsaEnumerateAccountRights', 'The system cannot find the file specified')
```

We were checking against the string `The system cannot find the file specified` rather than the locale independent error code `2` or `winerror.ERROR_FILE_NOT_FOUND`: [reference](https://github.com/mhammond/pywin32/blob/e57a73871e808beecb95daf434075f71a2522e95/win32/Lib/winerror.py#L217)

### What was the solution? (How)

Check the error code rather than the error string.

### What is the impact of this change?

Worker Agent should be more robust to non-english locales

### How was this change tested?

Added a test with a non-english error that reproduced the issue.

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*