### PR TITLE
test: cherry pick flaky fix

### DIFF
--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -10,6 +10,7 @@ import boto3
 import botocore
 import pytest
 import os
+from flaky import flaky
 
 import logging
 
@@ -118,6 +119,7 @@ class TestWindowsJobUserOverride:
             "Job should not run as the Windows Worker Agent user."
         )
 
+    @flaky(max_runs=3, min_passes=1)
     def test_config_file_user_override(
         self,
         deadline_resources,

--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -15,7 +15,7 @@ from flaky import flaky
 import logging
 
 from e2e.conftest import DeadlineResources
-from e2e.utils import windows_replace_and_verify
+from e2e.utils import is_worker_started, is_worker_stopped, windows_replace_and_verify
 from deadline_test_fixtures import (
     Job,
     Farm,
@@ -126,7 +126,24 @@ class TestWindowsJobUserOverride:
         class_worker: EC2InstanceWorker,
         deadline_client: DeadlineClient,
     ) -> None:
+        # Wait for worker to reach STARTED/IDLE via Deadline API before stopping.
+        # After tests 1/2, the worker needs time to finish session cleanup and
+        # return to an idle state. Polling the API is deterministic and avoids
+        # the race condition of stopping mid-transition.
+        assert is_worker_started(
+            deadline_client=deadline_client,
+            farm_id=deadline_resources.farm.id,
+            fleet_id=deadline_resources.fleet.id,
+            worker_id=class_worker.worker_id,
+        ), f"Worker {class_worker.worker_id} did not reach STARTED/IDLE before stop within 180s"
+
         class_worker.stop_worker_service()
+        assert is_worker_stopped(
+            deadline_client=deadline_client,
+            farm_id=deadline_resources.farm.id,
+            fleet_id=deadline_resources.fleet.id,
+            worker_id=class_worker.worker_id,
+        ), f"Worker {class_worker.worker_id} did not transition to STOPPED within 180s"
 
         windows_replace_and_verify(
             worker=class_worker,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`test_config_file_user_override` in `TestWindowsJobUserOverride` is flaky (Bea-54257). The test calls `stop_worker_service()` immediately after the previous test's job completes, but the worker hasn't finished its internal session cleanup yet — hitting a race condition where the worker is still transitioning from RUNNING → STARTED/IDLE.

### What was the solution? (How)

Cherry-picked two fixes from mainline:
1. **#943** — Mark the test as `@flaky(max_runs=3, min_passes=1)` for immediate relief
2. **#948** — Replace the brittle process-based poll (`Get-Process pythonservice` via SSM) with Deadline API-based polling: `is_worker_started()` before stop (waits for STARTED/IDLE) and `is_worker_stopped()` after stop (confirms STOPPED)

### What is the impact of this change?

Reduces flaky test failures in the release branch CI. The API-based approach was validated with 40/40 passes in diagnostic runs.

### How was this change tested?

- Diagnostic branch ran 40/40 passes confirming the API polling pattern eliminates the race condition
- The fix was merged and tested via mainline CI (PR #943, #948) before cherry-picking to release

### Was this change documented?

No documentation changes needed — test-only change.

### Is this a breaking change?

No.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*