### PR TITLE
test(e2e): get more information on failed worker start

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -380,12 +380,24 @@ def _grab_bootstrap_log(worker: DeadlineWorker) -> None:
     try:
         if hasattr(worker, "WIN2022_AMI_NAME"):
             log_path = r"C:\ProgramData\Amazon\Deadline\Logs\worker-agent-bootstrap.log"
-            cmd = f'Get-Content "{log_path}" -Tail 100'
+            toml_path = r"C:\ProgramData\Amazon\Deadline\Config\worker.toml"
+            cmd = (
+                f'Get-Content "{log_path}" -Tail 100 -ErrorAction SilentlyContinue; '
+                f'echo "--- worker.toml ---"; '
+                f'Get-Content "{toml_path}" -ErrorAction SilentlyContinue; '
+                f'echo "--- toml validation ---"; '
+                f"python -c \"import tomllib,sys; tomllib.load(open(sys.argv[1],'rb')); print('valid')\" \"{toml_path}\" 2>&1; "
+                f'echo "--- worker agent process ---"; '
+                f"Get-Process pythonservice -ErrorAction SilentlyContinue; "
+                f"Get-Service DeadlineWorker -ErrorAction SilentlyContinue"
+            )
         else:
             log_path = "/var/log/amazon/deadline/worker-agent-bootstrap.log"
             cmd = f"tail -n 100 {log_path}"
         result = worker.send_command(cmd, {"Delay": 5, "MaxAttempts": 6})
         LOG.error(f"--- Bootstrap log ({log_path}) ---\n{result.stdout}")
+        if result.stderr:
+            LOG.error(f"--- Debug command stderr ---\n{result.stderr}")
     except Exception as log_err:
         LOG.warning(f"Could not retrieve bootstrap log: {log_err}")
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Windows worker agent e2e tests are failing intermittently during startup. The SSM command to configure the worker agent is sent immediately after the userdata check succeeds, but occasionally hits an SSM delivery gap where the command is reported as `InProgress` but never actually executes on the instance. The waiter times out after 4 minutes, the command returns `exit_code: -1` with empty stdout/stderr, and the associated tests for that worker fail.

  ### What was the solution? (How)

Enhanced the `_grab_bootstrap_log` debug helper for Windows to also capture:
     - The worker.toml file contents
     - A Python-based toml validity check
     - Whether the `pythonservice` process is running
     - The `DeadlineWorker` service status
     - stderr output from the debug command

  ### What is the impact of this change?

Improves debuggability of future startup failures by providing more context in the test logs.

  ### How was this change tested?

  - Verified a successful configure command completes in ~1m35s, well within the 4-minute timeout
  - Launched a Windows Server 2022 instance and validated the debug SSM command works end-to-end via SSM

  ### Was this change documented?

N/A

  ### Is this a breaking change?

N/A

  ----

  *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*