### PR TITLE
feat: bump openjd-sessions to 0.10.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline-job-attachments == 0.1.0",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.10.7",
+    "openjd-sessions == 0.10.8",
     "openjd-model >= 0.8.1, < 0.10",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
 Looking to expose the OPENJD_SESSION_WORKING_DIR environment variable in the session environment when job attachment settings are configured.

### What was the solution? (How)
Bump openjd-sessions in the worker agent to latest 0.10.8

### What is the impact of this change?
Extra env variable is available

### How was this change tested?
Standard manual and unit/integ. 

### Was this change documented?
Version bump can be seen in latest pyproject.toml. As well, will show in release notes

### Is this a breaking change?
No. Adding extra variable, not changing existing


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*