### PR TITLE
fix: Increase timeout for Job Attachments sync with large number of files.

### DIFF
--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -1148,7 +1148,7 @@ if __name__ == "__main__":
 
         @backoff.on_predicate(
             wait_gen=backoff.constant,
-            max_time=120,
+            max_time=240,
             interval=2,
         )
         def check_percentage(complete_percentage) -> bool:


### PR DESCRIPTION
## fix: bump assert_single_task_log_contains poll budget for sync of 2,500 files on Windows

The `check_percentage` backoff in `test_worker_uses_job_attachment_sync[hash_script]` had a 120 s budget that no longer matches the 2,500-file workload (the budget was set when the test had ~250 files). On Windows under canary load, sync genuinely takes longer than 120 s, causing intermittent timeouts before `progressPercent` reaches 100. Worker behavior is correct; only the test budget is structurally tight.

Bump `max_time` from 120 s to 240 s. No change in the success case; worst-case test runtime grows by 120 s, well under the CodeBuild cap.

### What was the problem/requirement? (What/Why)

`test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_uses_job_attachment_sync[hash_script]` flaked once in the past 14 days on `release-windows-canary` build #4647 (2026-05-19). The test creates 2,500 small files in a job bundle, submits a job, and polls `list_session_actions` looking for `syncInputJobAttachments` `progressPercent == 100` with a 120 s budget at line 1149. On Windows under canary load, sync of 2,500 files genuinely takes longer than 120 s — build #4647's log showed ~50 consecutive `Backing off check_percentage(...)` retries with progress stuck below 100 right up to the timeout. The test never reached the hash assertion at line 1185+. The 120 s budget was set when the test had ~250 files and was never revisited when the count was bumped to 2,500. Linux runs of the same test pass consistently because per-file overhead is lower (no NTFS metadata / AV exclusion costs).

### What was the solution? (How)

Bump `max_time=120` to `max_time=240` in the `@backoff.on_predicate` decorator on `check_percentage`:

```python
@backoff.on_predicate(
    wait_gen=backoff.constant,
    max_time=240,   # was 120
    interval=2,
)
def check_percentage(complete_percentage) -> bool:
    ...
```

One-character class diff. No production code change.

### What is the impact of this change?

* Customer impact: none — this is e2e test infrastructure.
* Test runtime: unchanged in the success case (the test exits the backoff loop as soon as `progressPercent == 100`). In the formerly-flaky case, runtime grows by up to 120 s. Total test still well under the CodeBuild 2-h cap (build #4647 ran for 1h 45m end-to-end and the canary still had headroom).
* Reliability: eliminates the observed Windows timeout failure mode. Canary cycle on `release-windows-canary` should see this test pass instead of flake.

### How was this change tested?

* The change is a single literal `max_time` value bump in an `@backoff.on_predicate` decorator. There is no unit test exercising this decorator's argument, and the e2e test itself is the only consumer.
* I will validate the fix the same way the failure was observed: via `release-windows-canary` runs over the next 14 days. Expect 0 occurrences of "Expected `syncInputJobAttachments` progressPercent != 100 after 120 s".

### Was this change documented?

No — this is an internal canary test budget. The reasoning is in the commit message and PR description so future maintainers can understand the bump.

### Is this a breaking change?

No.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
