### PR TITLE
feat!: report task runs as INTERRUPTED if interrupted during input asset sync or env enter

### DIFF
--- a/docs/dev/worker_api_protocol.md
+++ b/docs/dev/worker_api_protocol.md
@@ -360,14 +360,26 @@ reported as `NEVER_ATTEMPTED` must not report `startedAt` or `endedAt` times. Th
 must not queue additional Session Actions to the Session except for `envExit` Session Actions that
 correspond to already completed `envEnter` Session Actions for the same Session.
 
+**Exception:** If a `syncInputJobAttachments` Session Action is reported as `INTERRUPTED`, then the Worker Agent
+must report all queued `taskRun` Session Actions after it as `INTERRUPTED` (not `NEVER_ATTEMPTED`). This ensures
+that the interruption reason (e.g. spot interruption) is propagated to the task run actions and is visible
+to the user in the console. Session Actions reported as `INTERRUPTED` in this manner must not report
+`startedAt` or `endedAt` times.
+
 #### Handling Unsuccessful `envEnter` Session Actions
 
-If the Worker Agent reports this Session Action as `FAILED`, `INTERRUPTED`, or `CANCELED`, then the Worker Agent must
+If the Worker Agent reports this Session Action as `FAILED` or `CANCELED`, then the Worker Agent must
 also report all queued Session Actions after it in the Session as `NEVER_ATTEMPTED`; except for
 `envExit` actions that correspond this `envEnter` or to already completed `envEnter` Session Actions.
 The service must not queue additional Session Actions to the Session except for `envExit` Session Actions
 that correspond to the failed `envEnter` and all already completed `envEnter` Session Actions for the
 same Session.
+
+If the Worker Agent reports this Session Action as `INTERRUPTED`, then the Worker Agent must
+report all queued `taskRun` Session Actions after it as `INTERRUPTED` (not `NEVER_ATTEMPTED`); except for
+`envExit` actions that correspond to this `envEnter` or to already completed `envEnter` Session Actions
+which follow existing behavior. This ensures that the interruption reason is propagated to the task run
+actions and is visible to the user.
 
 #### Handling Unsuccessful `envExit` Session Actions
 
@@ -448,7 +460,7 @@ immediately call the `UpdateWorkerSchedule` API:
         * `updatedSession Actions` must update all actively running Session Actions with
         `completedStatus=INTERRUPTED`.
         * `updatedSession Actions` must update all other Session Actions that have not yet been run with
-        `completedStatus=NEVER_ATTEMPTED`.
+        `completedStatus=INTERRUPTED`.
     * Response: Success(200) -> Continue
     * Response: ThrottlingException(429), InternalServerException(500) -> Perform exponential backoff,
     and then retry. Do not let retries prevent the Worker Agent from completing the drain; it is more important

