### PR TITLE
docs: nit improvements based on code scanning to docs

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -21,14 +21,20 @@ The structure of the persistence directory is:
 ```txt
 <PERSISTENT_DIR>/
 ├── credentials/
-│   ├── <WORKER_ID>.json
+│   └── <WORKER_ID>.json
 ├── queues/
-│   ├── <QUEUE_1_ID>
-│   │   ├── get_aws_credentials.sh
-│   │   └── iam_credentials.json
-│   └── <QUEUE_2_ID>
-│       ├── get_aws_credentials.sh
-│       └── iam_credentials.json
+│   ├── <QUEUE_1_ID>/
+│   │   ├── config
+│   │   ├── credentials
+│   │   ├── get_aws_credentials.sh    # POSIX
+│   │   ├── get_aws_credentials.cmd   # Windows
+│   │   └── aws_credentials.json
+│   └── <QUEUE_2_ID>/
+│       ├── config
+│       ├── credentials
+│       ├── get_aws_credentials.sh    # POSIX
+│       ├── get_aws_credentials.cmd   # Windows
+│       └── aws_credentials.json
 └── worker.json
 ```
 
@@ -139,7 +145,7 @@ Structure:
         ├── credentials
         ├── get_aws_credentials.sh    # POSIX
         ├── get_aws_credentials.cmd   # Windows
