### PR TITLE
test: fix session role env for domain users

### DIFF
--- a/test/e2e/test_domain_user.py
+++ b/test/e2e/test_domain_user.py
@@ -225,7 +225,7 @@ class TestDomainUser:
         )
         secret_arn = queue_response["jobRunAsUser"]["windows"]["passwordArn"]
 
-        queue_role_arn = os.environ["SESSION_ROLE"]
+        queue_role_arn = os.environ["SESSION_ROLE_ARN"]
         job_attachments_bucket = os.environ["JOB_ATTACHMENTS_BUCKET"]
         response = deadline_client.create_queue(
             farmId=deadline_resources.farm.id,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

```
2026-05-29T17:18:14.260Z
	
=========================== short test summary info ============================
ERROR test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_queue_user[ddl]
ERROR test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_queue_user[upn]
============ 53 passed, 17 skipped, 2 errors in 7333.64s (2:02:13) ============= 
```

```
    @pytest.fixture(scope="class")
    def domain_job_queue(
        self,
        deadline_resources: DeadlineResources,
        domain_controller: EC2InstanceWorker,
        region: str,
    ) -> Generator[Queue, None, None]:
        """Create a queue configured to run jobs as the domain job user."""
        deadline_client = boto3.client("deadline", region_name=region)
    
        queue_response = deadline_client.get_queue(
            farmId=deadline_resources.farm.id, queueId=deadline_resources.queue_a.id
        )
        secret_arn = queue_response["jobRunAsUser"]["windows"]["passwordArn"]
    
>       queue_role_arn = os.environ["SESSION_ROLE"]
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### What was the solution? (How)

It's `SESSION_ROLE_ARN` not `SESSION_ROLE`

### What is the impact of this change?

Last two domain tests should pass

### How was this change tested?

`hatch run fmt && hatch run lint`. it gets tested pretty fast in CI.

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*