### PR TITLE
feat: swap to deadline-job-attachments

### DIFF
--- a/.kiro/skills/worker-agent-testing/SKILL.md
+++ b/.kiro/skills/worker-agent-testing/SKILL.md
@@ -71,11 +71,11 @@ export WORKER_AGENT_WHL_PATH=$(pwd)/$(ls dist/*.whl)
 
 # Linux
 source .e2e_linux_infra.sh
-hatch run e2e-test
+hatch run e2e:test
 
 # Windows
 source .e2e_windows_infra.sh
-hatch run e2e-test
+hatch run e2e:test
 ```
 
 ### Using Local Wheel Files for Dependencies
@@ -98,7 +98,7 @@ These can be combined with `WORKER_AGENT_WHL_PATH`:
 export WORKER_AGENT_WHL_PATH=$(pwd)/$(ls dist/*.whl)
 export OPENJD_SESSIONS_WHL_PATH=/path/to/openjd_sessions-*.whl
 export DEADLINE_WHL_PATH=/path/to/deadline_cloud-*.whl
-hatch run e2e-test
+hatch run e2e:test
 ```
 
 ### Debugging Pytest Hanging
@@ -106,7 +106,7 @@ hatch run e2e-test
 If pytest hangs after tests complete (likely due to a non-exiting Python thread), enable thread stack debugging:
 ```sh
 export DEBUG_THREAD_STACKS=1
-hatch run e2e-test
+hatch run e2e:test
 ```
 
 ## Live Service Testing (Manual)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -122,11 +122,11 @@ export WORKER_AGENT_WHL_PATH=$(pwd)/$(ls dist/*.whl)
 
 # Linux
 source .e2e_linux_infra.sh
-hatch run e2e-test
+hatch run e2e:test
 
 # Windows
 source .e2e_windows_infra.sh
-hatch run e2e-test
+hatch run e2e:test
 ```
 
 You can also override the `openjd-sessions` and/or `deadline-cloud` packages installed on the worker

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -7,6 +7,14 @@ You can opt out of telemetry data collection by either:
 
 1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
 2. Providing the installer flag: `--telemetry-opt-out`
-3. Setting the config file: `deadline config set telemetry.opt_out true`
+3. Setting `opt_out = true` in the `[telemetry]` section of `worker.toml`:
 
-Note that setting the environment variable supersedes the config file setting.
+```toml
+[telemetry]
+opt_out = true
+```
+
+The priority order is: environment variable > worker agent config file (`worker.toml`) > default (enabled).
+
+Note: The worker agent will also check the legacy Deadline client config file (`~/.deadline/config`)
+as a fallback if the setting is not present in the environment or `worker.toml`.

--- a/hatch.toml
+++ b/hatch.toml
@@ -42,23 +42,22 @@ RUN_AS_ADMIN="true"
 
 [envs.e2e]
 detached = true
-pre-install-commands = [
-  "pip install -r requirements-e2e.txt"
-]
 
 [envs.e2e.scripts]
 sync = "pip install -r requirements-e2e.txt"
 test = [
+  "sync",
   "python test/e2e/pre_test_cleanup.py",
   "pytest --no-cov test/e2e {args:}",
   "echo pytest done",
 ]
-typing = "mypy {args:test/e2e}"
+typing = "mypy --config-file test/e2e/mypy.ini {args:test/e2e}"
 style = [
   "ruff check {args:test/e2e}",
   "ruff format --check {args:test/e2e}",
 ]
 lint = [
+  "sync",
   "style",
   "typing",
 ]

--- a/hatch.toml
+++ b/hatch.toml
@@ -11,13 +11,8 @@ test = "pytest test/unit --numprocesses=auto {args}"
 # See: https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers
 version = "hatch version"
 metadata = "hatch project metadata {args:}"
-e2e-test= [
-  "python test/e2e/pre_test_cleanup.py",
-  "pytest --no-cov test/e2e {args:}",
-  "echo pytest done",
-]
 integ-test = "pytest --no-cov test/integ {args:}"
-typing = "mypy {args:src test}"
+typing = "mypy {args:src test/unit test/integ}"
 style = [
   "ruff check {args:.}",
   "ruff format --check {args:.}"
@@ -44,6 +39,29 @@ python = ["3.9", "3.10", "3.11"]
 
 [envs.default.env-vars]
 RUN_AS_ADMIN="true"
+
+[envs.e2e]
+detached = true
+pre-install-commands = [
+  "pip install -r requirements-e2e.txt"
+]
+
+[envs.e2e.scripts]
+sync = "pip install -r requirements-e2e.txt"
+test = [
+  "python test/e2e/pre_test_cleanup.py",
+  "pytest --no-cov test/e2e {args:}",
+  "echo pytest done",
+]
+typing = "mypy {args:test/e2e}"
+style = [
+  "ruff check {args:test/e2e}",
+  "ruff format --check {args:test/e2e}",
+]
+lint = [
+  "style",
+  "typing",
+]
 
 [envs.release]
 detached = true

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -6,5 +6,6 @@ pip install --upgrade pip
 pip install --upgrade hatch "virtualenv<21"
 pip install --upgrade twine
 hatch -v run lint
+hatch -v run e2e:lint
 hatch run test
 hatch -v build

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -16,4 +16,4 @@ then
   fi
 fi
 
-hatch run e2e-test
+hatch run e2e:test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 dependencies = [
     "requests ~= 2.31",
     "boto3 >= 1.34.75",
-    "deadline >= 0.55,< 0.56",
+    "deadline-job-attachments == 0.1.0",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
     "openjd-sessions == 0.10.7",
     "openjd-model >= 0.8.1, < 0.10",

--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -1,10 +1,12 @@
 backoff == 2.2.*
 boto3 >= 1.34.75
 deadline >= 0.56, < 0.57
+deadline-job-attachments >= 0.0, < 0.1
 deadline-cloud-test-fixtures >= 0.18.11, < 0.19
 flaky == 3.8.*
 mypy >= 1.19.1, < 1.20
-pytest == 9.0.*; python_version >= "3.10"
-pytest ~= 8.4; python_version < "3.10"
+pytest == 9.0.*
+pytest-cov == 7.1.*
 pytest-timeout == 2.4.*
 ruff ~= 0.15.12
+types-PyYAML == 6.0.*

--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -1,0 +1,10 @@
+backoff == 2.2.*
+boto3 >= 1.34.75
+deadline >= 0.56, < 0.57
+deadline-cloud-test-fixtures >= 0.18.11, < 0.19
+flaky == 3.8.*
+mypy >= 1.19.1, < 1.20
+pytest == 9.0.*; python_version >= "3.10"
+pytest ~= 8.4; python_version < "3.10"
+pytest-timeout == 2.4.*
+ruff ~= 0.15.12

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -822,7 +822,7 @@ def _get_deadline_telemetry_client() -> TelemetryClient:
             {"deadline-job-attachments": ".".join(deadline_job_attachments_version.split(".")[:3])}
         )
     elif not _telemetry_client._initialized:
-        _telemetry_client._initialize()
+        _telemetry_client.initialize()
     return _telemetry_client
 
 

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -5,14 +5,13 @@ from time import sleep, monotonic
 from typing import Any, Callable, Dict, Optional, TypeVar, cast
 from threading import Event
 from dataclasses import asdict, dataclass
-from functools import wraps, cache
+from functools import wraps
 import random
 
 from botocore.retries.standard import RetryContext
 from botocore.exceptions import ClientError
 
-from deadline.client.api import TelemetryClient
-from deadline.client import version as deadline_client_lib_version
+from deadline.job_attachments import version as deadline_job_attachments_version
 from deadline.job_attachments.progress_tracker import SummaryStatistics
 from openjd.model import version as openjd_model_version
 from openjd.sessions import version as openjd_sessions_version
@@ -20,6 +19,7 @@ from openjd.sessions import version as openjd_sessions_version
 from ..._version import __version__ as version  # noqa
 from ...config import Configuration
 from ...capabilities import Capabilities
+from ...telemetry import TelemetryClient
 from ...boto import DeadlineClient, NoOverflowExponentialBackoff as Backoff
 from ...api_models import (
     AssumeFleetRoleForWorkerResponse,
@@ -800,22 +800,30 @@ def update_worker_schedule(
     return response
 
 
-@cache
+_telemetry_client: Optional[TelemetryClient] = None
+
+
 def _get_deadline_telemetry_client() -> TelemetryClient:
-    """Wrapper around the Deadline Client Library telemetry client, in order to set package-specific information"""
-    client = TelemetryClient(
-        package_name="deadline-cloud-worker-agent", package_ver=".".join(version.split(".")[:3])
-    )
-    client.update_common_details(
-        {"openjd-sessions-version": ".".join(openjd_sessions_version.split(".")[:3])}
-    )
-    client.update_common_details(
-        {"openjd-model-version": ".".join(openjd_model_version.split(".")[:3])}
-    )
-    client.update_common_details(
-        {"deadline-cloud": ".".join(deadline_client_lib_version.split(".")[:3])}
-    )
-    return client
+    """Wrapper around the telemetry client, in order to set package-specific information.
+    Re-attempts initialization if the client was not previously initialized."""
+    global _telemetry_client
+    if _telemetry_client is None:
+        _telemetry_client = TelemetryClient(
+            package_name="deadline-cloud-worker-agent",
+            package_ver=".".join(version.split(".")[:3]),
+        )
+        _telemetry_client.update_common_details(
+            {"openjd-sessions-version": ".".join(openjd_sessions_version.split(".")[:3])}
+        )
+        _telemetry_client.update_common_details(
+            {"openjd-model-version": ".".join(openjd_model_version.split(".")[:3])}
+        )
+        _telemetry_client.update_common_details(
+            {"deadline-job-attachments": ".".join(deadline_job_attachments_version.split(".")[:3])}
+        )
+    elif not _telemetry_client._initialized:
+        _telemetry_client._initialize()
+    return _telemetry_client
 
 
 def record_worker_start_telemetry_event(capabilities: Capabilities) -> None:

--- a/src/deadline_worker_agent/boto/config.py
+++ b/src/deadline_worker_agent/boto/config.py
@@ -3,16 +3,16 @@
 from botocore.config import Config
 
 from .._version import __version__ as worker_agent_version
-from deadline.client import version as deadline_client_lib_version
+from deadline.job_attachments import version as deadline_job_attachments_version
 from openjd.sessions import version as openjd_sessions_version
 
 
 def construct_user_agent() -> str:
     """
     Compute the user agent string to send over boto requests.
-        - Contains the versions of Deadline Worker Agent, Deadline Client Library, OpenJD Sessions.
+        - Contains the versions of Deadline Worker Agent, Deadline Job Attachments, OpenJD Sessions.
     """
-    return f"deadline_worker_agent/{worker_agent_version} deadline_cloud/{deadline_client_lib_version} openjd_sessions/{openjd_sessions_version}"
+    return f"deadline_worker_agent/{worker_agent_version} deadline_job_attachments/{deadline_job_attachments_version} openjd_sessions/{openjd_sessions_version}"
 
 
 DEADLINE_BOTOCORE_CONFIG = Config(
@@ -26,11 +26,11 @@ DEADLINE_BOTOCORE_CONFIG = Config(
 Botocore client configuration for AWS Deadline Cloud. This overrides to:
     - botocore retries - the worker agent has its own retry logic for AWS Deadline Cloud
       API requests. See the `aws/deadline` sub-package for that retry logic.
-    - add deadline, deadline worker agent and openjd package versions to user User-Agent request header
+    - add deadline worker agent, deadline job attachments and openjd package versions to user User-Agent request header
 """
 
 OTHER_BOTOCORE_CONFIG = Config(user_agent_extra=construct_user_agent())
 """
 Botocore client configuration for other AWS services. This overrides to:
-    - add deadline, deadline worker agent and openjd package versions to user User-Agent request header
+    - add deadline worker agent, deadline job attachments and openjd package versions to user User-Agent request header
 """

--- a/src/deadline_worker_agent/config/__main__.py
+++ b/src/deadline_worker_agent/config/__main__.py
@@ -164,6 +164,26 @@ def create_argument_parser() -> argparse.ArgumentParser:
         action="store_false",
         dest="backup",
     )
+
+    telemetry_group = parser.add_argument_group("Telemetry", "Settings related to telemetry")
+    parser.set_defaults(telemetry_opt_out=None)
+    telemetry_opt_out_group = telemetry_group.add_mutually_exclusive_group()
+    telemetry_opt_out_group.add_argument(
+        "--telemetry-opt-out",
+        help="Opt out of telemetry data collection",
+        action="store_const",
+        const=True,
+        required=False,
+    )
+    telemetry_opt_out_group.add_argument(
+        "--no-telemetry-opt-out",
+        help="Opt in to telemetry data collection",
+        action="store_const",
+        dest="telemetry_opt_out",
+        const=False,
+        required=False,
+    )
+
     return parser
 
 
@@ -222,6 +242,13 @@ def args_to_setting_modifications(parsed_args: ParsedArguments) -> list[SettingM
             SettingModification(
                 setting=ModifiableSetting.REGION,
                 value=parsed_args.region,
+            )
+        )
+    if parsed_args.telemetry_opt_out is not None:
+        settings_to_modify.append(
+            SettingModification(
+                setting=ModifiableSetting.TELEMETRY_OPT_OUT,
+                value=parsed_args.telemetry_opt_out,
             )
         )
 

--- a/src/deadline_worker_agent/config/config_file.py
+++ b/src/deadline_worker_agent/config/config_file.py
@@ -155,6 +155,27 @@ over this setting.
 Uncomment the line below and replace the value with your AWS region:
 """.lstrip(),
     )
+    TELEMETRY_OPT_OUT = ModifiableSettingData(
+        setting_name="opt_out",
+        table_name="telemetry",
+        preceding_comment="""
+Controls whether telemetry data is collected and sent to AWS. This value is overridden when the
+DEADLINE_CLOUD_TELEMETRY_OPT_OUT environment variable is set using one of the following
+case-insensitive values:
+
+    '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+
+By default, telemetry is enabled. To opt out, uncomment the line below:
+""".lstrip(),
+    )
+    TELEMETRY_IDENTIFIER = ModifiableSettingData(
+        setting_name="identifier",
+        table_name="telemetry",
+        preceding_comment="""
+A unique identifier used to correlate telemetry data across worker agent restarts.
+This is automatically generated and should not normally need to be changed.
+""".lstrip(),
+    )
 
 
 class SettingModification(NamedTuple):
@@ -211,12 +232,21 @@ class OsConfigSection(BaseModel):
         return values
 
 
+class TelemetryConfigSection(BaseModel):
+    opt_out: Optional[bool] = None
+    identifier: Optional[str] = Field(
+        regex=r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+        default=None,
+    )
+
+
 class ConfigFile(BaseModel):
     worker: WorkerConfigSection
     aws: AwsConfigSection
     logging: LoggingConfigSection
     os: OsConfigSection
     capabilities: Capabilities
+    telemetry: TelemetryConfigSection = TelemetryConfigSection()
 
     @classmethod
     def load(cls, config_path: Optional[Path] = None) -> ConfigFile:
@@ -454,5 +484,7 @@ class ConfigFile(BaseModel):
             output_settings["retain_session_dir"] = self.os.retain_session_dir
         if self.capabilities is not None:
             output_settings["capabilities"] = self.capabilities
+        if self.telemetry.opt_out is not None:
+            output_settings["telemetry_opt_out"] = self.telemetry.opt_out
 
         return output_settings

--- a/src/deadline_worker_agent/config/settings.py
+++ b/src/deadline_worker_agent/config/settings.py
@@ -121,6 +121,7 @@ class WorkerSettings(BaseSettings):
     host_metrics_logging_interval_seconds: float = 60
     retain_session_dir: bool = False
     structured_logs: bool = False
+    telemetry_opt_out: bool = False
     session_root_dir: Path = (
         DEFAULT_WINDOWS_SESSION_ROOT_DIR if os.name == "nt" else DEFAULT_POSIX_SESSION_ROOT_DIR
     )
@@ -152,6 +153,7 @@ class WorkerSettings(BaseSettings):
             },
             "retain_session_dir": {"env": "DEADLINE_WORKER_RETAIN_SESSION_DIR"},
             "structured_logs": {"env": "DEADLINE_WORKER_STRUCTURED_LOGS"},
+            "telemetry_opt_out": {"env": "DEADLINE_CLOUD_TELEMETRY_OPT_OUT"},
             "session_dir_root": {"env": "DEADLINE_WORKER_SESSION_ROOT_DIR"},
         }
 

--- a/src/deadline_worker_agent/installer/install.sh
+++ b/src/deadline_worker_agent/installer/install.sh
@@ -39,7 +39,6 @@ confirm=""
 region="unset"
 scripts_path="unset"
 worker_agent_program="deadline-worker-agent"
-client_library_program="deadline"
 allow_shutdown="no"
 disallow_instance_profile="no"
 no_install_service="no"
@@ -79,10 +78,10 @@ usage()
     echo "        Do not use the primary/effective group of the Worker Agent user specifeid in --user as"
     echo "        this is not a secure configuration. Defaults to $default_job_group."
     echo "    --scripts-path SCRIPTS_PATH"
-    echo "        An optional path to the directory that the Worker Agent and Deadline Cloud Library are"
+    echo "        An optional path to the directory that the Worker Agent is"
     echo "        installed. This is used as the program path when creating the systemd service for the "
-    echo "        Worker Agent. If not specified, the first program named 'deadline-worker-agent' and"
-    echo "        'deadline' found in the search path will be used."
+    echo "        Worker Agent. If not specified, the first program named 'deadline-worker-agent'"
+    echo "        found in the search path will be used."
     echo "    --python-interpreter-path"
     echo "        Path to the Python interpreter for the worker agent. If a Python virtual environment is "
     echo "        being used, this path should reference the Python executable of the virtual environment."
@@ -201,11 +200,6 @@ else
         echo "ERROR: Could not find deadline-worker-agent in scripts path: \"${worker_agent_program}\""
         exit 1
     fi
-    client_library_program="${scripts_path}"/deadline
-    if [[ ! -f "${client_library_program}" ]]; then
-        echo "ERROR: Could not find deadline in scripts path: \"${client_library_program}\""
-        exit 1
-    fi
     set -e
 fi
 if [[ "${python_interpreter_path}" == "unset" ]]; then
@@ -282,7 +276,6 @@ echo "Worker job group: ${job_group}"
 echo "Scripts path: ${scripts_path}"
 echo "Session root directory: ${session_root_dir}"
 echo "Worker agent program path: ${worker_agent_program}"
-echo "Deadline client program path: ${client_library_program}"
 echo "Allow worker agent shutdown: ${allow_shutdown}"
 echo "Start systemd service: ${start_service}"
 echo "Telemetry opt-out: ${telemetry_opt_out}"
@@ -431,6 +424,23 @@ fi
     --session-root-dir "${session_root_dir}" \
     --region "${region}"
 
+if [[ "${telemetry_opt_out}" == "yes" ]]; then
+    # Set telemetry opt-out in the worker agent configuration file
+    echo "Opting out of telemetry collection"
+    worker_config="/etc/amazon/deadline/worker.toml"
+    if grep -q '^\[telemetry\]' "$worker_config" 2>/dev/null; then
+        # Section exists, update or add the opt_out setting within it
+        sed -i '/^\[telemetry\]/,/^\[/{s/^opt_out.*/opt_out = true/; t}' "$worker_config"
+        # If opt_out wasn't already present, add it after the section header
+        if ! grep -q '^opt_out' "$worker_config"; then
+            sed -i '/^\[telemetry\]/a opt_out = true' "$worker_config"
+        fi
+    else
+        # Append a new [telemetry] section
+        printf '\n[telemetry]\nopt_out = true\n' >> "$worker_config"
+    fi
+fi
+
 if ! [[ "${no_install_service}" == "yes" ]]; then
     # Set up the service
     echo "Installing systemd service to /etc/systemd/system/deadline-worker.service"
@@ -494,12 +504,6 @@ EOF
         systemctl start deadline-worker
         echo "Done starting the service"
     fi
-fi
-
-if [[ "${telemetry_opt_out}" == "yes" ]]; then
-    # Set the Deadline Client Lib configuration setting
-    echo "Opting out of telemetry collection"
-    sudo -u "$wa_user" "$client_library_program" config set telemetry.opt_out true
 fi
 
 echo "Done"

--- a/src/deadline_worker_agent/installer/win_installer.py
+++ b/src/deadline_worker_agent/installer/win_installer.py
@@ -15,7 +15,6 @@ from getpass import getpass
 from pathlib import Path
 from typing import Any, Optional, Union
 
-import deadline.client.config.config_file
 import pywintypes
 import win32api
 import win32con
@@ -44,9 +43,6 @@ from ..windows.win_logon import generate_password, users_equal
 # Defaults
 DEFAULT_WA_USER = "deadline-worker"
 DEFAULT_JOB_GROUP = "deadline-job-users"
-
-# Environment variable that overrides the config path used by the Deadline client
-DEADLINE_CLIENT_CONFIG_PATH_OVERRIDE_ENV_VAR = "DEADLINE_CONFIG_FILE_PATH"
 
 
 class InstallerFailedException(Exception):