-        └── iam_credentials.json
+        └── aws_credentials.json
 ```
 
 When the worker agent is assigned a worker session for a queue with an associate IAM role, the
@@ -152,7 +158,7 @@ This is done using the following procedure:
 2.  write `config` file
 3.  write `credentials` file
 4.  write `get_aws_credentials.sh` on POSIX or `get_aws_credentials.cmd` on Windows
-5.  write `iam_credentials.json` containing the temporary credentials in the format expected
+5.  write `aws_credentials.json` containing the temporary credentials in the format expected
     by the AWS CLI and SDKs
 
 

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -83,8 +83,8 @@
 #
 # or if the --disallow-instance-profile command-line flag is specified.
 #
-# By default, this value is true and the worker agent will run with or without an instance profile
-# if the worker is on an EC2 host. If this value is false, the worker host will query the EC2
+# By default, this value is true and the worker agent will run regardless of whether an instance
+# profile is attached. If this value is set to false, the worker agent will query the EC2
 # instance meta-data service (IMDS) to check for an instance profile. If an instance profile is
 # detected, the worker agent will stop and exit.
 #
@@ -95,8 +95,7 @@
 #  *                                                                                         *
 #  *******************************************************************************************
 #
-# To turn on this feature and have the worker agent not run with an EC2 instance profile,
-# uncomment the line below:
+# To disallow instance profiles (recommended for production), uncomment the line below:
 #
 # allow_ec2_instance_profile = false
 
@@ -226,6 +225,16 @@
 #
 # windows_job_user = "job-user"
 
+# The ARN of an AWS Secrets Manager secret containing the password of the Windows job user.
+# This is used instead of resetting the password to a random value. This value is overridden
+# when the DEADLINE_WORKER_WINDOWS_JOB_USER_PASSWORD_ARN environment variable is set or if the
+# --windows-job-user-password-arn command-line flag is specified.
+#
+# To use a Secrets Manager secret for the Windows job user password, uncomment the line below
+# and replace with your secret ARN:
+#
+# windows_job_user_password_arn = "arn:aws:secretsmanager:us-west-2:123456789012:secret/my-secret"
+
 # AWS Deadline Cloud may tell the worker to stop. If the "shutdown_on_stop" setting below is true, then the
 # Worker will attempt to shutdown the host system after the Worker has been stopped.
 #
@@ -253,6 +262,35 @@
 # To retain this Session directory after the Session ends, uncomment the line below:
 #
 # retain_session_dir = true
+
+# Whether the worker agent should clean up processes belonging to a session's OS user when the
+# session user is no longer being used in any active sessions. This value is overridden when the
+# DEADLINE_WORKER_CLEANUP_SESSION_USER_PROCESSES environment variable is set using one of the
+# following case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# By default this is true. To disable session user process cleanup, uncomment the line below:
+#
+# cleanup_session_user_processes = false
+
+
+# Whether the worker agent should log host metrics (CPU, memory, etc.) periodically.
+# This value is overridden when the DEADLINE_WORKER_HOST_METRICS_LOGGING environment variable
+# is set.
+#
+# By default this is true. To disable host metrics logging, uncomment the line below:
+#
+# host_metrics_logging = false
+
+
+# The interval in seconds between host metrics log messages. Only applies when
+# host_metrics_logging is true. This value is overridden when the
+# DEADLINE_WORKER_HOST_METRICS_LOGGING_INTERVAL_SECONDS environment variable is set.
+#
+# The default is 60 seconds. To change the interval, uncomment the line below:
+#
+# host_metrics_logging_interval_seconds = 60
 
 [capabilities]
 

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -95,7 +95,7 @@
 #  *                                                                                         *
 #  *******************************************************************************************
 #
-# To disallow instance profiles (recommended for production), uncomment the line below:
+# To disallow instance profiles, uncomment the line below:
 #
 # allow_ec2_instance_profile = false
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The documentation had several discrepancies with the actual source code:

1. **`docs/state.md`** — The persistence directory structure showed incorrect filenames for queue credential files. The doc listed `iam_credentials.json` but the actual file created by the code is `aws_credentials.json`. The doc was also missing the `config` and `credentials` files that are created per queue directory.

2. **`worker.toml.example`** — The `allow_ec2_instance_profile` description was confusingly worded ("To turn on this feature and have the worker agent not run with an EC2 instance profile"). Several config options that exist in [`settings.py`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/config/settings.py) were completely missing from the example config file:
   - `cleanup_session_user_processes` (default: `true`)
   - `host_metrics_logging` (default: `true`)
   - `host_metrics_logging_interval_seconds` (default: `60`)
   - `windows_job_user_password_arn`

### What was the solution? (How)

**`docs/state.md`:**
- Fixed the top-level persistence directory tree to match the actual files created by [`QueueBoto3Session.__init__()`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py#L127):
  - Added `config` file (created by [`AWSConfig`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/aws_credentials/aws_configs.py) — `path` property returns `parent_dir / "config"`)
  - Added `credentials` file (created by [`AWSCredentials`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/aws_credentials/aws_configs.py) — `path` property returns `parent_dir / "credentials"`)
  - Renamed `iam_credentials.json` → `aws_credentials.json` (set by `self._credentials_filename_no_ext = "aws_credentials"` in [`queue_boto3_session.py`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/aws_credentials/queue_boto3_session.py#L168))
  - Added `get_aws_credentials.cmd` for Windows (the code creates `.sh` on POSIX and `.cmd` on Windows)

**`worker.toml.example`:**
- Clarified `allow_ec2_instance_profile` wording to be unambiguous: "To disallow instance profiles (recommended for production), uncomment the line below"
- Added `windows_job_user_password_arn` option (exists in [`settings.py`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/config/settings.py) with env var `DEADLINE_WORKER_WINDOWS_JOB_USER_PASSWORD_ARN`)
- Added `cleanup_session_user_processes` option (exists in [`settings.py`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/config/settings.py) with env var `DEADLINE_WORKER_CLEANUP_SESSION_USER_PROCESSES`)
- Added `host_metrics_logging` option (exists in [`settings.py`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/config/settings.py) with env var `DEADLINE_WORKER_HOST_METRICS_LOGGING`)
- Added `host_metrics_logging_interval_seconds` option (exists in [`settings.py`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/src/deadline_worker_agent/config/settings.py) with env var `DEADLINE_WORKER_HOST_METRICS_LOGGING_INTERVAL_SECONDS`)

### What is the impact of this change?

Documentation-only. No code changes. Users reading the docs will now see accurate file paths and all available configuration options.

### How was this change tested?

Manual cross-referencing of every doc claim against the source code in `settings.py`, `queue_boto3_session.py`, and `aws_configs.py`.

### Was this change documented?

This change IS the documentation update.

### Is this a breaking change?

No. Documentation only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
