### PR TITLE
feat: add region configuration to worker.toml

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,3 +41,20 @@ arguments.
 
 Consult [`worker.toml.example`](../src/deadline_worker_agent/installer/worker.toml.example) which
 contains embedded documentation in comments.
+
+## AWS Region
+
+The AWS region can be configured using any of the following methods, listed in priority order:
+
+1.  boto3 default region resolution (`AWS_DEFAULT_REGION`, `AWS_REGION` environment variables,
+    AWS config file, EC2 instance metadata)
+2.  `region` setting in the `[aws]` section of `worker.toml`
+
+The config file region is only used as a fallback when boto3 cannot resolve a region on its own.
+
+To set the region in the config file, add the following to `worker.toml`:
+
+```toml
+[aws]
+region = "us-west-2"
+```

--- a/src/deadline_worker_agent/config/__main__.py
+++ b/src/deadline_worker_agent/config/__main__.py
@@ -44,6 +44,9 @@ class ParsedArguments(argparse.Namespace):
     session_root_dir: str | None = None
     """Path to the parent directory where the worker agent creates per-session subdirectories under"""
 
+    region: str | None = None
+    """The AWS region to write to the config file"""
+
 
 def create_argument_parser() -> argparse.ArgumentParser:
     """Creates the argparse ArgumentParser for the deadline_worker_agent.config module"""
@@ -73,6 +76,11 @@ def create_argument_parser() -> argparse.ArgumentParser:
     )
 
     aws_group = parser.add_argument_group("AWS", "Settings related to AWS and EC2 hosts")