@@ -319,6 +315,7 @@ def update_config_file(
     shutdown_on_stop: Optional[bool] = None,
     windows_job_user: Optional[str] = None,
     session_root_dir: Optional[Path] = None,
+    telemetry_opt_out: bool = False,
 ) -> None:
     """
     Updates the worker configuration file, creating it from the example if it does not exist.
@@ -379,6 +376,13 @@ def update_config_file(
             SettingModification(
                 setting=ModifiableSetting.SESSION_ROOT_DIR,
                 value=str(session_root_dir),
+            )
+        )
+    if telemetry_opt_out:
+        settings_to_modify.append(
+            SettingModification(
+                setting=ModifiableSetting.TELEMETRY_OPT_OUT,
+                value=True,
             )
         )
 
@@ -469,45 +473,6 @@ def provision_directories(
         deadline_persistence_subdir=Path(deadline_persistence_subdir),
         deadline_config_subdir=Path(deadline_config_subdir),
     )
-
-
-def update_deadline_client_config(
-    user: str,
-    settings: dict[str, str],
-) -> None:
-    """
-    Updates the Deadline Client config for the specified user.
-
-    Args:
-        user (str): The user to update the Deadline Client config for.
-        settings (dict[str, str]]): The key-value pairs of settings to update.
-
-    Raises:
-        InstallerFailedException: _description_
-    """
-    # Build the Deadline client config path for the user
-    deadline_client_config_path = deadline.client.config.config_file.CONFIG_FILE_PATH
-    if not deadline_client_config_path.startswith("~"):
-        raise InstallerFailedException(
-            f"Cannot opt out of telemetry: Expected Deadline client config file path to start with a tilde (~), but got: {deadline_client_config_path}\n"
-            f"This is because the Deadline client program (version {deadline.client.version}) is not compatible with this version of the Worker agent installer\n"
-            f"To opt out of telemetry, please use a compatible version of the Deadline client program or run the following command as the worker user:\n\n"
-            "deadline config set telemetry.opt_out true\n"
-        )
-    user_deadline_client_config_path = f"~{user}" + deadline_client_config_path.removeprefix("~")
-
-    # Opt out of client telemetry for the agent user
-    old_environ = os.environ.copy()
-    try:
-        os.environ[DEADLINE_CLIENT_CONFIG_PATH_OVERRIDE_ENV_VAR] = user_deadline_client_config_path
-        for setting_key, setting_value in settings.items():
-            deadline.client.config.config_file.set_setting(setting_key, setting_value)
-    except Exception as e:
-        logging.error(f"Failed to update Deadline Client configuration for user '{user}': {e}")
-        raise
-    finally:
-        os.environ.clear()
-        os.environ.update(old_environ)
 
 
 def _check_and_stop_service(service_name: str):
@@ -993,15 +958,8 @@ def start_windows_installer(
         allow_ec2_instance_profile=allow_ec2_instance_profile,
         windows_job_user=windows_job_user,
         session_root_dir=session_root_dir,
+        telemetry_opt_out=telemetry_opt_out,
     )
-
-    if telemetry_opt_out:
-        logging.info("Opting out of client telemetry")
-        update_deadline_client_config(
-            user=user_name,
-            settings={"telemetry.opt_out": "true"},
-        )
-        logging.info("Opted out of client telemetry")
 
     # Install the Windows service if specified
     if install_service:

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -302,6 +302,18 @@
 #
 # host_metrics_logging_interval_seconds = 60
 
+[telemetry]
+
+# Controls whether telemetry data is collected and sent to AWS. This value is overridden when the
+# DEADLINE_CLOUD_TELEMETRY_OPT_OUT environment variable is set using one of the following
+# case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# By default, telemetry is enabled. To opt out, uncomment the line below:
+#
+# opt_out = true
+
 [capabilities]
 
 # Capabilities for the Worker can be declared in this config section. There are two types of

--- a/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from dataclasses import asdict
 import glob
 
-from deadline.client.config import config_file
 from deadline.job_attachments.api import human_readable_file_size
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
 from deadline.job_attachments.progress_tracker import ProgressTracker, ProgressStatus
@@ -341,7 +340,7 @@ def upload_output_assets(
                 manifest_metadata=manifest_props.as_output_metadata(),
                 source_root=Path(manifest_props.root_path),
                 asset_root=Path(manifest_props.local_root_path),
-                s3_check_cache_dir=config_file.get_cache_directory(),
+                s3_check_cache_dir=None,
                 progress_tracker=progress_tracker_per_root,
             )
 

--- a/src/deadline_worker_agent/telemetry.py
+++ b/src/deadline_worker_agent/telemetry.py
@@ -1,0 +1,312 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Telemetry client for the worker agent.
+
+Sends non-personally-identifiable telemetry events to the Deadline Cloud telemetry
+service in the background. Telemetry can be opted out of by setting the environment
+variable DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true.
+"""
+
+import atexit
+import json
+import logging
+import os
+import platform
+import random
+import time
+import uuid
+from configparser import ConfigParser
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from queue import Full, Queue
+from threading import Thread
+from typing import Any, Dict, Optional
+from urllib import error, request
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+_TRUE_VALUES = {"true", "yes", "on", "1"}
+
+# Default config file path, matching the deadline client convention
+_CONFIG_FILE_PATH = os.path.join("~", ".deadline", "config")
+_CONFIG_FILE_PATH_ENV_VAR = "DEADLINE_CONFIG_FILE_PATH"
+
+
+def _get_config_file_path() -> Path:
+    return Path(os.path.expanduser(os.environ.get(_CONFIG_FILE_PATH_ENV_VAR, _CONFIG_FILE_PATH)))
+
+
+def _read_config() -> ConfigParser:
+    config = ConfigParser()
+    config_path = _get_config_file_path()
+    if config_path.is_file():
+        config.read(str(config_path))
+    return config
+
+
+def _get_setting(setting_name: str, config: Optional[ConfigParser] = None) -> str:
+    """Read a setting from the deadline config file. Returns empty string if not found."""
+    if "." not in setting_name:
+        return ""
+    section, name = setting_name.split(".", 1)
+    if config is None:
+        config = _read_config()
+    for config_section in config.sections():
+        if config_section == section or config_section.endswith(f" {section}"):
+            if config.has_option(config_section, name):
+                return config.get(config_section, name)
+    return ""
+
+
+@dataclass
+class TelemetryEvent:
+    event_type: str = "com.amazon.rum.deadline.uncategorized"
+    event_details: Dict[str, Any] = field(default_factory=dict)
+
+
+def _swallow_exceptions(func):
+    """Decorator that catches all exceptions in telemetry functions to prevent
+    telemetry issues from affecting the main application flow."""
+
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            logger.debug(
+                "Swallowed exception in telemetry function %s", func.__name__, exc_info=True
+            )
+            return None
+
+    return wrapper
+
+
+class TelemetryClient:
+    """
+    Sends telemetry events to the Deadline Cloud telemetry service in the background.
+
+    Telemetry collection can be opted out of by setting the environment variable
+    DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true.
+    """
+
+    MAX_QUEUE_SIZE = 25
+    BASE_TIME = 0.5
+    MAX_BACKOFF_SECONDS = 10
+    MAX_RETRY_ATTEMPTS = 4
+    ENDPOINT_PREFIX = "management."
+
+    def __init__(self, package_name: str, package_ver: str) -> None:
+        self._initialized: bool = False
+        self.package_name = package_name
+        self.package_ver = ".".join(package_ver.split(".")[:3])
+        self._common_details: Dict[str, Any] = {}
+
+        self.session_id: str = str(uuid.uuid4())
+        self.telemetry_id: str = self._get_telemetry_identifier()
+        self._system_metadata = self._get_system_metadata()
+        self._set_opt_out()
+        self._initialize()
+
+    @_swallow_exceptions
+    def _set_opt_out(self) -> None:
+        # Priority: env var > worker agent config > deadline client config > default (enabled)
+        env_var_value = os.environ.get("DEADLINE_CLOUD_TELEMETRY_OPT_OUT", "")
+        if env_var_value:
+            self.telemetry_opted_out = env_var_value.lower() in _TRUE_VALUES
+        else:
+            self.telemetry_opted_out = self._read_opt_out_from_config()
+        logger.info(
+            "Deadline Cloud telemetry is "
+            + ("not enabled." if self.telemetry_opted_out else "enabled.")
+        )
+
+    @staticmethod
+    def _read_opt_out_from_config() -> bool:
+        """Check the worker agent config file for telemetry opt-out, falling back to
+        the deadline client config (~/.deadline/config) if not set."""
+        try:
+            from .config.config_file import ConfigFile
+
+            config_file = ConfigFile.load()
+            if config_file.telemetry.opt_out is not None:
+                return config_file.telemetry.opt_out
+        except Exception:
+            pass
+
+        # Fall back to legacy deadline client config (~/.deadline/config)
+        return _get_setting("telemetry.opt_out").lower() in _TRUE_VALUES
+
+    @_swallow_exceptions
+    def _initialize(self) -> None:
+        if self.telemetry_opted_out:
+            return
+        try:
+            endpoint_url = boto3.client("deadline").meta.endpoint_url
+            self.endpoint: str = self._get_prefixed_endpoint(
+                f"{endpoint_url}/2023-10-12/telemetry",
+                self.ENDPOINT_PREFIX,
+            )
+
+            from botocore.httpsession import create_urllib3_context, get_cert_path
+
+            self._urllib3_context = create_urllib3_context()
+            self._urllib3_context.load_verify_locations(cafile=get_cert_path(True))
+
+            self._initialized = True
+            self._start_threads()
+        except Exception:
+            return
+
+    def _get_prefixed_endpoint(self, endpoint: str, prefix: str) -> str:
+        if endpoint.startswith("https://"):
+            return endpoint[:8] + prefix + endpoint[8:]
+        return endpoint
+
+    def _get_telemetry_identifier(self) -> str:
+        """Get or create a persistent telemetry identifier.
+        Checks worker.toml, then ~/.deadline/config, then generates and persists a new one."""
+        # Check worker agent config
+        try:
+            from .config.config_file import ConfigFile
+
+            config_file = ConfigFile.load()
+            if config_file.telemetry.identifier is not None:
+                return config_file.telemetry.identifier
+        except Exception:
+            pass
+
+        # Fall back to legacy deadline client config
+        identifier = _get_setting("telemetry.identifier")
+        try:
+            uuid.UUID(identifier, version=4)
+        except ValueError:
+            identifier = str(uuid.uuid4())
+
+        # Persist to worker.toml for future runs
+        try:
+            from .config.config_file import (
+                ConfigFile,
+                ModifiableSetting,
+                SettingModification,
+            )
+
+            ConfigFile.modify_config_file_settings(
+                settings_to_modify=[
+                    SettingModification(
+                        setting=ModifiableSetting.TELEMETRY_IDENTIFIER,
+                        value=identifier,
+                    )
+                ],
+            )
+        except Exception:
+            logger.debug("Failed to persist telemetry identifier to worker.toml")
+
+        return identifier
+
+    def _get_system_metadata(self) -> Dict[str, Any]:
+        platform_info = platform.uname()
+        return {
+            "service": self.package_name,
+            "version": self.package_ver,
+            "python_version": platform.python_version(),
+            "osName": "macOS" if platform_info.system == "Darwin" else platform_info.system,
+            "osVersion": platform_info.release,
+        }
+
+    def _start_threads(self) -> None:
+        self.event_queue: Queue[Optional[TelemetryEvent]] = Queue(maxsize=self.MAX_QUEUE_SIZE)
+        atexit.register(self._exit_cleanly)
+        self.processing_thread: Thread = Thread(
+            target=self._process_event_queue_thread, daemon=True
+        )
+        self.processing_thread.start()
+
+    def _exit_cleanly(self) -> None:
+        try:
+            self.event_queue.put_nowait(None)
+        except Full:
+            pass
+        self.processing_thread.join()
+
+    def _send_request(self, req: request.Request) -> None:
+        attempts = 0
+        success = False
+        while not success:
+            try:
+                with request.urlopen(req, context=self._urllib3_context):
+                    logger.debug("Successfully sent telemetry.")
+                    success = True
+            except error.HTTPError as httpe:
+                if httpe.code in (429, 500):
+                    attempts += 1
+                    if attempts >= self.MAX_RETRY_ATTEMPTS:
+                        raise Exception("Max retries reached sending telemetry")
+                    backoff_sleep = random.uniform(
+                        0, min(self.MAX_BACKOFF_SECONDS, self.BASE_TIME * 2**attempts)
+                    )
+                    time.sleep(backoff_sleep)
+                else:
+                    raise
+
+    def _process_event_queue_thread(self) -> None:
+        while True:
+            event_data: Optional[TelemetryEvent] = self.event_queue.get()
+            if event_data is None:
+                return
+            try:
+                request_body = {
+                    "BatchId": str(uuid.uuid4()),
+                    "RumEvents": [
+                        {
+                            "details": json.dumps(event_data.event_details),
+                            "id": str(uuid.uuid4()),
+                            "metadata": json.dumps(self._system_metadata),
+                            "timestamp": int(datetime.now().timestamp()),
+                            "type": event_data.event_type,
+                        },
+                    ],
+                    "UserDetails": {
+                        "sessionId": self.session_id,
+                        "userId": self.telemetry_id,
+                    },
+                }
+                request_body_encoded = json.dumps(request_body).encode("utf-8")
+            except Exception as exc:
+                logger.debug(f"Failed to serialize telemetry data. {exc}")
+                continue
+
+            headers = {"Accept": "application-json", "Content-Type": "application-json"}
+            req = request.Request(url=self.endpoint, data=request_body_encoded, headers=headers)
+            try:
+                logger.debug("Sending telemetry data: %s", request_body)
+                self._send_request(req)
+            except Exception as exc:
+                logger.debug(f"Error received from service. {exc}")
+                return
+            self.event_queue.task_done()
+
+    def _put_telemetry_record(self, event: TelemetryEvent) -> None:
+        if not self._initialized or self.telemetry_opted_out:
+            return
+        try:
+            self.event_queue.put_nowait(event)
+        except Full:
+            pass
+
+    @_swallow_exceptions
+    def record_error(self, event_details: Dict[str, Any], exception_type: str) -> None:
+        event_details["exception_type"] = exception_type
+        self.record_event("com.amazon.rum.deadline.error", event_details)
+
+    @_swallow_exceptions
+    def record_event(self, event_type: str, event_details: Dict[str, Any], **kwargs: Any) -> None:
+        event_details.update(self._common_details)
+        self._put_telemetry_record(
+            TelemetryEvent(event_type=event_type, event_details=event_details)
+        )
+
+    def update_common_details(self, details: Dict[str, Any]) -> None:
+        self._common_details.update(details)

--- a/src/deadline_worker_agent/telemetry.py
+++ b/src/deadline_worker_agent/telemetry.py
@@ -162,7 +162,8 @@ class TelemetryClient:
     @staticmethod
     def _read_opt_out_from_config() -> bool:
         """Check the worker agent config file for telemetry opt-out, falling back to
-        the deadline client config (~/.deadline/config) if not set."""
+        the deadline client config (~/.deadline/config) if not set.
+        If found in legacy config, persists to worker.toml."""
         try:
             from .config.config_file import ConfigFile
 
@@ -173,7 +174,29 @@ class TelemetryClient:
             pass
 
         # Fall back to legacy deadline client config (~/.deadline/config)
-        return _get_setting("telemetry.opt_out").lower() in _TRUE_VALUES
+        legacy_value = _get_setting("telemetry.opt_out").lower() in _TRUE_VALUES
+
+        # Persist to worker.toml if opted out via legacy config
+        if legacy_value:
+            try:
+                from .config.config_file import (
+                    ConfigFile,
+                    ModifiableSetting,
+                    SettingModification,
+                )
+
+                ConfigFile.modify_config_file_settings(
+                    settings_to_modify=[
+                        SettingModification(
+                            setting=ModifiableSetting.TELEMETRY_OPT_OUT,
+                            value=True,
+                        )
+                    ],
+                )
+            except Exception:
+                logger.debug("Failed to persist telemetry opt-out to worker.toml")
+
+        return legacy_value
 
     @_swallow_exceptions
     def initialize(self) -> None:

--- a/src/deadline_worker_agent/telemetry.py
+++ b/src/deadline_worker_agent/telemetry.py
@@ -8,36 +8,55 @@ import os
 import platform
 import uuid
 import random
-import sys
 import time
 
 from botocore.config import Config as BotocoreConfig
 from configparser import ConfigParser
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from queue import Queue, Full
 from threading import Thread
 from typing import Any, Callable, Dict, Optional, TypeVar, cast
 from urllib import request, error
 
-from ...job_attachments.progress_tracker import SummaryStatistics
-
-from ._session import (
-    get_monitor_id,
-    get_user_and_identity_store_id,
-    get_boto3_client,
-    get_boto3_session,
-)
-from ..config import config_file
-from .. import version
-
-__cached_telemetry_clients: Dict[str, "TelemetryClient"] = {}
+import boto3
 
 logger = logging.getLogger(__name__)
 
-
 # Generic function return type.
 F = TypeVar("F", bound=Callable[..., Any])
+
+_TRUE_VALUES = {"true", "yes", "on", "1"}
+
+# Default config file path, matching the deadline client convention
+_CONFIG_FILE_PATH = os.path.join("~", ".deadline", "config")
+_CONFIG_FILE_PATH_ENV_VAR = "DEADLINE_CONFIG_FILE_PATH"
+
+
+def _get_config_file_path() -> Path:
+    return Path(os.path.expanduser(os.environ.get(_CONFIG_FILE_PATH_ENV_VAR, _CONFIG_FILE_PATH)))
+
+
+def _read_config() -> ConfigParser:
+    config = ConfigParser()
+    config_path = _get_config_file_path()
+    if config_path.is_file():
+        config.read(str(config_path))
+    return config
+
+
+def _get_setting(setting_name: str) -> str:
+    """Read a setting from the legacy deadline config file. Returns empty string if not found."""
+    if "." not in setting_name:
+        return ""
+    section, name = setting_name.split(".", 1)
+    config = _read_config()
+    for config_section in config.sections():
+        if config_section == section or config_section.endswith(f" {section}"):
+            if config.has_option(config_section, name):
+                return config.get(config_section, name)
+    return ""
 
 
 def _swallow_exceptions(func: F) -> F:
@@ -55,14 +74,6 @@ def _swallow_exceptions(func: F) -> F:
             return None
 
     return cast(F, wrapper)
-
-
-def get_deadline_endpoint_url(
-    config: Optional[ConfigParser] = None,
-) -> str:
-    # Use boto3's built-in logic to get the correct endpoint URL
-    client = get_boto3_client("deadline", config=config)
-    return client.meta.endpoint_url
 
 
 @dataclass
@@ -90,8 +101,8 @@ class TelemetryClient:
     UUID recorded in the configuration file), to aggregate data across multiple application
     lifetimes on the same machine.
 
-    Telemetry collection can be opted-out of by running:
-    'deadline config set "telemetry.opt_out" true' or setting the environment variable
+    Telemetry collection can be opted-out of by setting opt_out = true in the [telemetry]
+    section of worker.toml, or setting the environment variable
     'DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true'
     """
 
@@ -108,11 +119,8 @@ class TelemetryClient:
         self,
         package_name: str,
         package_ver: str,
-        config: Optional[ConfigParser] = None,
     ):
-        # Instance-level dicts so every TelemetryClient has its own state (avoid
-        # the mutable-class-attribute pitfall where updates would be shared by
-        # all instances).
+        # Instance-level dicts so every TelemetryClient has its own state
         self._common_details: Dict[str, Any] = {}
         self._system_metadata: Dict[str, Any] = {}
 
@@ -123,42 +131,52 @@ class TelemetryClient:
         # IDs for this session
         self.session_id: str = str(uuid.uuid4())
         try:
-            self.telemetry_id: str = self._get_telemetry_identifier(config=config)
+            self.telemetry_id: str = self._get_telemetry_identifier()
         except Exception:
             logger.debug("Swallowed exception in telemetry __init__", exc_info=True)
             self.telemetry_id = str(uuid.uuid4())
-        # If a different base package is provided, include info from this library as supplementary info
-        if package_name != "deadline-cloud-library":
-            self._common_details["deadline-cloud-version"] = version
         try:
-            self._system_metadata = self._get_system_metadata(config=config)
+            self._system_metadata = self._get_system_metadata()
         except Exception:
             logger.debug("Swallowed exception in telemetry __init__", exc_info=True)
             self._system_metadata = {}
-        self.set_opt_out(config=config)
-        self.initialize(config=config)
+        self.set_opt_out()
+        self.initialize()
 
     @_swallow_exceptions
-    def set_opt_out(self, config: Optional[ConfigParser] = None) -> None:
+    def set_opt_out(self) -> None:
         """
-        Checks whether telemetry has been opted out by checking the DEADLINE_CLOUD_TELEMETRY_OPT_OUT
-        environment variable and the 'telemetry.opt_out' config file setting.
-        Note the environment variable supersedes the config file setting.
+        Checks whether telemetry has been opted out.
+        Priority: env var > worker agent config (worker.toml) > legacy config (~/.deadline/config)
         """
         env_var_value = os.environ.get("DEADLINE_CLOUD_TELEMETRY_OPT_OUT")
         if env_var_value:
-            self.telemetry_opted_out = env_var_value in config_file._TRUE_VALUES
+            self.telemetry_opted_out = env_var_value.lower() in _TRUE_VALUES
         else:
-            self.telemetry_opted_out = config_file.str2bool(
-                config_file.get_setting("telemetry.opt_out", config=config)
-            )
+            self.telemetry_opted_out = self._read_opt_out_from_config()
         logger.info(
             "Deadline Cloud telemetry is "
             + ("not enabled." if self.telemetry_opted_out else "enabled.")
         )
 
+    @staticmethod
+    def _read_opt_out_from_config() -> bool:
+        """Check the worker agent config file for telemetry opt-out, falling back to
+        the deadline client config (~/.deadline/config) if not set."""
+        try:
+            from .config.config_file import ConfigFile
+
+            config_file = ConfigFile.load()
+            if config_file.telemetry.opt_out is not None:
+                return config_file.telemetry.opt_out
+        except Exception:
+            pass
+
+        # Fall back to legacy deadline client config (~/.deadline/config)
+        return _get_setting("telemetry.opt_out").lower() in _TRUE_VALUES
+
     @_swallow_exceptions
-    def initialize(self, config: Optional[ConfigParser] = None) -> None:
+    def initialize(self) -> None:
         """
         Starts up the telemetry background thread after getting settings from the boto3 client.
         Note that if this is called before boto3 is successfully configured / initialized,
@@ -168,8 +186,9 @@ class TelemetryClient:
         if self.telemetry_opted_out:
             return
 
+        endpoint_url = boto3.client("deadline").meta.endpoint_url
         self.endpoint: str = self._get_prefixed_endpoint(
-            f"{get_deadline_endpoint_url(config=config)}/2023-10-12/telemetry",
+            f"{endpoint_url}/2023-10-12/telemetry",
             TelemetryClient.ENDPOINT_PREFIX,
         )
 
@@ -178,14 +197,6 @@ class TelemetryClient:
 
         self._urllib3_context = create_urllib3_context()
         self._urllib3_context.load_verify_locations(cafile=get_cert_path(True))
-
-        user_id, _ = get_user_and_identity_store_id(config=config)
-        if user_id:
-            self._system_metadata["user_id"] = user_id
-
-        monitor_id: Optional[str] = get_monitor_id(config=config)
-        if monitor_id:
-            self._system_metadata["monitor_id"] = monitor_id
 
         self._initialized = True
         self._start_threads()
@@ -201,13 +212,45 @@ class TelemetryClient:
             return prefixed_endpoint
         return endpoint
 
-    def _get_telemetry_identifier(self, config: Optional[ConfigParser] = None):
-        identifier = config_file.get_setting("telemetry.identifier", config=config)
+    def _get_telemetry_identifier(self) -> str:
+        """Get or create a persistent telemetry identifier.
+        Checks worker.toml, then ~/.deadline/config, then generates and persists a new one."""
+        # Check worker agent config
+        try:
+            from .config.config_file import ConfigFile
+
+            config_file = ConfigFile.load()
+            if config_file.telemetry.identifier is not None:
+                return config_file.telemetry.identifier
+        except Exception:
+            pass
+
+        # Fall back to legacy deadline client config
+        identifier = _get_setting("telemetry.identifier")
         try:
             uuid.UUID(identifier, version=4)
-        except ValueError:  # Thrown if the user_id isn't in UUID4 format
+        except ValueError:
             identifier = str(uuid.uuid4())
-            config_file.set_setting("telemetry.identifier", identifier)
+
+        # Persist to worker.toml for future runs
+        try:
+            from .config.config_file import (
+                ConfigFile,
+                ModifiableSetting,
+                SettingModification,
+            )
+
+            ConfigFile.modify_config_file_settings(
+                settings_to_modify=[
+                    SettingModification(
+                        setting=ModifiableSetting.TELEMETRY_IDENTIFIER,
+                        value=identifier,
+                    )
+                ],
+            )
+        except Exception:
+            logger.debug("Failed to persist telemetry identifier to worker.toml")
+
         return identifier
 
     def _start_threads(self) -> None:
@@ -221,14 +264,12 @@ class TelemetryClient:
         )
         self.processing_thread.start()
 
-    def _get_system_metadata(self, config: Optional[ConfigParser]) -> Dict[str, Any]:
+    def _get_system_metadata(self) -> Dict[str, Any]:
         """
         Builds up a dict of non-identifiable metadata about the system environment.
