### PR TITLE
test: test_config_file_user_override checks before and after stopping …

### DIFF
--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -15,7 +15,7 @@ from flaky import flaky
 import logging
 
 from e2e.conftest import DeadlineResources
-from e2e.utils import windows_replace_and_verify
+from e2e.utils import is_worker_started, is_worker_stopped, windows_replace_and_verify
 from deadline_test_fixtures import (
     Job,
     Farm,
@@ -126,23 +126,24 @@ class TestWindowsJobUserOverride:
         class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
     ) -> None:
+        # Wait for worker to reach STARTED/IDLE via Deadline API before stopping.
+        # After tests 1/2, the worker needs time to finish session cleanup and
+        # return to an idle state. Polling the API is deterministic and avoids
+        # the race condition of stopping mid-transition.
+        assert is_worker_started(
+            deadline_client=deadline_client,
+            farm_id=deadline_resources.farm.id,
+            fleet_id=deadline_resources.fleet.id,
+            worker_id=class_worker.worker_id,
+        ), f"Worker {class_worker.worker_id} did not reach STARTED/IDLE before stop within 180s"
+
         class_worker.stop_worker_service()
-
-        @backoff.on_exception(
-            backoff.constant,
-            Exception,
-            max_time=45,
-            interval=5,
-        )
-        def check_worker_process_stopped() -> None:
-            cmd_result = class_worker.send_command(
-                "IF(Get-Process pythonservice -ErrorAction SilentlyContinue)"
-                '{throw "Agent process still running"}'
-                "ELSE{echo 'Agent process stopped'}"
-            )
-            assert cmd_result.exit_code == 0
-
-        check_worker_process_stopped()
+        assert is_worker_stopped(
+            deadline_client=deadline_client,
+            farm_id=deadline_resources.farm.id,
+            fleet_id=deadline_resources.fleet.id,
+            worker_id=class_worker.worker_id,
+        ), f"Worker {class_worker.worker_id} did not transition to STOPPED within 180s"
 
         windows_replace_and_verify(
             worker=class_worker,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`test_config_file_user_override` on Windows was flaky because it called `stop_worker_service()` immediately after the previous test completed a job, without waiting for the worker to finish its internal session cleanup. The previous test's `job.wait_until_complete()` only confirms the job is done — not that the worker has transitioned back to an idle state. 

### What was the solution? (How)

Added an `is_worker_started()` API poll before calling `stop_worker_service()`. This waits for the worker to reach `STARTED` or `IDLE` status via the Deadline API, ensuring it has fully completed post-job cleanup before we initiate a stop. Replaced the previous brittle approach of polling Windows process state via SSM.F rom gathered test data, the status of the first two tests running before this test in the class have leftover items for the worker; some delay before triggering stop and then checking AFTER the stop is complete before writing to the `worker.toml` made sure that this flakiness is reduced significantly

### What is the impact of this change?

Reduces flakiness in `test_config_file_user_override` by making the pre-stop wait deterministic. No behavioral change to production code.

### How was this change tested?

Ran the whole `TestWindowsJobUserOverride` test class with 20 consecutive passing runs that confirmed the worker always reaches `STARTED` status before stop when given sufficient time. The `is_worker_started` utility is already used and proven in other e2e tests. Then did another pass with 30 more consecutive test runs for additional verification.


```
===Flaky Test Report===

test_config_file_user_override passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
============================= slowest 5 durations ==============================
374.70s setup    test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_no_user_override
74.91s call     test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_installer_user_override
62.98s call     test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_config_file_user_override
42.23s call     test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_env_var_user_override
20.84s call     test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_no_jobs_run_as_windows_worker_agent
=========== 5 passed, 59 deselected, 1 warning in 594.76s (0:09:54) ============
..
========== SUMMARY ==========
PASS on run 1
PASS on run 2
PASS on run 3
PASS on run 4
PASS on run 5
PASS on run 6
PASS on run 7
PASS on run 8
PASS on run 9
PASS on run 10
PASS on run 11
PASS on run 12
PASS on run 13
PASS on run 14
PASS on run 15
PASS on run 16
PASS on run 17
PASS on run 18
PASS on run 19
PASS on run 20
PASS on run 21
PASS on run 22
PASS on run 23
PASS on run 24
PASS on run 25
PASS on run 26
PASS on run 27
PASS on run 28
PASS on run 29
PASS on run 30
```

### Was this change documented?

No documentation changes needed — test-only change.

### Is this a breaking change?

No.