### PR TITLE
test: retry stop_worker on ConflictException during e2e teardown

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -12,9 +12,11 @@ from contextlib import contextmanager
 from dataclasses import InitVar, dataclass, field
 from typing import Callable, Type
 
+import backoff
 import boto3
 import pytest
 from botocore.client import BaseClient
+from botocore.exceptions import ClientError
 from deadline.client.api import (
     get_boto3_client,
     get_queue_user_boto3_session,
@@ -485,8 +487,18 @@ def stop_worker(request: pytest.FixtureRequest, worker: DeadlineWorker) -> None:
             LOG.info("KEEP_WORKER_AFTER_FAILURE is set, not stopping worker")
             return
 
-    try:
+    @backoff.on_exception(
+        backoff.constant,
+        ClientError,
+        max_tries=5,
+        interval=30,
+        giveup=lambda e: e.response["Error"]["Code"] != "ConflictException",
+    )
+    def _stop_with_retry() -> None:
         worker.stop()
+
+    try:
+        _stop_with_retry()
     except Exception as e:
         LOG.exception(f"Error while stopping worker: {e}")
         LOG.error(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

During e2e test teardown, `stop_worker` calls `UpdateWorker(status=STOPPED)`. If the farm scheduler is performing a concurrent update, the API returns `ConflictException` with the message "The farm is currently being updated. Please try again in one minute." This causes the test to report ERROR even though the test itself passed — a purely teardown flakiness issue.

### What was the solution? (How)

Added a `backoff` retry (constant 30s interval, max 5 attempts) around `worker.stop()` in the `stop_worker` fixture. The retry only triggers on `ConflictException` — any other `ClientError` fails immediately via the `giveup` lambda.

### What is the impact of this change?

Eliminates spurious ERROR results caused by transient ConflictException during worker teardown. No impact on test logic — only affects the cleanup path.

### How was this change tested?

- `hatch run lint` passes (ruff check + ruff format + mypy)
- Local smoke test confirming retry logic retries on ConflictException and fails fast on other errors
- ran one E2E test to make sure tests still run

```
====================================================== slowest 5 durations ======================================================
178.57s setup    test/e2e/test_worker_status.py::TestWorkerStatus::test_worker_lifecycle_status_is_expected
5.47s call     test/e2e/test_worker_status.py::TestWorkerStatus::test_worker_lifecycle_status_is_expected
2.17s teardown test/e2e/test_worker_status.py::TestWorkerStatus::test_worker_lifecycle_status_is_expected
========================================= 1 passed, 71 deselected in 186.30s (0:03:06) ==========================================
cmd [4] | echo pytest done
pytest done
```

### Was this change documented?

No documentation changes needed — internal test infrastructure.

### Is this a breaking change?

No.