### PR TITLE
fix!: require IMDS when allow_ec2_instance_profile is false

### DIFF
--- a/src/deadline_worker_agent/startup/bootstrap.py
+++ b/src/deadline_worker_agent/startup/bootstrap.py
@@ -53,6 +53,13 @@ _logger = _logging.getLogger(__name__)
 INSTANCE_PROFILE_REMOVAL_ATTEMPTS = 120
 INSTANCE_PROFILE_CHECK_DURATION_SECONDS = 1
 
+# The number of retry attempts and backoff parameters for IMDS connectivity errors during the
+# instance profile security check. These are separate from the profile removal polling loop.
+IMDS_RETRY_MAX_ATTEMPTS = 5
+IMDS_RETRY_INITIAL_BACKOFF_SECONDS = 1.0
+IMDS_RETRY_BACKOFF_FACTOR = 2.0
+IMDS_RETRY_MAX_BACKOFF_SECONDS = 16.0
+
 
 class WorkerDeregisteredError(Exception):
     """Exception raised when Worker is deregistered"""
@@ -76,6 +83,24 @@ class InstanceProfileAttachedError(Exception):
         return (
             "Worker's EC2 instance profile not allowed but attached after "
             f"{INSTANCE_PROFILE_REMOVAL_ATTEMPTS} attempts"
+        )
+
+
+class IMDSUnreachableError(Exception):
+    """
+    Exception raised when IMDS cannot be reached after retries during the instance profile
+    security check. This indicates a transient IMDS failure rather than "not running on EC2",
+    and the worker must not proceed to avoid bypassing the security check.
+    """
+
+    def __init__(self, *, attempts: int) -> None:
+        self._attempts = attempts
+
+    def __str__(self) -> str:  # pragma: no cover
+        return (
+            "IMDS could not be reached after "
+            f"{self._attempts} attempts during instance profile security check. "
+            "Worker cannot confirm instance profile status and must exit."
         )
 
 
@@ -246,7 +271,7 @@ def bootstrap_worker(config: Configuration, *, use_existing_worker: bool = True)
         )
         return bootstrap_worker(config, use_existing_worker=False)
 