-
-        This will be used in the Rum event metadata, which has a limit of 10 unique values.
         """
         platform_info = platform.uname()
-        metadata: Dict[str, Any] = {
+        return {
             "service": self.package_name,
             "version": self.package_ver,
             "python_version": platform.python_version(),
@@ -236,16 +277,11 @@ class TelemetryClient:
             "osVersion": platform_info.release,
         }
 
-        return metadata
-
     @_swallow_exceptions
     def _exit_cleanly(self):
         try:
             self.event_queue.put_nowait(None)
         except Full:
-            # If the queue is full, it may mean the telemetry processing thread has already joined
-            # since it is daemon and the Python runtime will shut it down on exit.
-            # Ignore the error, since this is a best-effort cleanup.
             pass
         self.processing_thread.join()
 
@@ -279,13 +315,14 @@ class TelemetryClient:
     def _process_event_queue_thread(self):
         """Background thread for processing the telemetry event data queue and sending telemetry requests."""
         # Resolve the AWS account ID once on this background thread so callers
-        # of record_event() are never blocked (e.g. by a slow STS timeout on a
-        # restricted network). The resolved value is stored on _common_details
-        # and merged into every event's payload below, so events enqueued
-        # before resolution completes still include the account ID when sent.
-        account_id = self.get_account_id(get_boto3_session())
-        if account_id:
-            self.update_common_details({"accountId": account_id})
+        # of record_event() are never blocked.
+        try:
+            session = boto3.Session()
+            account_id = self.get_account_id(session)
+            if account_id:
+                self.update_common_details({"accountId": account_id})
+        except Exception:
+            logger.debug("Could not resolve account ID for telemetry", exc_info=True)
 
         while True:
             # Blocks until we get a new entry in the queue
@@ -296,9 +333,7 @@ class TelemetryClient:
 
             headers = {"Accept": "application-json", "Content-Type": "application-json"}
             try:
-                # Merge _common_details into the per-event details at send
-                # time (not enqueue time) so late-resolved fields like
-                # accountId are included.
+                # Merge _common_details into the per-event details at send time
                 details = {**event_data.event_details, **self._common_details}
                 request_body = {
                     "BatchId": str(uuid.uuid4()),
@@ -337,39 +372,12 @@ class TelemetryClient:
             # Silently swallow the error if the event queue is full (due to throttling of the service)
             pass
 
-    def record_vfs_mounting(self, successfully_mounted: bool):
-        details: Dict[str, Any] = {"successfully_mounted": successfully_mounted}
-        event_type = "com.amazon.rum.deadline.job_attachments.vfs_mount"
-        self.record_event(event_type=event_type, event_details=details, from_gui=False)
-
-    def _record_summary_statistics(
-        self, event_type: str, summary: SummaryStatistics, from_gui: bool
-    ):
-        details: Dict[str, Any] = asdict(summary)
-        self.record_event(event_type=event_type, event_details=details, from_gui=from_gui)
-
-    def record_hashing_summary(self, summary: SummaryStatistics, *, from_gui: bool = False):
-        self._record_summary_statistics(
-            "com.amazon.rum.deadline.job_attachments.hashing_summary", summary, from_gui
-        )
-
-    def record_upload_summary(self, summary: SummaryStatistics, *, from_gui: bool = False):
-        self._record_summary_statistics(
-            "com.amazon.rum.deadline.job_attachments.upload_summary", summary, from_gui
-        )
-
-    def record_error(
-        self, event_details: Dict[str, Any], exception_type: str, from_gui: bool = False
-    ):
+    def record_error(self, event_details: Dict[str, Any], exception_type: str):
         event_details["exception_type"] = exception_type
-        # Possibility to add stack trace here
-        self.record_event("com.amazon.rum.deadline.error", event_details, from_gui=from_gui)
+        self.record_event("com.amazon.rum.deadline.error", event_details)
 
     @_swallow_exceptions
-    def record_event(
-        self, event_type: str, event_details: Dict[str, Any], *, from_gui: bool = False
-    ):
-        event_details["usage_mode"] = "GUI" if from_gui else "CLI"
+    def record_event(self, event_type: str, event_details: Dict[str, Any], **kwargs: Any):
         self._put_telemetry_record(
             TelemetryEvent(
                 event_type=event_type,
@@ -379,27 +387,12 @@ class TelemetryClient:
 
     @lru_cache
     def get_account_id(self, boto3_session) -> Optional[str]:
-        """Best-effort AWS account ID lookup for telemetry, cached per
-        (client, session) so it runs at most once per telemetry client
-        instance.
-
-        Prefers ``session.get_credentials().account_id`` (populated for free
-        by SSO, AssumeRole, IMDS/ECS, or a ``credential_process`` that emits
-        ``AccountId``). Deadline Cloud monitor delivers its credentials
-        through ``credential_process`` (see ``_get_boto3_session_for_profile``
-        in ``_session.py``), so if DCM's process output includes
-        ``AccountId`` this fast path covers the common monitor user flow
-        without an STS call. Falls back to ``sts:GetCallerIdentity`` with a
-        short timeout, returning ``None`` on any failure so users on
-        restricted networks without STS access can still run the CLI.
-        """
+        """Best-effort AWS account ID lookup for telemetry, cached per session."""
         try:
             credentials = boto3_session.get_credentials()
             account_id = getattr(credentials, "account_id", None) if credentials else None
             if account_id:
                 return account_id
-            # Short-timeout best-effort fallback; runs on the telemetry background
-            # thread so blocking is fine.
             sts = boto3_session.client(
                 "sts",
                 config=BotocoreConfig(
@@ -414,105 +407,3 @@ class TelemetryClient:
     def update_common_details(self, details: Dict[str, Any]):
         """Updates the dict of common data that is included in every telemetry request."""
         self._common_details.update(details)
-
-
-def get_telemetry_client(
-    package_name: str, package_ver: str, config: Optional[ConfigParser] = None
-) -> TelemetryClient:
-    """
-    Retrieves the cached telemetry client, lazy-loading the first time this is called.
-    :param package_name: Base package name to associate data by.
-    :param package_ver: Base package version to associate data by.
-    :param config: Optional configuration to use for the client. Loads defaults if not given.
-    :return: Telemetry client to make requests with.
-    """
-    global __cached_telemetry_clients
-    cached = __cached_telemetry_clients.get(package_name)
-    if not cached:
-        cached = TelemetryClient(
-            package_name=package_name,
-            package_ver=package_ver,
-            config=config,
-        )
-        __cached_telemetry_clients[package_name] = cached
-    elif not cached.is_initialized:
-        cached.initialize(config=config)
-
-    return cached
-
-
-def get_deadline_cloud_library_telemetry_client(
-    config: Optional[ConfigParser] = None,
-) -> TelemetryClient:
-    """
-    Retrieves the cached telemetry client, specifying the Deadline Cloud Client Library's package information.
-    :param config: Optional configuration to use for the client. Loads defaults if not given.
-    :return: Telemetry client to make requests with.
-    """
-    return get_telemetry_client("deadline-cloud-library", version, config=config)
-
-
-def record_success_fail_telemetry_event(**decorator_kwargs: Any) -> Callable[[F], F]:
-    """
-    Decorator to try catch a function. Sends a success / fail telemetry event.
-    :param ** Python variable arguments. See https://docs.python.org/3/glossary.html#term-parameter.
-    """
-
-    def inner(function: F) -> F:
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            """
-            Wrapper to try-catch a function for telemetry
-            :param * Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter
-            :param ** Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter
-            """
-            success: bool = False
-            try:
-                result = function(*args, **kwargs)
-                success = True
-                return result
-            finally:
-                event_name = decorator_kwargs.get("metric_name", function.__name__)
-
-                event_details: dict = decorator_kwargs.get("event_details", {})
-                event_details["is_success"] = success
-                raised_exception = sys.exc_info()[1]
-                if raised_exception is not None:
-                    event_details["exception_type"] = type(raised_exception).__name__
-
-                get_deadline_cloud_library_telemetry_client().record_event(
-                    event_type=f"com.amazon.rum.deadline.{event_name}",
-                    event_details=event_details,
-                )
-
-        wrapper.__doc__ = function.__doc__
-        return cast(F, wrapper)
-
-    return inner
-
-
-def record_function_latency_telemetry_event(**decorator_kwargs: Any) -> Callable[[F], F]:
-    """
-    Decorator to time a function. Sends a latency telemetry event.
-    :param ** Python variable arguments. See https://docs.python.org/3/glossary.html#term-parameter.
-    """
-
-    def inner(function: F) -> F:
-        @wraps(function)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            start_t = time.perf_counter_ns()
-            ret_val = function(*args, **kwargs)
-            end_t = time.perf_counter_ns()
-
-            latency = end_t - start_t
-
-            event_name = decorator_kwargs.get("metric_name", function.__name__)
-            get_deadline_cloud_library_telemetry_client().record_event(
-                event_type="com.amazon.rum.deadline.latency",
-                event_details={"latency": latency, "function_call": event_name},
-            )
-
-            return ret_val
-
-        return cast(F, wrapper)
-
-    return inner

--- a/src/deadline_worker_agent/telemetry.py
+++ b/src/deadline_worker_agent/telemetry.py
@@ -1,78 +1,51 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-"""
-Telemetry client for the worker agent.
-
-Sends non-personally-identifiable telemetry events to the Deadline Cloud telemetry
-service in the background. Telemetry can be opted out of by setting the environment
-variable DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true.
-"""
-
 import atexit
+from functools import lru_cache, wraps
 import json
 import logging
 import os
 import platform
-import random
-import time
 import uuid
-from configparser import ConfigParser
-from dataclasses import dataclass, field
-from datetime import datetime
-from pathlib import Path
-from queue import Full, Queue
-from threading import Thread
-from typing import Any, Dict, Optional
-from urllib import error, request
+import random
+import sys
+import time
 
-import boto3
+from botocore.config import Config as BotocoreConfig
+from configparser import ConfigParser
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from queue import Queue, Full
+from threading import Thread
+from typing import Any, Callable, Dict, Optional, TypeVar, cast
+from urllib import request, error
+
+from ...job_attachments.progress_tracker import SummaryStatistics
+
+from ._session import (
+    get_monitor_id,
+    get_user_and_identity_store_id,
+    get_boto3_client,
+    get_boto3_session,
+)
+from ..config import config_file
+from .. import version
+
+__cached_telemetry_clients: Dict[str, "TelemetryClient"] = {}
 
 logger = logging.getLogger(__name__)
 
-_TRUE_VALUES = {"true", "yes", "on", "1"}
 
-# Default config file path, matching the deadline client convention
-_CONFIG_FILE_PATH = os.path.join("~", ".deadline", "config")
-_CONFIG_FILE_PATH_ENV_VAR = "DEADLINE_CONFIG_FILE_PATH"
+# Generic function return type.
+F = TypeVar("F", bound=Callable[..., Any])
 
 
-def _get_config_file_path() -> Path:
-    return Path(os.path.expanduser(os.environ.get(_CONFIG_FILE_PATH_ENV_VAR, _CONFIG_FILE_PATH)))
-
-
-def _read_config() -> ConfigParser:
-    config = ConfigParser()
-    config_path = _get_config_file_path()
-    if config_path.is_file():
-        config.read(str(config_path))
-    return config
-
-
-def _get_setting(setting_name: str, config: Optional[ConfigParser] = None) -> str:
-    """Read a setting from the deadline config file. Returns empty string if not found."""
-    if "." not in setting_name:
-        return ""
-    section, name = setting_name.split(".", 1)
-    if config is None:
-        config = _read_config()
-    for config_section in config.sections():
-        if config_section == section or config_section.endswith(f" {section}"):
-            if config.has_option(config_section, name):
-                return config.get(config_section, name)
-    return ""
-
-
-@dataclass
-class TelemetryEvent:
-    event_type: str = "com.amazon.rum.deadline.uncategorized"
-    event_details: Dict[str, Any] = field(default_factory=dict)
-
-
-def _swallow_exceptions(func):
+def _swallow_exceptions(func: F) -> F:
     """Decorator that catches all exceptions in telemetry functions to prevent
     telemetry issues from affecting the main application flow."""
 
-    def wrapper(*args, **kwargs):
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return func(*args, **kwargs)
         except Exception:
@@ -81,134 +54,181 @@ def _swallow_exceptions(func):
             )
             return None
 
-    return wrapper
+    return cast(F, wrapper)
+
+
+def get_deadline_endpoint_url(
+    config: Optional[ConfigParser] = None,
+) -> str:
+    # Use boto3's built-in logic to get the correct endpoint URL
+    client = get_boto3_client("deadline", config=config)
+    return client.meta.endpoint_url
+
+
+@dataclass
+class TelemetryEvent:
+    """Base class for telemetry events"""
+
+    event_type: str = "com.amazon.rum.deadline.uncategorized"
+    event_details: Dict[str, Any] = field(default_factory=dict)
 
 
 class TelemetryClient:
     """
-    Sends telemetry events to the Deadline Cloud telemetry service in the background.
+    Sends telemetry events periodically to the Deadline Cloud telemetry service.
 