--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -78,7 +78,7 @@ AttachmentDownloadActionQueueEntry = SessionActionQueueEntry[AttachmentDownloadA
 AttachmentDownloadActionStepDependenciesQueueEntry = SessionActionQueueEntry[
     AttachmentDownloadActionApiModel
 ]
-CancelOutcome = Literal["FAILED", "NEVER_ATTEMPTED"]
+CancelOutcome = Literal["FAILED", "NEVER_ATTEMPTED", "INTERRUPTED"]
 
 
 class SessionActionQueue:
@@ -203,8 +203,8 @@ class SessionActionQueue:
             The identifier of the action to be canceled
         message : str | None
             An optional message to include explaining why this action was canceled
-        cancel_outcome : Literal["NEVER_ATTEMPTED", "FAILED"]
-            Whether to fail the action or mark it as never attempted
+        cancel_outcome : Literal["NEVER_ATTEMPTED", "FAILED", "INTERRUPTED"]
+            The status to report for the canceled action
         """
         action: SessionActionQueueEntry
         action = self._actions_by_id.pop(id)
@@ -237,6 +237,7 @@ class SessionActionQueue:
         *,
         message: str | None = None,
         ignore_env_exits: bool = True,
+        cancel_outcome: CancelOutcome = "NEVER_ATTEMPTED",
     ) -> None:
         """Cancels all queued actions
 
@@ -246,6 +247,8 @@ class SessionActionQueue:
             An optional message to include explaining why this action was canceled
         ignore_env_exits : bool
             If True, ENV_EXIT actions will not be canceled. Defaults to canceling ENV_EXIT actions.
+        cancel_outcome : CancelOutcome
+            The status to report for the canceled actions. Defaults to NEVER_ATTEMPTED.
         """
 
         action_ids = [
@@ -261,7 +264,7 @@ class SessionActionQueue:
                 self._cancel(
                     id=action_id,
                     message=message,
-                    cancel_outcome="NEVER_ATTEMPTED",
+                    cancel_outcome=cancel_outcome,
                 )
         if action_ids:
             logger.info(

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -448,6 +448,9 @@ class Session:
 
         self._queue.cancel_all(
             message=self._stop_fail_message,
+            cancel_outcome=self._stop_current_action_result
+            if self._stop_current_action_result == "INTERRUPTED"
+            else "NEVER_ATTEMPTED",
         )
 
         # After canceling the running action, we exit any active environments

--- a/test/e2e/test_spot_interruption.py
+++ b/test/e2e/test_spot_interruption.py
@@ -1,0 +1,217 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+This test module verifies that when a worker agent is interrupted (simulating a spot interruption)
+during different session action phases, the session actions are reported with the correct statuses.
+
+Specifically, it tests that when an interruption occurs during:
+- Job attachment sync (SYNC_INPUT_JOB_ATTACHMENTS)
+- Environment enter (ENV_ENTER)
+
+The interrupted action is reported as INTERRUPTED, and subsequent queued task run actions
+are also reported as INTERRUPTED (not NEVER_ATTEMPTED), so that the interruption reason
+is visible to the user in the console's retries modal.
+"""
+
+import logging
+import os
+import time
+from typing import Any, Dict, List
+
+import backoff
+import pytest
+from deadline_test_fixtures import (
+    DeadlineClient,
+    EC2InstanceWorker,
+    Job,
+)
+
+from e2e.conftest import DeadlineResources
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.mark.skipif(
+    os.environ.get("OPERATING_SYSTEM") == "windows",
+    reason="Linux specific test (SIGTERM simulation)",
+)
+class TestSpotInterruption:
+    """Tests that session actions are correctly reported as INTERRUPTED when the worker
+    is interrupted (simulating a spot interruption via SIGTERM)."""
+
+    def _send_sigterm_to_worker(self, worker: EC2InstanceWorker) -> None:
+        """Send SIGTERM to the worker agent process to simulate a spot interruption."""
+        result = worker.send_command(
+            f"sudo pkill --signal TERM --full -u {worker.configuration.agent_user} deadline-worker-agent"
+        )
+        assert result.exit_code == 0, f"Failed to send SIGTERM to worker agent: {result}"
+        LOG.info("Sent SIGTERM to worker agent")
+
+    def _wait_for_action_running(
+        self,
+        deadline_client: DeadlineClient,
+        job: Job,
+        action_type: str,
+        timeout: int = 120,
+    ) -> str:
+        """Wait until a session action of the given type is in RUNNING status.
+
+        Returns the session ID where the action was found running.
+        """
+
+        @backoff.on_predicate(
+            wait_gen=backoff.constant,
+            max_time=timeout,
+            interval=5,
+        )
+        def _poll() -> str | None:
+            sessions = deadline_client.list_sessions(
+                farmId=job.farm.id,
+                queueId=job.queue.id,
+                jobId=job.id,
+            ).get("sessions", [])
+
+            for session in sessions:
+                session_actions = deadline_client.list_session_actions(
+                    farmId=job.farm.id,
+                    queueId=job.queue.id,
+                    jobId=job.id,
+                    sessionId=session["sessionId"],
+                ).get("sessionActions", [])
+
+                for action in session_actions:
+                    if (
+                        action_type in action.get("definition", {})
+                        and action["status"] == "RUNNING"
+                    ):
+                        LOG.info(
+                            f"Found {action_type} action in RUNNING status: {action['sessionActionId']}"
+                        )
+                        return session["sessionId"]
+            return None
+
+        session_id = _poll()
+        assert session_id is not None, f"Timed out waiting for {action_type} action to be RUNNING"
+        return session_id
+
+    def _get_session_actions(
+        self,
+        deadline_client: DeadlineClient,
+        job: Job,
+        session_id: str,
+    ) -> List[Dict[str, Any]]:
+        """Get all session actions for a given session."""
+        return deadline_client.list_session_actions(
+            farmId=job.farm.id,
+            queueId=job.queue.id,
+            jobId=job.id,
+            sessionId=session_id,
+        ).get("sessionActions", [])
+
+    def test_task_run_reported_as_interrupted_when_sync_input_interrupted(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        function_worker: EC2InstanceWorker,
+    ) -> None:
+        """
+        Tests that when a spot interruption (SIGTERM) occurs during job attachment sync,
+        the sync action is reported as INTERRUPTED and the subsequent task run action
+        is also reported as INTERRUPTED (not NEVER_ATTEMPTED).
+        """
+        # GIVEN
+        # Submit a job with a long-running step (sleep 300) so the sync has time to be interrupted.
+        # The job attachment sync will be triggered by the job template having attachments.
+        # We use a large embedded file to simulate attachment sync taking time.
+        job = Job.submit(
+            client=deadline_client,
+            farm=deadline_resources.farm,
+            queue=deadline_resources.queue_a,
+            priority=98,
+            max_retries_per_task=0,
+            template={
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": "test-spot-interrupt-during-sync",
+                "steps": [
+                    {
+                        "hostRequirements": {
+                            "attributes": [
+                                {
+                                    "name": "attr.worker.os.family",
+                                    "allOf": ["linux"],
+                                }
+                            ]
+                        },
+                        "name": "SleepStep",
+                        "script": {
+                            "actions": {
+                                "onRun": {
+                                    "command": "/bin/sleep",
+                                    "args": ["300"],
+                                }
+                            },
+                        },
+                    },
+                ],
+                # Add a job environment that sleeps to give us time to interrupt during env enter
+                "jobEnvironments": [
+                    {
+                        "name": "LongEnvEnter",
+                        "script": {
+                            "actions": {
+                                "onEnter": {
+                                    "command": "/bin/sleep",
+                                    "args": ["120"],
+                                },
+                                "onExit": {
+                                    "command": "/bin/true",
+                                },
+                            }
+                        },
+                    }
+                ],
+            },
+        )
+
+        LOG.info(f"Submitted job {job.id}")
+
+        # WHEN
+        # Wait for the environment enter action to be running
+        session_id = self._wait_for_action_running(
+            deadline_client, job, action_type="envEnter", timeout=120
+        )
+
+        # Give the action a few seconds to get underway
+        time.sleep(5)
+
+        # Send SIGTERM to simulate spot interruption
+        self._send_sigterm_to_worker(function_worker)
+
+        # Wait for the job to reach a terminal state
+        job.wait_until_complete(client=deadline_client, max_retries=20)
+
+        # THEN
+        session_actions = self._get_session_actions(deadline_client, job, session_id)
+        LOG.info(f"Session actions after interruption: {session_actions}")
+
+        # Find the env enter and task run actions
+        env_enter_action = None
+        task_run_action = None
+        for action in session_actions:
+            if "envEnter" in action.get("definition", {}):
+                env_enter_action = action
+            elif "taskRun" in action.get("definition", {}):
+                task_run_action = action
+
+        # The env enter action should be INTERRUPTED
+        assert env_enter_action is not None, "Expected to find an envEnter session action"
+        assert env_enter_action["status"] == "INTERRUPTED", (
+            f"Expected envEnter action to be INTERRUPTED, got {env_enter_action['status']}"
+        )
+
+        # The task run action should be INTERRUPTED (not NEVER_ATTEMPTED)
+        assert task_run_action is not None, "Expected to find a taskRun session action"
+        assert task_run_action["status"] == "INTERRUPTED", (
+            f"Expected taskRun action to be INTERRUPTED, got {task_run_action['status']}. "
+            f"This is the bug from Bea-33959 — task runs should show INTERRUPTED when a "
+            f"preceding action was interrupted due to spot interruption."
+        )

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -470,6 +470,57 @@ class TestCancelAll:
                 id="env-exit", message=message, cancel_outcome=cancel_outcome
             )
 