-    # raises: InstanceProfileAttachedError
+    # raises: InstanceProfileAttachedError, IMDSUnreachableError
     _enforce_no_instance_profile_or_stop_worker(
         config=config,
         deadline_client=deadline_client,
@@ -539,6 +564,9 @@ def _enforce_no_instance_profile_or_stop_worker(
 
     If the maximum number of retries is reached, the Worker will attempt to be stopped. This is a
     best-effort attempt and will utilize boto3's default retry behavior.
+
+    If IMDS becomes unreachable (non-timeout error) after retries, the Worker will also be stopped
+    and the error re-raised to cause a non-zero exit.
     """
 
     _logger.debug("Allow instance profile: %s", config.allow_instance_profile)
@@ -547,7 +575,7 @@ def _enforce_no_instance_profile_or_stop_worker(
 
     try:
         _enforce_no_instance_profile()
-    except InstanceProfileAttachedError:
+    except (InstanceProfileAttachedError, IMDSUnreachableError):
         try:
             update_worker(
                 deadline_client=deadline_client,
@@ -621,15 +649,48 @@ def _enforce_no_instance_profile() -> None:
         the host EC2 instance)
     2.  The maximum number of attempts (see INSTANCE_PROFILE_REMOVAL_ATTEMPTS) is reached
         (raises InstanceProfileAttachedError)
+    3.  IMDS returns None — retries with exponential backoff up to IMDS_RETRY_MAX_ATTEMPTS,
+        then raises IMDSUnreachableError. A None response during the security check is treated
+        as a transient IMDS failure, NOT as "not running on EC2", because this function is only
+        called when we already know we need to enforce the instance profile check.
 
     The function will sleep for a number of seconds (see INSTANCE_PROFILE_CHECK_DURATION_SECONDS)
     between attempts.
+
+    Raises:
+        InstanceProfileAttachedError: If the instance profile is still attached after all attempts.
+        IMDSUnreachableError: If IMDS cannot be reached after retries.
     """
     for i in range(INSTANCE_PROFILE_REMOVAL_ATTEMPTS):
-        response = _get_metadata("iam/info")
-        if response is None:
-            _logger.warning("Not running on EC2 but --no-allow-instance-profile argument specified")
-            break
+        # Query IMDS with retry — if IMDS is unreachable (returns None), we cannot
+        # assume "not on EC2" during the security check. Retry with backoff.
+        response = None
+        backoff = IMDS_RETRY_INITIAL_BACKOFF_SECONDS
+        attempts = 0
+        while response is None:
+            response = _get_metadata("iam/info")
+            if response is not None:
+                break
+            attempts += 1
+            if attempts > IMDS_RETRY_MAX_ATTEMPTS:
+                _logger.error(
+                    "IMDS could not be reached after %d attempts. "
+                    "Cannot confirm instance profile status. Worker must exit.",
+                    attempts,
+                )
+                raise IMDSUnreachableError(attempts=attempts)
+            _logger.warning(
+                "IMDS returned no response during instance profile check "
+                "(attempt %d of %d, retry %d of %d). Retrying in %.1fs.",
+                i + 1,
+                INSTANCE_PROFILE_REMOVAL_ATTEMPTS,
+                attempts,
+                IMDS_RETRY_MAX_ATTEMPTS,
+                backoff,
+            )
+            sleep(backoff)
+            backoff = min(backoff * IMDS_RETRY_BACKOFF_FACTOR, IMDS_RETRY_MAX_BACKOFF_SECONDS)
+
         _logger.info("IMDS /iam/info response %d", response.status_code)
         if response.status_code == 404:
             _logger.info("Instance profile disassociated, proceeding to run tasks.")

--- a/test/unit/startup/test_bootstrap.py
+++ b/test/unit/startup/test_bootstrap.py
@@ -1014,6 +1014,41 @@ class TestEnforceNoInstanceProfile:
         )
         assert result is None
 
+    def test_imds_none_then_recovers(
+        self,
+        get_metadata_mock: MagicMock,
+    ) -> None:
+        """When _get_metadata returns None initially but succeeds on retry with 404,
+        the function should return normally."""
+        # GIVEN
+        success_response = MagicMock()
+        success_response.status_code = 404
+
+        get_metadata_mock.side_effect = [None, success_response]
+
+        # WHEN/THEN (no error raised)
+        bootstrap_mod._enforce_no_instance_profile()
+
+        # THEN
+        assert get_metadata_mock.call_count == 2
+
+    def test_imds_none_all_retries_exhausted_raises(
+        self,
+        get_metadata_mock: MagicMock,
+    ) -> None:
+        """When _get_metadata always returns None, IMDSUnreachableError should be raised
+        after IMDS_RETRY_MAX_ATTEMPTS + 1 calls (1 initial + retries)."""
+        # GIVEN
+        get_metadata_mock.return_value = None
+
+        # THEN
+        with raises(bootstrap_mod.IMDSUnreachableError):
+            # WHEN
+            bootstrap_mod._enforce_no_instance_profile()
+
+        # THEN - 1 initial call + IMDS_RETRY_MAX_ATTEMPTS retries
+        assert get_metadata_mock.call_count == 1 + bootstrap_mod.IMDS_RETRY_MAX_ATTEMPTS
+
 
 class TestEnforceNoInstanceProfileOrStopWorker:
     @fixture(autouse=True)
@@ -1085,6 +1120,40 @@ class TestEnforceNoInstanceProfileOrStopWorker:
 
         # THEN
         with raises(bootstrap_mod.InstanceProfileAttachedError) as raise_ctx:
+            # WHEN
+            bootstrap_mod._enforce_no_instance_profile_or_stop_worker(
+                config=config,
+                worker_id=worker_id,
+                deadline_client=client,
+            )
+
+        # THEN
+        assert raise_ctx.value is exception
+        mock_enforce_no_instance_profile.assert_called_once_with()
+        update_worker_mock.assert_called_once_with(
+            deadline_client=client,
+            farm_id=config.farm_id,
+            fleet_id=config.fleet_id,
+            worker_id=worker_id,
+            status=WorkerStatus.STOPPED,
+        )
+
+    def test_imds_unreachable_stops_worker(
+        self,
+        mock_enforce_no_instance_profile: MagicMock,
+        update_worker_mock: MagicMock,
+        config: Configuration,
+        worker_id: str,
+        client: MagicMock,
+    ) -> None:
+        """When _enforce_no_instance_profile raises IMDSUnreachableError,
+        the worker should be stopped and the error re-raised."""
+        # GIVEN
+        exception = bootstrap_mod.IMDSUnreachableError(attempts=5)
+        mock_enforce_no_instance_profile.side_effect = exception
+
+        # THEN
+        with raises(bootstrap_mod.IMDSUnreachableError) as raise_ctx:
             # WHEN
             bootstrap_mod._enforce_no_instance_profile_or_stop_worker(
                 config=config,


### PR DESCRIPTION
## BREAKING CHANGE

Customers running the worker agent on non-EC2 machines will need to ensure they do not have `--disallow-instance-profile` configured for their worker, otherwise the worker will not exit rather than assuming the worker is not on EC2 and continuing to process jobs anyway

### What was the problem/requirement? (What/Why)

When `allow_ec2_instance_profile=false` is configured, the worker polls IMDS to confirm the instance profile has been disassociated before running sessions. However, if IMDS becomes temporarily unreachable during this polling loop, the worker incorrectly interprets the failure as "not running on EC2" and proceeds to run sessions. 

We need to change this behaviour so that IMDS being temporarily available does not result in the worker running sessions on EC2 with an instance profile when configured not to.

### What was the solution? (How)

Changed the code that `_enforce_no_instance_profile()` to always require a response from IMDS rather than assuming the Worker is not running on EC2 and continuing anyway.

When `_get_metadata()` returns `None`:
1. The function retries with exponential backoff
    - If a retry succeeds (gets an actual HTTP response), normal processing continues.
    - If all retries are exhausted, the worker status is updated to STOPPED and the process exits with a non-zero exit code via a new `IMDSUnreachableError` exception.
        - The OS service will automatically restart the worker process if this happens to ensure the Worker keeps trying in case IMDS recovers

### What is the impact of this change?

- Workers with `allow_ec2_instance_profile=false` always require a response from IMDS, otherwise the worker process will exit
- Workers not using this setting (`allow_ec2_instance_profile=true`, the default) are unaffected.

### How was this change tested?

- Unit tests added
- Manual testing on both a non EC2 instance and an EC2 instance (logs below). Verified that:
    - The worker can still register and run with default configuration
    - The worker just exits if `allow_ec2_instance_profile=false`
- [WIP] Ran E2E tests

#### Non-EC2, --disallow-instance-profile provided

Command
```
$ deadline-worker-agent --farm-id $FARM_ID --fleet-id $FLEET_ID --no-cleanup-session-user-processes --no-shutdown --run-jobs-as-agent-user --disallow-instance-profile
```

Logs
```
[2026-05-12 13:37:49,729][INFO    ] 💻 Worker.Status 💻 Status set to STARTED. [farm-3f2a6eef1da54073b8eb2ba677c1e236/fleet-e2e262f0129240049549802b4e9bab66/worker-67308320f67f4852879c8a86e4b9a9eb]
[2026-05-12 13:37:50,236][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 13:37:50,239][WARNING ] IMDS returned no response during instance profile check (attempt 1 of 120, retry 1 of 5). Retrying in 1.0s.
[2026-05-12 13:37:51,252][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 13:37:51,257][WARNING ] IMDS returned no response during instance profile check (attempt 1 of 120, retry 2 of 5). Retrying in 2.0s.
[2026-05-12 13:37:53,266][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 13:37:53,270][WARNING ] IMDS returned no response during instance profile check (attempt 1 of 120, retry 3 of 5). Retrying in 4.0s.
[2026-05-12 13:37:57,278][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 13:37:57,281][WARNING ] IMDS returned no response during instance profile check (attempt 1 of 120, retry 4 of 5). Retrying in 8.0s.
[2026-05-12 13:38:05,296][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 13:38:05,301][WARNING ] IMDS returned no response during instance profile check (attempt 1 of 120, retry 5 of 5). Retrying in 16.0s.
[2026-05-12 13:38:21,814][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 13:38:21,818][ERROR   ] IMDS could not be reached after 6 attempts. Cannot confirm instance profile status. Worker must exit.
[2026-05-12 13:38:21,822][INFO    ] 📤 API.Req 📤 [deadline:UpdateWorker] resource={'farm-id': 'farm-3f2a6eef1da54073b8eb2ba677c1e236', 'fleet-id': 'fleet-e2e262f0129240049549802b4e9bab66', 'worker-id': 'worker-67308320f67f4852879c8a86e4b9a9eb'} params={'status': 'STOPPED'} request_url=https://scheduling.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3f2a6eef1da54073b8eb2ba677c1e236/fleets/fleet-e2e262f0129240049549802b4e9bab66/workers/worker-67308320f67f4852879c8a86e4b9a9eb
[2026-05-12 13:38:22,032][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorker](200) params={} request_id=e774b2d1-e6be-47d5-82b1-81386b9cca1e
[2026-05-12 13:38:22,037][INFO    ] 💻 Worker.Status 💻 Status set to STOPPED. [farm-3f2a6eef1da54073b8eb2ba677c1e236/fleet-e2e262f0129240049549802b4e9bab66/worker-67308320f67f4852879c8a86e4b9a9eb]
[2026-05-12 13:38:22,039][CRITICAL] IMDS could not be reached after 6 attempts during instance profile security check. Worker cannot confirm instance profile status and must exit.
[2026-05-12 13:38:22,047][INFO    ] 🚪 Worker Agent exiting
```

#### EC2, --disallow-instance-profile

Simulate IMDS outage with [`iptables`](https://linux.die.net/man/8/iptables):
```sh
#!/bin/bash
# IMDS chaos script — blocks and unblocks IMDS in a loop to simulate transient outages.
# Logs to both stdout and a file with timestamps for correlation with worker agent logs.

LOG_FILE="/tmp/imds_chaos.log"
BLOCK_DURATION=10
UNBLOCK_DURATION=30

log() {
    echo "$(date -u '+%Y-%m-%dT%H:%M:%S.%3NZ') $1" | tee -a "$LOG_FILE"
}

log "=== IMDS chaos script started ==="
log "Block duration: ${BLOCK_DURATION}s, Unblock duration: ${UNBLOCK_DURATION}s"
log "Logging to: $LOG_FILE"

while true; do
    log "BLOCKING IMDS (169.254.169.254)"
    sudo iptables -A OUTPUT -d 169.254.169.254 -j DROP
    sleep "$BLOCK_DURATION"

    log "UNBLOCKING IMDS (169.254.169.254)"
    sudo iptables -D OUTPUT -d 169.254.169.254 -j DROP
    sleep "$UNBLOCK_DURATION"
done
```

Command:
```
deadline-worker-agent --farm-id $FARM_ID --fleet-id $FLEET_ID --no-cleanup-session-user-processes --no-shutdown --run-jobs-as-agent-user --disallow-instance-profile
```

Worker Logs:
```
[2026-05-12 21:18:25,010][INFO    ] Instance profile is still associated (attempt 117 of 120)
[2026-05-12 21:18:26,016][INFO    ] IMDS /iam/info response 200
[2026-05-12 21:18:26,017][INFO    ] Instance profile is still associated (attempt 118 of 120)
[2026-05-12 21:18:27,021][INFO    ] IMDS /iam/info response 200
[2026-05-12 21:18:27,023][INFO    ] Instance profile is still associated (attempt 119 of 120)
[2026-05-12 21:18:28,525][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:18:28,527][WARNING ] IMDS returned no response during instance profile check (attempt 120 of 120, retry 1 of 5). Retrying in 1.0s.
[2026-05-12 21:18:30,029][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:18:30,031][WARNING ] IMDS returned no response during instance profile check (attempt 120 of 120, retry 2 of 5). Retrying in 2.0s.
[2026-05-12 21:18:32,533][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:18:32,535][WARNING ] IMDS returned no response during instance profile check (attempt 120 of 120, retry 3 of 5). Retrying in 4.0s.
[2026-05-12 21:18:37,037][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:18:37,039][WARNING ] IMDS returned no response during instance profile check (attempt 120 of 120, retry 4 of 5). Retrying in 8.0s.
[2026-05-12 21:18:45,043][INFO    ] IMDS /iam/info response 200
[2026-05-12 21:18:45,044][INFO    ] Instance profile is still associated (attempt 120 of 120)
[2026-05-12 21:18:46,046][INFO    ] 📤 API.Req 📤 [deadline:UpdateWorker] resource={'farm-id': 'farm-3f2a6eef1da54073b8eb2ba677c1e236', 'fleet-id': 'fleet-e2e262f0129240049549802b4e9bab66', 'worker-id': 'worker-d1700303d92a4c21b621d48a928dac67'} params={'status': 'STOPPED'} request_url=https://scheduling.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3f2a6eef1da54073b8eb2ba677c1e236/fleets/fleet-e2e262f0129240049549802b4e9bab66/workers/worker-d1700303d92a4c21b621d48a928dac67
[2026-05-12 21:18:46,261][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorker](200) params={} request_id=26b47ced-aaa5-45bf-9ede-71f9cd79d50a
[2026-05-12 21:18:46,262][INFO    ] 💻 Worker.Status 💻 Status set to STOPPED. [farm-3f2a6eef1da54073b8eb2ba677c1e236/fleet-e2e262f0129240049549802b4e9bab66/worker-d1700303d92a4c21b621d48a928dac67]
[2026-05-12 21:18:46,264][CRITICAL] Worker's EC2 instance profile not allowed but attached after 120 attempts
[2026-05-12 21:18:46,266][INFO    ] 🚪 Worker Agent exiting
```

iptables script log:
```
2026-05-12T21:15:06.541Z === IMDS chaos script started ===
2026-05-12T21:15:06.543Z Block duration: 10s, Unblock duration: 30s
2026-05-12T21:15:06.545Z Logging to: /tmp/imds_chaos.log
2026-05-12T21:15:06.546Z BLOCKING IMDS (169.254.169.254)
2026-05-12T21:15:16.615Z UNBLOCKING IMDS (169.254.169.254)
2026-05-12T21:15:46.763Z BLOCKING IMDS (169.254.169.254)
2026-05-12T21:15:56.807Z UNBLOCKING IMDS (169.254.169.254)
2026-05-12T21:16:26.903Z BLOCKING IMDS (169.254.169.254)
2026-05-12T21:16:36.942Z UNBLOCKING IMDS (169.254.169.254)
2026-05-12T21:17:07.033Z BLOCKING IMDS (169.254.169.254)
2026-05-12T21:17:17.078Z UNBLOCKING IMDS (169.254.169.254)
2026-05-12T21:17:47.242Z BLOCKING IMDS (169.254.169.254)
2026-05-12T21:17:57.282Z UNBLOCKING IMDS (169.254.169.254)
2026-05-12T21:18:27.432Z BLOCKING IMDS (169.254.169.254)
2026-05-12T21:18:37.472Z UNBLOCKING IMDS (169.254.169.254)
2026-05-12T21:19:07.632Z BLOCKING IMDS (169.254.169.254)
2026-05-12T21:19:17.672Z UNBLOCKING IMDS (169.254.169.254)
```

#### EC2, bumped up IMDS block to 60s

iptables script
```
2026-05-12T21:57:17.031Z === IMDS chaos script started ===
2026-05-12T21:57:17.033Z Block duration: 60s, Unblock duration: 30s
2026-05-12T21:57:17.034Z Logging to: /tmp/imds_chaos.log
2026-05-12T21:57:17.036Z BLOCKING IMDS (169.254.169.254)
```

Worker logs
```
[2026-05-12 21:57:14,500][INFO    ] Instance profile is still associated (attempt 5 of 120)
[2026-05-12 21:57:15,504][INFO    ] IMDS /iam/info response 200
[2026-05-12 21:57:15,506][INFO    ] Instance profile is still associated (attempt 6 of 120)
[2026-05-12 21:57:16,510][INFO    ] IMDS /iam/info response 200
[2026-05-12 21:57:16,511][INFO    ] Instance profile is still associated (attempt 7 of 120)
[2026-05-12 21:57:18,014][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:57:18,016][WARNING ] IMDS returned no response during instance profile check (attempt 8 of 120, retry 1 of 5). Retrying in 1.0s.
[2026-05-12 21:57:19,518][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:57:19,520][WARNING ] IMDS returned no response during instance profile check (attempt 8 of 120, retry 2 of 5). Retrying in 2.0s.
[2026-05-12 21:57:22,023][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:57:22,024][WARNING ] IMDS returned no response during instance profile check (attempt 8 of 120, retry 3 of 5). Retrying in 4.0s.
[2026-05-12 21:57:26,527][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:57:26,528][WARNING ] IMDS returned no response during instance profile check (attempt 8 of 120, retry 4 of 5). Retrying in 8.0s.
[2026-05-12 21:57:35,031][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:57:35,033][WARNING ] IMDS returned no response during instance profile check (attempt 8 of 120, retry 5 of 5). Retrying in 16.0s.
[2026-05-12 21:57:51,535][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 21:57:51,537][ERROR   ] IMDS could not be reached after 6 attempts. Cannot confirm instance profile status. Worker must exit.
[2026-05-12 21:57:51,538][INFO    ] 📤 API.Req 📤 [deadline:UpdateWorker] resource={'farm-id': 'farm-3f2a6eef1da54073b8eb2ba677c1e236', 'fleet-id': 'fleet-e2e262f0129240049549802b4e9bab66', 'worker-id': 'worker-d1700303d92a4c21b621d48a928dac67'} params={'status': 'STOPPED'} request_url=https://scheduling.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3f2a6eef1da54073b8eb2ba677c1e236/fleets/fleet-e2e262f0129240049549802b4e9bab66/workers/worker-d1700303d92a4c21b621d48a928dac67
[2026-05-12 21:57:51,757][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorker](200) params={} request_id=9f8fe806-f1ac-4bfc-ba87-0f5d0f06b3fa
[2026-05-12 21:57:51,758][INFO    ] 💻 Worker.Status 💻 Status set to STOPPED. [farm-3f2a6eef1da54073b8eb2ba677c1e236/fleet-e2e262f0129240049549802b4e9bab66/worker-d1700303d92a4c21b621d48a928dac67]
[2026-05-12 21:57:51,760][CRITICAL] IMDS could not be reached after 6 attempts during instance profile security check. Worker cannot confirm instance profile status and must exit.
[2026-05-12 21:57:51,762][INFO    ] 🚪 Worker Agent exiting
```

#### EC2, 30s IMDS Block, Detach Instance Profile

iptables script
```
2026-05-12T22:04:40.541Z === IMDS chaos script started ===
2026-05-12T22:04:40.543Z Block duration: 30s, Unblock duration: 30s
2026-05-12T22:04:40.544Z Logging to: /tmp/imds_chaos.log
2026-05-12T22:04:40.546Z BLOCKING IMDS (169.254.169.254)
2026-05-12T22:05:10.587Z UNBLOCKING IMDS (169.254.169.254)
2026-05-12T22:05:40.743Z BLOCKING IMDS (169.254.169.254)
2026-05-12T22:06:10.783Z UNBLOCKING IMDS (169.254.169.254)
```

Worker logs
```
[2026-05-12 22:04:36,449][INFO    ] 💻 Worker.Status 💻 Status set to STARTED. [farm-3f2a6eef1da54073b8eb2ba677c1e236/fleet-e2e262f0129240049549802b4e9bab66/worker-d1700303d92a4c21b621d48a928dac67]
[2026-05-12 22:04:36,453][INFO    ] IMDS /iam/info response 200
[2026-05-12 22:04:36,454][INFO    ] Instance profile is still associated (attempt 1 of 120)
[2026-05-12 22:04:37,460][INFO    ] IMDS /iam/info response 200
[2026-05-12 22:04:37,461][INFO    ] Instance profile is still associated (attempt 2 of 120)
[2026-05-12 22:04:38,465][INFO    ] IMDS /iam/info response 200
[2026-05-12 22:04:38,466][INFO    ] Instance profile is still associated (attempt 3 of 120)
[2026-05-12 22:04:39,470][INFO    ] IMDS /iam/info response 200
[2026-05-12 22:04:39,471][INFO    ] Instance profile is still associated (attempt 4 of 120)
[2026-05-12 22:04:40,476][INFO    ] IMDS /iam/info response 200
[2026-05-12 22:04:40,478][INFO    ] Instance profile is still associated (attempt 5 of 120)
[2026-05-12 22:04:41,980][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 22:04:41,982][WARNING ] IMDS returned no response during instance profile check (attempt 6 of 120, retry 1 of 5). Retrying in 1.0s.
[2026-05-12 22:04:43,484][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 22:04:43,486][WARNING ] IMDS returned no response during instance profile check (attempt 6 of 120, retry 2 of 5). Retrying in 2.0s.
[2026-05-12 22:04:45,989][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 22:04:45,990][WARNING ] IMDS returned no response during instance profile check (attempt 6 of 120, retry 3 of 5). Retrying in 4.0s.
[2026-05-12 22:04:50,493][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 22:04:50,494][WARNING ] IMDS returned no response during instance profile check (attempt 6 of 120, retry 4 of 5). Retrying in 8.0s.
[2026-05-12 22:04:58,997][INFO    ] Not running on EC2 or the metadata service was unable to be found!
[2026-05-12 22:04:58,998][WARNING ] IMDS returned no response during instance profile check (attempt 6 of 120, retry 5 of 5). Retrying in 16.0s.
[2026-05-12 22:05:15,003][INFO    ] IMDS /iam/info response 404
[2026-05-12 22:05:15,005][INFO    ] Instance profile disassociated, proceeding to run tasks.
[2026-05-12 22:05:15,006][INFO    ] 💻 Worker.ID 💻 Agent identity. [farm-3f2a6eef1da54073b8eb2ba677c1e236/fleet-e2e262f0129240049549802b4e9bab66/worker-d1700303d92a4c21b621d48a928dac67]
[2026-05-12 22:05:15,056][INFO    ] Worker successfully bootstrapped and is now running.
[2026-05-12 22:05:15,057][WARNING ] The content and formatting of unstructured logs may change at any time and without warning. We recommend structured logs for programmatic log queries.
[2026-05-12 22:05:15,059][WARNING ] The content and formatting of structured log records that do not have a 'type' field may change at any time and without warning and must not be relied upon for programmatic log queries.
[2026-05-12 22:05:15,060][INFO    ] AgentInfo
Python Interpreter: /home/ec2-user/.local/share/hatch/env/virtual/deadline-cloud-worker-agent/GkibAa_w/deadline-cloud-worker-agent/bin/python
Python Version: 3.12.13 (main, Apr 17 2026, 00:00:00) [GCC 11.5.0 20240719 (Red Hat 11.5.0-5)]
Platform: linux
Agent Version: 0.0.post1.dev655
Installed at: /home/ec2-user/deadline-cloud-worker-agent/src
Running as user: ec2-user
Dependency versions installed:
        openjd.model: 0.9.0
        openjd.sessions: 0.10.8
        deadline.job_attachments: 0.1.0
[2026-05-12 22:05:15,063][INFO    ] 🔑 AWSCreds.Refresh 🔑 Refresh scheduled. (ScheduledTime: 2026-05-12T22:06:15.063467+00:00) [worker-d1700303d92a4c21b621d48a928dac67]
[2026-05-12 22:05:15,066][INFO    ] 📊 Metrics.System 📊 cpu-usage-percent 0.2 memory-total-bytes 32912969728 memory-used-bytes 913772544 memory-used-percent 2.8 swap-used-bytes 0 total-disk-bytes 32132542464 total-disk-used-bytes 2574630912 total-disk-used-percent 0.1 user-disk-available-bytes 29557911552 network-sent-bytes-per-second 0 network-recv-bytes-per-second 0 disk-read-bytes-per-second 0 disk-write-bytes-per-second 0
[2026-05-12 22:05:15,069][INFO    ] 📤 API.Req 📤 [deadline:UpdateWorkerSchedule] resource={'farm-id': 'farm-3f2a6eef1da54073b8eb2ba677c1e236', 'fleet-id': 'fleet-e2e262f0129240049549802b4e9bab66', 'worker-id': 'worker-d1700303d92a4c21b621d48a928dac67'} params={'updatedSessionActions': {}} request_url=https://scheduling.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3f2a6eef1da54073b8eb2ba677c1e236/fleets/fleet-e2e262f0129240049549802b4e9bab66/workers/worker-d1700303d92a4c21b621d48a928dac67/schedule
[2026-05-12 22:05:15,312][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorkerSchedule](200) params={'assignedSessions': {}, 'cancelSessionActions': {}, 'updateIntervalSeconds': 17} request_id=902feba3-5a30-482d-8a4b-c6a0b717ea62
[2026-05-12 22:05:32,489][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorkerSchedule](200) params=(Duplicate removed, see previous response) request_id=3ba2cda1-c15d-4981-8d27-a69fbb48e6e0
[2026-05-12 22:05:49,640][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorkerSchedule](200) params=(Duplicate removed, see previous response) request_id=78ea8510-17f3-43a5-babf-90731df8fd96
[2026-05-12 22:06:06,775][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorkerSchedule](200) params=(Duplicate removed, see previous response) request_id=9f687cb8-0c3f-48a0-8d82-da3ff5d6c7c6
[2026-05-12 22:06:15,063][INFO    ] 🔑 AWSCreds.Query 🔑 Requesting AWS Credentials [worker-d1700303d92a4c21b621d48a928dac67]
[2026-05-12 22:06:15,069][INFO    ] 📤 API.Req 📤 [deadline:AssumeFleetRoleForWorker] resource={'farm-id': 'farm-3f2a6eef1da54073b8eb2ba677c1e236', 'fleet-id': 'fleet-e2e262f0129240049549802b4e9bab66', 'worker-id': 'worker-d1700303d92a4c21b621d48a928dac67'} params={} request_url=https://scheduling.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3f2a6eef1da54073b8eb2ba677c1e236/fleets/fleet-e2e262f0129240049549802b4e9bab66/workers/worker-d1700303d92a4c21b621d48a928dac67/fleet-roles
[2026-05-12 22:06:15,073][INFO    ] 📊 Metrics.System 📊 cpu-usage-percent 0.0 memory-total-bytes 32912969728 memory-used-bytes 920137728 memory-used-percent 2.8 swap-used-bytes 0 total-disk-bytes 32132542464 total-disk-used-bytes 2574630912 total-disk-used-percent 0.1 user-disk-available-bytes 29557911552 network-sent-bytes-per-second 1894 network-recv-bytes-per-second 1880 disk-read-bytes-per-second 0 disk-write-bytes-per-second 87313
[2026-05-12 22:06:15,389][INFO    ] 📥 API.Resp 📥 [deadline:AssumeFleetRoleForWorker](200) params={'credentials': {'accessKeyId': 'ASIASL3YCSADNWIFN4L6', 'secretAccessKey': '*REDACTED*', 'sessionToken': '*REDACTED*', 'expiration': '2026-05-12 23:06:15+00:00'}} request_id=1de16228-d7b1-4694-a529-be9b7b47a839
[2026-05-12 22:06:15,392][INFO    ] 🔑 AWSCreds.Query 🔑 Obtained temporary Worker AWS Credentials. (Expires: 2026-05-12 23:06:15+00:00) [worker-d1700303d92a4c21b621d48a928dac67]
[2026-05-12 22:06:15,394][INFO    ] 💾 FileSystem.Write 💾 Worker AWS Credentials cached. [/var/lib/deadline/credentials/worker-d1700303d92a4c21b621d48a928dac67.json]
[2026-05-12 22:06:15,396][INFO    ] 🔑 AWSCreds.Refresh 🔑 Refresh scheduled. (ScheduledTime: 2026-05-12T22:51:15+00:00) [worker-d1700303d92a4c21b621d48a928dac67]
[2026-05-12 22:06:23,494][INFO    ] Received signal 2. Initiating application shutdown.
[2026-05-12 22:06:23,496][INFO    ] Main event loop exited.
[2026-05-12 22:06:23,497][INFO    ] Draining any remaining Sessions.
[2026-05-12 22:06:23,499][INFO    ] Worker shutdown complete
[2026-05-12 22:06:23,500][INFO    ] Setting Worker state to STOPPED.
[2026-05-12 22:06:23,502][INFO    ] 📤 API.Req 📤 [deadline:UpdateWorker] resource={'farm-id': 'farm-3f2a6eef1da54073b8eb2ba677c1e236', 'fleet-id': 'fleet-e2e262f0129240049549802b4e9bab66', 'worker-id': 'worker-d1700303d92a4c21b621d48a928dac67'} params={'status': 'STOPPED'} request_url=https://scheduling.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3f2a6eef1da54073b8eb2ba677c1e236/fleets/fleet-e2e262f0129240049549802b4e9bab66/workers/worker-d1700303d92a4c21b621d48a928dac67
[2026-05-12 22:06:23,677][INFO    ] 📥 API.Resp 📥 [deadline:UpdateWorker](200) params={} request_id=2a515361-51db-4bb5-ad57-4e85688bc95a
[2026-05-12 22:06:23,679][INFO    ] 💻 Worker.Status 💻 Status set to STOPPED. [farm-3f2a6eef1da54073b8eb2ba677c1e236/fleet-e2e262f0129240049549802b4e9bab66/worker-d1700303d92a4c21b621d48a928dac67]
[2026-05-12 22:06:23,786][INFO    ] 🚪 Worker Agent exiting
```

### Was this change documented?

No

### Is this a breaking change?

Yes

Workers configured with `allow_ec2_instance_profile=false` that are running on non-EC2 hosts (where IMDS is never reachable) will now fail to start after exhausting retries, rather than silently proceeding. Customers running the worker agent off-EC2 with this flag set will need to remove the `allow_ec2_instance_profile=false` setting (since it's irrelevant off-EC2), or

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