-    Telemetry collection can be opted out of by setting the environment variable
-    DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true.
+    This client holds a queue of events which is written to synchronously, and processed
+    asynchronously, where events are sent in the background, so that it does not slow
+    down user interactivity.
+
+    Telemetry events contain non-personally-identifiable information that helps us
+    understand how users interact with our software so we know what features our
+    customers use, and/or what existing pain points are.
+
+    Data is aggregated across a session ID (a UUID created at runtime), used to mark every
+    telemetry event for the lifetime of the application), and a 'telemetry identifier' (a
+    UUID recorded in the configuration file), to aggregate data across multiple application
+    lifetimes on the same machine.
+
+    Telemetry collection can be opted-out of by running:
+    'deadline config set "telemetry.opt_out" true' or setting the environment variable
+    'DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true'
     """
 
+    # Used for backing off requests if we encounter errors from the service.
+    # See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
     MAX_QUEUE_SIZE = 25
     BASE_TIME = 0.5
-    MAX_BACKOFF_SECONDS = 10
+    MAX_BACKOFF_SECONDS = 10  # The maximum amount of time to wait between retries
     MAX_RETRY_ATTEMPTS = 4
+
     ENDPOINT_PREFIX = "management."
 
-    def __init__(self, package_name: str, package_ver: str) -> None:
+    def __init__(
+        self,
+        package_name: str,
+        package_ver: str,
+        config: Optional[ConfigParser] = None,
+    ):
+        # Instance-level dicts so every TelemetryClient has its own state (avoid
+        # the mutable-class-attribute pitfall where updates would be shared by
+        # all instances).
+        self._common_details: Dict[str, Any] = {}
+        self._system_metadata: Dict[str, Any] = {}
+
         self._initialized: bool = False
         self.package_name = package_name
         self.package_ver = ".".join(package_ver.split(".")[:3])
-        self._common_details: Dict[str, Any] = {}
 
+        # IDs for this session
         self.session_id: str = str(uuid.uuid4())
-        self.telemetry_id: str = self._get_telemetry_identifier()
-        self._system_metadata = self._get_system_metadata()
-        self._set_opt_out()
-        self._initialize()
+        try:
+            self.telemetry_id: str = self._get_telemetry_identifier(config=config)
+        except Exception:
+            logger.debug("Swallowed exception in telemetry __init__", exc_info=True)
+            self.telemetry_id = str(uuid.uuid4())
+        # If a different base package is provided, include info from this library as supplementary info
+        if package_name != "deadline-cloud-library":
+            self._common_details["deadline-cloud-version"] = version
+        try:
+            self._system_metadata = self._get_system_metadata(config=config)
+        except Exception:
+            logger.debug("Swallowed exception in telemetry __init__", exc_info=True)
+            self._system_metadata = {}
+        self.set_opt_out(config=config)
+        self.initialize(config=config)
 
     @_swallow_exceptions
-    def _set_opt_out(self) -> None:
-        # Priority: env var > worker agent config > deadline client config > default (enabled)
-        env_var_value = os.environ.get("DEADLINE_CLOUD_TELEMETRY_OPT_OUT", "")
+    def set_opt_out(self, config: Optional[ConfigParser] = None) -> None:
+        """
+        Checks whether telemetry has been opted out by checking the DEADLINE_CLOUD_TELEMETRY_OPT_OUT
+        environment variable and the 'telemetry.opt_out' config file setting.
+        Note the environment variable supersedes the config file setting.
+        """
+        env_var_value = os.environ.get("DEADLINE_CLOUD_TELEMETRY_OPT_OUT")
         if env_var_value:
-            self.telemetry_opted_out = env_var_value.lower() in _TRUE_VALUES
+            self.telemetry_opted_out = env_var_value in config_file._TRUE_VALUES
         else:
-            self.telemetry_opted_out = self._read_opt_out_from_config()
+            self.telemetry_opted_out = config_file.str2bool(
+                config_file.get_setting("telemetry.opt_out", config=config)
+            )
         logger.info(
             "Deadline Cloud telemetry is "
             + ("not enabled." if self.telemetry_opted_out else "enabled.")
         )
 
-    @staticmethod
-    def _read_opt_out_from_config() -> bool:
-        """Check the worker agent config file for telemetry opt-out, falling back to
-        the deadline client config (~/.deadline/config) if not set."""
-        try:
-            from .config.config_file import ConfigFile
-
-            config_file = ConfigFile.load()
-            if config_file.telemetry.opt_out is not None:
-                return config_file.telemetry.opt_out
-        except Exception:
-            pass
-
-        # Fall back to legacy deadline client config (~/.deadline/config)
-        return _get_setting("telemetry.opt_out").lower() in _TRUE_VALUES
-
     @_swallow_exceptions
-    def _initialize(self) -> None:
+    def initialize(self, config: Optional[ConfigParser] = None) -> None:
+        """
+        Starts up the telemetry background thread after getting settings from the boto3 client.
+        Note that if this is called before boto3 is successfully configured / initialized,
+        an error can be raised. In that case we silently fail and don't mark the client as
+        initialized.
+        """
         if self.telemetry_opted_out:
             return
-        try:
-            endpoint_url = boto3.client("deadline").meta.endpoint_url
-            self.endpoint: str = self._get_prefixed_endpoint(
-                f"{endpoint_url}/2023-10-12/telemetry",
-                self.ENDPOINT_PREFIX,
-            )
 
-            from botocore.httpsession import create_urllib3_context, get_cert_path
+        self.endpoint: str = self._get_prefixed_endpoint(
+            f"{get_deadline_endpoint_url(config=config)}/2023-10-12/telemetry",
+            TelemetryClient.ENDPOINT_PREFIX,
+        )
 
-            self._urllib3_context = create_urllib3_context()
-            self._urllib3_context.load_verify_locations(cafile=get_cert_path(True))
+        # Some environments might not have SSL, so we'll use the vendored botocore SSL context
+        from botocore.httpsession import create_urllib3_context, get_cert_path
 
-            self._initialized = True
-            self._start_threads()
-        except Exception:
-            return
+        self._urllib3_context = create_urllib3_context()
+        self._urllib3_context.load_verify_locations(cafile=get_cert_path(True))
+
+        user_id, _ = get_user_and_identity_store_id(config=config)
+        if user_id:
+            self._system_metadata["user_id"] = user_id
+
+        monitor_id: Optional[str] = get_monitor_id(config=config)
+        if monitor_id:
+            self._system_metadata["monitor_id"] = monitor_id
+
+        self._initialized = True
+        self._start_threads()
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
 
     def _get_prefixed_endpoint(self, endpoint: str, prefix: str) -> str:
+        """Insert the prefix right after 'https://'"""
         if endpoint.startswith("https://"):
-            return endpoint[:8] + prefix + endpoint[8:]
+            prefixed_endpoint = endpoint[:8] + prefix + endpoint[8:]
+            return prefixed_endpoint
         return endpoint
 
-    def _get_telemetry_identifier(self) -> str:
-        """Get or create a persistent telemetry identifier.
-        Checks worker.toml, then ~/.deadline/config, then generates and persists a new one."""
-        # Check worker agent config
-        try:
-            from .config.config_file import ConfigFile
-
-            config_file = ConfigFile.load()
-            if config_file.telemetry.identifier is not None:
-                return config_file.telemetry.identifier
-        except Exception:
-            pass
-
-        # Fall back to legacy deadline client config
-        identifier = _get_setting("telemetry.identifier")
+    def _get_telemetry_identifier(self, config: Optional[ConfigParser] = None):
+        identifier = config_file.get_setting("telemetry.identifier", config=config)
         try:
             uuid.UUID(identifier, version=4)
-        except ValueError:
+        except ValueError:  # Thrown if the user_id isn't in UUID4 format
             identifier = str(uuid.uuid4())
-
-        # Persist to worker.toml for future runs
-        try:
-            from .config.config_file import (
-                ConfigFile,
-                ModifiableSetting,
-                SettingModification,
-            )
-
-            ConfigFile.modify_config_file_settings(
-                settings_to_modify=[
-                    SettingModification(
-                        setting=ModifiableSetting.TELEMETRY_IDENTIFIER,
-                        value=identifier,
-                    )
-                ],
-            )
-        except Exception:
-            logger.debug("Failed to persist telemetry identifier to worker.toml")
-
+            config_file.set_setting("telemetry.identifier", identifier)
         return identifier
 
-    def _get_system_metadata(self) -> Dict[str, Any]:
+    def _start_threads(self) -> None:
+        """Set up background threads for shutdown checking and request sending"""
+        self.event_queue: Queue[Optional[TelemetryEvent]] = Queue(
+            maxsize=TelemetryClient.MAX_QUEUE_SIZE
+        )
+        atexit.register(self._exit_cleanly)
+        self.processing_thread: Thread = Thread(
+            target=self._process_event_queue_thread, daemon=True
+        )
+        self.processing_thread.start()
+
+    def _get_system_metadata(self, config: Optional[ConfigParser]) -> Dict[str, Any]:
+        """
+        Builds up a dict of non-identifiable metadata about the system environment.
+
+        This will be used in the Rum event metadata, which has a limit of 10 unique values.
+        """
         platform_info = platform.uname()
-        return {
+        metadata: Dict[str, Any] = {
             "service": self.package_name,
             "version": self.package_ver,
             "python_version": platform.python_version(),
@@ -216,18 +236,16 @@ class TelemetryClient:
             "osVersion": platform_info.release,
         }
 
-    def _start_threads(self) -> None:
-        self.event_queue: Queue[Optional[TelemetryEvent]] = Queue(maxsize=self.MAX_QUEUE_SIZE)
-        atexit.register(self._exit_cleanly)
-        self.processing_thread: Thread = Thread(
-            target=self._process_event_queue_thread, daemon=True
-        )
-        self.processing_thread.start()
+        return metadata
 
-    def _exit_cleanly(self) -> None:
+    @_swallow_exceptions
+    def _exit_cleanly(self):
         try:
             self.event_queue.put_nowait(None)
         except Full:
+            # If the queue is full, it may mean the telemetry processing thread has already joined
+            # since it is daemon and the Python runtime will shut it down on exit.
+            # Ignore the error, since this is a best-effort cleanup.
             pass
         self.processing_thread.join()
 
@@ -240,51 +258,73 @@ class TelemetryClient:
                     logger.debug("Successfully sent telemetry.")
                     success = True
             except error.HTTPError as httpe:
-                if httpe.code in (429, 500):
+                if httpe.code == 429 or httpe.code == 500:
+                    logger.debug(f"Error received from service. Waiting to retry: {str(httpe)}")
+
                     attempts += 1
-                    if attempts >= self.MAX_RETRY_ATTEMPTS:
+                    if attempts >= TelemetryClient.MAX_RETRY_ATTEMPTS:
                         raise Exception("Max retries reached sending telemetry")
+
                     backoff_sleep = random.uniform(
-                        0, min(self.MAX_BACKOFF_SECONDS, self.BASE_TIME * 2**attempts)
+                        0,
+                        min(
+                            TelemetryClient.MAX_BACKOFF_SECONDS,
+                            TelemetryClient.BASE_TIME * 2**attempts,
+                        ),
                     )
                     time.sleep(backoff_sleep)
-                else:
+                else:  # Reraise any exceptions we didn't expect
                     raise
 
-    def _process_event_queue_thread(self) -> None:
+    def _process_event_queue_thread(self):
+        """Background thread for processing the telemetry event data queue and sending telemetry requests."""
+        # Resolve the AWS account ID once on this background thread so callers
+        # of record_event() are never blocked (e.g. by a slow STS timeout on a
+        # restricted network). The resolved value is stored on _common_details
+        # and merged into every event's payload below, so events enqueued
+        # before resolution completes still include the account ID when sent.
+        account_id = self.get_account_id(get_boto3_session())
+        if account_id:
+            self.update_common_details({"accountId": account_id})
+
         while True:
+            # Blocks until we get a new entry in the queue
             event_data: Optional[TelemetryEvent] = self.event_queue.get()
+            # We've received the shutdown signal
             if event_data is None:
                 return
+
+            headers = {"Accept": "application-json", "Content-Type": "application-json"}
             try:
+                # Merge _common_details into the per-event details at send
+                # time (not enqueue time) so late-resolved fields like
+                # accountId are included.
+                details = {**event_data.event_details, **self._common_details}
                 request_body = {
                     "BatchId": str(uuid.uuid4()),
                     "RumEvents": [
                         {
-                            "details": json.dumps(event_data.event_details),
+                            "details": str(json.dumps(details)),
                             "id": str(uuid.uuid4()),
-                            "metadata": json.dumps(self._system_metadata),
+                            "metadata": str(json.dumps(self._system_metadata)),
                             "timestamp": int(datetime.now().timestamp()),
                             "type": event_data.event_type,
                         },
                     ],
-                    "UserDetails": {
-                        "sessionId": self.session_id,
-                        "userId": self.telemetry_id,
-                    },
+                    "UserDetails": {"sessionId": self.session_id, "userId": self.telemetry_id},
                 }
-                request_body_encoded = json.dumps(request_body).encode("utf-8")
+                request_body_encoded = str(json.dumps(request_body)).encode("utf-8")
             except Exception as exc:
-                logger.debug(f"Failed to serialize telemetry data. {exc}")
+                logger.debug(f"Failed to serialize telemetry data. {str(exc)}")
                 continue
 
-            headers = {"Accept": "application-json", "Content-Type": "application-json"}
             req = request.Request(url=self.endpoint, data=request_body_encoded, headers=headers)
             try:
                 logger.debug("Sending telemetry data: %s", request_body)
                 self._send_request(req)
             except Exception as exc:
-                logger.debug(f"Error received from service. {exc}")
+                # Swallow any kind of uncaught exception and stop sending telemetry
+                logger.debug(f"Error received from service. {str(exc)}")
                 return
             self.event_queue.task_done()
 
@@ -294,19 +334,185 @@ class TelemetryClient:
         try:
             self.event_queue.put_nowait(event)
         except Full:
+            # Silently swallow the error if the event queue is full (due to throttling of the service)
             pass
 
-    @_swallow_exceptions
-    def record_error(self, event_details: Dict[str, Any], exception_type: str) -> None:
-        event_details["exception_type"] = exception_type
-        self.record_event("com.amazon.rum.deadline.error", event_details)
+    def record_vfs_mounting(self, successfully_mounted: bool):
+        details: Dict[str, Any] = {"successfully_mounted": successfully_mounted}
+        event_type = "com.amazon.rum.deadline.job_attachments.vfs_mount"
+        self.record_event(event_type=event_type, event_details=details, from_gui=False)
 
-    @_swallow_exceptions
-    def record_event(self, event_type: str, event_details: Dict[str, Any], **kwargs: Any) -> None:
-        event_details.update(self._common_details)
-        self._put_telemetry_record(
-            TelemetryEvent(event_type=event_type, event_details=event_details)
+    def _record_summary_statistics(
+        self, event_type: str, summary: SummaryStatistics, from_gui: bool
+    ):
+        details: Dict[str, Any] = asdict(summary)
+        self.record_event(event_type=event_type, event_details=details, from_gui=from_gui)
+
+    def record_hashing_summary(self, summary: SummaryStatistics, *, from_gui: bool = False):
+        self._record_summary_statistics(
+            "com.amazon.rum.deadline.job_attachments.hashing_summary", summary, from_gui
         )
 
-    def update_common_details(self, details: Dict[str, Any]) -> None:
+    def record_upload_summary(self, summary: SummaryStatistics, *, from_gui: bool = False):
+        self._record_summary_statistics(
+            "com.amazon.rum.deadline.job_attachments.upload_summary", summary, from_gui
+        )
+
+    def record_error(
+        self, event_details: Dict[str, Any], exception_type: str, from_gui: bool = False
+    ):
+        event_details["exception_type"] = exception_type
+        # Possibility to add stack trace here
+        self.record_event("com.amazon.rum.deadline.error", event_details, from_gui=from_gui)
+
+    @_swallow_exceptions
+    def record_event(
+        self, event_type: str, event_details: Dict[str, Any], *, from_gui: bool = False
+    ):
+        event_details["usage_mode"] = "GUI" if from_gui else "CLI"
+        self._put_telemetry_record(
+            TelemetryEvent(
+                event_type=event_type,
+                event_details=event_details,
+            )
+        )
+
+    @lru_cache
+    def get_account_id(self, boto3_session) -> Optional[str]:
+        """Best-effort AWS account ID lookup for telemetry, cached per
+        (client, session) so it runs at most once per telemetry client
+        instance.
+
+        Prefers ``session.get_credentials().account_id`` (populated for free
+        by SSO, AssumeRole, IMDS/ECS, or a ``credential_process`` that emits
+        ``AccountId``). Deadline Cloud monitor delivers its credentials
+        through ``credential_process`` (see ``_get_boto3_session_for_profile``
+        in ``_session.py``), so if DCM's process output includes
+        ``AccountId`` this fast path covers the common monitor user flow
+        without an STS call. Falls back to ``sts:GetCallerIdentity`` with a
+        short timeout, returning ``None`` on any failure so users on
+        restricted networks without STS access can still run the CLI.
+        """
+        try:
+            credentials = boto3_session.get_credentials()
+            account_id = getattr(credentials, "account_id", None) if credentials else None
+            if account_id:
+                return account_id
+            # Short-timeout best-effort fallback; runs on the telemetry background
+            # thread so blocking is fine.
+            sts = boto3_session.client(
+                "sts",
+                config=BotocoreConfig(
+                    connect_timeout=2, read_timeout=2, retries={"max_attempts": 1}
+                ),
+            )
+            return sts.get_caller_identity()["Account"]
+        except Exception:
+            logger.debug("Could not resolve account ID for telemetry", exc_info=True)
+            return None
+
+    def update_common_details(self, details: Dict[str, Any]):
+        """Updates the dict of common data that is included in every telemetry request."""
         self._common_details.update(details)
+
+
+def get_telemetry_client(
+    package_name: str, package_ver: str, config: Optional[ConfigParser] = None
+) -> TelemetryClient:
+    """
+    Retrieves the cached telemetry client, lazy-loading the first time this is called.
+    :param package_name: Base package name to associate data by.
+    :param package_ver: Base package version to associate data by.
+    :param config: Optional configuration to use for the client. Loads defaults if not given.
+    :return: Telemetry client to make requests with.
+    """
+    global __cached_telemetry_clients
+    cached = __cached_telemetry_clients.get(package_name)
+    if not cached:
+        cached = TelemetryClient(
+            package_name=package_name,
+            package_ver=package_ver,
+            config=config,
+        )
+        __cached_telemetry_clients[package_name] = cached
+    elif not cached.is_initialized:
+        cached.initialize(config=config)
+
+    return cached
+
+
+def get_deadline_cloud_library_telemetry_client(
+    config: Optional[ConfigParser] = None,
+) -> TelemetryClient:
+    """
+    Retrieves the cached telemetry client, specifying the Deadline Cloud Client Library's package information.
+    :param config: Optional configuration to use for the client. Loads defaults if not given.
+    :return: Telemetry client to make requests with.
+    """
+    return get_telemetry_client("deadline-cloud-library", version, config=config)
+
+
+def record_success_fail_telemetry_event(**decorator_kwargs: Any) -> Callable[[F], F]:
+    """
+    Decorator to try catch a function. Sends a success / fail telemetry event.
+    :param ** Python variable arguments. See https://docs.python.org/3/glossary.html#term-parameter.
+    """
+
+    def inner(function: F) -> F:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            """
+            Wrapper to try-catch a function for telemetry
+            :param * Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter
+            :param ** Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter
+            """
+            success: bool = False
+            try:
+                result = function(*args, **kwargs)
+                success = True
+                return result
+            finally:
+                event_name = decorator_kwargs.get("metric_name", function.__name__)
+
+                event_details: dict = decorator_kwargs.get("event_details", {})
+                event_details["is_success"] = success
+                raised_exception = sys.exc_info()[1]
+                if raised_exception is not None:
+                    event_details["exception_type"] = type(raised_exception).__name__
+
+                get_deadline_cloud_library_telemetry_client().record_event(
+                    event_type=f"com.amazon.rum.deadline.{event_name}",
+                    event_details=event_details,
+                )
+
+        wrapper.__doc__ = function.__doc__
+        return cast(F, wrapper)
+
+    return inner
+
+
+def record_function_latency_telemetry_event(**decorator_kwargs: Any) -> Callable[[F], F]:
+    """
+    Decorator to time a function. Sends a latency telemetry event.
+    :param ** Python variable arguments. See https://docs.python.org/3/glossary.html#term-parameter.
+    """
+
+    def inner(function: F) -> F:
+        @wraps(function)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            start_t = time.perf_counter_ns()
+            ret_val = function(*args, **kwargs)
+            end_t = time.perf_counter_ns()
+
+            latency = end_t - start_t
+
+            event_name = decorator_kwargs.get("metric_name", function.__name__)
+            get_deadline_cloud_library_telemetry_client().record_event(
+                event_type="com.amazon.rum.deadline.latency",
+                event_details={"latency": latency, "function_call": event_name},
+            )
+
+            return ret_val
+
+        return cast(F, wrapper)
+
+    return inner

--- a/test/e2e/mypy.ini
+++ b/test/e2e/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+check_untyped_defs = true
+show_error_codes = true
+pretty = true
+ignore_missing_imports = true

--- a/test/e2e/pre_test_cleanup.py
+++ b/test/e2e/pre_test_cleanup.py
@@ -10,7 +10,7 @@ You must first follow the E2E test setup instructions in DEVELOPMENT.md and sour
 the environment files before running this script.
 
 This script will automatically run before the tests, if the tests are run with
-hatch run e2e-test
+hatch run e2e:test
 """
 
 import logging

--- a/test/e2e/test_job_submissions.py
+++ b/test/e2e/test_job_submissions.py
@@ -772,7 +772,7 @@ class TestJobSubmission:
                                     if os.environ["OPERATING_SYSTEM"] == "linux"
                                     else {
                                         "command": "powershell",
-                                        "args": ["{{ Task.File.runScript }}"],
+                                        "args": ["{{ Task.File.runScript }}"],  # type: ignore[dict-item]
                                     }
                                 ),
                             },
@@ -807,7 +807,7 @@ class TestJobSubmission:
                                         if os.environ["OPERATING_SYSTEM"] == "linux"
                                         else {
                                             "command": "powershell",
-                                            "args": ["{{ Env.File.runScript }}"],
+                                            "args": ["{{ Env.File.runScript }}"],  # type: ignore[dict-item]
                                         }
                                     )
                                     if expected_canceled_action == "envEnter"

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -50,8 +50,8 @@ def wait_for_job_output(
         step_id=None,
         task_id=None,
     )
-    output_paths_by_root = job_output_downloader.get_paths_by_root()
-    LOG.info(f"Output paths by root: {output_paths_by_root}")
+    output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+    LOG.info(f"Output paths by root: {job_output_downloader.outputs_by_root}")
 
     # Download file and place it into the output_paths_by_root
     if output_root_path is not None:
