### PR TITLE
chore: handle CONCURRENT_MODIFICATION in CreateWorker API calls

### DIFF
--- a/docs/dev/worker_api_protocol.md
+++ b/docs/dev/worker_api_protocol.md
@@ -31,6 +31,7 @@ The steps to take are:
         `CREATE_IN_PROGRESS` -> Perform exponential backoff, and then retry.
         * `reason` is `STATUS_CONFLICT`, `resourceId` is the Worker's Fleet ID, and `context["status"]` is
         not `CREATE_IN_PROGRESS` -> Stop. Exit the application. The Fleet for this Worker cannot be joined.
+        * `reason` is `CONCURRENT_MODIFICATION` -> Perform exponential backoff, and then retry.
         * Otherwise -> Stop. Exit the application.
 2. Invoke the `AssumeFleetRoleForWorker` API with (farmId, fleetId, workerId)
     * Use the AWS Credentials that the Worker Agent was started with access to. i.e. The default credentials

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -449,6 +449,8 @@ def create_worker(
                         )
                     else:
                         raise DeadlineRequestUnrecoverableError(e)
+                elif exception_reason == "CONCURRENT_MODIFICATION":
+                    _logger.info(f"CreateWorker conflict. Retrying in {delay} seconds...")
                 else:
                     # Unknown exception_reason. Treat as unrecoverable
                     raise DeadlineRequestUnrecoverableError(e)

--- a/test/unit/aws/deadline/test_create_worker.py
+++ b/test/unit/aws/deadline/test_create_worker.py
@@ -132,6 +132,17 @@ def test_success(
             None,
             id="Fleet-CREATE_IN_PROGRESS",
         ),
