### PR TITLE
feat: add SessionRuntime ABC and factory

### DIFF
--- a/src/deadline_worker_agent/sessions/__init__.py
+++ b/src/deadline_worker_agent/sessions/__init__.py
@@ -1,9 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from .job_entities.job_entities import JobEntities
+from .runtime import RuntimeKind
 from .session import Session
 
 __all__ = [
     "JobEntities",
+    "RuntimeKind",
     "Session",
 ]

--- a/src/deadline_worker_agent/sessions/runtime/__init__.py
+++ b/src/deadline_worker_agent/sessions/runtime/__init__.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from ._abc import SessionRuntime
+from ._config import ActionCallback, SessionRuntimeConfig
+from ._factory import create_session_runtime
+from ._kind import RuntimeKind
+
+__all__ = [
+    "ActionCallback",
+    "RuntimeKind",
+    "SessionRuntime",
+    "SessionRuntimeConfig",
+    "create_session_runtime",
+]

--- a/src/deadline_worker_agent/sessions/runtime/_abc.py
+++ b/src/deadline_worker_agent/sessions/runtime/_abc.py
@@ -1,0 +1,96 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from openjd.sessions import (
+        ActionStatus,
+        EnvironmentIdentifier,
+        EnvironmentModel,
+        StepScriptModel,
+    )
+
+
+class SessionRuntime(ABC):
+    """Abstract surface every session backend implements.
+
+    Mirrors ``openjd.sessions.Session``'s public surface 1:1.
+    """
+
+    @abstractmethod
+    def enter_environment(
+        self,
+        *,
+        environment: EnvironmentModel,
+        identifier: Optional[EnvironmentIdentifier] = None,
+        os_env_vars: Optional[dict[str, str]] = None,
+    ) -> EnvironmentIdentifier:
+        """Enter an environment; returns its identifier."""
+        ...
+
+    @abstractmethod
+    def exit_environment(
+        self,
+        *,
+        identifier: EnvironmentIdentifier,
+        os_env_vars: Optional[dict[str, str]] = None,
+        keep_session_running: bool = False,
+    ) -> None:
+        """Exit a previously entered environment."""
+        ...
+
+    @abstractmethod
+    def run_task(
+        self,
+        *,
+        step_script: StepScriptModel,
+        task_parameter_values: dict[str, Any],
+        os_env_vars: Optional[dict[str, str]] = None,
+        log_task_banner: bool = True,
+    ) -> None:
+        """Run a task within the session's active environment(s)."""
+        ...
+
+    @abstractmethod
+    def _run_task_without_session_env(
+        self,
+        *,
+        step_script: StepScriptModel,
+        task_parameter_values: dict[str, Any],
+        os_env_vars: Optional[dict[str, str]] = None,
+        log_task_banner: bool = True,
+    ) -> None:
+        """Run a task without entering a session environment (attachment-sync path)."""
+        ...
+
+    @abstractmethod
+    def cancel_action(
+        self,
+        *,
+        time_limit: Optional[timedelta] = None,
+        mark_action_failed: bool = False,
+    ) -> None:
+        """Cancel the currently running action (env enter/exit, run_task, etc.)."""
+        ...
+
+    @abstractmethod
+    def cleanup(self) -> None:
+        """Tear down the runtime and release any external resources."""
+        ...
+
+    @property
+    @abstractmethod
+    def working_directory(self) -> Path:
+        """The session's working directory on disk."""
+        ...
+
+    @property
+    @abstractmethod
+    def action_status(self) -> Optional[ActionStatus]:
+        """Status of the most recent action; ``None`` if no action has run yet."""
+        ...