@@ -68,9 +68,9 @@ def wait_for_job_output(
                 os.makedirs(root_output_path, exist_ok=True)
                 job_output_downloader.set_root_path(root_path, os.path.abspath(root_output_path))
 
-    download_stats = job_output_downloader.download()
+    download_stats = job_output_downloader.download_job_output()
     LOG.info(f"Download summary statistics: {dataclasses.asdict(download_stats)}")
-    return job_output_downloader.get_paths_by_root()
+    return job_output_downloader.get_output_paths_by_root()
 
 
 def submit_sleep_job(

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -50,8 +50,8 @@ def wait_for_job_output(
         step_id=None,
         task_id=None,
     )
-    output_paths_by_root = job_output_downloader.get_output_paths_by_root()
-    LOG.info(f"Output paths by root: {job_output_downloader.outputs_by_root}")
+    output_paths_by_root = job_output_downloader.get_paths_by_root()
+    LOG.info(f"Output paths by root: {output_paths_by_root}")
 
     # Download file and place it into the output_paths_by_root
     if output_root_path is not None:
@@ -68,9 +68,9 @@ def wait_for_job_output(
                 os.makedirs(root_output_path, exist_ok=True)
                 job_output_downloader.set_root_path(root_path, os.path.abspath(root_output_path))
 
-    download_stats = job_output_downloader.download_job_output()
+    download_stats = job_output_downloader.download()
     LOG.info(f"Download summary statistics: {dataclasses.asdict(download_stats)}")
-    return job_output_downloader.get_output_paths_by_root()
+    return job_output_downloader.get_paths_by_root()
 
 
 def submit_sleep_job(
@@ -293,7 +293,7 @@ def submit_custom_job(
                                 if os.environ["OPERATING_SYSTEM"] == "linux"
                                 else {
                                     "command": "powershell",
-                                    "args": ["{{ Task.File.runScript }}"],
+                                    "args": ["{{ Task.File.runScript }}"],  # type: ignore[dict-item]
                                 }
                             ),
                         },

--- a/test/integ/config/data/commented/identifier/input.toml
+++ b/test/integ/config/data/commented/identifier/input.toml
@@ -1,0 +1,5 @@
+[telemetry]
+
+# A unique identifier used to correlate telemetry data across worker agent restarts.
+# This is automatically generated and should not normally need to be changed.
+# identifier = "old-value"

--- a/test/integ/config/data/commented/identifier/output.toml
+++ b/test/integ/config/data/commented/identifier/output.toml
@@ -1,0 +1,5 @@
+[telemetry]
+
+# A unique identifier used to correlate telemetry data across worker agent restarts.
+# This is automatically generated and should not normally need to be changed.
+identifier = "new-value"

--- a/test/integ/config/data/commented/opt_out/input.toml
+++ b/test/integ/config/data/commented/opt_out/input.toml
@@ -1,0 +1,10 @@
+[telemetry]
+
+# Controls whether telemetry data is collected and sent to AWS. This value is overridden when the
+# DEADLINE_CLOUD_TELEMETRY_OPT_OUT environment variable is set using one of the following
+# case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# By default, telemetry is enabled. To opt out, uncomment the line below:
+# opt_out = false

--- a/test/integ/config/data/commented/opt_out/output.toml
+++ b/test/integ/config/data/commented/opt_out/output.toml
@@ -1,0 +1,10 @@
+[telemetry]
+
+# Controls whether telemetry data is collected and sent to AWS. This value is overridden when the
+# DEADLINE_CLOUD_TELEMETRY_OPT_OUT environment variable is set using one of the following
+# case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# By default, telemetry is enabled. To opt out, uncomment the line below:
+opt_out = true

--- a/test/integ/config/data/existing/identifier/input.toml
+++ b/test/integ/config/data/existing/identifier/input.toml
@@ -1,0 +1,5 @@
+[telemetry]
+
+# A unique identifier used to correlate telemetry data across worker agent restarts.
+# This is automatically generated and should not normally need to be changed.
+identifier = "old-value"

--- a/test/integ/config/data/existing/identifier/output.toml
+++ b/test/integ/config/data/existing/identifier/output.toml
@@ -1,0 +1,5 @@
+[telemetry]
+
+# A unique identifier used to correlate telemetry data across worker agent restarts.
+# This is automatically generated and should not normally need to be changed.
+identifier = "new-value"

--- a/test/integ/config/data/existing/opt_out/input.toml
+++ b/test/integ/config/data/existing/opt_out/input.toml
@@ -1,0 +1,10 @@
+[telemetry]
+
+# Controls whether telemetry data is collected and sent to AWS. This value is overridden when the
+# DEADLINE_CLOUD_TELEMETRY_OPT_OUT environment variable is set using one of the following
+# case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# By default, telemetry is enabled. To opt out, uncomment the line below:
+opt_out = false

--- a/test/integ/config/data/existing/opt_out/output.toml
+++ b/test/integ/config/data/existing/opt_out/output.toml
@@ -1,0 +1,10 @@
+[telemetry]
+
+# Controls whether telemetry data is collected and sent to AWS. This value is overridden when the
+# DEADLINE_CLOUD_TELEMETRY_OPT_OUT environment variable is set using one of the following
+# case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# By default, telemetry is enabled. To opt out, uncomment the line below:
+opt_out = true

--- a/test/integ/config/data/missing/identifier/input.toml
+++ b/test/integ/config/data/missing/identifier/input.toml
@@ -1,0 +1,7 @@
+[telemetry]
+
+# Some prior content that should be preserved
+prior_setting_1 = 1
+
+# More content to preserve
+prior_setting_2 = "abc"  # and here's an inline comment

--- a/test/integ/config/data/missing/identifier/output.toml
+++ b/test/integ/config/data/missing/identifier/output.toml
@@ -1,0 +1,12 @@
+[telemetry]
+
+# Some prior content that should be preserved
+prior_setting_1 = 1
+
+# More content to preserve
+prior_setting_2 = "abc"  # and here's an inline comment
+
+
+# A unique identifier used to correlate telemetry data across worker agent restarts.
+# This is automatically generated and should not normally need to be changed.
+identifier = "new-value"

--- a/test/integ/config/data/missing/opt_out/input.toml
+++ b/test/integ/config/data/missing/opt_out/input.toml
@@ -1,0 +1,7 @@
+[telemetry]
+
+# Some prior content that should be preserved
+prior_setting_1 = 1
+
+# More content to preserve
+prior_setting_2 = "abc"  # and here's an inline comment

--- a/test/integ/config/data/missing/opt_out/output.toml
+++ b/test/integ/config/data/missing/opt_out/output.toml
@@ -1,0 +1,17 @@
+[telemetry]
+
+# Some prior content that should be preserved
+prior_setting_1 = 1
+
+# More content to preserve
+prior_setting_2 = "abc"  # and here's an inline comment
+
+
+# Controls whether telemetry data is collected and sent to AWS. This value is overridden when the
+# DEADLINE_CLOUD_TELEMETRY_OPT_OUT environment variable is set using one of the following
+# case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# By default, telemetry is enabled. To opt out, uncomment the line below:
+opt_out = true

--- a/test/integ/config/data/unset/identifier/input.toml
+++ b/test/integ/config/data/unset/identifier/input.toml
@@ -1,0 +1,5 @@
+[telemetry]
+
+# A unique identifier used to correlate telemetry data across worker agent restarts.
+# This is automatically generated and should not normally need to be changed.
+identifier = "old-value"

--- a/test/integ/config/data/unset/identifier/output.toml
+++ b/test/integ/config/data/unset/identifier/output.toml
@@ -1,0 +1,5 @@
+[telemetry]
+
+# A unique identifier used to correlate telemetry data across worker agent restarts.
+# This is automatically generated and should not normally need to be changed.
+# identifier = "old-value"

--- a/test/integ/config/data/unset/opt_out/input.toml
+++ b/test/integ/config/data/unset/opt_out/input.toml
@@ -1,0 +1,10 @@
+[telemetry]
+
+# Controls whether telemetry data is collected and sent to AWS. This value is overridden when the
+# DEADLINE_CLOUD_TELEMETRY_OPT_OUT environment variable is set using one of the following
+# case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# By default, telemetry is enabled. To opt out, uncomment the line below:
+opt_out = true

--- a/test/integ/config/data/unset/opt_out/output.toml
+++ b/test/integ/config/data/unset/opt_out/output.toml
@@ -1,0 +1,10 @@
+[telemetry]
+
+# Controls whether telemetry data is collected and sent to AWS. This value is overridden when the
+# DEADLINE_CLOUD_TELEMETRY_OPT_OUT environment variable is set using one of the following
+# case-insensitive values:
+#
+#     '0', 'off', 'f', 'false', 'n', 'no', '1', 'on', 't', 'true', 'y', 'yes'.
+#
+# By default, telemetry is enabled. To opt out, uncomment the line below:
+# opt_out = true

--- a/test/integ/config/test_config_cli.py
+++ b/test/integ/config/test_config_cli.py
@@ -81,6 +81,17 @@ def cli_args_for_region(value: str | bool | None) -> list[str]:
         raise NotImplementedError(f"Unexpected value: {value}")
 
 
+def cli_args_for_telemetry_opt_out(value: str | bool | None) -> list[str]:
+    if value is None:
+        return []
+    elif value is True:
+        return ["--telemetry-opt-out"]
+    elif value is False:
+        return ["--no-telemetry-opt-out"]
+    else:
+        raise NotImplementedError(f"Unexpected value: {value}")
+
+
 SETTING_TO_CLI_ARGS: dict[
     config_file.ModifiableSetting, Callable[[str | bool | None], list[str]]
 ] = {
@@ -91,6 +102,7 @@ SETTING_TO_CLI_ARGS: dict[
     config_file.ModifiableSetting.SHUTDOWN_ON_STOP: cli_args_for_shutdown_on_stop,
     config_file.ModifiableSetting.SESSION_ROOT_DIR: cli_args_for_session_root_dir,
     config_file.ModifiableSetting.REGION: cli_args_for_region,
+    config_file.ModifiableSetting.TELEMETRY_OPT_OUT: cli_args_for_telemetry_opt_out,
 }
 
 
@@ -102,7 +114,7 @@ def value_to_set_cli_args(
     try:
         setting_to_cli_args = SETTING_TO_CLI_ARGS[modifiable_setting]
     except KeyError:
-        raise NotImplementedError(f"Unhandled setting: {modifiable_setting.name}") from None
+        pytest.skip(f"No CLI args for setting: {modifiable_setting.name}")
 
     return setting_to_cli_args(value_to_set)
 

--- a/test/integ/config/test_config_file.py
+++ b/test/integ/config/test_config_file.py
@@ -13,9 +13,9 @@ def test(
     setting_name: str,
     value_to_set: str | bool,
     worker_config_path: Path,
+    modifiable_setting: config_file.ModifiableSetting,
 ) -> None:
     # GIVEN
-    modifiable_setting = getattr(config_file.ModifiableSetting, setting_name.upper())
     settings_to_modify = [
         config_file.SettingModification(
             setting=modifiable_setting,

--- a/test/integ/windows/test_installer.py
+++ b/test/integ/windows/test_installer.py
@@ -22,7 +22,6 @@ import win32security
 import win32file
 import ntsecuritycon
 
-import deadline.client.config.config_file
 from deadline_worker_agent.installer import win_installer
 from deadline_worker_agent.installer.win_installer import (
     add_user_to_group,
@@ -34,7 +33,6 @@ from deadline_worker_agent.installer.win_installer import (
     get_effective_user_rights,
     grant_account_rights,
     provision_directories,
-    update_deadline_client_config,
     is_user_in_group,
     WorkerAgentDirectories,
 )
@@ -362,25 +360,6 @@ def test_provision_directories(
     verify_least_privilege(windows_user, actual_dirs.deadline_config_subdir)
     assert session_root_dir.exists()
     verify_least_privilege(windows_user, session_root_dir, is_session_root=True)
-
-
-def test_update_deadline_client_config(tmp_path: Path) -> None:
-    # GIVEN
-    deadline_client_config_path = tmp_path / "deadline_client_config"
-    deadline_client_config_path.touch(mode=0o644, exist_ok=False)
-
-    with patch(
-        "deadline.client.config.config_file.get_config_file_path",
-        return_value=deadline_client_config_path,
-    ):
-        # WHEN
-        update_deadline_client_config(
-            user="",  # Doesn't matter, config path is mocked out anyway
-            settings={"telemetry.opt_out": "true"},
-        )
-
-        # THEN
-        assert deadline.client.config.config_file.get_setting("telemetry.opt_out") == "true"
 
 
 def test_grant_account_rights(windows_user: str):

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -269,8 +269,8 @@ def test_get_deadline_telemetry_client_sets_service_name():
     Tests that _get_deadline_telemetry_client() creates a TelemetryClient with the correct
     service name by directly constructing the client.
     """
-    # Clear the cache to ensure fresh initialization
-    _get_deadline_telemetry_client.cache_clear()
+    # Clear the cached client to ensure fresh initialization
+    deadline_mod._telemetry_client = None
 
     mock_telemetry_client = MagicMock()
 

--- a/test/unit/boto/test_config.py
+++ b/test/unit/boto/test_config.py
@@ -3,7 +3,7 @@
 from botocore.config import Config
 
 from deadline_worker_agent._version import __version__
-from deadline.client import version as deadline_client_lib_version
+from deadline.job_attachments import version as deadline_job_attachments_version
 from openjd.sessions import version as openjd_sessions_version
 import deadline_worker_agent.boto.config as boto_config_mod
 
@@ -24,7 +24,7 @@ class TestDeadlineBotocoreConfig:
         assert isinstance(DEADLINE_BOTOCORE_CONFIG, Config)
         libraries: list[str] = DEADLINE_BOTOCORE_CONFIG.user_agent_extra.split(" ")
         assert libraries[0] == f"deadline_worker_agent/{__version__}"
-        assert libraries[1] == f"deadline_cloud/{deadline_client_lib_version}"
+        assert libraries[1] == f"deadline_job_attachments/{deadline_job_attachments_version}"
         assert libraries[2] == f"openjd_sessions/{openjd_sessions_version}"
 
     def test_does_not_retry(self) -> None:
@@ -67,5 +67,5 @@ class TestOtherBotocoreConfig:
         assert isinstance(OTHER_BOTOCORE_CONFIG, Config)
         libraries: list[str] = OTHER_BOTOCORE_CONFIG.user_agent_extra.split(" ")
         assert libraries[0] == f"deadline_worker_agent/{__version__}"
-        assert libraries[1] == f"deadline_cloud/{deadline_client_lib_version}"
+        assert libraries[1] == f"deadline_job_attachments/{deadline_job_attachments_version}"
         assert libraries[2] == f"openjd_sessions/{openjd_sessions_version}"

--- a/test/unit/config/test_settings.py
+++ b/test/unit/config/test_settings.py
@@ -152,6 +152,13 @@ FIELD_TEST_CASES: list[FieldTestCaseParams] = [
         expected_default_factory_return_value=None,
     ),
     FieldTestCaseParams(
+        field_name="telemetry_opt_out",
+        expected_type=bool,
+        expected_required=False,
+        expected_default=False,
+        expected_default_factory_return_value=None,
+    ),
+    FieldTestCaseParams(
         field_name="host_metrics_logging",
         expected_type=bool,
         expected_required=False,

--- a/test/unit/sessions/actions/scripts/test_attachment_upload.py
+++ b/test/unit/sessions/actions/scripts/test_attachment_upload.py
@@ -315,12 +315,10 @@ class TestAttachmentUpload:
     )
     @patch("builtins.print")
     @patch.object(attachment_upload_mod, "ProgressTracker")
-    @patch.object(attachment_upload_mod.config_file, "get_cache_directory")
     @patch.object(attachment_upload_mod, "S3AssetUploader")
     def test_upload_output_assets(
         self,
         mock_uploader_class: Mock,
-        mock_get_cache_directory: Mock,
         mock_progress_tracker: Mock,
         mock_print: Mock,
         mock_record_attachment_upload_telemetry_event: Mock,
@@ -441,7 +439,7 @@ class TestAttachmentUpload:
                     manifest_metadata=worker_props[0].as_output_metadata(),
                     source_root=Path(worker_props[0].root_path),
                     asset_root=Path(worker_props[0].local_root_path),
-                    s3_check_cache_dir=mock_get_cache_directory.return_value,
+                    s3_check_cache_dir=None,
                     progress_tracker=progress_tracker_stub,
                 ),
                 call(
@@ -452,7 +450,7 @@ class TestAttachmentUpload:
                     manifest_metadata=worker_props[1].as_output_metadata(),
                     source_root=Path(worker_props[1].root_path),
                     asset_root=Path(worker_props[1].local_root_path),
-                    s3_check_cache_dir=mock_get_cache_directory.return_value,
+                    s3_check_cache_dir=None,
                     progress_tracker=progress_tracker_stub,
                 ),
             ],

--- a/test/unit/test_telemetry.py
+++ b/test/unit/test_telemetry.py
@@ -1,38 +1,435 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from typing import Any, Dict
 import json
 import platform
-import time
+import pytest
 import uuid
-from queue import Full
-from unittest.mock import MagicMock, patch
+import time
+
+from unittest.mock import patch, MagicMock
+from dataclasses import asdict
 from urllib import request
 
-import pytest
-
-from deadline_worker_agent.telemetry import (
+from deadline.client import api, config
+from deadline.client.api._telemetry import (
     TelemetryClient,
     TelemetryEvent,
     _swallow_exceptions,
+    get_deadline_cloud_library_telemetry_client,
+    get_telemetry_client,
+    record_success_fail_telemetry_event,
+    record_function_latency_telemetry_event,
 )
+from deadline.job_attachments.progress_tracker import SummaryStatistics
 
 
-@pytest.fixture
-def mock_telemetry_client():
-    """Creates a TelemetryClient with threads and network mocked out."""
-    with patch.object(TelemetryClient, "_start_threads"), patch(
-        "deadline_worker_agent.telemetry.boto3.client"
-    ) as mock_boto_client:
-        mock_boto_client.return_value.meta.endpoint_url = "https://fake-endpoint-url"
+@pytest.fixture(scope="function", name="mock_telemetry_client")
+def fixture_telemetry_client(fresh_deadline_config):
+    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
+    with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
+        api._telemetry, "get_monitor_id", side_effect=["monitor-id"]
+    ), patch.object(api._telemetry, "get_monitor_id", side_effect=[None]), patch.object(
+        api._telemetry,
+        "get_user_and_identity_store_id",
+        side_effect=[("user-id", "identity-store-id")],
+    ), patch.object(
+        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
+    ):
         client = TelemetryClient(
-            package_name="deadline-cloud-worker-agent",
-            package_ver="1.2.3.4567",
+            package_name="deadline-cloud-library",
+            package_ver="0.1.2.1234",
+            config=config.config_file.read_config(),
         )
-        assert client._initialized
+        assert client.is_initialized
         return client
 
 
-class TestSwallowExceptions:
+def test_opt_out_config(fresh_deadline_config):
+    """Ensures the telemetry client doesn't fully initialize if the opt out config setting is set"""
+    # GIVEN
+    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
+    config.set_setting("telemetry.opt_out", "true")
+    # WHEN
+    client = TelemetryClient(
+        "deadline-cloud-library", "test-version", config=config.config_file.read_config()
+    )
+    # THEN
+    assert not client.is_initialized
+    assert not hasattr(client, "endpoint")
+    assert not hasattr(client, "event_queue")
+    assert not hasattr(client, "processing_thread")
+    # Ensure nothing blows up if we try recording telemetry after we've opted out
+    client.record_hashing_summary(SummaryStatistics(), from_gui=True)
+    client.record_upload_summary(SummaryStatistics(), from_gui=False)
+    client.record_error({}, str(type(Exception)))
+
+
+@pytest.mark.parametrize(
+    "env_var_value",
+    [
+        pytest.param("true"),
+        pytest.param("1"),
+        pytest.param("yes"),
+        pytest.param("on"),
+    ],
+)
+def test_opt_out_env_var(fresh_deadline_config, monkeypatch, env_var_value):
+    """Ensures the telemetry client doesn't fully initialize if the opt out env var is set"""
+    # GIVEN
+    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
+    monkeypatch.setenv("DEADLINE_CLOUD_TELEMETRY_OPT_OUT", env_var_value)
+    config.set_setting(
+        "telemetry.opt_out", "false"
+    )  # Ensure we ignore the config file if env var is set
+    # WHEN
+    client = TelemetryClient(
+        "deadline-cloud-library", "test-version", config=config.config_file.read_config()
+    )
+    # THEN
+    assert not client.is_initialized
+    assert not hasattr(client, "endpoint")
+    assert not hasattr(client, "event_queue")
+    assert not hasattr(client, "processing_thread")
+    # Ensure nothing blows up if we try recording telemetry after we've opted out
+    client.record_hashing_summary(SummaryStatistics(), from_gui=True)
+    client.record_upload_summary(SummaryStatistics(), from_gui=False)
+    client.record_error({}, str(type(Exception)))
+
+
+def test_initialize_failure_then_success(fresh_deadline_config):
+    """
+    Tests that a failure in initializing set keeps the property as false, but trying again
+    without an exception initializes everything successfully.
+    """
+    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
+    with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
+        api._telemetry, "get_monitor_id", side_effect=["monitor-id"]
+    ), patch.object(
+        api._telemetry,
+        "get_user_and_identity_store_id",
+        side_effect=[("user-id", "identity-store-id")],
+    ), patch.object(
+        api._telemetry,
+        "get_deadline_endpoint_url",
+        side_effect=[Exception("Boto3 blew up!"), "https://fake-endpoint-url"],
+    ):
+        client = TelemetryClient(
+            package_name="deadline-cloud-library",
+            package_ver="0.1.2.1234",
+            config=config.config_file.read_config(),
+        )
+
+        assert not client.is_initialized
+        assert not hasattr(client, "endpoint")
+        assert not hasattr(client, "event_queue")
+        assert not hasattr(client, "processing_thread")
+
+        client.initialize(config=config.config_file.read_config())
+        assert client.is_initialized
+        assert client.endpoint == "https://management.fake-endpoint-url/2023-10-12/telemetry"
+        assert client._system_metadata["user_id"] == "user-id"
+        assert client._system_metadata["monitor_id"] == "monitor-id"
+
+
+def test_get_telemetry_identifier(fresh_deadline_config, mock_telemetry_client):
+    """Ensures that getting the local-user-id handles empty/malformed strings"""
+    # Confirm that we generate a new UUID if the setting doesn't exist, and write to config
+    uuid.UUID(mock_telemetry_client.telemetry_id, version=4)  # Should not raise ValueError
+    assert config.get_setting("telemetry.identifier") == mock_telemetry_client.telemetry_id
+
+    # Confirm we generate a new UUID if the local_user_id is not a valid UUID
+    config.set_setting("telemetry.identifier", "bad-id")
+    telemetry_id = mock_telemetry_client._get_telemetry_identifier()
+    assert telemetry_id != "bad-id"
+    uuid.UUID(telemetry_id, version=4)  # Should not raise ValueError
+
+    # Confirm the new user id was saved and is retrieved properly
+    assert config.get_setting("telemetry.identifier") == telemetry_id
+    assert mock_telemetry_client._get_telemetry_identifier() == telemetry_id
+
+
+@pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
+def test_process_event_queue_thread(fresh_deadline_config, mock_telemetry_client):
+    """Test that the queue processing thread function exits cleanly after getting None"""
+    # GIVEN
+    queue_mock = MagicMock()
+    queue_mock.get.side_effect = [TelemetryEvent(), None]
+    mock_telemetry_client.event_queue = queue_mock
+    # WHEN
+    with patch.object(request, "urlopen") as urlopen_mock, patch.object(
+        TelemetryClient, "get_account_id", return_value=None
+    ), patch.object(api._telemetry, "get_boto3_session"):
+        mock_telemetry_client._process_event_queue_thread()
+        urlopen_mock.assert_called_once()
+    # THEN
+    assert queue_mock.get.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "http_code,attempt_count",
+    [
+        (400, 1),
+        (429, TelemetryClient.MAX_RETRY_ATTEMPTS),
+        (500, TelemetryClient.MAX_RETRY_ATTEMPTS),
+    ],
+)
+@pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
+def test_process_event_queue_thread_retries_and_exits(
+    fresh_deadline_config, mock_telemetry_client, http_code, attempt_count
+):
+    """Test that the thread exits cleanly after getting an unexpected exception"""
+    # GIVEN
+    http_error = request.HTTPError("http://test.com", http_code, "Http Error", {}, None)  # type: ignore
+    queue_mock = MagicMock()
+    queue_mock.get.side_effect = [TelemetryEvent(), None]
+    mock_telemetry_client.event_queue = queue_mock
+    # WHEN
+    with patch.object(request, "urlopen", side_effect=http_error) as urlopen_mock, patch.object(
+        time, "sleep"
+    ) as sleep_mock, patch.object(
+        TelemetryClient, "get_account_id", return_value=None
+    ), patch.object(api._telemetry, "get_boto3_session"):
+        mock_telemetry_client._process_event_queue_thread()
+        urlopen_mock.call_count = attempt_count
+        sleep_mock.call_count = attempt_count
+    # THEN
+    assert queue_mock.get.call_count == 1
+
+
+@pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
+def test_process_event_queue_thread_handles_unexpected_error(
+    fresh_deadline_config, mock_telemetry_client
+):
+    """Test that the thread exits cleanly after getting an unexpected exception"""
+    # GIVEN
+    queue_mock = MagicMock()
+    queue_mock.get.side_effect = [TelemetryEvent(), None]
+    mock_telemetry_client.event_queue = queue_mock
+    # WHEN
+    with patch.object(
+        request, "urlopen", side_effect=Exception("Some error")
+    ) as urlopen_mock, patch.object(
+        TelemetryClient, "get_account_id", return_value=None
+    ), patch.object(api._telemetry, "get_boto3_session"):
+        mock_telemetry_client._process_event_queue_thread()
+        urlopen_mock.assert_called_once()
+    # THEN
+    assert queue_mock.get.call_count == 1
+
+
+def test_record_hashing_summary(fresh_deadline_config, mock_telemetry_client):
+    """Tests that recording a hashing summary sends the expected TelemetryEvent to the thread queue"""
+    # GIVEN
+    queue_mock = MagicMock()
+    test_summary = SummaryStatistics(total_bytes=123, total_files=12, total_time=12345)
+    expected_summary = asdict(test_summary)
+    expected_summary["usage_mode"] = "CLI"
+    expected_event = TelemetryEvent(
+        event_type="com.amazon.rum.deadline.job_attachments.hashing_summary",
+        event_details=expected_summary,
+    )
+    mock_telemetry_client.event_queue = queue_mock
+
+    # WHEN
+    mock_telemetry_client.record_hashing_summary(test_summary)
+
+    # THEN
+    queue_mock.put_nowait.assert_called_once_with(expected_event)
+
+
+def test_record_upload_summary(fresh_deadline_config, mock_telemetry_client):
+    """Tests that recording an upload summary sends the expected TelemetryEvent to the thread queue"""
+    # GIVEN
+    queue_mock = MagicMock()
+    test_summary = SummaryStatistics(total_bytes=123, total_files=12, total_time=12345)
+    expected_summary = asdict(test_summary)
+    expected_summary["usage_mode"] = "GUI"
+    expected_event = TelemetryEvent(
+        event_type="com.amazon.rum.deadline.job_attachments.upload_summary",
+        event_details=expected_summary,
+    )
+    mock_telemetry_client.event_queue = queue_mock
+
+    # WHEN
+    mock_telemetry_client.record_upload_summary(test_summary, from_gui=True)
+
+    # THEN
+    queue_mock.put_nowait.assert_called_once_with(expected_event)
+
+
+def test_record_error(fresh_deadline_config, mock_telemetry_client):
+    """Test that recording an error sends the expected TelemetryEvent to the thread queue"""
+    # GIVEN
+    queue_mock = MagicMock()
+    test_error_details = {"some_field": "some_value"}
+    test_exc = Exception("some exception")
+    expected_event_details = {
+        "some_field": "some_value",
+        "exception_type": str(type(test_exc)),
+        "usage_mode": "CLI",
+    }
+    expected_event = TelemetryEvent(
+        event_type="com.amazon.rum.deadline.error", event_details=expected_event_details
+    )
+    mock_telemetry_client.event_queue = queue_mock
+
+    # WHEN
+    mock_telemetry_client.record_error(test_error_details, str(type(test_exc)))
+
+    # THEN
+    queue_mock.put_nowait.assert_called_once_with(expected_event)
+
+
+@pytest.mark.parametrize(
+    "endpoint,prefix,expected_result",
+    [
+        pytest.param(
+            "test.endpoint.url",
+            "",
+            "test.endpoint.url",
+            id="The endpoint is not prefixed if the prefix is empty.",
+        ),
+        pytest.param(
+            "test.endpoint.url",
+            "management.",
+            "test.endpoint.url",
+            id="The endpoint is not prefixed if the endpoint does not start with 'https://'.",
+        ),
+        pytest.param(
+            "https://test.endpoint.url",
+            "management.",
+            "https://management.test.endpoint.url",
+            id="The prefix is inserted right after 'https://'.",
+        ),
+    ],
+)
+def test_get_prefixed_endpoint(
+    fresh_deadline_config,
+    mock_telemetry_client: TelemetryClient,
+    endpoint: str,
+    prefix: str,
+    expected_result: str,
+):
+    """Test that the _get_prefixed_endpoint function returns the expected prefixed endpoint"""
+    assert mock_telemetry_client._get_prefixed_endpoint(endpoint, prefix) == expected_result
+
+
+def test_record_decorator_success(fresh_deadline_config):
+    """Tests that recording a decorator successful metric"""
+    with patch.object(
+        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
+    ):
+        # GIVEN
+        queue_mock = MagicMock()
+        expected_summary: Dict[str, Any] = dict()
+        expected_summary["is_success"] = True
+        expected_summary["usage_mode"] = "CLI"
+        expected_event = TelemetryEvent(
+            event_type="com.amazon.rum.deadline.successful",
+            event_details=expected_summary,
+        )
+        telemetry_client = get_deadline_cloud_library_telemetry_client()
+        telemetry_client.event_queue = queue_mock
+
+        @record_success_fail_telemetry_event()
+        def successful():
+            return
+
+        # WHEN
+        successful()  # type:ignore
+
+        # THEN
+        queue_mock.put_nowait.assert_called_once_with(expected_event)
+
+
+def test_record_decorator_fails(fresh_deadline_config):
+    """Tests that recording a decorator failed metric"""
+    with patch.object(
+        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
+    ):
+        # GIVEN
+        queue_mock = MagicMock()
+        expected_summary: Dict[str, Any] = dict()
+        expected_summary["is_success"] = False
+        expected_summary["exception_type"] = "RuntimeError"
+        expected_summary["usage_mode"] = "CLI"
+        expected_event = TelemetryEvent(
+            event_type="com.amazon.rum.deadline.fails",
+            event_details=expected_summary,
+        )
+        telemetry_client = get_deadline_cloud_library_telemetry_client()
+        telemetry_client.event_queue = queue_mock
+
+        @record_success_fail_telemetry_event()
+        def fails():
+            raise RuntimeError("foobar")
+
+        # WHEN
+        with pytest.raises(RuntimeError):
+            fails()  # type:ignore
+
+        # THEN
+        queue_mock.put_nowait.assert_called_once_with(expected_event)
+
+
+def test_latency_decorator(fresh_deadline_config):
+    """Tests that the latency recording decorator works"""
+    with patch.object(
+        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
+    ), patch.object(time, "perf_counter_ns", return_value=0):
+        # GIVEN
+        queue_mock = MagicMock()
+        expected_summary: Dict[str, Any] = dict()
+        expected_summary["latency"] = 0
+        expected_summary["function_call"] = "test_call"
+        expected_summary["usage_mode"] = "CLI"
+        expected_event = TelemetryEvent(
+            event_type="com.amazon.rum.deadline.latency",
+            event_details=expected_summary,
+        )
+        telemetry_client = get_deadline_cloud_library_telemetry_client()
+        telemetry_client.event_queue = queue_mock
+
+        @record_function_latency_telemetry_event()
+        def test_call():
+            return
+
+        # WHEN
+        test_call()  # type:ignore
+
+        # THEN
+        queue_mock.put_nowait.assert_called_once_with(expected_event)
+
+
+def test_get_telemetry_client_caches_by_package_name(fresh_deadline_config):
+    """
+    Verify that get_telemetry_client returns different clients for different package names.
+    """
+    import deadline.client.api._telemetry as telemetry_mod
+
+    telemetry_mod.__cached_telemetry_clients = {}
+
+    def fake_init(self, **kwargs):
+        self._initialized = True
+        self.package_name = kwargs["package_name"]
+
+    with patch.object(TelemetryClient, "__init__", fake_init):
+        client_a = get_telemetry_client("package-a", "1.0.0")
+        client_b = get_telemetry_client("package-b", "2.0.0")
+        client_a_again = get_telemetry_client("package-a", "1.0.0")
+
+        assert client_a is not client_b
+        assert client_a is client_a_again
+        assert client_a.package_name == "package-a"
+        assert client_b.package_name == "package-b"
+
+    telemetry_mod.__cached_telemetry_clients = {}
+
+
+class TestSwallowExceptionsDecorator:
+    """Tests for the _swallow_exceptions decorator"""
+
     def test_returns_value_on_success(self):
         @_swallow_exceptions
         def succeeds():
@@ -52,263 +449,204 @@ class TestSwallowExceptions:
         def fails():
             raise RuntimeError("boom")
 
-        with patch("deadline_worker_agent.telemetry.logger") as mock_logger:
+        with patch("deadline.client.api._telemetry.logger") as mock_logger:
             fails()
             mock_logger.debug.assert_called_once()
             assert "fails" in mock_logger.debug.call_args[0][1]
 
+    def test_preserves_function_name(self):
+        @_swallow_exceptions
+        def my_func():
+            pass
 
-class TestOptOut:
-    def test_opt_out_env_var(self, monkeypatch):
-        """Telemetry client doesn't initialize if env var is set."""
-        monkeypatch.setenv("DEADLINE_CLOUD_TELEMETRY_OPT_OUT", "true")
-        with patch.object(TelemetryClient, "_start_threads"):
-            client = TelemetryClient("test-package", "1.0.0")
-        assert not client._initialized
-        assert client.telemetry_opted_out
-
-    @pytest.mark.parametrize("env_var_value", ["true", "1", "yes", "on"])
-    def test_opt_out_env_var_values(self, monkeypatch, env_var_value):
-        """Various truthy env var values all opt out."""
-        monkeypatch.setenv("DEADLINE_CLOUD_TELEMETRY_OPT_OUT", env_var_value)
-        with patch.object(TelemetryClient, "_start_threads"):
-            client = TelemetryClient("test-package", "1.0.0")
-        assert client.telemetry_opted_out
-
-    def test_opt_out_worker_config(self):
-        """Telemetry client doesn't initialize if worker config has opt_out=true."""
-        mock_config_file = MagicMock()
-        mock_config_file.telemetry.opt_out = True
-
-        with patch.object(TelemetryClient, "_start_threads"), patch(
-            "deadline_worker_agent.telemetry.os.environ.get", return_value=""
-        ), patch(
-            "deadline_worker_agent.telemetry.TelemetryClient._read_opt_out_from_config",
-            return_value=True,
-        ):
-            client = TelemetryClient("test-package", "1.0.0")
-        assert client.telemetry_opted_out
-        assert not client._initialized
-
-    def test_not_opted_out_records_events(self, mock_telemetry_client):
-        """When not opted out, events are queued."""
-        queue_mock = MagicMock()
-        mock_telemetry_client.event_queue = queue_mock
-
-        mock_telemetry_client.record_event(
-            event_type="com.amazon.rum.deadline.test", event_details={"key": "value"}
-        )
-
-        queue_mock.put_nowait.assert_called_once()
-
-    def test_opted_out_does_not_record(self, mock_telemetry_client):
-        """When opted out, events are not queued."""
-        mock_telemetry_client.telemetry_opted_out = True
-        queue_mock = MagicMock()
-        mock_telemetry_client.event_queue = queue_mock
-
-        mock_telemetry_client.record_event(
-            event_type="com.amazon.rum.deadline.test", event_details={}
-        )
-
-        queue_mock.put_nowait.assert_not_called()
+        assert my_func.__name__ == "my_func"
 
 
-class TestInitialize:
-    def test_initialize_failure_then_success(self):
-        """A failure in initialize keeps _initialized False; retrying succeeds."""
-        with patch.object(TelemetryClient, "_start_threads"), patch(
-            "deadline_worker_agent.telemetry.boto3.client"
-        ) as mock_boto_client:
-            mock_boto_client.side_effect = [
-                Exception("Boto3 blew up!"),
-                MagicMock(meta=MagicMock(endpoint_url="https://fake-endpoint-url")),
-            ]
-            client = TelemetryClient(
-                package_name="test-package",
-                package_ver="1.0.0",
-            )
-            assert not client._initialized
+class TestTelemetryClientSwallowExceptions:
+    """Tests that decorated TelemetryClient methods don't propagate exceptions"""
 
-            # Retry
-            mock_boto_client.side_effect = None
-            mock_boto_client.return_value.meta.endpoint_url = "https://fake-endpoint-url"
-            client._initialize()
-            assert client._initialized
-            assert client.endpoint == "https://management.fake-endpoint-url/2023-10-12/telemetry"
+    def test_set_opt_out_swallows_exception(self, fresh_deadline_config, mock_telemetry_client):
+        with patch.object(config.config_file, "get_setting", side_effect=RuntimeError("boom")):
+            mock_telemetry_client.set_opt_out()
 
-    def test_initialize_swallows_exception(self, mock_telemetry_client):
-        """_initialize doesn't propagate exceptions."""
+    def test_initialize_swallows_exception(self, fresh_deadline_config, mock_telemetry_client):
         mock_telemetry_client._initialized = False
         mock_telemetry_client.telemetry_opted_out = False
-        with patch(
-            "deadline_worker_agent.telemetry.boto3.client", side_effect=RuntimeError("boom")
+        with patch.object(
+            api._telemetry, "get_deadline_endpoint_url", side_effect=RuntimeError("boom")
         ):
-            mock_telemetry_client._initialize()
-        assert not mock_telemetry_client._initialized
+            mock_telemetry_client.initialize()
+        assert not mock_telemetry_client.is_initialized
 
-
-class TestGetPrefixedEndpoint:
-    @pytest.mark.parametrize(
-        "endpoint,prefix,expected",
-        [
-            ("test.endpoint.url", "", "test.endpoint.url"),
-            ("test.endpoint.url", "management.", "test.endpoint.url"),
-            (
-                "https://test.endpoint.url",
-                "management.",
-                "https://management.test.endpoint.url",
-            ),
-        ],
-    )
-    def test_get_prefixed_endpoint(self, mock_telemetry_client, endpoint, prefix, expected):
-        assert mock_telemetry_client._get_prefixed_endpoint(endpoint, prefix) == expected
-
-
-class TestProcessEventQueueThread:
-    @pytest.mark.timeout(5)
-    def test_exits_on_none(self, mock_telemetry_client):
-        """Queue processing thread exits cleanly after getting None."""
-        queue_mock = MagicMock()
-        queue_mock.get.side_effect = [TelemetryEvent(), None]
-        mock_telemetry_client.event_queue = queue_mock
-
-        with patch.object(request, "urlopen"):
-            mock_telemetry_client._process_event_queue_thread()
-
-        assert queue_mock.get.call_count == 2
-
-    @pytest.mark.parametrize(
-        "http_code,expected_attempts",
-        [
-            (400, 1),
-            (429, TelemetryClient.MAX_RETRY_ATTEMPTS),
-            (500, TelemetryClient.MAX_RETRY_ATTEMPTS),
-        ],
-    )
-    @pytest.mark.timeout(5)
-    def test_retries_and_exits(self, mock_telemetry_client, http_code, expected_attempts):
-        """Thread retries on 429/500 and exits on other errors."""
-        http_error = request.HTTPError(
-            "http://test.com", http_code, "Http Error", {}, None  # type: ignore
-        )
-        queue_mock = MagicMock()
-        queue_mock.get.side_effect = [TelemetryEvent(), None]
-        mock_telemetry_client.event_queue = queue_mock
-
-        with patch.object(request, "urlopen", side_effect=http_error), patch.object(
-            time, "sleep"
-        ):
-            mock_telemetry_client._process_event_queue_thread()
-
-        # On non-retryable errors, only 1 event is dequeued (thread exits)
-        assert queue_mock.get.call_count == 1
-
-    @pytest.mark.timeout(5)
-    def test_handles_unexpected_error(self, mock_telemetry_client):
-        """Thread exits cleanly on unexpected exceptions."""
-        queue_mock = MagicMock()
-        queue_mock.get.side_effect = [TelemetryEvent(), None]
-        mock_telemetry_client.event_queue = queue_mock
-
-        with patch.object(request, "urlopen", side_effect=Exception("Some error")):
-            mock_telemetry_client._process_event_queue_thread()
-
-        assert queue_mock.get.call_count == 1
-
-
-class TestRecordEvent:
-    def test_record_error(self, mock_telemetry_client):
-        """Recording an error sends the expected event."""
-        queue_mock = MagicMock()
-        mock_telemetry_client.event_queue = queue_mock
-
-        mock_telemetry_client.record_error({"some_field": "value"}, "RuntimeError")
-
-        queue_mock.put_nowait.assert_called_once()
-        event = queue_mock.put_nowait.call_args[0][0]
-        assert event.event_type == "com.amazon.rum.deadline.error"
-        assert event.event_details["exception_type"] == "RuntimeError"
-        assert event.event_details["some_field"] == "value"
-
-    def test_record_event_includes_common_details(self, mock_telemetry_client):
-        """Common details are merged into event details."""
-        queue_mock = MagicMock()
-        mock_telemetry_client.event_queue = queue_mock
-        mock_telemetry_client.update_common_details({"common_key": "common_value"})
-
-        mock_telemetry_client.record_event(
-            event_type="com.amazon.rum.deadline.test",
-            event_details={"event_key": "event_value"},
-        )
-
-        event = queue_mock.put_nowait.call_args[0][0]
-        assert event.event_details["common_key"] == "common_value"
-        assert event.event_details["event_key"] == "event_value"
-
-    def test_record_event_swallows_exception(self, mock_telemetry_client):
-        """record_event doesn't propagate exceptions."""
+    def test_record_event_swallows_exception(self, fresh_deadline_config, mock_telemetry_client):
         with patch.object(
             mock_telemetry_client, "_put_telemetry_record", side_effect=RuntimeError("boom")
         ):
-            # Should not raise
             mock_telemetry_client.record_event(
-                event_type="com.amazon.rum.deadline.test", event_details={}
+                event_type="com.amazon.rum.deadline.test",
+                event_details={},
+                from_gui=False,
             )
 
-
-class TestExitCleanly:
-    def test_exit_cleanly_swallows_exception(self, mock_telemetry_client):
-        """_exit_cleanly doesn't propagate exceptions from a full queue."""
+    def test_exit_cleanly_swallows_exception(self, fresh_deadline_config, mock_telemetry_client):
         mock_telemetry_client.event_queue = MagicMock()
-        mock_telemetry_client.event_queue.put_nowait.side_effect = Full()
-        mock_telemetry_client.processing_thread = MagicMock()
-
-        # Should not raise
+        mock_telemetry_client.event_queue.put_nowait.side_effect = RuntimeError("boom")
         mock_telemetry_client._exit_cleanly()
 
+    def test_init_swallows_get_telemetry_identifier_exception(self, fresh_deadline_config):
+        config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
+        with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
+            api._telemetry, "get_monitor_id", side_effect=[None]
+        ), patch.object(
+            api._telemetry,
+            "get_user_and_identity_store_id",
+            side_effect=[("user-id", "identity-store-id")],
+        ), patch.object(
+            api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
+        ), patch.object(config.config_file, "get_setting", side_effect=RuntimeError("boom")):
+            client = TelemetryClient(
+                package_name="deadline-cloud-library",
+                package_ver="0.1.2.1234",
+                config=config.config_file.read_config(),
+            )
+            assert client.telemetry_id is not None
 
-class TestSystemMetadata:
-    def test_get_system_metadata(self, mock_telemetry_client):
-        """System metadata contains expected fields."""
-        metadata = mock_telemetry_client._get_system_metadata()
-        assert metadata["service"] == "deadline-cloud-worker-agent"
-        assert metadata["version"] == "1.2.3"
-        assert "python_version" in metadata
-        assert "osName" in metadata
-        assert "osVersion" in metadata
+    def test_init_swallows_get_system_metadata_exception(self, fresh_deadline_config):
+        config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
+        with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
+            api._telemetry, "get_monitor_id", side_effect=[None]
+        ), patch.object(
+            api._telemetry,
+            "get_user_and_identity_store_id",
+            side_effect=[("user-id", "identity-store-id")],
+        ), patch.object(
+            api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
+        ), patch.object(platform, "uname", side_effect=RuntimeError("boom")):
+            client = TelemetryClient(
+                package_name="deadline-cloud-library",
+                package_ver="0.1.2.1234",
+                config=config.config_file.read_config(),
+            )
+            assert "version" not in client._system_metadata
 
-    def test_get_system_metadata_macos(self, mock_telemetry_client):
-        """Darwin is reported as macOS."""
-        with patch.object(
-            platform, "uname", return_value=MagicMock(system="Darwin", release="23.0.0")
-        ):
-            metadata = mock_telemetry_client._get_system_metadata()
-        assert metadata["osName"] == "macOS"
+
+class TestGetAccountId:
+    """Tests for the background-thread account ID resolution."""
+
+    def test_prefers_credential_account_id(self, fresh_deadline_config, mock_telemetry_client):
+        """When credentials expose account_id, it is used directly without any STS call."""
+        session_mock = MagicMock()
+        session_mock.get_credentials.return_value.account_id = "111122223333"
+        # Bypass the @lru_cache so each test gets a fresh call.
+        mock_telemetry_client.get_account_id.cache_clear()
+        assert mock_telemetry_client.get_account_id(session_mock) == "111122223333"
+        session_mock.client.assert_not_called()
+
+    def test_falls_back_to_sts_when_credentials_lack_account_id(
+        self, fresh_deadline_config, mock_telemetry_client
+    ):
+        """When credentials don't expose account_id, a short-timeout STS call is used."""
+        session_mock = MagicMock()
+        session_mock.get_credentials.return_value.account_id = None
+        session_mock.client.return_value.get_caller_identity.return_value = {
+            "Account": "444455556666"
+        }
+        mock_telemetry_client.get_account_id.cache_clear()
+        assert mock_telemetry_client.get_account_id(session_mock) == "444455556666"
+        # The STS client must be built with a short-timeout Config.
+        args, kwargs = session_mock.client.call_args
+        assert args[0] == "sts"
+        assert kwargs["config"].connect_timeout == 2
+        assert kwargs["config"].read_timeout == 2
+
+    def test_returns_none_when_sts_unreachable(self, fresh_deadline_config, mock_telemetry_client):
+        """When STS is unreachable, get_account_id silently returns None."""
+        session_mock = MagicMock()
+        session_mock.get_credentials.return_value.account_id = None
+        session_mock.client.return_value.get_caller_identity.side_effect = Exception(
+            "STS unreachable"
+        )
+        mock_telemetry_client.get_account_id.cache_clear()
+        assert mock_telemetry_client.get_account_id(session_mock) is None
+
+    def test_returns_none_when_no_credentials(self, fresh_deadline_config, mock_telemetry_client):
+        """When there are no credentials at all, returns None without calling STS."""
+        session_mock = MagicMock()
+        session_mock.get_credentials.return_value = None
+        session_mock.client.return_value.get_caller_identity.side_effect = Exception(
+            "no creds, no STS"
+        )
+        mock_telemetry_client.get_account_id.cache_clear()
+        assert mock_telemetry_client.get_account_id(session_mock) is None
 
 
-class TestGetTelemetryIdentifier:
-    def test_uses_existing_valid_uuid(self):
-        """Uses existing identifier if it's a valid UUID4."""
-        test_id = str(uuid.uuid4())
-        with patch(
-            "deadline_worker_agent.telemetry._get_setting", return_value=test_id
-        ), patch.object(TelemetryClient, "_start_threads"), patch(
-            "deadline_worker_agent.telemetry.boto3.client"
-        ) as mock_boto:
-            mock_boto.return_value.meta.endpoint_url = "https://fake"
-            client = TelemetryClient("test", "1.0.0")
-        assert client.telemetry_id == test_id
+@pytest.mark.timeout(5)
+def test_process_event_queue_thread_attaches_account_id(
+    fresh_deadline_config, mock_telemetry_client
+):
+    """The background thread resolves the account ID once and attaches it to _common_details."""
+    queue_mock = MagicMock()
+    queue_mock.get.side_effect = [TelemetryEvent(), None]
+    mock_telemetry_client.event_queue = queue_mock
 
-    def test_generates_new_uuid_if_invalid(self):
-        """Generates a new UUID if the stored one is invalid."""
-        with patch(
-            "deadline_worker_agent.telemetry._get_setting", return_value="not-a-uuid"
-        ), patch.object(TelemetryClient, "_start_threads"), patch(
-            "deadline_worker_agent.telemetry.boto3.client"
-        ) as mock_boto:
-            mock_boto.return_value.meta.endpoint_url = "https://fake"
-            client = TelemetryClient("test", "1.0.0")
-        # Should be a valid UUID4
-        uuid.UUID(client.telemetry_id, version=4)
-        assert client.telemetry_id != "not-a-uuid"
+    with patch.object(
+        TelemetryClient, "get_account_id", return_value="111122223333"
+    ) as resolve_mock, patch.object(api._telemetry, "get_boto3_session"), patch.object(
+        request, "urlopen"
+    ):
+        mock_telemetry_client._process_event_queue_thread()
+
+    resolve_mock.assert_called_once()
+    assert mock_telemetry_client._common_details.get("accountId") == "111122223333"
+
+
+@pytest.mark.timeout(5)
+def test_process_event_queue_thread_merges_common_details_into_payload(
+    fresh_deadline_config, mock_telemetry_client
+):
+    """Common details (including a late-resolved account ID) are merged into the event
+    payload at send time, so even an event that was enqueued before resolution completes
+    still includes the resolved accountId in the outgoing request body."""
+    queue_mock = MagicMock()
+    queue_mock.get.side_effect = [
+        TelemetryEvent(
+            event_type="com.amazon.rum.deadline.test",
+            event_details={"probe": 1, "usage_mode": "CLI"},
+        ),
+        None,
+    ]
+    mock_telemetry_client.event_queue = queue_mock
+
+    with patch.object(TelemetryClient, "get_account_id", return_value="111122223333"), patch.object(
+        api._telemetry, "get_boto3_session"
+    ), patch.object(request, "urlopen") as urlopen_mock:
+        mock_telemetry_client._process_event_queue_thread()
+
+    # Inspect the actual HTTP request body sent by urlopen.
+    assert urlopen_mock.call_count == 1
+    sent_request = urlopen_mock.call_args[0][0]
+    body = json.loads(sent_request.data.decode("utf-8"))
+    details = json.loads(body["RumEvents"][0]["details"])
+    assert details["accountId"] == "111122223333"
+    assert details["probe"] == 1
+    assert details["usage_mode"] == "CLI"
+
+
+@pytest.mark.timeout(5)
+def test_process_event_queue_thread_skips_account_id_when_resolution_fails(
+    fresh_deadline_config, mock_telemetry_client
+):
+    """When the account ID can't be resolved, no accountId key is added to common details."""
+    queue_mock = MagicMock()
+    queue_mock.get.side_effect = [TelemetryEvent(), None]
+    mock_telemetry_client.event_queue = queue_mock
+
+    with patch.object(
+        TelemetryClient, "get_account_id", return_value=None
+    ) as resolve_mock, patch.object(api._telemetry, "get_boto3_session"), patch.object(
+        request, "urlopen"
+    ):
+        mock_telemetry_client._process_event_queue_thread()
+
+    resolve_mock.assert_called_once()
+    assert "accountId" not in mock_telemetry_client._common_details

--- a/test/unit/test_telemetry.py
+++ b/test/unit/test_telemetry.py
@@ -1,0 +1,314 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+import platform
+import time
+import uuid
+from queue import Full
+from unittest.mock import MagicMock, patch
+from urllib import request
+
+import pytest
+
+from deadline_worker_agent.telemetry import (
+    TelemetryClient,
+    TelemetryEvent,
+    _swallow_exceptions,
+)
+
+
+@pytest.fixture
+def mock_telemetry_client():
+    """Creates a TelemetryClient with threads and network mocked out."""
+    with patch.object(TelemetryClient, "_start_threads"), patch(
+        "deadline_worker_agent.telemetry.boto3.client"
+    ) as mock_boto_client:
+        mock_boto_client.return_value.meta.endpoint_url = "https://fake-endpoint-url"
+        client = TelemetryClient(
+            package_name="deadline-cloud-worker-agent",
+            package_ver="1.2.3.4567",
+        )
+        assert client._initialized
+        return client
+
+
+class TestSwallowExceptions:
+    def test_returns_value_on_success(self):
+        @_swallow_exceptions
+        def succeeds():
+            return 42
+
+        assert succeeds() == 42
+
+    def test_returns_none_on_exception(self):
+        @_swallow_exceptions
+        def fails():
+            raise RuntimeError("boom")
+
+        assert fails() is None
+
+    def test_logs_exception(self):
+        @_swallow_exceptions
+        def fails():
+            raise RuntimeError("boom")
+
+        with patch("deadline_worker_agent.telemetry.logger") as mock_logger:
+            fails()
+            mock_logger.debug.assert_called_once()
+            assert "fails" in mock_logger.debug.call_args[0][1]
+
+
+class TestOptOut:
+    def test_opt_out_env_var(self, monkeypatch):
+        """Telemetry client doesn't initialize if env var is set."""
+        monkeypatch.setenv("DEADLINE_CLOUD_TELEMETRY_OPT_OUT", "true")
+        with patch.object(TelemetryClient, "_start_threads"):
+            client = TelemetryClient("test-package", "1.0.0")
+        assert not client._initialized
+        assert client.telemetry_opted_out
+
+    @pytest.mark.parametrize("env_var_value", ["true", "1", "yes", "on"])
+    def test_opt_out_env_var_values(self, monkeypatch, env_var_value):
+        """Various truthy env var values all opt out."""
+        monkeypatch.setenv("DEADLINE_CLOUD_TELEMETRY_OPT_OUT", env_var_value)
+        with patch.object(TelemetryClient, "_start_threads"):
+            client = TelemetryClient("test-package", "1.0.0")
+        assert client.telemetry_opted_out
+
+    def test_opt_out_worker_config(self):
+        """Telemetry client doesn't initialize if worker config has opt_out=true."""
+        mock_config_file = MagicMock()
+        mock_config_file.telemetry.opt_out = True
+
+        with patch.object(TelemetryClient, "_start_threads"), patch(
+            "deadline_worker_agent.telemetry.os.environ.get", return_value=""
+        ), patch(
+            "deadline_worker_agent.telemetry.TelemetryClient._read_opt_out_from_config",
+            return_value=True,
+        ):
+            client = TelemetryClient("test-package", "1.0.0")
+        assert client.telemetry_opted_out
+        assert not client._initialized
+
+    def test_not_opted_out_records_events(self, mock_telemetry_client):
+        """When not opted out, events are queued."""
+        queue_mock = MagicMock()
+        mock_telemetry_client.event_queue = queue_mock
+
+        mock_telemetry_client.record_event(
+            event_type="com.amazon.rum.deadline.test", event_details={"key": "value"}
+        )
+
+        queue_mock.put_nowait.assert_called_once()
+
+    def test_opted_out_does_not_record(self, mock_telemetry_client):
+        """When opted out, events are not queued."""
+        mock_telemetry_client.telemetry_opted_out = True
+        queue_mock = MagicMock()
+        mock_telemetry_client.event_queue = queue_mock
+
+        mock_telemetry_client.record_event(
+            event_type="com.amazon.rum.deadline.test", event_details={}
+        )
+
+        queue_mock.put_nowait.assert_not_called()
+
+
+class TestInitialize:
+    def test_initialize_failure_then_success(self):
+        """A failure in initialize keeps _initialized False; retrying succeeds."""
+        with patch.object(TelemetryClient, "_start_threads"), patch(
+            "deadline_worker_agent.telemetry.boto3.client"
+        ) as mock_boto_client:
+            mock_boto_client.side_effect = [
+                Exception("Boto3 blew up!"),
+                MagicMock(meta=MagicMock(endpoint_url="https://fake-endpoint-url")),
+            ]
+            client = TelemetryClient(
+                package_name="test-package",
+                package_ver="1.0.0",
+            )
+            assert not client._initialized
+
+            # Retry
+            mock_boto_client.side_effect = None
+            mock_boto_client.return_value.meta.endpoint_url = "https://fake-endpoint-url"
+            client._initialize()
+            assert client._initialized
+            assert client.endpoint == "https://management.fake-endpoint-url/2023-10-12/telemetry"
+
+    def test_initialize_swallows_exception(self, mock_telemetry_client):
+        """_initialize doesn't propagate exceptions."""
+        mock_telemetry_client._initialized = False
+        mock_telemetry_client.telemetry_opted_out = False
+        with patch(
+            "deadline_worker_agent.telemetry.boto3.client", side_effect=RuntimeError("boom")
+        ):
+            mock_telemetry_client._initialize()
+        assert not mock_telemetry_client._initialized
+
+
+class TestGetPrefixedEndpoint:
+    @pytest.mark.parametrize(
+        "endpoint,prefix,expected",
+        [
+            ("test.endpoint.url", "", "test.endpoint.url"),
+            ("test.endpoint.url", "management.", "test.endpoint.url"),
+            (
+                "https://test.endpoint.url",
+                "management.",
+                "https://management.test.endpoint.url",
+            ),
+        ],
+    )
+    def test_get_prefixed_endpoint(self, mock_telemetry_client, endpoint, prefix, expected):
+        assert mock_telemetry_client._get_prefixed_endpoint(endpoint, prefix) == expected
+
+
+class TestProcessEventQueueThread:
+    @pytest.mark.timeout(5)
+    def test_exits_on_none(self, mock_telemetry_client):
+        """Queue processing thread exits cleanly after getting None."""
+        queue_mock = MagicMock()
+        queue_mock.get.side_effect = [TelemetryEvent(), None]
+        mock_telemetry_client.event_queue = queue_mock
+
+        with patch.object(request, "urlopen"):
+            mock_telemetry_client._process_event_queue_thread()
+
+        assert queue_mock.get.call_count == 2
+
+    @pytest.mark.parametrize(
+        "http_code,expected_attempts",
+        [
+            (400, 1),
+            (429, TelemetryClient.MAX_RETRY_ATTEMPTS),
+            (500, TelemetryClient.MAX_RETRY_ATTEMPTS),
+        ],
+    )
+    @pytest.mark.timeout(5)
+    def test_retries_and_exits(self, mock_telemetry_client, http_code, expected_attempts):
+        """Thread retries on 429/500 and exits on other errors."""
+        http_error = request.HTTPError(
+            "http://test.com", http_code, "Http Error", {}, None  # type: ignore
+        )
+        queue_mock = MagicMock()
+        queue_mock.get.side_effect = [TelemetryEvent(), None]
+        mock_telemetry_client.event_queue = queue_mock
+
+        with patch.object(request, "urlopen", side_effect=http_error), patch.object(
+            time, "sleep"
+        ):
+            mock_telemetry_client._process_event_queue_thread()
+
+        # On non-retryable errors, only 1 event is dequeued (thread exits)
+        assert queue_mock.get.call_count == 1
+
+    @pytest.mark.timeout(5)
+    def test_handles_unexpected_error(self, mock_telemetry_client):
+        """Thread exits cleanly on unexpected exceptions."""
+        queue_mock = MagicMock()
+        queue_mock.get.side_effect = [TelemetryEvent(), None]
+        mock_telemetry_client.event_queue = queue_mock
+
+        with patch.object(request, "urlopen", side_effect=Exception("Some error")):
+            mock_telemetry_client._process_event_queue_thread()
+
+        assert queue_mock.get.call_count == 1
+
+
+class TestRecordEvent:
+    def test_record_error(self, mock_telemetry_client):
+        """Recording an error sends the expected event."""
+        queue_mock = MagicMock()
+        mock_telemetry_client.event_queue = queue_mock
+
+        mock_telemetry_client.record_error({"some_field": "value"}, "RuntimeError")
+
+        queue_mock.put_nowait.assert_called_once()
+        event = queue_mock.put_nowait.call_args[0][0]
+        assert event.event_type == "com.amazon.rum.deadline.error"
+        assert event.event_details["exception_type"] == "RuntimeError"
+        assert event.event_details["some_field"] == "value"
+
+    def test_record_event_includes_common_details(self, mock_telemetry_client):
+        """Common details are merged into event details."""
+        queue_mock = MagicMock()
+        mock_telemetry_client.event_queue = queue_mock
+        mock_telemetry_client.update_common_details({"common_key": "common_value"})
+
+        mock_telemetry_client.record_event(
+            event_type="com.amazon.rum.deadline.test",
+            event_details={"event_key": "event_value"},
+        )
+
+        event = queue_mock.put_nowait.call_args[0][0]
+        assert event.event_details["common_key"] == "common_value"
+        assert event.event_details["event_key"] == "event_value"
+
+    def test_record_event_swallows_exception(self, mock_telemetry_client):
+        """record_event doesn't propagate exceptions."""
+        with patch.object(
+            mock_telemetry_client, "_put_telemetry_record", side_effect=RuntimeError("boom")
+        ):
+            # Should not raise
+            mock_telemetry_client.record_event(
+                event_type="com.amazon.rum.deadline.test", event_details={}
+            )
+
+
+class TestExitCleanly:
+    def test_exit_cleanly_swallows_exception(self, mock_telemetry_client):
+        """_exit_cleanly doesn't propagate exceptions from a full queue."""
+        mock_telemetry_client.event_queue = MagicMock()
+        mock_telemetry_client.event_queue.put_nowait.side_effect = Full()
+        mock_telemetry_client.processing_thread = MagicMock()
+
+        # Should not raise
+        mock_telemetry_client._exit_cleanly()
+
+
+class TestSystemMetadata:
+    def test_get_system_metadata(self, mock_telemetry_client):
+        """System metadata contains expected fields."""
+        metadata = mock_telemetry_client._get_system_metadata()
+        assert metadata["service"] == "deadline-cloud-worker-agent"
+        assert metadata["version"] == "1.2.3"
+        assert "python_version" in metadata
+        assert "osName" in metadata
+        assert "osVersion" in metadata
+
+    def test_get_system_metadata_macos(self, mock_telemetry_client):
+        """Darwin is reported as macOS."""
+        with patch.object(
+            platform, "uname", return_value=MagicMock(system="Darwin", release="23.0.0")
+        ):
+            metadata = mock_telemetry_client._get_system_metadata()
+        assert metadata["osName"] == "macOS"
+
+
+class TestGetTelemetryIdentifier:
+    def test_uses_existing_valid_uuid(self):
+        """Uses existing identifier if it's a valid UUID4."""
+        test_id = str(uuid.uuid4())
+        with patch(
+            "deadline_worker_agent.telemetry._get_setting", return_value=test_id
+        ), patch.object(TelemetryClient, "_start_threads"), patch(
+            "deadline_worker_agent.telemetry.boto3.client"
+        ) as mock_boto:
+            mock_boto.return_value.meta.endpoint_url = "https://fake"
+            client = TelemetryClient("test", "1.0.0")
+        assert client.telemetry_id == test_id
+
+    def test_generates_new_uuid_if_invalid(self):
+        """Generates a new UUID if the stored one is invalid."""
+        with patch(
+            "deadline_worker_agent.telemetry._get_setting", return_value="not-a-uuid"
+        ), patch.object(TelemetryClient, "_start_threads"), patch(
+            "deadline_worker_agent.telemetry.boto3.client"
+        ) as mock_boto:
+            mock_boto.return_value.meta.endpoint_url = "https://fake"
+            client = TelemetryClient("test", "1.0.0")
+        # Should be a valid UUID4
+        uuid.UUID(client.telemetry_id, version=4)
+        assert client.telemetry_id != "not-a-uuid"

--- a/test/unit/test_telemetry.py
+++ b/test/unit/test_telemetry.py
@@ -136,6 +136,145 @@ def test_get_telemetry_identifier_uses_existing():
     assert client.telemetry_id == test_id
 
 
+class TestFallbackMechanism:
+    """Tests for the legacy config fallback and persistence to worker.toml"""
+
+    def test_opt_out_from_worker_toml(self):
+        """opt_out in worker.toml is used directly without fallback."""
+        mock_config = MagicMock()
+        mock_config.telemetry.opt_out = True
+
+        with patch(
+            "deadline_worker_agent.config.config_file.ConfigFile.load",
+            return_value=mock_config,
+        ):
+            result = TelemetryClient._read_opt_out_from_config()
+
+        assert result is True
+
+    def test_opt_out_falls_back_to_legacy_config(self):
+        """When worker.toml has no opt_out, reads from ~/.deadline/config."""
+        mock_config = MagicMock()
+        mock_config.telemetry.opt_out = None
+
+        with (
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.load",
+                return_value=mock_config,
+            ),
+            patch(
+                "deadline_worker_agent.telemetry._get_setting", return_value="true"
+            ) as mock_get_setting,
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.modify_config_file_settings",
+            ) as mock_modify,
+        ):
+            result = TelemetryClient._read_opt_out_from_config()
+
+        assert result is True
+        mock_get_setting.assert_called_once_with("telemetry.opt_out")
+        mock_modify.assert_called_once()
+
+    def test_opt_out_legacy_false_does_not_persist(self):
+        """When legacy config has opt_out=false, does not write to worker.toml."""
+        mock_config = MagicMock()
+        mock_config.telemetry.opt_out = None
+
+        with (
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.load",
+                return_value=mock_config,
+            ),
+            patch("deadline_worker_agent.telemetry._get_setting", return_value="false"),
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.modify_config_file_settings",
+            ) as mock_modify,
+        ):
+            result = TelemetryClient._read_opt_out_from_config()
+
+        assert result is False
+        mock_modify.assert_not_called()
+
+    def test_opt_out_no_worker_toml_falls_back(self):
+        """When worker.toml doesn't exist, falls back to legacy config."""
+        with (
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.load",
+                side_effect=FileNotFoundError,
+            ),
+            patch("deadline_worker_agent.telemetry._get_setting", return_value="true"),
+        ):
+            result = TelemetryClient._read_opt_out_from_config()
+
+        assert result is True
+
+    def test_identifier_from_legacy_config_persists_to_worker_toml(self):
+        """Identifier from legacy config is persisted to worker.toml."""
+        test_id = str(uuid.uuid4())
+
+        with (
+            patch.object(TelemetryClient, "_start_threads"),
+            patch("deadline_worker_agent.telemetry.boto3.client") as mock_boto,
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.load",
+                side_effect=FileNotFoundError,
+            ),
+            patch("deadline_worker_agent.telemetry._get_setting", return_value=test_id),
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.modify_config_file_settings",
+            ) as mock_modify,
+        ):
+            mock_boto.return_value.meta.endpoint_url = "https://fake"
+            client = TelemetryClient("test", "1.0.0")
+
+        assert client.telemetry_id == test_id
+        mock_modify.assert_called_once()
+
+    def test_identifier_generated_when_legacy_invalid(self):
+        """A new UUID is generated when legacy config has invalid identifier."""
+        with (
+            patch.object(TelemetryClient, "_start_threads"),
+            patch("deadline_worker_agent.telemetry.boto3.client") as mock_boto,
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.load",
+                side_effect=FileNotFoundError,
+            ),
+            patch("deadline_worker_agent.telemetry._get_setting", return_value="not-a-uuid"),
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.modify_config_file_settings",
+            ) as mock_modify,
+        ):
+            mock_boto.return_value.meta.endpoint_url = "https://fake"
+            client = TelemetryClient("test", "1.0.0")
+
+        assert client.telemetry_id != "not-a-uuid"
+        uuid.UUID(client.telemetry_id, version=4)
+        mock_modify.assert_called_once()
+
+    def test_identifier_from_worker_toml_does_not_persist(self):
+        """When identifier exists in worker.toml, no write occurs."""
+        test_id = str(uuid.uuid4())
+        mock_config = MagicMock()
+        mock_config.telemetry.identifier = test_id
+
+        with (
+            patch.object(TelemetryClient, "_start_threads"),
+            patch("deadline_worker_agent.telemetry.boto3.client") as mock_boto,
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.load",
+                return_value=mock_config,
+            ),
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.modify_config_file_settings",
+            ) as mock_modify,
+        ):
+            mock_boto.return_value.meta.endpoint_url = "https://fake"
+            client = TelemetryClient("test", "1.0.0")
+
+        assert client.telemetry_id == test_id
+        mock_modify.assert_not_called()
+
+
 @pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
 def test_process_event_queue_thread(mock_telemetry_client):
     """Test that the queue processing thread function exits cleanly after getting None"""

