### PR TITLE
test(e2e): remove job-attachments private api usage

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -22,7 +22,7 @@ from deadline.client.api import (
     get_queue_user_boto3_session,
 )
 from deadline.client.config import set_setting as set_deadline_setting
-from deadline.job_attachments._aws.aws_clients import get_s3_client, get_s3_transfer_manager
+from deadline.job_attachments.download import get_s3_client, get_s3_transfer_manager
 from deadline_test_fixtures import (
     BootstrapResources,
     DeadlineWorker,

--- a/test/e2e/s3_validation_utils.py
+++ b/test/e2e/s3_validation_utils.py
@@ -8,17 +8,26 @@ import json
 import logging
 from typing import Dict, List, Optional, Tuple
 
+import re
+from collections import defaultdict
+
 import boto3
 from botocore.exceptions import ClientError
 
-from deadline.job_attachments._aws.deadline import get_job, get_queue
 from deadline.job_attachments.asset_manifests.hash_algorithms import hash_data
 from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import DEFAULT_HASH_ALG
-from deadline.job_attachments.download import _get_tasks_manifests_keys_from_s3
-from deadline.job_attachments._aws.aws_clients import get_s3_client
+from deadline.job_attachments.download import get_s3_client
+from deadline.job_attachments.models import (
+    Attachments,
+    JobAttachmentsFileSystem,
+    ManifestProperties,
+    PathFormat,
+)
 
 from deadline_test_fixtures import DeadlineClient, Job
 from datetime import datetime
+
+from e2e.utils import _get_queue_attachment_settings
 
 LOG = logging.getLogger(__name__)
 
@@ -27,6 +36,85 @@ class S3ValidationError(Exception):
     """Exception raised when S3 validation fails."""
 
     pass
+
+
+def _get_job_details(
+    deadline_client: DeadlineClient, farm_id: str, queue_id: str, job_id: str
+) -> "_JobDetails":
+    """Get job attachment details from the Deadline API."""
+    response = deadline_client.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    attachments = None
+    if response.get("attachments"):
+        attachments = Attachments(
+            manifests=[
+                ManifestProperties(
+                    fileSystemLocationName=m.get("fileSystemLocationName"),
+                    rootPath=m["rootPath"],
+                    rootPathFormat=PathFormat(m["rootPathFormat"]),
+                    outputRelativeDirectories=m.get("outputRelativeDirectories"),
+                    inputManifestPath=m.get("inputManifestPath"),
+                )
+                for m in response["attachments"]["manifests"]
+            ],
+            fileSystem=JobAttachmentsFileSystem(
+                response["attachments"].get("fileSystem", JobAttachmentsFileSystem.COPIED.value)
+            ),
+        )
+    return _JobDetails(attachments=attachments)
+
+
+class _JobDetails:
+    def __init__(self, attachments: Optional[Attachments]):
+        self.attachments = attachments
+
+
+def _get_task_manifest_keys_from_s3(
+    manifest_prefix: str,
+    s3_bucket: str,
+    session: Optional[boto3.Session] = None,
+) -> List[str]:
+    """List S3 manifest keys under a prefix, selecting the latest per task."""
+    s3_client = get_s3_client(session=session) if session else get_s3_client()
+    all_contents: List[Dict] = []
+    continuation_token = None
+
+    while True:
+        kwargs: Dict = {"Bucket": s3_bucket, "Prefix": manifest_prefix}
+        if continuation_token:
+            kwargs["ContinuationToken"] = continuation_token
+        response = s3_client.list_objects_v2(**kwargs)
+        all_contents.extend(response.get("Contents", []))
+        if not response.get("IsTruncated"):
+            break
+        continuation_token = response.get("NextContinuationToken")
+
+    manifests_keys: List[str] = []
+    task_prefixes: Dict[str, List[str]] = defaultdict(list)
+    step_pattern = re.compile(r"step-.*/.*/.*output.*")
+
+    for content in all_contents:
+        key = content["Key"]
+        if step_pattern.search(key):
+            if "task-" in key:
+                parts = key.split("/")
+                for i, part in enumerate(parts):
+                    if "task-" in part:
+                        task_folder = "/".join(parts[: i + 1])
+                        task_prefixes[task_folder].append(key)
+                        break
+            else:
+                # Chunked step manifests (no task ID) — include all unconditionally
+                manifests_keys.append(key)
+
+    # Select latest per task (by alphabetical sort of subfolder name)
+    for task_folder, files in task_prefixes.items():
+        last_subfolder = sorted(
+            set(f.split("/")[len(task_folder.split("/"))] for f in files),
+            reverse=True,
+        )[0]
+        manifests_keys += [f for f in files if f.startswith(f"{task_folder}/{last_subfolder}/")]
+
+    return manifests_keys
 
 
 def validate_s3_job_output_manifest(
@@ -55,20 +143,24 @@ def validate_s3_job_output_manifest(
     farm_id = job.farm.id
     queue_id = job.queue.id
     # Get job and queue details
-    job_details = get_job(farm_id=farm_id, queue_id=queue_id, job_id=job.id, session=session)
-    queue_details = get_queue(farm_id=farm_id, queue_id=queue_id, session=session)
+    job_details = _get_job_details(
+        deadline_client=deadline_client, farm_id=farm_id, queue_id=queue_id, job_id=job.id
+    )
+    queue_settings = _get_queue_attachment_settings(
+        deadline_client=deadline_client, farm_id=farm_id, queue_id=queue_id
+    )
 
     assert job_details.attachments, f"Job {job.id} has no attachments"
     assert job_details.attachments.manifests, f"Job {job.id} has no manifests"
 
     LOG.debug(f"Job {job.id} has {len(job_details.attachments.manifests)} manifest(s)")
 
-    assert queue_details.jobAttachmentSettings, f"Queue {queue_id} has no job attachment settings"
+    assert queue_settings, f"Queue {queue_id} has no job attachment settings"
     LOG.debug(f"Queue {queue_id} has job attachment settings configured")
 
     # Extract S3 configuration
-    s3_bucket = queue_details.jobAttachmentSettings.s3BucketName
-    root_prefix = queue_details.jobAttachmentSettings.rootPrefix
+    s3_bucket = queue_settings.s3BucketName
+    root_prefix = queue_settings.rootPrefix
 
     for manifest_properties in job_details.attachments.manifests:
         root_path = manifest_properties.rootPath
@@ -82,7 +174,7 @@ def validate_s3_job_output_manifest(
             manifest_prefix = f"{root_prefix}/Manifests/{farm_id}/{queue_id}/{job.id}/{step_id}"
 
             try:
-                manifest_keys = _get_tasks_manifests_keys_from_s3(
+                manifest_keys = _get_task_manifest_keys_from_s3(
                     manifest_prefix=manifest_prefix, s3_bucket=s3_bucket, session=session
                 )
 

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -11,8 +11,9 @@ from glob import glob
 from typing import Any, Dict, Optional, List
 from pathlib import Path
 from configparser import ConfigParser
-from deadline.job_attachments._aws.deadline import get_queue
 from deadline.job_attachments import download
+from deadline.job_attachments.download import get_s3_client
+from deadline.job_attachments.models import JobAttachmentS3Settings
 from deadline_test_fixtures import (
     DeadlineClient,
     EC2InstanceWorker,
@@ -23,9 +24,22 @@ from deadline_test_fixtures import (
 from deadline.client.api import create_job_from_job_bundle  # type: ignore
 import backoff
 from e2e.conftest import DeadlineResources
-from deadline.job_attachments._aws.aws_clients import get_s3_client
 
 LOG = logging.getLogger(__name__)
+
+
+def _get_queue_attachment_settings(
+    deadline_client: DeadlineClient, farm_id: str, queue_id: str
+) -> Optional[JobAttachmentS3Settings]:
+    """Get job attachment settings from a queue using the Deadline API directly."""
+    response = deadline_client.get_queue(farmId=farm_id, queueId=queue_id)
+    settings = response.get("jobAttachmentSettings")
+    if settings and settings.get("s3BucketName"):
+        return JobAttachmentS3Settings(
+            s3BucketName=settings["s3BucketName"],
+            rootPrefix=settings["rootPrefix"],
+        )
+    return None
 
 
 def wait_for_job_output(
@@ -36,10 +50,11 @@ def wait_for_job_output(
 ) -> dict[str, list[str]]:
     job.wait_until_complete(client=deadline_client, max_retries=20)
 
-    job_attachment_settings = get_queue(
+    job_attachment_settings = _get_queue_attachment_settings(
+        deadline_client=deadline_client,
         farm_id=deadline_resources.farm.id,
         queue_id=deadline_resources.queue_a.id,
-    ).jobAttachmentSettings
+    )
 
     assert job_attachment_settings is not None
 
@@ -417,13 +432,17 @@ def submit_job_from_create_job_API(
     debug_snapshot_dir = os.path.normpath(debug_snapshot_dir)
     LOG.info(f"Submitting bundle {debug_snapshot_dir} to farm {farm.id} and queue {queue.id}")
 
-    queue_details = get_queue(farm_id=farm.id, queue_id=queue.id)
+    job_attachment_settings = _get_queue_attachment_settings(
+        deadline_client=deadline_client,
+        farm_id=farm.id,
+        queue_id=queue.id,
+    )
 
-    if not queue_details.jobAttachmentSettings:
+    if not job_attachment_settings:
         raise ValueError("Queue does not have job attachment settings configured")
 
-    s3_bucket = queue_details.jobAttachmentSettings.s3BucketName
-    rootPrefix = queue_details.jobAttachmentSettings.rootPrefix
+    s3_bucket = job_attachment_settings.s3BucketName
+    rootPrefix = job_attachment_settings.rootPrefix
 
     s3_client = get_s3_client()
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We were accessing private APIs, making our job attachments usage in e2e more fragile than it needs to be

### What was the solution? (How)

Remove the private api usage and use the public api

### What is the impact of this change?

More reliable upgrades, can pin looser once we don't use private apis in the source code.

### How was this change tested?

```
hatch run fmt && hatch run e2e:lint
```

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*