+    def test_cancel_all_with_interrupted_outcome(
+        self,
+        session_queue: SessionActionQueue,
+    ) -> None:
+        """Tests that when SessionActionQueue.cancel_all(..., cancel_outcome="INTERRUPTED") is
+        called, all canceled actions are reported with cancel_outcome="INTERRUPTED"."""
+
+        # GIVEN
+        session_queue._actions = [
+            TaskRunQueueEntry(
+                Mock(),  # cancel event
+                TaskRunAction(
+                    sessionActionId="task-run-1",
+                    actionType="TASK_RUN",
+                    taskId="taskId1",
+                    stepId="stepId1",
+                    parameters=OrderedDict(
+                        strP={"string": "stringValue"},
+                    ),
+                ),
+            ),
+            TaskRunQueueEntry(
+                Mock(),  # cancel event
+                TaskRunAction(
+                    sessionActionId="task-run-2",
+                    actionType="TASK_RUN",
+                    taskId="taskId2",
+                    stepId="stepId2",
+                    parameters=OrderedDict(
+                        strP={"string": "stringValue"},
+                    ),
+                ),
+            ),
+        ]
+        session_queue._actions_by_id = {"task-run-1": dict(), "task-run-2": dict()}  # type: ignore
+        with patch.object(session_queue, "_cancel") as cancel_mock:
+            # WHEN
+            session_queue.cancel_all(
+                message="spot interruption",
+                cancel_outcome="INTERRUPTED",
+            )
+
+        # THEN
+        assert cancel_mock.call_count == 2
+        cancel_mock.assert_any_call(
+            id="task-run-1", message="spot interruption", cancel_outcome="INTERRUPTED"
+        )
+        cancel_mock.assert_any_call(
+            id="task-run-2", message="spot interruption", cancel_outcome="INTERRUPTED"
+        )
+
 
 class TestIdentifiers:
     @pytest.mark.parametrize(

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -1915,6 +1915,35 @@ class TestSessionCleanup:
         # THEN
         mock_queue_cancel_all.assert_called_once_with(
             message=session._stop_fail_message,
+            cancel_outcome="NEVER_ATTEMPTED",
+        )
+
+    @pytest.mark.parametrize(
+        argnames="stop_fail_message",
+        argvalues=("spot interruption", "some other message", None),
+        ids=("msg-spot", "msg-other", "msg-None"),
+    )
+    def test_calls_queue_cancel_all_interrupted(
+        self,
+        session: Session,
+        session_action_queue: MagicMock,
+        current_action: CurrentAction,
+        stop_fail_message: str | None,
+    ) -> None:
+        """Tests that Session._cleanup() cancels all queued actions with cancel_outcome="INTERRUPTED"
+        when _stop_current_action_result is "INTERRUPTED", and passes through the fail message."""
+        # GIVEN
+        session._stop_current_action_result = "INTERRUPTED"
+        session._stop_fail_message = stop_fail_message
+        mock_queue_cancel_all: MagicMock = session_action_queue.cancel_all
+
+        # WHEN
+        session._cleanup()
+
+        # THEN
+        mock_queue_cancel_all.assert_called_once_with(
+            message=stop_fail_message,
+            cancel_outcome="INTERRUPTED",
         )
 
     def test_calls_openjd_cleanup(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Worker Agent protocol currently has task runs being reported as `NEVER_ATTEMPTED` in the event of a spot interruption during input asset attachment sync or env enter phases. We have received customer feedback that it would be better to have the task runs reported as `INTERRUPTED` in these cases so it is easier to tell at a glance from the Deadline Cloud monitor which tasks were not attempted due to spot interruptions during these phases.

### What was the solution? (How)
- Update the worker protocol so that task runs are reported as `INTERRUPTED` if a spot interruption occurs during input asset sync or env enter
- Update the Worker agent to report task runs as `INTERRUPTED` instead of `NEVER_ATTEMPTED` in the above scenario

### What is the impact of this change?
Task runs are now reported as `INTERRUPTED` rather than `NEVER_ATTEMPTED` if a spot interruption occurs during input asset sync or env enter

### How was this change tested?
- Unit tests
- [WIP] E2E test
- Manual e2e testing via code in this branch: https://github.com/jericht/deadline-cloud-worker-agent/tree/jericht/spot_int

### Was this change documented?
No

### Is this a breaking change?
Yes

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*