--- a/test/unit/test_telemetry.py
+++ b/test/unit/test_telemetry.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from typing import Any, Dict
 import json
 import platform
 import pytest
@@ -8,60 +7,45 @@ import uuid
 import time
 
 from unittest.mock import patch, MagicMock
-from dataclasses import asdict
 from urllib import request
 
-from deadline.client import api, config
-from deadline.client.api._telemetry import (
+from deadline_worker_agent.telemetry import (
     TelemetryClient,
     TelemetryEvent,
     _swallow_exceptions,
-    get_deadline_cloud_library_telemetry_client,
-    get_telemetry_client,
-    record_success_fail_telemetry_event,
-    record_function_latency_telemetry_event,
 )
-from deadline.job_attachments.progress_tracker import SummaryStatistics
 
 
 @pytest.fixture(scope="function", name="mock_telemetry_client")
-def fixture_telemetry_client(fresh_deadline_config):
-    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
-    with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
-        api._telemetry, "get_monitor_id", side_effect=["monitor-id"]
-    ), patch.object(api._telemetry, "get_monitor_id", side_effect=[None]), patch.object(
-        api._telemetry,
-        "get_user_and_identity_store_id",
-        side_effect=[("user-id", "identity-store-id")],
-    ), patch.object(
-        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
+def fixture_telemetry_client():
+    with (
+        patch.object(TelemetryClient, "_start_threads"),
+        patch("deadline_worker_agent.telemetry.boto3.client") as mock_boto_client,
     ):
+        mock_boto_client.return_value.meta.endpoint_url = "https://fake-endpoint-url"
         client = TelemetryClient(
-            package_name="deadline-cloud-library",
-            package_ver="0.1.2.1234",
-            config=config.config_file.read_config(),
+            package_name="deadline-cloud-worker-agent",
+            package_ver="1.2.3.4567",
         )
         assert client.is_initialized
         return client
 
 
-def test_opt_out_config(fresh_deadline_config):
+def test_opt_out_config():
     """Ensures the telemetry client doesn't fully initialize if the opt out config setting is set"""
-    # GIVEN
-    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
-    config.set_setting("telemetry.opt_out", "true")
-    # WHEN
-    client = TelemetryClient(
-        "deadline-cloud-library", "test-version", config=config.config_file.read_config()
-    )
-    # THEN
+    with (
+        patch.object(TelemetryClient, "_start_threads"),
+        patch(
+            "deadline_worker_agent.telemetry.TelemetryClient._read_opt_out_from_config",
+            return_value=True,
+        ),
+    ):
+        client = TelemetryClient("deadline-cloud-worker-agent", "1.0.0")
     assert not client.is_initialized
     assert not hasattr(client, "endpoint")
     assert not hasattr(client, "event_queue")
     assert not hasattr(client, "processing_thread")
     # Ensure nothing blows up if we try recording telemetry after we've opted out
-    client.record_hashing_summary(SummaryStatistics(), from_gui=True)
-    client.record_upload_summary(SummaryStatistics(), from_gui=False)
     client.record_error({}, str(type(Exception)))
 
 
@@ -74,50 +58,32 @@ def test_opt_out_config(fresh_deadline_config):
         pytest.param("on"),
     ],
 )
