### PR TITLE
test: fix e2e linting

### DIFF
--- a/test/e2e/test_domain_user.py
+++ b/test/e2e/test_domain_user.py
@@ -378,6 +378,7 @@ class TestDomainUser:
         config_path = "C:\\ProgramData\\Amazon\\Deadline\\Config\\worker.toml"
 
         domain_controller.stop_worker_service()
+        assert domain_controller.worker_id is not None
         assert is_worker_stopped(
             deadline_client=deadline_client,
             farm_id=deadline_resources.farm.id,
@@ -416,6 +417,7 @@ class TestDomainUser:
         finally:
             # Always reset config regardless of test outcome
             domain_controller.stop_worker_service()
+            assert domain_controller.worker_id is not None
             assert is_worker_stopped(
                 deadline_client=deadline_client,
                 farm_id=deadline_resources.farm.id,

--- a/test/e2e/test_override_job_user.py
+++ b/test/e2e/test_override_job_user.py
@@ -130,6 +130,7 @@ class TestWindowsJobUserOverride:
         # After tests 1/2, the worker needs time to finish session cleanup and
         # return to an idle state. Polling the API is deterministic and avoids
         # the race condition of stopping mid-transition.
+        assert class_worker.worker_id is not None
         assert is_worker_started(
             deadline_client=deadline_client,
             farm_id=deadline_resources.farm.id,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1. `hatch run e2e:lint` was failing, which is currently only ran in pipeline/build.sh which only runs on publish

```
cmd [4] | mypy --config-file test/e2e/mypy.ini test/e2e
  test/e2e/test_override_job_user.py:137: error: Argument "worker_id" to "is_worker_started" has incompatible type "str | None"; expected "str"
  [arg-type]
                  worker_id=class_worker.worker_id,
                            ^~~~~~~~~~~~~~~~~~~~~~
  test/e2e/test_override_job_user.py:145: error: Argument "worker_id" to "is_worker_stopped" has incompatible type "str | None"; expected "str"
  [arg-type]
                  worker_id=class_worker.worker_id,
                            ^~~~~~~~~~~~~~~~~~~~~~
  test/e2e/test_domain_user.py:385: error: Argument "worker_id" to "is_worker_stopped" has incompatible type "str | None"; expected "str"  [arg-type]
                  worker_id=domain_controller.worker_id,
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  test/e2e/test_domain_user.py:423: error: Argument "worker_id" to "is_worker_stopped" has incompatible type "str | None"; expected "str"  [arg-type]
                      worker_id=domain_controller.worker_id,
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  Found 4 errors in 2 files (checked 14 source files)
```

### What was the solution? (How)

1. fix linting

I'll add a github workflow change shortly to enforce the linting passes way before

### What is the impact of this change?

everything works

### How was this change tested?

```
hatch run e2e:lint
```

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*