### PR TITLE
feat: expose job attachment S3 bucket and root prefix as session env vars

### DIFF
--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -1101,6 +1101,10 @@ class WorkerScheduler:
                 "DEADLINE_FLEET_ID": self._fleet_id,
                 "DEADLINE_WORKER_ID": self._worker_id,
             }
+            # Expose job attachment bucket for plugin delivery mechanisms
+            if job_details.job_attachment_settings:
+                env["DEADLINE_JA_S3_BUCKET"] = job_details.job_attachment_settings.s3_bucket_name
+                env["DEADLINE_JA_ROOT_PREFIX"] = job_details.job_attachment_settings.root_prefix
             if queue_credentials:
                 env.update(
                     {

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -35,6 +35,7 @@ from deadline_worker_agent.scheduler.scheduler import (
 )
 from deadline_worker_agent.scheduler.session_action_status import SessionActionStatus
 from deadline_worker_agent.sessions.job_entities.job_details import (
+    JobAttachmentSettings,
     JobDetails,
     JobRunAsUser,
     JobRunAsWindowsUser,
@@ -1826,3 +1827,153 @@ class TestSessionLogPath:
 
         # THEN
         assert result == queue_log_dir / f"{session_id}.log"
+
+
+class TestSessionEnvVars:
+    """Tests for session environment variable construction."""
+
+    @pytest.fixture
+    def queue_id(self) -> str:
+        return "queue-abcdef0123456789abcdef0123456789"
+
+    @pytest.fixture
+    def session_id(self) -> str:
+        return "session-abcdef0123456789abcdef0123456789"
+
+    @pytest.fixture
+    def assigned_sessions(
+        self,
+        queue_id: str,
+        session_id: str,
+    ) -> dict[str, AssignedSession]:
+        return {
+            session_id: AssignedSession(
+                queueId=queue_id,
+                jobId="job-abcdef0123456789abcdef0123456789",
+                logConfiguration=LogConfiguration(
+                    logDriver="awslogs",
+                    options={
+                        "logGroupName": "logGroup",
+                        "logStreamName": "logStreamName",
+                    },
+                    parameters={"interval": "15"},
+                ),
+                sessionActions=[
+                    EnvironmentAction(
+                        actionType="ENV_ENTER",
+                        environmentId="env-1",
+                        sessionActionId="action-1",
+                    ),
+                    TaskRunAction(
+                        actionType="TASK_RUN",
+                        parameters={},
+                        sessionActionId="action-2",
+                        stepId="step-1",
+                        taskId="task-1",
+                    ),
+                ],
+            ),
+        }
+
+    @pytest.fixture
+    def mock_job_entities(self) -> Generator[MagicMock, None, None]:
+        with patch.object(scheduler_mod, "JobEntities") as job_entities_mock:
+            yield job_entities_mock
+
+    def test_env_includes_job_attachment_vars_when_settings_present(
+        self,
+        scheduler: WorkerScheduler,
+        mock_session: MagicMock,
+        assigned_sessions: dict[str, AssignedSession],
+        mock_job_entities: MagicMock,
+    ) -> None:
+        """
+        GIVEN job_details with job_attachment_settings
+        WHEN _start_session constructs the env dict
+        THEN env contains DEADLINE_JA_S3_BUCKET and DEADLINE_JA_ROOT_PREFIX
+        """
+        # GIVEN
+        job_entity_mock = MagicMock()
+        job_entity_mock.job_details.return_value = JobDetails(
+            log_group_name="/aws/deadline/queue-0000",
+            schema_version=SpecificationRevision.v2023_09,
+            job_run_as_user=JobRunAsUser(
+                posix=(
+                    PosixSessionUser(user="username", group="group") if os.name == "posix" else None
+                ),
+                windows=(
+                    WindowsSessionUser(user="username", password="password")
+                    if os.name == "nt"
+                    else None
+                ),
+            ),
+            job_attachment_settings=JobAttachmentSettings(
+                s3_bucket_name="my-bucket",
+                root_prefix="my-prefix",
+            ),
+            queue_role_arn="arn:aws:iam::123456789012:role/QueueRole",
+        )
+        mock_job_entities.return_value = job_entity_mock
+        scheduler._job_run_as_user_override = JobsRunAsUserOverride(run_as_agent=True)
+
+        # Mock queue credentials with proper string values for session attributes
+        mock_queue_creds = MagicMock()
+        mock_queue_creds.session.credential_process_profile_name = "test-profile"
+        mock_queue_creds.session.aws_config.path = "/tmp/aws_config"
+        mock_queue_creds.session.aws_credentials.path = "/tmp/aws_credentials"
+
+        with (
+            patch.object(scheduler, "_executor"),
+            patch.object(scheduler, "_get_queue_aws_credentials", return_value=mock_queue_creds),
+            patch.object(scheduler_mod, "AssetSync"),
+        ):
+            # WHEN
+            scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
+
+        # THEN
+        mock_session.assert_called_once()
+        env = mock_session.call_args.kwargs["env"]
+        assert env["DEADLINE_JA_S3_BUCKET"] == "my-bucket"
+        assert env["DEADLINE_JA_ROOT_PREFIX"] == "my-prefix"
+
+    def test_env_excludes_job_attachment_vars_when_settings_none(
+        self,
+        scheduler: WorkerScheduler,
+        mock_session: MagicMock,
+        assigned_sessions: dict[str, AssignedSession],
+        mock_job_entities: MagicMock,
+    ) -> None:
+        """
+        GIVEN job_details with job_attachment_settings = None
+        WHEN _start_session constructs the env dict
+        THEN env does NOT contain DEADLINE_JA_S3_BUCKET or DEADLINE_JA_ROOT_PREFIX
+        """
+        # GIVEN
+        job_entity_mock = MagicMock()
+        job_entity_mock.job_details.return_value = JobDetails(
+            log_group_name="/aws/deadline/queue-0000",
+            schema_version=SpecificationRevision.v2023_09,
+            job_run_as_user=JobRunAsUser(
+                posix=(
+                    PosixSessionUser(user="username", group="group") if os.name == "posix" else None
+                ),
+                windows=(
+                    WindowsSessionUser(user="username", password="password")
+                    if os.name == "nt"
+                    else None
+                ),
+            ),
+            job_attachment_settings=None,
+        )
+        mock_job_entities.return_value = job_entity_mock
+        scheduler._job_run_as_user_override = JobsRunAsUserOverride(run_as_agent=True)
+
+        with patch.object(scheduler, "_executor"):
+            # WHEN
+            scheduler._create_new_sessions(assigned_sessions=assigned_sessions)
+
+        # THEN
+        mock_session.assert_called_once()
+        env = mock_session.call_args.kwargs["env"]
+        assert "DEADLINE_JA_S3_BUCKET" not in env
+        assert "DEADLINE_JA_ROOT_PREFIX" not in env


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

Session scripts and actions currently have no way to discover the S3 bucket and root prefix where job attachments are stored. This information is available internally within the worker agent (loaded from `BatchGetJobEntity`), but is not exposed to the session environment. Any script needing this information would have to make additional API calls to retrieve it.

## What was the solution? (How)

Added two new environment variables to the session environment dict in `scheduler.py`:

- `DEADLINE_JA_S3_BUCKET` — the S3 bucket name from `job_attachment_settings`
- `DEADLINE_JA_ROOT_PREFIX` — the root prefix from `job_attachment_settings`

These are only set when `job_attachment_settings` exists on the job details. The data is already loaded from the `BatchGetJobEntity` API response — no new API calls are introduced.

```python
if job_details.job_attachment_settings:
    env["DEADLINE_JA_S3_BUCKET"] = job_details.job_attachment_settings.s3_bucket_name
    env["DEADLINE_JA_ROOT_PREFIX"] = job_details.job_attachment_settings.root_prefix
```

## What is the impact of this change?

- Session scripts and actions can now read `DEADLINE_JA_S3_BUCKET` and `DEADLINE_JA_ROOT_PREFIX` from their environment to locate job attachment storage
- Jobs without job attachments configured are unaffected — the env vars are simply not set
- No changes to existing behavior or API interactions

## How was this change tested?

- **Unit tests**: Added `TestSessionEnvVars` class in `test/unit/scheduler/test_scheduler.py` with two test cases:
  - `test_env_includes_job_attachment_vars_when_settings_present` — verifies env vars are set correctly when `job_attachment_settings` exists
  - `test_env_excludes_job_attachment_vars_when_settings_none` — verifies env vars are absent when `job_attachment_settings` is None

Unit:
```
========================= 2710 passed, 33 skipped, 9 warnings in 20.96s ============================================================================================================
```
Integ:
```
========================= 62 passed, 1 skipped, 2 warnings in 21.43s =============================================================================================================
```
E2E:
```
Linux:

===End Flaky Test Report===
======================================================================================================== slowest 5 durations ========================================================================================================
622.99s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
330.19s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
249.67s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_local_session_logs_can_be_turned_off
249.19s setup    test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_enters_stopping_state_while_draining
218.52s setup    test/e2e/test_override_job_user.py::TestLinuxJobUserOverride::test_no_user_override
====================================================================================== 49 passed, 15 skipped, 1 warning in 4861.66s (1:21:01) =======================================================================================
cmd [3] | echo pytest done

Windows:

===End Flaky Test Report===
======================================================================================================== slowest 5 durations =========================================================================================================
686.37s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
435.15s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_local_session_logs_can_be_turned_off
425.53s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
414.80s setup    test/e2e/test_installer.py::TestWindowsInstaller::test_custom_worker_agent_permissions
368.86s setup    test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_no_user_override
======================================================================================= 47 passed, 17 skipped, 1 warning in 6663.64s (1:51:03) =======================================================================================
cmd [3] | echo pytest done

```

### Manual Testing with Queue Environment
Added host config to pull latest Worker Agent and OpenJD sessions changes, and printed out environment variables after conda activate. Submitted a sample blender job to test.
(My bucket name is indeed sharedbuc)
```
2026/04/27 13:43:47-07:00
==============================================
--------- Entering Environment: EnvVarCheck
==============================================
----------------------------------------------
Phase: Setup
----------------------------------------------
----------------------------------------------
Phase: Running action
----------------------------------------------
Running command sudo -u job-user -i setsid -w /sessions/session-f8a4ac27a19343548ca64a012ebb1eee6kvo41nd/tmpipix2xhn.sh
Command started as pid: 13697

Output:
=== VERIFYING NEW ENV VARS ===
DEADLINE_JA_S3_BUCKET=sharedbuc
DEADLINE_JA_ROOT_PREFIX=DeadlineCloud
OPENJD_SESSION_WORKING_DIR=/sessions/session-f8a4ac27a19343548ca64a012ebb1eee6kvo41nd
=== END ENV VAR CHECK ===

Process pid 13697 exited with code: 0 (unsigned) / 0x0 (hex)

```

## Was this change documented?

No documentation changes required. The env vars follow the existing `DEADLINE_*` naming convention and are self-documenting.

## Is this a breaking change?

No. This is a purely additive change — new environment variables are added to sessions when job attachment settings are present. No existing behavior is modified or removed.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*