-def test_opt_out_env_var(fresh_deadline_config, monkeypatch, env_var_value):
+def test_opt_out_env_var(monkeypatch, env_var_value):
     """Ensures the telemetry client doesn't fully initialize if the opt out env var is set"""
-    # GIVEN
-    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
     monkeypatch.setenv("DEADLINE_CLOUD_TELEMETRY_OPT_OUT", env_var_value)
-    config.set_setting(
-        "telemetry.opt_out", "false"
-    )  # Ensure we ignore the config file if env var is set
-    # WHEN
-    client = TelemetryClient(
-        "deadline-cloud-library", "test-version", config=config.config_file.read_config()
-    )
-    # THEN
+    with patch.object(TelemetryClient, "_start_threads"):
+        client = TelemetryClient("deadline-cloud-worker-agent", "1.0.0")
     assert not client.is_initialized
     assert not hasattr(client, "endpoint")
     assert not hasattr(client, "event_queue")
     assert not hasattr(client, "processing_thread")
     # Ensure nothing blows up if we try recording telemetry after we've opted out
-    client.record_hashing_summary(SummaryStatistics(), from_gui=True)
-    client.record_upload_summary(SummaryStatistics(), from_gui=False)
     client.record_error({}, str(type(Exception)))
 
 
-def test_initialize_failure_then_success(fresh_deadline_config):
+def test_initialize_failure_then_success():
     """
-    Tests that a failure in initializing set keeps the property as false, but trying again
+    Tests that a failure in initializing keeps the property as false, but trying again
     without an exception initializes everything successfully.
     """
-    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
-    with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
-        api._telemetry, "get_monitor_id", side_effect=["monitor-id"]
-    ), patch.object(
-        api._telemetry,
-        "get_user_and_identity_store_id",
-        side_effect=[("user-id", "identity-store-id")],
-    ), patch.object(
-        api._telemetry,
-        "get_deadline_endpoint_url",
-        side_effect=[Exception("Boto3 blew up!"), "https://fake-endpoint-url"],
+    with (
+        patch.object(TelemetryClient, "_start_threads"),
+        patch("deadline_worker_agent.telemetry.boto3.client") as mock_boto_client,
     ):
+        mock_boto_client.side_effect = Exception("Boto3 blew up!")
         client = TelemetryClient(
-            package_name="deadline-cloud-library",
-            package_ver="0.1.2.1234",
-            config=config.config_file.read_config(),
+            package_name="deadline-cloud-worker-agent",
+            package_ver="1.2.3.4567",
         )
 
         assert not client.is_initialized
@@ -125,44 +91,63 @@ def test_initialize_failure_then_success(fresh_deadline_config):
         assert not hasattr(client, "event_queue")
         assert not hasattr(client, "processing_thread")
 
-        client.initialize(config=config.config_file.read_config())
+        mock_boto_client.side_effect = None
+        mock_boto_client.return_value.meta.endpoint_url = "https://fake-endpoint-url"
+        client.initialize()
         assert client.is_initialized
         assert client.endpoint == "https://management.fake-endpoint-url/2023-10-12/telemetry"
-        assert client._system_metadata["user_id"] == "user-id"
-        assert client._system_metadata["monitor_id"] == "monitor-id"
 
 
-def test_get_telemetry_identifier(fresh_deadline_config, mock_telemetry_client):
-    """Ensures that getting the local-user-id handles empty/malformed strings"""
-    # Confirm that we generate a new UUID if the setting doesn't exist, and write to config
-    uuid.UUID(mock_telemetry_client.telemetry_id, version=4)  # Should not raise ValueError
-    assert config.get_setting("telemetry.identifier") == mock_telemetry_client.telemetry_id
+def test_get_telemetry_identifier():
+    """Ensures that getting the telemetry identifier handles empty/malformed strings"""
+    with (
+        patch.object(TelemetryClient, "_start_threads"),
+        patch("deadline_worker_agent.telemetry.boto3.client") as mock_boto_client,
+        patch(
+            "deadline_worker_agent.config.config_file.ConfigFile.load",
+            side_effect=FileNotFoundError,
+        ),
+        patch("deadline_worker_agent.telemetry._get_setting", return_value=""),
+    ):
+        mock_boto_client.return_value.meta.endpoint_url = "https://fake"
+        client = TelemetryClient("deadline-cloud-worker-agent", "1.0.0")
 
-    # Confirm we generate a new UUID if the local_user_id is not a valid UUID
-    config.set_setting("telemetry.identifier", "bad-id")
-    telemetry_id = mock_telemetry_client._get_telemetry_identifier()
-    assert telemetry_id != "bad-id"
-    uuid.UUID(telemetry_id, version=4)  # Should not raise ValueError
+    # Should have generated a valid UUID
+    uuid.UUID(client.telemetry_id, version=4)
 
-    # Confirm the new user id was saved and is retrieved properly
-    assert config.get_setting("telemetry.identifier") == telemetry_id
-    assert mock_telemetry_client._get_telemetry_identifier() == telemetry_id
+
+def test_get_telemetry_identifier_uses_existing():
+    """Uses existing identifier from worker config if valid."""
+    test_id = str(uuid.uuid4())
+    mock_config = MagicMock()
+    mock_config.telemetry.identifier = test_id
+
+    with (
+        patch.object(TelemetryClient, "_start_threads"),
+        patch("deadline_worker_agent.telemetry.boto3.client") as mock_boto_client,
+        patch(
+            "deadline_worker_agent.config.config_file.ConfigFile.load",
+            return_value=mock_config,
+        ),
+    ):
+        mock_boto_client.return_value.meta.endpoint_url = "https://fake"
+        client = TelemetryClient("deadline-cloud-worker-agent", "1.0.0")
+
+    assert client.telemetry_id == test_id
 
 
 @pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
-def test_process_event_queue_thread(fresh_deadline_config, mock_telemetry_client):
+def test_process_event_queue_thread(mock_telemetry_client):
     """Test that the queue processing thread function exits cleanly after getting None"""
-    # GIVEN
     queue_mock = MagicMock()
     queue_mock.get.side_effect = [TelemetryEvent(), None]
     mock_telemetry_client.event_queue = queue_mock
-    # WHEN
-    with patch.object(request, "urlopen") as urlopen_mock, patch.object(
-        TelemetryClient, "get_account_id", return_value=None
-    ), patch.object(api._telemetry, "get_boto3_session"):
+    with (
+        patch.object(request, "urlopen"),
+        patch.object(TelemetryClient, "get_account_id", return_value=None),
+        patch("deadline_worker_agent.telemetry.boto3.Session"),
+    ):
         mock_telemetry_client._process_event_queue_thread()
-        urlopen_mock.assert_called_once()
-    # THEN
     assert queue_mock.get.call_count == 2
 
 
@@ -174,110 +159,54 @@ def test_process_event_queue_thread(fresh_deadline_config, mock_telemetry_client
         (500, TelemetryClient.MAX_RETRY_ATTEMPTS),
     ],
 )