--- a/src/deadline_worker_agent/sessions/runtime/_config.py
+++ b/src/deadline_worker_agent/sessions/runtime/_config.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+if TYPE_CHECKING:
+    from openjd.sessions import (
+        ActionStatus,
+        PathMappingRule,
+        SessionUser,
+    )
+
+# Matches openjd.sessions.SessionCallbackType: Callable[[session_id, ActionStatus], None]
+ActionCallback = Callable[[str, "ActionStatus"], None]
+
+
+@dataclass(frozen=True)
+class SessionRuntimeConfig:
+    """Construction arguments for a SessionRuntime.
+
+    Mirrors ``openjd.sessions.Session``'s constructor surface but expressed in
+    primitives that any backend (Python, Rust) can translate at its boundary.
+    ``spec_revision`` and ``supported_extensions`` carry OpenJD revision info
+    that each adapter converts into its native types.
+    """
+
+    session_id: str
+    job_parameter_values: dict[str, Any]
+    path_mapping_rules: Optional[list[PathMappingRule]]
+    retain_working_dir: bool
+    user: Optional[SessionUser]
+    action_callback: ActionCallback
+    os_env_vars: Optional[dict[str, str]]
+    session_root_directory: Path
+    spec_revision: str = "2023-09"
+    supported_extensions: tuple[str, ...] = ()

--- a/src/deadline_worker_agent/sessions/runtime/_factory.py
+++ b/src/deadline_worker_agent/sessions/runtime/_factory.py
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from ._abc import SessionRuntime
+from ._config import SessionRuntimeConfig
+from ._kind import RuntimeKind
+
+
+def create_session_runtime(kind: RuntimeKind, config: SessionRuntimeConfig) -> SessionRuntime:
+    """Construct a SessionRuntime for the given kind.
+
+    Adapter modules are imported lazily so callers that never request a
+    particular adapter don't pay the cost (or risk the failure) of importing it.
+
+    Raises:
+        ValueError: ``kind`` is not a recognised RuntimeKind.
+        NotImplementedError: the adapter module for ``kind`` cannot be imported
+            (e.g. the Rust binding is unavailable on this platform).
+    """
+    if kind is RuntimeKind.SERVICE_SELECTED:
+        raise ValueError(
+            "SERVICE_SELECTED must be resolved to PYTHON or RUST via "
+            "select_runtime() before calling create_session_runtime()"
+        )
+
+    if kind is RuntimeKind.PYTHON:
+        try:
+            from .python import PythonSessionRuntime  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise NotImplementedError(
+                f"PythonSessionRuntime adapter is not available: {exc}"
+            ) from exc
+        return PythonSessionRuntime(config)
+
+    if kind is RuntimeKind.RUST:
+        try:
+            from .rust import RustSessionRuntime  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise NotImplementedError(
+                f"RustSessionRuntime adapter is not available: {exc}"
+            ) from exc
+        return RustSessionRuntime(config)
+
+    # Defensive: new variants without a branch should fail loudly.
+    raise ValueError(f"Unhandled RuntimeKind: {kind!r}")

--- a/src/deadline_worker_agent/sessions/runtime/_kind.py
+++ b/src/deadline_worker_agent/sessions/runtime/_kind.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RuntimeKind(str, Enum):
+    """Identifies a SessionRuntime implementation.
+
+    The string values are user-facing (CLI flags, config files) and must
+    remain stable. Subclassing ``str`` lets these values flow through
+    config layers without manual conversion.
+    """
+
+    PYTHON = "python"
+    RUST = "rust"
+    SERVICE_SELECTED = "service-selected"

