### PR TITLE
chore(dev): remove manual test gate - all tests are automated

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -66,15 +66,8 @@ jobs:
     concurrency:
       group: windowse2erelease
 
-  ManualTestGate:
-    needs: [TagRelease, LinuxE2ETests, WindowsE2ETests]
-    runs-on: ubuntu-latest
-    environment: release-gate
-    steps:
-      - run: echo "Manual testing approved for ${{ needs.TagRelease.outputs.tag }}"
-
   PreRelease:
-    needs: [TagRelease, ManualTestGate]
+    needs: [TagRelease, LinuxE2ETests, WindowsE2ETests]
     uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
     permissions:
       id-token: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Worker Agent has comprehensive tests, we don't need a manual test gate

### What was the solution? (How)

remove the test gate, and make pre-release depend on what the manual test gate relied on

### What is the impact of this change?

Automated Publishes

### How was this change tested?

n/a

### Was this change documented?

n/a

### Is this a breaking change?

n/a

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*