-@pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
+@pytest.mark.timeout(5)
 def test_process_event_queue_thread_retries_and_exits(
-    fresh_deadline_config, mock_telemetry_client, http_code, attempt_count
+    mock_telemetry_client, http_code, attempt_count
 ):
     """Test that the thread exits cleanly after getting an unexpected exception"""
-    # GIVEN
     http_error = request.HTTPError("http://test.com", http_code, "Http Error", {}, None)  # type: ignore
     queue_mock = MagicMock()
     queue_mock.get.side_effect = [TelemetryEvent(), None]
     mock_telemetry_client.event_queue = queue_mock
-    # WHEN
-    with patch.object(request, "urlopen", side_effect=http_error) as urlopen_mock, patch.object(
-        time, "sleep"
-    ) as sleep_mock, patch.object(
-        TelemetryClient, "get_account_id", return_value=None
-    ), patch.object(api._telemetry, "get_boto3_session"):
+    with (
+        patch.object(request, "urlopen", side_effect=http_error),
+        patch.object(time, "sleep"),
+        patch.object(TelemetryClient, "get_account_id", return_value=None),
+        patch("deadline_worker_agent.telemetry.boto3.Session"),
+    ):
         mock_telemetry_client._process_event_queue_thread()
-        urlopen_mock.call_count = attempt_count
-        sleep_mock.call_count = attempt_count
-    # THEN
     assert queue_mock.get.call_count == 1
 
 
-@pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
-def test_process_event_queue_thread_handles_unexpected_error(
-    fresh_deadline_config, mock_telemetry_client
-):
+@pytest.mark.timeout(5)
+def test_process_event_queue_thread_handles_unexpected_error(mock_telemetry_client):
     """Test that the thread exits cleanly after getting an unexpected exception"""
-    # GIVEN
     queue_mock = MagicMock()
     queue_mock.get.side_effect = [TelemetryEvent(), None]
     mock_telemetry_client.event_queue = queue_mock
-    # WHEN
-    with patch.object(
-        request, "urlopen", side_effect=Exception("Some error")
-    ) as urlopen_mock, patch.object(
-        TelemetryClient, "get_account_id", return_value=None
-    ), patch.object(api._telemetry, "get_boto3_session"):
+    with (
+        patch.object(request, "urlopen", side_effect=Exception("Some error")),
+        patch.object(TelemetryClient, "get_account_id", return_value=None),
+        patch("deadline_worker_agent.telemetry.boto3.Session"),
+    ):
         mock_telemetry_client._process_event_queue_thread()
-        urlopen_mock.assert_called_once()
-    # THEN
     assert queue_mock.get.call_count == 1
 
 
-def test_record_hashing_summary(fresh_deadline_config, mock_telemetry_client):
-    """Tests that recording a hashing summary sends the expected TelemetryEvent to the thread queue"""
-    # GIVEN
-    queue_mock = MagicMock()
-    test_summary = SummaryStatistics(total_bytes=123, total_files=12, total_time=12345)
-    expected_summary = asdict(test_summary)
-    expected_summary["usage_mode"] = "CLI"
-    expected_event = TelemetryEvent(
-        event_type="com.amazon.rum.deadline.job_attachments.hashing_summary",
-        event_details=expected_summary,
-    )
-    mock_telemetry_client.event_queue = queue_mock
-
-    # WHEN
-    mock_telemetry_client.record_hashing_summary(test_summary)
-
-    # THEN
-    queue_mock.put_nowait.assert_called_once_with(expected_event)
-
-
-def test_record_upload_summary(fresh_deadline_config, mock_telemetry_client):
-    """Tests that recording an upload summary sends the expected TelemetryEvent to the thread queue"""
-    # GIVEN
-    queue_mock = MagicMock()
-    test_summary = SummaryStatistics(total_bytes=123, total_files=12, total_time=12345)
-    expected_summary = asdict(test_summary)
-    expected_summary["usage_mode"] = "GUI"
-    expected_event = TelemetryEvent(
-        event_type="com.amazon.rum.deadline.job_attachments.upload_summary",
-        event_details=expected_summary,
-    )
-    mock_telemetry_client.event_queue = queue_mock
-
-    # WHEN
-    mock_telemetry_client.record_upload_summary(test_summary, from_gui=True)
-
-    # THEN
-    queue_mock.put_nowait.assert_called_once_with(expected_event)
-
-
-def test_record_error(fresh_deadline_config, mock_telemetry_client):
+def test_record_error(mock_telemetry_client):
     """Test that recording an error sends the expected TelemetryEvent to the thread queue"""
-    # GIVEN
     queue_mock = MagicMock()
     test_error_details = {"some_field": "some_value"}
     test_exc = Exception("some exception")
-    expected_event_details = {
-        "some_field": "some_value",
-        "exception_type": str(type(test_exc)),
-        "usage_mode": "CLI",
-    }
     expected_event = TelemetryEvent(
-        event_type="com.amazon.rum.deadline.error", event_details=expected_event_details
+        event_type="com.amazon.rum.deadline.error",
+        event_details={
+            "some_field": "some_value",
+            "exception_type": str(type(test_exc)),
+        },
     )
     mock_telemetry_client.event_queue = queue_mock
-
-    # WHEN
     mock_telemetry_client.record_error(test_error_details, str(type(test_exc)))
-
-    # THEN
     queue_mock.put_nowait.assert_called_once_with(expected_event)
 
 
@@ -305,7 +234,6 @@ def test_record_error(fresh_deadline_config, mock_telemetry_client):
     ],
 )
 def test_get_prefixed_endpoint(
-    fresh_deadline_config,
     mock_telemetry_client: TelemetryClient,
     endpoint: str,
     prefix: str,
@@ -315,116 +243,33 @@ def test_get_prefixed_endpoint(
     assert mock_telemetry_client._get_prefixed_endpoint(endpoint, prefix) == expected_result
 
 
-def test_record_decorator_success(fresh_deadline_config):
-    """Tests that recording a decorator successful metric"""
-    with patch.object(
-        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
+@pytest.mark.timeout(5)
+def test_process_event_queue_thread_merges_common_details_into_payload(mock_telemetry_client):
+    """Common details are merged into the event payload at send time."""
+    mock_telemetry_client.update_common_details({"common_key": "common_value"})
+    queue_mock = MagicMock()
+    queue_mock.get.side_effect = [
+        TelemetryEvent(
+            event_type="com.amazon.rum.deadline.test",
+            event_details={"probe": 1},
+        ),
+        None,
+    ]
+    mock_telemetry_client.event_queue = queue_mock
+
+    with (
+        patch.object(request, "urlopen") as urlopen_mock,
+        patch.object(TelemetryClient, "get_account_id", return_value=None),
+        patch("deadline_worker_agent.telemetry.boto3.Session"),
     ):
-        # GIVEN
-        queue_mock = MagicMock()
-        expected_summary: Dict[str, Any] = dict()
-        expected_summary["is_success"] = True
-        expected_summary["usage_mode"] = "CLI"
-        expected_event = TelemetryEvent(
-            event_type="com.amazon.rum.deadline.successful",
-            event_details=expected_summary,
-        )
-        telemetry_client = get_deadline_cloud_library_telemetry_client()
-        telemetry_client.event_queue = queue_mock
+        mock_telemetry_client._process_event_queue_thread()
 
-        @record_success_fail_telemetry_event()
-        def successful():
-            return
-
-        # WHEN
-        successful()  # type:ignore
-
-        # THEN
-        queue_mock.put_nowait.assert_called_once_with(expected_event)
-
-
-def test_record_decorator_fails(fresh_deadline_config):
-    """Tests that recording a decorator failed metric"""
-    with patch.object(
-        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
-    ):
-        # GIVEN
-        queue_mock = MagicMock()
-        expected_summary: Dict[str, Any] = dict()
-        expected_summary["is_success"] = False
-        expected_summary["exception_type"] = "RuntimeError"
-        expected_summary["usage_mode"] = "CLI"
-        expected_event = TelemetryEvent(
-            event_type="com.amazon.rum.deadline.fails",
-            event_details=expected_summary,
-        )
-        telemetry_client = get_deadline_cloud_library_telemetry_client()
-        telemetry_client.event_queue = queue_mock
-
-        @record_success_fail_telemetry_event()
-        def fails():
-            raise RuntimeError("foobar")
-
-        # WHEN
-        with pytest.raises(RuntimeError):
-            fails()  # type:ignore
-
-        # THEN
-        queue_mock.put_nowait.assert_called_once_with(expected_event)
-
-
-def test_latency_decorator(fresh_deadline_config):
-    """Tests that the latency recording decorator works"""
-    with patch.object(
-        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
-    ), patch.object(time, "perf_counter_ns", return_value=0):
-        # GIVEN
-        queue_mock = MagicMock()
-        expected_summary: Dict[str, Any] = dict()
-        expected_summary["latency"] = 0
-        expected_summary["function_call"] = "test_call"
-        expected_summary["usage_mode"] = "CLI"
-        expected_event = TelemetryEvent(
-            event_type="com.amazon.rum.deadline.latency",
-            event_details=expected_summary,
-        )
-        telemetry_client = get_deadline_cloud_library_telemetry_client()
-        telemetry_client.event_queue = queue_mock
-
-        @record_function_latency_telemetry_event()
-        def test_call():
-            return
-
-        # WHEN
-        test_call()  # type:ignore
-
-        # THEN
-        queue_mock.put_nowait.assert_called_once_with(expected_event)
-
-
-def test_get_telemetry_client_caches_by_package_name(fresh_deadline_config):
-    """
-    Verify that get_telemetry_client returns different clients for different package names.
-    """
-    import deadline.client.api._telemetry as telemetry_mod
-
-    telemetry_mod.__cached_telemetry_clients = {}
-
-    def fake_init(self, **kwargs):
-        self._initialized = True
-        self.package_name = kwargs["package_name"]
-
-    with patch.object(TelemetryClient, "__init__", fake_init):
-        client_a = get_telemetry_client("package-a", "1.0.0")
-        client_b = get_telemetry_client("package-b", "2.0.0")
-        client_a_again = get_telemetry_client("package-a", "1.0.0")
-
-        assert client_a is not client_b
-        assert client_a is client_a_again
-        assert client_a.package_name == "package-a"
-        assert client_b.package_name == "package-b"
-
-    telemetry_mod.__cached_telemetry_clients = {}
+    assert urlopen_mock.call_count == 1
+    sent_request = urlopen_mock.call_args[0][0]
+    body = json.loads(sent_request.data.decode("utf-8"))
+    details = json.loads(body["RumEvents"][0]["details"])
+    assert details["common_key"] == "common_value"
+    assert details["probe"] == 1
 
 
 class TestSwallowExceptionsDecorator:
@@ -449,7 +294,7 @@ class TestSwallowExceptionsDecorator:
         def fails():
             raise RuntimeError("boom")
 
-        with patch("deadline.client.api._telemetry.logger") as mock_logger:
+        with patch("deadline_worker_agent.telemetry.logger") as mock_logger:
             fails()
             mock_logger.debug.assert_called_once()
             assert "fails" in mock_logger.debug.call_args[0][1]
@@ -465,67 +310,62 @@ class TestSwallowExceptionsDecorator:
 class TestTelemetryClientSwallowExceptions:
     """Tests that decorated TelemetryClient methods don't propagate exceptions"""
 
-    def test_set_opt_out_swallows_exception(self, fresh_deadline_config, mock_telemetry_client):
-        with patch.object(config.config_file, "get_setting", side_effect=RuntimeError("boom")):
+    def test_set_opt_out_swallows_exception(self, mock_telemetry_client):
+        with patch(
+            "deadline_worker_agent.telemetry.os.environ.get", side_effect=RuntimeError("boom")
+        ):
             mock_telemetry_client.set_opt_out()
 
-    def test_initialize_swallows_exception(self, fresh_deadline_config, mock_telemetry_client):
+    def test_initialize_swallows_exception(self, mock_telemetry_client):
         mock_telemetry_client._initialized = False
         mock_telemetry_client.telemetry_opted_out = False
-        with patch.object(
-            api._telemetry, "get_deadline_endpoint_url", side_effect=RuntimeError("boom")
+        with patch(
+            "deadline_worker_agent.telemetry.boto3.client", side_effect=RuntimeError("boom")
         ):
             mock_telemetry_client.initialize()
         assert not mock_telemetry_client.is_initialized
 
-    def test_record_event_swallows_exception(self, fresh_deadline_config, mock_telemetry_client):
+    def test_record_event_swallows_exception(self, mock_telemetry_client):
         with patch.object(
             mock_telemetry_client, "_put_telemetry_record", side_effect=RuntimeError("boom")
         ):
             mock_telemetry_client.record_event(
                 event_type="com.amazon.rum.deadline.test",
                 event_details={},
-                from_gui=False,
             )
 
-    def test_exit_cleanly_swallows_exception(self, fresh_deadline_config, mock_telemetry_client):
+    def test_exit_cleanly_swallows_exception(self, mock_telemetry_client):
         mock_telemetry_client.event_queue = MagicMock()
         mock_telemetry_client.event_queue.put_nowait.side_effect = RuntimeError("boom")
         mock_telemetry_client._exit_cleanly()
 
-    def test_init_swallows_get_telemetry_identifier_exception(self, fresh_deadline_config):
-        config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
-        with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
-            api._telemetry, "get_monitor_id", side_effect=[None]
-        ), patch.object(
-            api._telemetry,
-            "get_user_and_identity_store_id",
-            side_effect=[("user-id", "identity-store-id")],
-        ), patch.object(
-            api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
-        ), patch.object(config.config_file, "get_setting", side_effect=RuntimeError("boom")):
+    def test_init_swallows_get_telemetry_identifier_exception(self):
+        with (
+            patch.object(TelemetryClient, "_start_threads"),
+            patch("deadline_worker_agent.telemetry.boto3.client") as mock_boto,
+            patch(
+                "deadline_worker_agent.config.config_file.ConfigFile.load",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("deadline_worker_agent.telemetry._get_setting", side_effect=RuntimeError("boom")),
+        ):
+            mock_boto.return_value.meta.endpoint_url = "https://fake"
             client = TelemetryClient(
-                package_name="deadline-cloud-library",
-                package_ver="0.1.2.1234",
-                config=config.config_file.read_config(),
+                package_name="deadline-cloud-worker-agent",
+                package_ver="1.0.0",
             )
             assert client.telemetry_id is not None
 
-    def test_init_swallows_get_system_metadata_exception(self, fresh_deadline_config):
-        config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
-        with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
-            api._telemetry, "get_monitor_id", side_effect=[None]
-        ), patch.object(
-            api._telemetry,
-            "get_user_and_identity_store_id",
-            side_effect=[("user-id", "identity-store-id")],
-        ), patch.object(
-            api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
-        ), patch.object(platform, "uname", side_effect=RuntimeError("boom")):
+    def test_init_swallows_get_system_metadata_exception(self):
+        with (
+            patch.object(TelemetryClient, "_start_threads"),
+            patch("deadline_worker_agent.telemetry.boto3.client") as mock_boto,
+            patch.object(platform, "uname", side_effect=RuntimeError("boom")),
+        ):
+            mock_boto.return_value.meta.endpoint_url = "https://fake"
             client = TelemetryClient(
-                package_name="deadline-cloud-library",
-                package_ver="0.1.2.1234",
-                config=config.config_file.read_config(),
+                package_name="deadline-cloud-worker-agent",
+                package_ver="1.0.0",
             )
             assert "version" not in client._system_metadata
 
@@ -533,19 +373,14 @@ class TestTelemetryClientSwallowExceptions:
 class TestGetAccountId:
     """Tests for the background-thread account ID resolution."""
 
-    def test_prefers_credential_account_id(self, fresh_deadline_config, mock_telemetry_client):
-        """When credentials expose account_id, it is used directly without any STS call."""
+    def test_prefers_credential_account_id(self, mock_telemetry_client):
         session_mock = MagicMock()
         session_mock.get_credentials.return_value.account_id = "111122223333"
-        # Bypass the @lru_cache so each test gets a fresh call.
         mock_telemetry_client.get_account_id.cache_clear()
         assert mock_telemetry_client.get_account_id(session_mock) == "111122223333"
         session_mock.client.assert_not_called()
 
-    def test_falls_back_to_sts_when_credentials_lack_account_id(
-        self, fresh_deadline_config, mock_telemetry_client
-    ):
-        """When credentials don't expose account_id, a short-timeout STS call is used."""
+    def test_falls_back_to_sts_when_credentials_lack_account_id(self, mock_telemetry_client):
         session_mock = MagicMock()
         session_mock.get_credentials.return_value.account_id = None
         session_mock.client.return_value.get_caller_identity.return_value = {
@@ -553,14 +388,8 @@ class TestGetAccountId:
         }
         mock_telemetry_client.get_account_id.cache_clear()
         assert mock_telemetry_client.get_account_id(session_mock) == "444455556666"
-        # The STS client must be built with a short-timeout Config.
-        args, kwargs = session_mock.client.call_args
-        assert args[0] == "sts"
-        assert kwargs["config"].connect_timeout == 2
-        assert kwargs["config"].read_timeout == 2
 
-    def test_returns_none_when_sts_unreachable(self, fresh_deadline_config, mock_telemetry_client):
-        """When STS is unreachable, get_account_id silently returns None."""
+    def test_returns_none_when_sts_unreachable(self, mock_telemetry_client):
         session_mock = MagicMock()
         session_mock.get_credentials.return_value.account_id = None
         session_mock.client.return_value.get_caller_identity.side_effect = Exception(
@@ -569,8 +398,7 @@ class TestGetAccountId:
         mock_telemetry_client.get_account_id.cache_clear()
         assert mock_telemetry_client.get_account_id(session_mock) is None
 
-    def test_returns_none_when_no_credentials(self, fresh_deadline_config, mock_telemetry_client):
-        """When there are no credentials at all, returns None without calling STS."""
+    def test_returns_none_when_no_credentials(self, mock_telemetry_client):
         session_mock = MagicMock()
         session_mock.get_credentials.return_value = None
         session_mock.client.return_value.get_caller_identity.side_effect = Exception(
@@ -578,75 +406,3 @@ class TestGetAccountId:
         )
         mock_telemetry_client.get_account_id.cache_clear()
         assert mock_telemetry_client.get_account_id(session_mock) is None
-
-
-@pytest.mark.timeout(5)
-def test_process_event_queue_thread_attaches_account_id(
-    fresh_deadline_config, mock_telemetry_client
-):
-    """The background thread resolves the account ID once and attaches it to _common_details."""
-    queue_mock = MagicMock()
-    queue_mock.get.side_effect = [TelemetryEvent(), None]
-    mock_telemetry_client.event_queue = queue_mock
-
-    with patch.object(
-        TelemetryClient, "get_account_id", return_value="111122223333"
-    ) as resolve_mock, patch.object(api._telemetry, "get_boto3_session"), patch.object(
-        request, "urlopen"
-    ):
-        mock_telemetry_client._process_event_queue_thread()
-
-    resolve_mock.assert_called_once()
-    assert mock_telemetry_client._common_details.get("accountId") == "111122223333"
-
-
-@pytest.mark.timeout(5)
-def test_process_event_queue_thread_merges_common_details_into_payload(
-    fresh_deadline_config, mock_telemetry_client
-):
-    """Common details (including a late-resolved account ID) are merged into the event
-    payload at send time, so even an event that was enqueued before resolution completes
-    still includes the resolved accountId in the outgoing request body."""
-    queue_mock = MagicMock()
-    queue_mock.get.side_effect = [
-        TelemetryEvent(
-            event_type="com.amazon.rum.deadline.test",
-            event_details={"probe": 1, "usage_mode": "CLI"},
-        ),
-        None,
-    ]
-    mock_telemetry_client.event_queue = queue_mock
-
-    with patch.object(TelemetryClient, "get_account_id", return_value="111122223333"), patch.object(
-        api._telemetry, "get_boto3_session"
-    ), patch.object(request, "urlopen") as urlopen_mock:
-        mock_telemetry_client._process_event_queue_thread()
-
-    # Inspect the actual HTTP request body sent by urlopen.
-    assert urlopen_mock.call_count == 1
-    sent_request = urlopen_mock.call_args[0][0]
-    body = json.loads(sent_request.data.decode("utf-8"))
-    details = json.loads(body["RumEvents"][0]["details"])
-    assert details["accountId"] == "111122223333"
-    assert details["probe"] == 1
-    assert details["usage_mode"] == "CLI"
-
-
-@pytest.mark.timeout(5)
-def test_process_event_queue_thread_skips_account_id_when_resolution_fails(
-    fresh_deadline_config, mock_telemetry_client
-):
-    """When the account ID can't be resolved, no accountId key is added to common details."""
-    queue_mock = MagicMock()
-    queue_mock.get.side_effect = [TelemetryEvent(), None]
-    mock_telemetry_client.event_queue = queue_mock
-
-    with patch.object(
-        TelemetryClient, "get_account_id", return_value=None
-    ) as resolve_mock, patch.object(api._telemetry, "get_boto3_session"), patch.object(
-        request, "urlopen"
-    ):
-        mock_telemetry_client._process_event_queue_thread()
-
-    resolve_mock.assert_called_once()
-    assert "accountId" not in mock_telemetry_client._common_details


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent currently has `deadline` as a dependency, but that was mainly to get access to job-attachments. With `deadline-job-attachments` now being its own package we can remove the deadline to shrink the closure and get updates faster (ie. when deadline-job-attachments releases, rather than deadline-job-attachments -> deadline).

### What was the solution? (How)
Swapping to deadline-job-attachments requires a few changes:
1. remove dependence on deadline client config, still try to read it for fallback though. This means that all new installs will set telemetry option in the worker agent config and any previous installs that upgrade will use the client config to determine the values and add them to the worker config. Whenever we remove the fallback, we'll make it a breaking change.
2. remove dependence on deadline telemetry code. This means we copy the telemetry code from deadline client and remove any unnecessary code paths. You can compare this one with the deadline-cloud one for the true diff since it was using that previously.

Also since we use deadline for e2e testing, we need a separate detached hatch env to run the e2e so that its job attachments dep doesn't conflict with ours (ie. we can have different versions).


### What is the impact of this change?

1. Worker agent can focus on the job attachments changes, rather than the whole of the client library/cli
2. We have new options in the worker.toml for telemetry
3. We have a new opt-out CLI flag for the worker-agent

### How was this change tested?

```
hatch run lint
hatch run e2e:lint
hatch run test
```

I also deployed the e2e infrastructure and ran the tests.

```
hatch run e2e:test
```

```
=========================================================================================================== slowest 5 durations ===========================================================================================================
635.61s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
269.55s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_local_session_logs_can_be_turned_off
259.30s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_session_root_dir
247.60s call     test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_reports_canceled_sync_input_actions_as_canceled
238.65s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
========================================================================================= 49 passed, 15 skipped, 1 warning in 4712.78s (1:18:32) ==========================================================================================
cmd [4] | echo pytest done
```

### Was this change documented?

In the repo yes, doesn't have to be anywhere else.

### Is this a breaking change?

No, since we're still reading from the deadline client config as a fallback mechanism.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*