--- a/test/unit/sessions/runtime/conftest.py
+++ b/test/unit/sessions/runtime/conftest.py
@@ -1,0 +1,99 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+from deadline_worker_agent.sessions.runtime import SessionRuntime, SessionRuntimeConfig
+
+
+@pytest.fixture()
+def runtime_config() -> SessionRuntimeConfig:
+    """Minimal valid SessionRuntimeConfig for testing."""
+    return SessionRuntimeConfig(
+        session_id="session-1",
+        job_parameter_values={},
+        path_mapping_rules=None,
+        retain_working_dir=False,
+        user=None,
+        action_callback=lambda session_id, status: None,
+        os_env_vars=None,
+        session_root_directory=Path("/tmp/sessions/session-1"),
+    )
+
+
+def _make_stub_runtime_class() -> type[SessionRuntime]:
+    """Return a concrete SessionRuntime subclass with all abstracts stubbed."""
+
+    class _StubRuntime(SessionRuntime):
+        def __init__(self, config: SessionRuntimeConfig) -> None:
+            self._config = config
+
+        def enter_environment(
+            self,
+            *,
+            environment: Any = None,
+            identifier: Any = None,
+            os_env_vars: Optional[dict[str, str]] = None,
+        ) -> str:
+            return "env-id"
+
+        def exit_environment(
+            self,
+            *,
+            identifier: Any = None,
+            os_env_vars: Optional[dict[str, str]] = None,
+            keep_session_running: bool = False,
+        ) -> None:
+            return None
+
+        def run_task(
+            self,
+            *,
+            step_script: Any = None,
+            task_parameter_values: dict[str, Any] | None = None,
+            os_env_vars: Optional[dict[str, str]] = None,
+            log_task_banner: bool = True,
+        ) -> None:
+            return None
+
+        def _run_task_without_session_env(
+            self,
+            *,
+            step_script: Any = None,
+            task_parameter_values: dict[str, Any] | None = None,
+            os_env_vars: Optional[dict[str, str]] = None,
+            log_task_banner: bool = True,
+        ) -> None:
+            return None
+
+        def cancel_action(
+            self,
+            *,
+            time_limit: Optional[timedelta] = None,
+            mark_action_failed: bool = False,
+        ) -> None:
+            return None
+
+        def cleanup(self) -> None:
+            return None
+
+        @property
+        def working_directory(self) -> Path:
+            return Path("/tmp")
+
+        @property
+        def action_status(self) -> None:
+            return None
+
+    return _StubRuntime
+
+
+@pytest.fixture()
+def stub_runtime_cls() -> type[SessionRuntime]:
+    """A complete SessionRuntime subclass for testing."""
+    return _make_stub_runtime_class()

--- a/test/unit/sessions/runtime/test_abc.py
+++ b/test/unit/sessions/runtime/test_abc.py
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from deadline_worker_agent.sessions.runtime import SessionRuntime, SessionRuntimeConfig
+
+
+class TestSessionRuntimeABC:
+    def test_session_runtime_is_abstract(self) -> None:
+        with pytest.raises(TypeError, match="abstract"):
+            SessionRuntime()  # type: ignore[abstract]
+
+    @pytest.mark.parametrize(
+        "missing_method",
+        [
+            "enter_environment",
+            "exit_environment",
+            "run_task",
+            "_run_task_without_session_env",
+            "cancel_action",
+            "cleanup",
+            "working_directory",
+            "action_status",
+        ],
+    )
+    def test_session_runtime_subclass_must_implement_all_methods(
+        self, missing_method: str, stub_runtime_cls: type[SessionRuntime]
+    ) -> None:
+        """A subclass missing any single abstract cannot be instantiated."""
+        namespace: dict[str, Any] = {
+            k: v
+            for k, v in stub_runtime_cls.__dict__.items()
+            if k != missing_method and not k.startswith("__")
+        }
+        incomplete_cls = type("Incomplete", (SessionRuntime,), namespace)
+
+        with pytest.raises(TypeError, match="abstract"):
+            incomplete_cls()  # type: ignore[abstract]
+
+    def test_session_runtime_complete_subclass_can_be_instantiated(
+        self,
+        runtime_config: SessionRuntimeConfig,
+        stub_runtime_cls: type[SessionRuntime],
+    ) -> None:
+        instance = stub_runtime_cls(runtime_config)  # type: ignore[call-arg]
+        assert isinstance(instance, SessionRuntime)

