### PR TITLE
test(e2e): capture bootstrap log on worker start failure

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -371,6 +371,23 @@ def function_worker_factory(
         stop_worker(request, worker)
 
 
+def _grab_bootstrap_log(worker: DeadlineWorker) -> None:
+    """Best-effort grab of the worker bootstrap log after a start failure."""
+    if not isinstance(worker, EC2InstanceWorker):
+        return
+    try:
+        if hasattr(worker, "WIN2022_AMI_NAME"):
+            log_path = r"C:\ProgramData\Amazon\Deadline\Logs\worker-agent-bootstrap.log"
+            cmd = f'Get-Content "{log_path}" -Tail 100'
+        else:
+            log_path = "/var/log/amazon/deadline/worker-agent-bootstrap.log"
+            cmd = f"tail -n 100 {log_path}"
+        result = worker.send_command(cmd, {"Delay": 5, "MaxAttempts": 6})
+        LOG.error(f"--- Bootstrap log ({log_path}) ---\n{result.stdout}")
+    except Exception as log_err:
+        LOG.warning(f"Could not retrieve bootstrap log: {log_err}")
+
+
 def create_worker(
     worker_config: DeadlineWorkerConfiguration,
     ec2_worker_type: Type[EC2InstanceWorker],
@@ -453,6 +470,7 @@ def create_worker(
             worker.start()
         except Exception as e:
             LOG.error(f"Failed to start worker: {e}")
+            _grab_bootstrap_log(worker)
             LOG.info("Stopping worker because it failed to start")
             stop_worker(request, worker)
             raise


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When the Windows e2e canary fails during worker setup (e.g. SSM configure timeout or Start-Service hang), we have no visibility into what happened on the instance. The worker-agent-bootstrap.log contains the service startup sequence but the instance is terminated during teardown before anyone can inspect it. This makes diagnosing canary flakiness significantly harder — we've been seeing a 67% failure rate with no on-instance diagnostics.

### What was the solution? (How)

Added a `_grab_bootstrap_log()` helper in the e2e conftest that is called in the existing `_context_for_fixture` exception handler, between detecting the failure and tearing down the instance. It sends a best-effort SSM command to retrieve the last 100 lines of `worker-agent-bootstrap.log` (handles both Windows and Linux paths). The result is logged at ERROR level so it appears in CodeBuild output. The entire call is wrapped in try/except so it never masks the original failure — if the instance is unreachable (e.g. SSM Undeliverable), it logs a warning and continues with normal teardown.

### What is the impact of this change?

On worker start failure, the bootstrap log will now appear in test output, providing immediate visibility into whether the worker agent started, registered with the Deadline API, or failed during initialization. No impact on passing tests — the code only executes in the failure path.

### How was this change tested?

- `hatch run lint` passes (ruff check + ruff format + mypy)
- Manual e2e test run to confirm the conftest loads and worker creation still works on the happy path
- The failure path will be validated naturally by the next canary failure (currently 67% failure rate)

### Was this change documented?

No documentation changes needed — this is internal test infrastructure.

### Is this a breaking change?

No.