+        pytest.param(
+            ClientError(
+                {
+                    "Error": {"Code": "ConflictException", "Message": "A message"},
+                    "reason": "CONCURRENT_MODIFICATION",
+                },
+                "CreateWorker",
+            ),
+            None,
+            id="ConcurrentModification",
+        ),
     ],
 )
 def test_retries_when_appropriate(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When the worker agent calls `CreateWorker` to register itself,  the service may return a 409 `ConflictException` with `reason=CONCURRENT_MODIFICATION`.

Currently, `create_worker()` treats all unrecognized 409 reasons as unrecoverable errors and exits. However, `CONCURRENT_MODIFICATION` is already handled as a retryable condition in both `update_worker()` and `update_worker_schedule()`. `CreateWorker` is the only API in the worker protocol missing this handling.

### What was the solution? (How)

Added `CONCURRENT_MODIFICATION` as a retryable 409 reason in `create_worker()`, consistent with the existing pattern in `update_worker()` and `update_worker_schedule()`. When received, the agent logs at INFO level and retries with exponential backoff.

### What is the impact of this change?

The worker agent will now retry with exponential backoff when `CreateWorker` returns a 409 `CONCURRENT_MODIFICATION`, instead of crashing. This improves resilience during worker startup.

### How was this change tested?

- Added unit test case
- Manual E2E testing with a mocked out service endpoint and a CreateWorker handler that returns 409 twice for an instance then handles the request as usual. Logs are below.

### Was this change documented?

Yes. Updated `docs/dev/worker_api_protocol.md` to add `CONCURRENT_MODIFICATION` handling to the CreateWorker 409 specification, consistent with UpdateWorker and UpdateWorkerSchedule.

### Is this a breaking change?

No.

### Manual testing logs

```
[03/30/26 18:46:43] INFO     [2026-03-30 18:46:43,871][INFO    ] 👋 Worker Agent starting                                                                                                                                                                                      entrypoint.py:77
                    INFO     [2026-03-30 18:46:43,876][INFO    ] AgentInfo                                                                                                                                                                                                    entrypoint.py:555
                             Python Interpreter: /home/jericht/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/4zLt7-Hx/deadline-cloud-worker-agent/bin/python                                                                                                                      
                             Python Version: 3.11.7 (main, Feb  8 2024, 02:44:56) [GCC 7.3.1 20180712 (Red Hat 7.3.1-17)]                                                                                                                                                                      
                             Platform: linux                                                                                                                                                                                                                                                   
                             Agent Version: 0.29.0.post1.dev4                                                                                                                                                                                                                                  
                             Installed at: /local/home/jericht/repositories/github/deadline-cloud-worker-agent/src                                                                                                                                                                             
                             Running as user: jericht                                                                                                                                                                                                                                          
                             Dependency versions installed:                                                                                                                                                                                                                                    
                                     openjd.model: 0.9.0                                                                                                                                                                                                                                       
                                     openjd.sessions: 0.10.7                                                                                                                                                                                                                                   
                                     deadline.job_attachments: 0.54.3                                                                                                                                                                                                                          
                    WARNING  [2026-03-30 18:46:43,882][WARNING ] Could not detect GPU count, nvidia-smi not found                                                                                                                                                            capabilities.py:84
                    WARNING  [2026-03-30 18:46:43,886][WARNING ] Could not detect GPU memory, nvidia-smi not found                                                                                                                                                          capabilities.py:138
                    INFO     [2026-03-30 18:46:43,889][INFO    ] Deadline Cloud telemetry is enabled.                                                                                                                                                                         _telemetry.py:126
[03/30/26 18:46:44] INFO     [2026-03-30 18:46:44,005][INFO    ] CAP_KILL was not found in the thread's inheritable capability set (=)                                                                                                                                      capabilities.py:221
                    INFO     [2026-03-30 18:46:44,019][INFO    ] Worker host is running on instance i-0823ef7e1e230c08e.                                                                                                                                                       bootstrap.py:607
                    INFO     [2026-03-30 18:46:44,020][INFO    ] 💾 FileSystem.Read 💾 Worker state from previous run. [/var/lib/deadline/worker.json]                                                                                                                         bootstrap.py:112
                    INFO     [2026-03-30 18:46:44,021][INFO    ] 💻 Worker.Load 💻 Worker identity loaded from prior run. [farm-bed190f214f74afb90b2b44680137385/fleet-e28487c06e3f4f0e930d14dffb37fb08/worker-a7b1ffbc7c48425e8c2b226379237e92]                               bootstrap.py:328
                    INFO     [2026-03-30 18:46:44,130][INFO    ] 📤 API.Req 📤 [deadline:UpdateWorker] resource={'farm-id': 'farm-bed190f214f74afb90b2b44680137385', 'fleet-id': 'fleet-e28487c06e3f4f0e930d14dffb37fb08', 'worker-id':                                   session_events.py:408
                             'worker-a7b1ffbc7c48425e8c2b226379237e92'} params={'status': 'STARTED', 'capabilities': {'amounts': [{'name': 'amount.worker.vcpu', 'value': 16.0}, {'name': 'amount.worker.memory', 'value': 31406.99609375}, {'name':                                           
                             'amount.worker.disk.scratch', 'value': 141973.0}, {'name': 'amount.worker.gpu', 'value': 0.0}, {'name': 'amount.worker.gpu.memory', 'value': 0.0}], 'attributes': [{'name': 'attr.worker.os.family', 'values': ['linux']}, {'name':                               
                             'attr.worker.cpu.arch', 'values': ['x86_64']}]}, 'hostProperties': **REDACTED**}                                                                                                          
                             request_url=https://"**REDACTED**/farms/farm-bed190f214f74afb90b2b44680137385/fleets/fleet-e28487c06e3f4f0e930d14dffb37fb08/workers/worker-a7b1ffbc7c48425e8c2b226379237e92                                           
                    ERROR    [2026-03-30 18:46:44,578][ERROR   ] 📥 API.Resp 📥 [deadline:UpdateWorker](404) error={'Message': 'Resource of type worker with id worker-a7b1ffbc7c48425e8c2b226379237e92 does not exist.', 'Code': 'ResourceNotFoundException'}            session_events.py:522
                             params={'message': 'Resource of type worker with id worker-a7b1ffbc7c48425e8c2b226379237e92 does not exist.', 'resourceId': 'worker-a7b1ffbc7c48425e8c2b226379237e92', 'resourceType': 'worker'}                                                                  
                             request_id=2a6cda6f-ef0c-4980-abfe-acf883dbef1d                                                                                                                                                                                                                   
                    ERROR    [2026-03-30 18:46:44,580][ERROR   ] 💻 Worker.Load 💻 Worker status could not be set to STARTED. Creating a new Worker. [farm-bed190f214f74afb90b2b44680137385/fleet-e28487c06e3f4f0e930d14dffb37fb08/worker-a7b1ffbc7c48425e8c2b226379237e92]    bootstrap.py:233
                    INFO     [2026-03-30 18:46:44,594][INFO    ] Worker host is running on instance i-0823ef7e1e230c08e.                                                                                                                                                       bootstrap.py:607
                    INFO     [2026-03-30 18:46:44,663][INFO    ] 💻 Worker.Load 💻 Creating worker for hostname "**REDACTED**" [farm-bed190f214f74afb90b2b44680137385/fleet-e28487c06e3f4f0e930d14dffb37fb08]                              bootstrap.py:343
                    INFO     [2026-03-30 18:46:44,665][INFO    ] 📤 API.Req 📤 [deadline:CreateWorker] resource={'farm-id': 'farm-bed190f214f74afb90b2b44680137385', 'fleet-id': 'fleet-e28487c06e3f4f0e930d14dffb37fb08'} params={'hostProperties': "**REDACTED**}                                                                                                                                                                                                  
                             request_url=https://"**REDACTED**/farms/farm-bed190f214f74afb90b2b44680137385/fleets/fleet-e28487c06e3f4f0e930d14dffb37fb08/workers                                                                                   
[03/30/26 18:46:49] ERROR    [2026-03-30 18:46:49,677][ERROR   ] 📥 API.Resp 📥 [deadline:CreateWorker](409) error={'Message': 'STUB: EC2 instance unknown not yet available. (attempt 1/2)', 'Code': 'ConflictException'} params={'message': 'STUB: EC2 instance unknown session_events.py:522
                             not yet available. (attempt 1/2)', 'reason': 'CONCURRENT_MODIFICATION', 'resourceId': 'unknown', 'resourceType': 'Worker'} request_id=803748e6-ccaa-46d0-a4e4-365b873ffdbc                                                                                        
                    INFO     [2026-03-30 18:46:49,680][INFO    ] CreateWorker conflict. Retrying in 0.4070108399223682 seconds...                                                                                                                                               __init__.py:453
[03/30/26 18:46:50] INFO     [2026-03-30 18:46:50,089][INFO    ] 📤 API.Req 📤 [deadline:CreateWorker] resource={'farm-id': 'farm-bed190f214f74afb90b2b44680137385', 'fleet-id': 'fleet-e28487c06e3f4f0e930d14dffb37fb08'} params={'hostProperties': "**REDACTED**}                                                                                                                                                                                                  
                             request_url=https://"**REDACTED**/farms/farm-bed190f214f74afb90b2b44680137385/fleets/fleet-e28487c06e3f4f0e930d14dffb37fb08/workers                                                                                   
                    ERROR    [2026-03-30 18:46:50,273][ERROR   ] 📥 API.Resp 📥 [deadline:CreateWorker](409) error={'Message': 'STUB: EC2 instance unknown not yet available. (attempt 2/2)', 'Code': 'ConflictException'} params={'message': 'STUB: EC2 instance unknown session_events.py:522
                             not yet available. (attempt 2/2)', 'reason': 'CONCURRENT_MODIFICATION', 'resourceId': 'unknown', 'resourceType': 'Worker'} request_id=3f8f5fdf-426c-4995-9fe0-c1ea44bffdda                                                                                        
                    INFO     [2026-03-30 18:46:50,276][INFO    ] CreateWorker conflict. Retrying in 0.49460370506274565 seconds...                                                                                                                                              __init__.py:453
                    INFO     [2026-03-30 18:46:50,773][INFO    ] 📤 API.Req 📤 [deadline:CreateWorker] resource={'farm-id': 'farm-bed190f214f74afb90b2b44680137385', 'fleet-id': 'fleet-e28487c06e3f4f0e930d14dffb37fb08'} params={'hostProperties': "**REDACTED**}                                                                                                                                                                                                  
                             request_url=https://"**REDACTED**/farms/farm-bed190f214f74afb90b2b44680137385/fleets/fleet-e28487c06e3f4f0e930d14dffb37fb08/workers                                                                                   
[03/30/26 18:46:51] INFO     [2026-03-30 18:46:51,385][INFO    ] 📥 API.Resp 📥 [deadline:CreateWorker](200) params={'workerId': 'worker-4d59ba58922c4d43b1c6d2f18561916d'} request_id=b856ec38-73dc-4111-9ea9-6296bdaaf170                                               session_events.py:524
                    INFO     [2026-03-30 18:46:51,387][INFO    ] 💻 Worker.Create 💻 Worker successfully created [farm-bed190f214f74afb90b2b44680137385/fleet-e28487c06e3f4f0e930d14dffb37fb08/worker-4d59ba58922c4d43b1c6d2f18561916d]                                        bootstrap.py:362
                    INFO     [2026-03-30 18:46:51,389][INFO    ] 💾 FileSystem.Write 💾 Worker state saved. [/var/lib/deadline/worker.json]                                                                                                                                    bootstrap.py:169
```

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