--- a/test/unit/sessions/runtime/test_factory.py
+++ b/test/unit/sessions/runtime/test_factory.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from deadline_worker_agent.sessions.runtime import (
+    RuntimeKind,
+    SessionRuntime,
+    SessionRuntimeConfig,
+    create_session_runtime,
+)
+
+
+class TestCreateSessionRuntime:
+    def test_service_selected_raises_value_error(
+        self, runtime_config: SessionRuntimeConfig
+    ) -> None:
+        with pytest.raises(ValueError, match="SERVICE_SELECTED must be resolved"):
+            create_session_runtime(RuntimeKind.SERVICE_SELECTED, runtime_config)
+
+    def test_python_not_implemented_when_module_missing(
+        self, runtime_config: SessionRuntimeConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, "deadline_worker_agent.sessions.runtime.python", None)
+        with pytest.raises(NotImplementedError, match="PythonSessionRuntime"):
+            create_session_runtime(RuntimeKind.PYTHON, runtime_config)
+
+    def test_rust_not_implemented_when_module_missing(
+        self, runtime_config: SessionRuntimeConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, "deadline_worker_agent.sessions.runtime.rust", None)
+        with pytest.raises(NotImplementedError, match="RustSessionRuntime"):
+            create_session_runtime(RuntimeKind.RUST, runtime_config)
+
+    def test_python_returns_adapter(
+        self,
+        runtime_config: SessionRuntimeConfig,
+        stub_runtime_cls: type[SessionRuntime],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_module = ModuleType("deadline_worker_agent.sessions.runtime.python")
+        fake_module.PythonSessionRuntime = stub_runtime_cls  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "deadline_worker_agent.sessions.runtime.python", fake_module
+        )
+
+        result = create_session_runtime(RuntimeKind.PYTHON, runtime_config)
+        assert isinstance(result, SessionRuntime)
+        assert isinstance(result, stub_runtime_cls)
+        assert result._config is runtime_config  # type: ignore[attr-defined]
+
+    def test_rust_returns_adapter(
+        self,
+        runtime_config: SessionRuntimeConfig,
+        stub_runtime_cls: type[SessionRuntime],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_module = ModuleType("deadline_worker_agent.sessions.runtime.rust")
+        fake_module.RustSessionRuntime = stub_runtime_cls  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "deadline_worker_agent.sessions.runtime.rust", fake_module)
+
+        result = create_session_runtime(RuntimeKind.RUST, runtime_config)
+        assert isinstance(result, SessionRuntime)
+        assert isinstance(result, stub_runtime_cls)
+        assert result._config is runtime_config  # type: ignore[attr-defined]

--- a/test/unit/sessions/runtime/test_kind.py
+++ b/test/unit/sessions/runtime/test_kind.py
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from deadline_worker_agent.sessions.runtime import RuntimeKind
+
+
+class TestRuntimeKind:
+    def test_runtime_kind_values(self) -> None:
+        assert RuntimeKind.PYTHON.value == "python"
+        assert RuntimeKind.RUST.value == "rust"
+        assert isinstance(RuntimeKind.PYTHON, str)
+        assert isinstance(RuntimeKind.RUST, str)

--- a/test/unit/sessions/runtime/test_runtime_config.py
+++ b/test/unit/sessions/runtime/test_runtime_config.py
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import pytest
+
+from deadline_worker_agent.sessions.runtime import SessionRuntimeConfig
+
+
+class TestSessionRuntimeConfig:
+    def test_session_runtime_config_defaults(self, runtime_config: SessionRuntimeConfig) -> None:
+        assert runtime_config.spec_revision == "2023-09"
+        assert runtime_config.supported_extensions == ()
+
+    def test_session_runtime_config_is_frozen(self, runtime_config: SessionRuntimeConfig) -> None:
+        with pytest.raises(AttributeError):
+            runtime_config.session_id = "mutated"  # type: ignore[misc]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent's `Session` class is tightly coupled to `openjd.sessions.Session`. To support multiple runtime backends (Python and Rust), we need an abstraction seam and a factory to select between them.

### What was the solution? (How)

Added a `SessionRuntime` ABC, a `RuntimeKind` enum (`python`, `rust`, `service-selected`), a frozen `SessionRuntimeConfig` dataclass, and a `create_session_runtime()` factory with lazy adapter imports.

Purely additive — no existing code paths modified.

### What is the impact of this change?

None. New modules and tests only. Existing behavior is untouched until follow-up PRs wire `Session` through the adapter.

### How was this change tested?

- 12 unit tests (enum values, config immutability, ABC enforcement, factory error paths, adapter injection)
- `hatch run all:test` — 2901 passed (Python 3.9/3.10/3.11)
- `hatch run integ-test` — 73 passed
- Module coverage: 97%

### Was this change documented?

Docstrings on all public classes and functions. No user-facing docs needed.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*