### PR TITLE
test: worker agent flakey E2E for test_config_file_user_override Windows

### DIFF
--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -126,6 +126,22 @@ class TestWindowsJobUserOverride:
     ) -> None:
         class_worker.stop_worker_service()
 
+        @backoff.on_exception(
+            backoff.constant,
+            Exception,
+            max_time=45,
+            interval=5,
+        )
+        def check_worker_process_stopped() -> None:
+            cmd_result = class_worker.send_command(
+                "IF(Get-Process pythonservice -ErrorAction SilentlyContinue)"
+                '{throw "Agent process still running"}'
+                "ELSE{echo 'Agent process stopped'}"
+            )
+            assert cmd_result.exit_code == 0
+
+        check_worker_process_stopped()
+
         windows_replace_and_verify(
             worker=class_worker,
             file_path="C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Windows E2E test `test_config_file_user_override` has a ~15% flake rate. The failure mode: session log shows `I am: job-user` instead of `I am: config-override`, meaning the restarted agent read stale config values despite the file being confirmed modified.

Theory: After Stop-Service returns, the pythonservice.exe process can still be briefly alive, causing `start_worker_service()` to detect the old dying process instead of the new one, and the restarted agent to load stale config. The Linux version of this test explicitly polls for process exit before proceeding and doesn't flake, while the windows version doesn't. We added this extra guard similar to the linux process.

### What was the solution? (How)

Added a `backoff`-based poll after `stop_worker_service()` that waits until `pythonservice.exe` is completely gone before modifying the config. This matches the pattern used in the Linux version of this test (which polls `systemctl is-active` before proceeding).

### What is the impact of this change?

- Eliminates the ~15% flake rate on `test_config_file_user_override` (Windows)
- Adds ~2-5 seconds to the happy path (one SSM round-trip to verify process is gone)
- In the rare case the process lingers, retries every 5 seconds up to 45 seconds total

### How was this change tested?

**30 consecutive E2E runs — all passed (30/30):**
```
============================= slowest 5 durations ==============================
358.92s setup    test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_config_file_user_override
68.11s call     test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_config_file_user_override
5.81s teardown test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_config_file_user_override
1.62s teardown test/e2e/test_override_job_user.py::TestLinuxJobUserOverride::test_config_file_user_override

(1 durations < 0.005s hidden.  Use -vv to show these durations.)
====== 1 passed, 1 skipped, 62 deselected, 1 warning in 434.57s (0:07:14) ======
cmd [4] | echo pytest done
pytest done
Current stats: 30 pass / 0 fail out of 30
========== SUMMARY ==========
PASS on run 1
PASS on run 2
PASS on run 3
PASS on run 4
PASS on run 5
PASS on run 6
PASS on run 7
PASS on run 8
PASS on run 9
PASS on run 10
PASS on run 11
PASS on run 12
PASS on run 13
PASS on run 14
PASS on run 15
PASS on run 16
PASS on run 17
PASS on run 18
PASS on run 19
PASS on run 20
PASS on run 21
PASS on run 22
PASS on run 23
PASS on run 24
PASS on run 25
PASS on run 26
PASS on run 27
PASS on run 28
PASS on run 29
PASS on run 30
Pass rate: 30/30
```

With a baseline 15% flake rate, 30/30 passes gives 99.2% confidence the fix eliminated the flake.

**Backoff mechanism manually verified** by temporarily changing the check to target `svchost` (always-running process), confirming retries trigger correctly:
```
BACKOFF CHECK: exit_code=1, stdout=
[2026-05-15 16:58:16,566] [test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_config_file_user_override] Backing off check_worker_process_stopped(...) for 0.4s (AssertionError: assert 1 == 0
```

### Was this change documented?

Test fix only

### Is this a breaking change?

No.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*