### PR TITLE
ci(integ): ensure integ tests run on their respective python version

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -39,10 +39,15 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.tag || inputs.branch || github.ref }}
-    
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch "virtualenv<21"
+        pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
 
     - name: Run Integration Tests
       run: hatch run integ-test

--- a/.github/workflows/mainline_e2e_canary.yml
+++ b/.github/workflows/mainline_e2e_canary.yml
@@ -17,10 +17,15 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v6
-    
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch "virtualenv<21"
+        pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
 
     - name: Run Integration Tests
       run: hatch run integ-test

--- a/.github/workflows/mainline_e2e_test.yml
+++ b/.github/workflows/mainline_e2e_test.yml
@@ -20,10 +20,15 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v6
-    
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch "virtualenv<21"
+        pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
 
     - name: Run Integration Tests
       run: hatch run integ-test

--- a/.github/workflows/release_e2e_canary.yml
+++ b/.github/workflows/release_e2e_canary.yml
@@ -17,10 +17,15 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v6
-    
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch "virtualenv<21"
+        pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
 
     - name: Run Integration Tests
       run: hatch run integ-test


### PR DESCRIPTION
integration tests weren't setting up python, so they were always using the default which was 3.12

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*