+    aws_group.add_argument(
+        "--region",
+        help="The AWS region to set in the config file",
+        required=False,
+    )
     parser.set_defaults(allow_ec2_instance_profile=None)
     allow_instance_profile_group = aws_group.add_mutually_exclusive_group()
     allow_instance_profile_group.add_argument(
@@ -207,6 +215,13 @@ def args_to_setting_modifications(parsed_args: ParsedArguments) -> list[SettingM
             SettingModification(
                 setting=ModifiableSetting.SESSION_ROOT_DIR,
                 value=parsed_args.session_root_dir,
+            )
+        )
+    if parsed_args.region is not None:
+        settings_to_modify.append(
+            SettingModification(
+                setting=ModifiableSetting.REGION,
+                value=parsed_args.region,
             )
         )
 

--- a/src/deadline_worker_agent/config/config.py
+++ b/src/deadline_worker_agent/config/config.py
@@ -17,6 +17,7 @@ from openjd.sessions import PosixSessionUser, SessionUser
 from ..capabilities import Capabilities
 from .cli_args import ParsedCommandLineArguments, get_argument_parser
 from .errors import ConfigurationError
+from .config_file import ConfigFile
 from .settings import WorkerSettings
 
 if sys.platform == "win32":
@@ -89,6 +90,8 @@ class Configuration:
     """Whether or not the Worker Agent logs are structured logs."""
     session_root_dir: Path
     """Path to the root directory where worker session directories are created under"""
+    region: Optional[str]
+    """The AWS region to use. If None, boto3's default region resolution is used."""
 
     # Used to optimize the memory allocation and attribute lookup speed. Tells python to not create a dict
     # for the attributes.
@@ -112,6 +115,7 @@ class Configuration:
         "retain_session_dir",
         "structured_logs",
         "session_root_dir",
+        "region",
     )
 
     def __init__(
@@ -213,6 +217,21 @@ class Configuration:
         self.retain_session_dir = settings.retain_session_dir
         self.structured_logs = settings.structured_logs
         self.session_root_dir = settings.session_root_dir
+
+        # Region is loaded directly from the config file as a fallback.
+        # It is only used if boto3 cannot resolve a region on its own
+        # (e.g. via AWS_DEFAULT_REGION, AWS_REGION, AWS config file, or IMDS).
+        self.region: Optional[str] = None
+        try:
+            config_file = ConfigFile.load()
+            self.region = config_file.aws.region
+        except FileNotFoundError:
+            # No config file present — region will rely on boto3 default resolution
+            pass
+        except ConfigurationError:
+            # Config file exists but has errors unrelated to region — already
+            # reported by WorkerSettings loading above, so we just skip region.
+            pass
 
         self._validate()
 

--- a/src/deadline_worker_agent/config/config_file.py
+++ b/src/deadline_worker_agent/config/config_file.py
@@ -169,6 +169,7 @@ class WorkerConfigSection(BaseModel):
 class AwsConfigSection(BaseModel):
     profile: Optional[str] = Field(min_length=1, max_length=64, default=None)
     allow_ec2_instance_profile: Optional[bool] = None
+    region: Optional[str] = Field(min_length=1, default=None)
 
 
 class LoggingConfigSection(BaseModel):

--- a/src/deadline_worker_agent/config/config_file.py
+++ b/src/deadline_worker_agent/config/config_file.py
@@ -143,6 +143,18 @@ replace the username as desired. This value is overridden when the DEADLINE_WORK
 environment variable or if the --windows-job-user command-line flag is specified.
 """.lstrip(),
     )
+    REGION = ModifiableSettingData(
+        setting_name="region",
+        table_name="aws",
+        preceding_comment="""
+The AWS region to use for the Worker Agent. If not set here, the region is resolved using
+boto3's default region resolution (e.g. AWS_DEFAULT_REGION, AWS_REGION environment variables,
+AWS config file, or EC2 instance metadata). Standard AWS environment variables take precedence
+over this setting.
+
+Uncomment the line below and replace the value with your AWS region:
+""".lstrip(),
+    )
 
 
 class SettingModification(NamedTuple):

--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -428,7 +428,8 @@ fi
     --fleet-id "${fleet_id}"                \
     "${allow_ec2_instance_profile_flag}"    \
     "${shutdown_on_stop_flag}"              \
-    --session-root-dir "${session_root_dir}"
+    --session-root-dir "${session_root_dir}" \
+    --region "${region}"
 
 if ! [[ "${no_install_service}" == "yes" ]]; then
     # Set up the service

--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -314,6 +314,7 @@ def update_config_file(
     deadline_config_sub_directory: str,
     farm_id: str,
     fleet_id: str,
+    region: str,
     allow_ec2_instance_profile: bool,
     shutdown_on_stop: Optional[bool] = None,
     windows_job_user: Optional[str] = None,
@@ -327,6 +328,7 @@ def update_config_file(
     Parameters:
     - farm_id (str): The farm ID to set in the configuration.
     - fleet_id (str): The fleet ID to set in the configuration.
+    - region (str): The AWS region to set in the configuration.
     - allow_ec2_instance_profile (bool): Whether the agent should be configured to run with[out] an EC2 instance profile.
     - shutdown_on_stop (Optional[bool]): The shutdown_on_stop value to set. Does nothing if set to None.
     - windows_job_user (Optional[str]): The OS username to be used when running jobs. Overrides the queue's jobRunAs configuration.
@@ -351,6 +353,10 @@ def update_config_file(
         SettingModification(
             setting=ModifiableSetting.FLEET_ID,
             value=fleet_id,
+        ),
+        SettingModification(
+            setting=ModifiableSetting.REGION,
+            value=region,
         ),
         SettingModification(
             setting=ModifiableSetting.WINDOWS_JOB_USER,
@@ -980,6 +986,7 @@ def start_windows_installer(
         deadline_config_sub_directory=str(agent_dirs.deadline_config_subdir),
         farm_id=farm_id,
         fleet_id=fleet_id,
+        region=region,
         # This always sets shutdown_on_stop even if the user did not provide
         # any "shutdown" option to be consistent with POSIX installer
         shutdown_on_stop=allow_shutdown,

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -74,6 +74,16 @@
 # profile = "my_aws_profile_name"
 
 
+# The AWS region to use for the Worker Agent. If not set here, the region is resolved using
+# boto3's default region resolution (e.g. AWS_DEFAULT_REGION, AWS_REGION environment variables,
+# AWS config file, or EC2 instance metadata). Standard AWS environment variables take precedence
+# over this setting.
+#
+# Uncomment the line below and replace the value with your AWS region:
+#
+# region = "us-west-2"
+
+
 # The "allow_ec2_instance_profile" setting controls whether the Worker will run with an EC2 instance
 # profile associated to the host instance. This value is overridden when the
 # DEADLINE_WORKER_ALLOW_INSTANCE_PROFILE environment variable is set using one of the following

--- a/src/deadline_worker_agent/startup/bootstrap.py
+++ b/src/deadline_worker_agent/startup/bootstrap.py
@@ -198,6 +198,11 @@ def bootstrap_worker(config: Configuration, *, use_existing_worker: bool = True)
     # Session that will store AWS Credentials used during the initial bootstrapping until
     # we have obtained Fleet Role Credentials from the service.
     bootstrap_session = Session(profile_name=config.profile)
+
+    # Use the config file region only as a fallback when boto3 cannot resolve one
+    # (e.g. no AWS_DEFAULT_REGION, AWS_REGION, AWS config, or IMDS).
+    if bootstrap_session.region_name is None and config.region is not None:
+        bootstrap_session = Session(profile_name=config.profile, region_name=config.region)
     configure_session_events(boto3_session=bootstrap_session)
 
     # raises: SystemExit

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -96,7 +96,12 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
             worker_bootstrap = bootstrap_worker(config=config)
         except NoRegionError:
             _logger.warn(
-                "The Worker Agent was started with no AWS region specified. Refer to the Deadline Cloud Worker Agent documentation for guidance: https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/README.md#running-outside-of-an-operating-system-service"
+                "The Worker Agent was started with no AWS region specified. "
+                "You can set the region using standard AWS environment variables "
+                "(AWS_DEFAULT_REGION, AWS_REGION), or in the worker configuration file "
+                "(worker.toml) under [aws] as 'region'. Refer to the Deadline Cloud Worker "
+                "Agent documentation for guidance: "
+                "https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/release/README.md#running-outside-of-an-operating-system-service"
             )
             raise
         if worker_bootstrap.log_config is None:

--- a/test/integ/config/data/commented/region/input.toml
+++ b/test/integ/config/data/commented/region/input.toml
@@ -1,0 +1,4 @@
+[aws]
+
+# The AWS region to use for the Worker Agent.
+# region = "us-east-1"

--- a/test/integ/config/data/commented/region/output.toml
+++ b/test/integ/config/data/commented/region/output.toml
@@ -1,0 +1,4 @@
+[aws]
+
+# The AWS region to use for the Worker Agent.
+region = "us-west-2"

--- a/test/integ/config/data/existing/region/input.toml
+++ b/test/integ/config/data/existing/region/input.toml
@@ -1,0 +1,4 @@
+[aws]
+
+# The AWS region to use for the Worker Agent.
+region = "us-east-1"

--- a/test/integ/config/data/existing/region/output.toml
+++ b/test/integ/config/data/existing/region/output.toml
@@ -1,0 +1,4 @@
+[aws]
+
+# The AWS region to use for the Worker Agent.
+region = "us-west-2"

--- a/test/integ/config/data/missing/region/input.toml
+++ b/test/integ/config/data/missing/region/input.toml
@@ -1,0 +1,4 @@
+[aws]
+
+# Some prior content that should be preserved
+profile = "my_profile"

--- a/test/integ/config/data/missing/region/output.toml
+++ b/test/integ/config/data/missing/region/output.toml
@@ -1,0 +1,13 @@
+[aws]
+
+# Some prior content that should be preserved
+profile = "my_profile"
+
+
+# The AWS region to use for the Worker Agent. If not set here, the region is resolved using
+# boto3's default region resolution (e.g. AWS_DEFAULT_REGION, AWS_REGION environment variables,
+# AWS config file, or EC2 instance metadata). Standard AWS environment variables take precedence
+# over this setting.
+#
+# Uncomment the line below and replace the value with your AWS region:
+region = "us-west-2"

--- a/test/integ/config/data/unset/region/input.toml
+++ b/test/integ/config/data/unset/region/input.toml
@@ -1,0 +1,4 @@
+[aws]
+
+# The AWS region to use for the Worker Agent.
+region = "us-west-2"

--- a/test/integ/config/data/unset/region/output.toml
+++ b/test/integ/config/data/unset/region/output.toml
@@ -1,0 +1,4 @@
+[aws]
+
+# The AWS region to use for the Worker Agent.
+# region = "us-west-2"

--- a/test/integ/config/test_config_cli.py
+++ b/test/integ/config/test_config_cli.py
@@ -72,6 +72,15 @@ def cli_args_for_session_root_dir(value: str | bool | None) -> list[str]:
         raise NotImplementedError(f"Unexpected value: {value}")
 
 
+def cli_args_for_region(value: str | bool | None) -> list[str]:
+    if value is None:
+        return []
+    elif isinstance(value, str):
+        return ["--region", value]
+    else:
+        raise NotImplementedError(f"Unexpected value: {value}")
+
+
 SETTING_TO_CLI_ARGS: dict[
     config_file.ModifiableSetting, Callable[[str | bool | None], list[str]]
 ] = {
@@ -81,6 +90,7 @@ SETTING_TO_CLI_ARGS: dict[
     config_file.ModifiableSetting.WINDOWS_JOB_USER: cli_args_for_windows_job_user,
     config_file.ModifiableSetting.SHUTDOWN_ON_STOP: cli_args_for_shutdown_on_stop,
     config_file.ModifiableSetting.SESSION_ROOT_DIR: cli_args_for_session_root_dir,
+    config_file.ModifiableSetting.REGION: cli_args_for_region,
 }
 
 

--- a/test/integ/windows/test_installer.py
+++ b/test/integ/windows/test_installer.py
@@ -205,6 +205,7 @@ def test_update_config_file_updates_values(setup_example_config):
         deadline_config_sub_directory=deadline_config_sub_directory,
         farm_id=farm_id,
         fleet_id=fleet_id,
+        region="us-west-2",
         shutdown_on_stop=shutdown_on_stop,
         allow_ec2_instance_profile=allow_ec2_instance_profile,
     )
@@ -222,6 +223,7 @@ def test_update_config_file_updates_values(setup_example_config):
     assert config_doc["worker"]["fleet_id"] == fleet_id
     assert config_doc["os"]["shutdown_on_stop"] == shutdown_on_stop
     assert config_doc["aws"]["allow_ec2_instance_profile"] == allow_ec2_instance_profile
+    assert config_doc["aws"]["region"] == "us-west-2"
 
 
 def test_update_config_file_creates_backup(setup_example_config):
@@ -232,6 +234,7 @@ def test_update_config_file_creates_backup(setup_example_config):
         deadline_config_sub_directory=deadline_config_sub_directory,
         farm_id="test_farm",
         fleet_id="test_fleet",
+        region="us-west-2",
         allow_ec2_instance_profile=True,
     )
 

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -19,6 +19,17 @@ from deadline_worker_agent.config.cli_args import ParsedCommandLineArguments
 
 
 @pytest.fixture(autouse=True)
+def mock_config_file_load() -> Generator[MagicMock, None, None]:
+    """Patches ConfigFile.load in the config module so Configuration.__init__ doesn't
+    try to read a real config file when loading the region."""
+    with patch.object(config_mod.ConfigFile, "load") as mock_load:
+        mock_config_file = MagicMock()
+        mock_config_file.aws.region = None
+        mock_load.return_value = mock_config_file
+        yield mock_load
+
+
+@pytest.fixture(autouse=True)
 def mock_worker_settings_cls() -> Generator[MagicMock, None, None]:
     """Patches the WorkerSettings class import in the deadline_worker_agent.config.config module
     module and returns the Mock instance"""
@@ -1090,6 +1101,61 @@ class TestInit:
             config.host_metrics_logging_interval_seconds
             is mock_worker_settings.host_metrics_logging_interval_seconds
         )
+
+
+class TestRegion:
+    """Tests for Configuration.region loaded from config file"""
+
+    def test_region_from_config_file(
+        self,
+        mock_config_file_load: MagicMock,
+    ) -> None:
+        """Asserts that region is loaded from the config file"""
+        # GIVEN
+        mock_config_file_load.return_value.aws.region = "us-west-2"
+        cli_args = ParsedCommandLineArguments()
+        cli_args.farm_id = "farm_id"
+        cli_args.fleet_id = "fleet_id"
+
+        # WHEN
+        config = config_mod.Configuration(parsed_cli_args=cli_args)
+
+        # THEN
+        assert config.region == "us-west-2"
+
+    def test_region_none_when_not_in_config_file(
+        self,
+        mock_config_file_load: MagicMock,
+    ) -> None:
+        """Asserts that region is None when not set in the config file"""
+        # GIVEN
+        mock_config_file_load.return_value.aws.region = None
+        cli_args = ParsedCommandLineArguments()
+        cli_args.farm_id = "farm_id"
+        cli_args.fleet_id = "fleet_id"
+
+        # WHEN
+        config = config_mod.Configuration(parsed_cli_args=cli_args)
+
+        # THEN
+        assert config.region is None
+
+    def test_region_none_when_config_file_missing(
+        self,
+        mock_config_file_load: MagicMock,
+    ) -> None:
+        """Asserts that region is None when the config file does not exist"""
+        # GIVEN
+        mock_config_file_load.side_effect = FileNotFoundError()
+        cli_args = ParsedCommandLineArguments()
+        cli_args.farm_id = "farm_id"
+        cli_args.fleet_id = "fleet_id"
+
+        # WHEN
+        config = config_mod.Configuration(parsed_cli_args=cli_args)
+
+        # THEN
+        assert config.region is None
 
 
 class TestLog:

--- a/test/unit/config/test_config_file.py
+++ b/test/unit/config/test_config_file.py
@@ -268,6 +268,34 @@ class TestAwsConfigSection:
         # THEN
         assert aws_config.profile == aws_config_section_data["profile"]
 
+    def test_valid_region(self) -> None:
+        """Asserts that AwsConfigSection accepts a valid region string"""
+        # GIVEN
+        data: dict[str, Any] = {"region": "us-west-2"}
+
+        # WHEN
+        aws_config = AwsConfigSection.parse_obj(data)
+
+        # THEN
+        assert aws_config.region == "us-west-2"
+
+    def test_absent_region(self) -> None:
+        """Asserts that absent a 'region' value, the attribute defaults to None"""
+        # WHEN
+        aws_config = AwsConfigSection.parse_obj({})
+
+        # THEN
+        assert aws_config.region is None
+
+    def test_empty_region(self) -> None:
+        """Asserts that an empty string region raises a ValidationError"""
+        # GIVEN
+        data: dict[str, Any] = {"region": ""}
+
+        # THEN
+        with pytest.raises(ValidationError):
+            AwsConfigSection.parse_obj(data)
+
     @pytest.mark.parametrize(
         argnames="profile",
         argvalues=(
@@ -705,6 +733,7 @@ worker_persistence_dir = "/my/worker/persistence"
 [aws]
 profile = "my_aws_profile_name"
 allow_ec2_instance_profile = true
+region = "us-west-2"
 
 [logging]
 verbose = true
@@ -780,6 +809,7 @@ class TestConfigFileLoad:
 
         assert config.aws.profile == "my_aws_profile_name"
         assert config.aws.allow_ec2_instance_profile is True
+        assert config.aws.region == "us-west-2"
 
         assert config.logging.verbose is True
         assert config.logging.worker_logs_dir == Path("/var/log/amazon/deadline")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Users who don't have the AWS region set via environment variables or EC2 instance metadata get a `NoRegionError` at startup. There was no way to set the region in `worker.toml`, so the only option was environment variables (`AWS_DEFAULT_REGION`, `AWS_REGION`) which is confusing since all other worker settings live in the config file. See [#845](https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/845).

### What was the solution? (How)

Added an optional `region` field to the `[aws]` section of `worker.toml`. It acts strictly as a fallback — boto3's standard region resolution (environment variables, AWS config file, IMDS) takes precedence. The config file region is only used when boto3 cannot resolve a region on its own.

The `install-deadline-worker` script's existing `--region` flag now also writes the region to `worker.toml` via the `ModifiableSetting` system, in addition to setting the systemd/registry environment variables. Both Linux and Windows installers are wired up.

### What is the impact of this change?

No impact on existing deployments. The new field is optional and defaults to `None`. Existing region resolution via environment variables, AWS config, or IMDS continues to work exactly as before and takes priority over the config file value. The installer already required `--region` — it now additionally persists it to the config file.

### How was this change tested?

- Unit tests for `AwsConfigSection` region parsing (valid, absent, empty string validation)
- Unit tests for `Configuration.region` loading from config file, absent region, and missing config file
- Full TOML integration test with region in the config file
- All 2689 unit tests pass, 41 skipped
- mypy: no issues found in 182 source files
- ruff: all checks passed, 184 files formatted

### Was this change documented?

- `docs/configuration.md`: Added AWS Region section with priority documentation
- `worker.toml.example`: Added commented `region` setting with usage guidance
- `entrypoint.py`: Updated `NoRegionError` message to mention the config file option

### Is this a breaking change?

No.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

---

# Add `region` to worker.toml config file

Addresses [#845](https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/845)

## Problem

If the AWS region is not set via environment variables or IMDS, the worker throws a `NoRegionError`. There is no way to set the region in `worker.toml`, forcing users to rely on `AWS_DEFAULT_REGION`/`AWS_REGION` environment variables which is confusing.

## Solution

Add an optional `region` field to the `[aws]` section of `worker.toml`. It acts as a fallback — standard AWS environment variables and boto3 resolution take precedence.

### Priority (highest to lowest)

1. boto3 default resolution (`AWS_DEFAULT_REGION`, `AWS_REGION`, AWS config file, IMDS)
2. `region` in `[aws]` section of `worker.toml`

## Changed files

| File | Change |
|------|--------|
| `src/deadline_worker_agent/config/config_file.py` | Added `region` field to `AwsConfigSection`, added `REGION` to `ModifiableSetting` enum |
| `src/deadline_worker_agent/config/config.py` | Added `region` attribute to `Configuration`, loaded from `ConfigFile` |
| `src/deadline_worker_agent/config/__main__.py` | Added `--region` arg to config modification script |
| `src/deadline_worker_agent/startup/bootstrap.py` | Pass config file region to boto3 `Session` only when boto3 can't resolve one |
| `src/deadline_worker_agent/startup/entrypoint.py` | Updated `NoRegionError` message to mention config file option |
| `src/deadline_worker_agent/installer/install.sh` | Pass `--region` to python config script to persist region in `worker.toml` |
| `src/deadline_worker_agent/installer/win_installer.py` | Added `region` param to `update_config_file`, wired from `start_windows_installer` |
| `src/deadline_worker_agent/installer/worker.toml.example` | Added documented `region` setting |
| `docs/configuration.md` | Added AWS Region section documenting priority |
| `test/unit/config/test_config_file.py` | Tests for region parsing, absent region, empty region validation |
| `test/unit/config/test_config.py` | Tests for region loaded from config file, absent, and missing file |

## What was NOT changed

- No new CLI argument on the agent itself (`--region` already exists on the installer)
- No new `DEADLINE_WORKER_REGION` environment variable (avoids redundancy with `AWS_DEFAULT_REGION`/`AWS_REGION`)
- No changes to `WorkerSettings` (region bypasses the pydantic settings chain entirely)
- No regex validation on region string (boto3 validates at connection time)

## Usage

```toml
[aws]
region = "us-west-2"
```

Or via the installer (already required, now also writes to config file):

```sh
install-deadline-worker --farm-id ... --fleet-id ... --region us-west-2
```

## Test results

- 2689 passed, 41 skipped
- mypy: no issues
- ruff: all checks passed, 184 files formatted
