### PR TITLE
feat: add PythonSessionRuntime adapter

### DIFF
--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -1,0 +1,125 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+from openjd.model import RevisionExtensions, SpecificationRevision
+from openjd.sessions import Session as OpenJDSession
+
+from . import SessionRuntime, SessionRuntimeConfig
+
+if TYPE_CHECKING:
+    from openjd.sessions import (
+        ActionStatus,
+        EnvironmentIdentifier,
+        EnvironmentModel,
+        StepScriptModel,
+    )
+
+__all__ = ["PythonSessionRuntime"]
+
+
+class PythonSessionRuntime(SessionRuntime):
+    """SessionRuntime backed by openjd.sessions (v0 Python implementation)."""
+
+    _session: OpenJDSession
+
+    def __init__(self, config: SessionRuntimeConfig) -> None:
+        self._session = OpenJDSession(
+            session_id=config.session_id,
+            job_parameter_values=config.job_parameter_values,
+            path_mapping_rules=config.path_mapping_rules,
+            retain_working_dir=config.retain_working_dir,
+            user=config.user,
+            callback=config.action_callback,
+            os_env_vars=config.os_env_vars,
+            session_root_directory=config.session_root_directory,
+            revision_extensions=RevisionExtensions(
+                # Currently for simplicity request that our session allow all extensions.
+                # This does not obey the spec. It should be changed at a later date to the
+                # list of requested extensions once those are returned by BatchGetJobEntity.
+                spec_rev=SpecificationRevision(config.spec_revision),
+                supported_extensions=list(config.supported_extensions),
+            ),
+        )
+
+    def enter_environment(
+        self,
+        *,
+        environment: EnvironmentModel,
+        identifier: Optional[EnvironmentIdentifier] = None,
+        os_env_vars: Optional[dict[str, str]] = None,
+    ) -> EnvironmentIdentifier:
+        return self._session.enter_environment(
+            environment=environment,
+            identifier=identifier,
+            os_env_vars=os_env_vars,
+        )
+
+    def exit_environment(
+        self,
+        *,
+        identifier: EnvironmentIdentifier,
+        os_env_vars: Optional[dict[str, str]] = None,
+        keep_session_running: bool = False,
+    ) -> None:
+        self._session.exit_environment(
+            identifier=identifier,
+            os_env_vars=os_env_vars,
+            keep_session_running=keep_session_running,
+        )
+
+    def run_task(
+        self,
+        *,
+        step_script: StepScriptModel,
+        task_parameter_values: dict[str, Any],
+        os_env_vars: Optional[dict[str, str]] = None,
+        log_task_banner: bool = True,
+    ) -> None:
+        self._session.run_task(
+            step_script=step_script,
+            task_parameter_values=task_parameter_values,
+            os_env_vars=os_env_vars,
+            log_task_banner=log_task_banner,
+        )
+
+    def _run_task_without_session_env(
+        self,
+        *,
+        step_script: StepScriptModel,
+        task_parameter_values: dict[str, Any],
+        os_env_vars: Optional[dict[str, str]] = None,
+        log_task_banner: bool = True,
+    ) -> None:
+        self._session._run_task_without_session_env(
+            step_script=step_script,
+            task_parameter_values=task_parameter_values,
+            os_env_vars=os_env_vars,
+            log_task_banner=log_task_banner,
+        )
+
+    def cancel_action(
+        self,
+        *,
+        time_limit: Optional[timedelta] = None,
+        mark_action_failed: bool = False,
+    ) -> None:
+        self._session.cancel_action(
+            time_limit=time_limit,
+            mark_action_failed=mark_action_failed,
+        )
+
+    def cleanup(self) -> None:
+        self._session.cleanup()
+
+    @property
+    def working_directory(self) -> Path:
+        return self._session.working_directory
+
+    @property
+    def action_status(self) -> Optional[ActionStatus]:
+        return self._session.action_status

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -1,0 +1,216 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openjd.model import SpecificationRevision
+
+from deadline_worker_agent.sessions.runtime import SessionRuntimeConfig
+from deadline_worker_agent.sessions.runtime import python as python_module
+from deadline_worker_agent.sessions.runtime.python import PythonSessionRuntime
+
+
+@pytest.fixture()
+def runtime_config() -> SessionRuntimeConfig:
+    """Minimal valid SessionRuntimeConfig for testing."""
+    return SessionRuntimeConfig(
+        session_id="session-1",
+        job_parameter_values={"Param1": "value1"},
+        path_mapping_rules=None,
+        retain_working_dir=False,
+        user=None,
+        action_callback=lambda session_id, status: None,
+        os_env_vars=None,
+        session_root_directory=Path("/tmp/sessions/session-1"),
+    )
+
+
+@pytest.fixture()
+def mock_openjd_session() -> Generator[MagicMock, None, None]:
+    with patch.object(python_module, "OpenJDSession") as mock_cls:
+        yield mock_cls
+
+
+class TestPythonSessionRuntimeConstruction:
+    def test_construction_when_default_config_delegates_to_openjd_session(
+        self, runtime_config: SessionRuntimeConfig, mock_openjd_session: MagicMock
+    ) -> None:
+        PythonSessionRuntime(runtime_config)
+
+        mock_openjd_session.assert_called_once()
+        call_kwargs = mock_openjd_session.call_args.kwargs
+        assert call_kwargs["session_id"] == "session-1"
+        assert call_kwargs["job_parameter_values"] == {"Param1": "value1"}
+        assert call_kwargs["path_mapping_rules"] is None
+        assert call_kwargs["retain_working_dir"] is False
+        assert call_kwargs["user"] is None
+        assert call_kwargs["callback"] is runtime_config.action_callback
+        assert call_kwargs["os_env_vars"] is None
+        assert call_kwargs["session_root_directory"] == Path("/tmp/sessions/session-1")
+        rev_ext = call_kwargs["revision_extensions"]
+        assert rev_ext.spec_rev == SpecificationRevision.v2023_09
+        assert rev_ext.extensions == set()
+
+    def test_construction_when_spec_revision_string_converts_to_enum(
+        self, mock_openjd_session: MagicMock
+    ) -> None:
+        config = SessionRuntimeConfig(
+            session_id="session-2",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda session_id, status: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-2"),
+            spec_revision="2023-09",
+            supported_extensions=("WRAP_ACTIONS",),
+        )
+
+        PythonSessionRuntime(config)
+
+        call_kwargs = mock_openjd_session.call_args.kwargs
+        rev_ext = call_kwargs["revision_extensions"]
+        assert rev_ext.spec_rev == SpecificationRevision.v2023_09
+        assert rev_ext.extensions == {"WRAP_ACTIONS"}
+
+
+class TestPythonSessionRuntimeDelegation:
+    @pytest.fixture()
+    def adapter(
+        self, runtime_config: SessionRuntimeConfig, mock_openjd_session: MagicMock
+    ) -> PythonSessionRuntime:
+        return PythonSessionRuntime(runtime_config)
+
+    @pytest.fixture()
+    def mock_session_instance(self, mock_openjd_session: MagicMock) -> MagicMock:
+        return mock_openjd_session.return_value
+
+    def test_enter_environment_when_called_delegates_to_wrapped_session(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        env = MagicMock()
+        identifier = MagicMock()
+        os_env = {"KEY": "VAL"}
+
+        result = adapter.enter_environment(
+            environment=env, identifier=identifier, os_env_vars=os_env
+        )
+
+        mock_session_instance.enter_environment.assert_called_once_with(
+            environment=env, identifier=identifier, os_env_vars=os_env
+        )
+        # enter_environment is the only non-void method — verify the return value
+        # (EnvironmentIdentifier) flows through the adapter.
+        assert result is mock_session_instance.enter_environment.return_value
+
+    def test_exit_environment_when_called_delegates_to_wrapped_session(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        identifier = MagicMock()
+
+        adapter.exit_environment(
+            identifier=identifier, os_env_vars={"A": "B"}, keep_session_running=True
+        )
+
+        mock_session_instance.exit_environment.assert_called_once_with(
+            identifier=identifier, os_env_vars={"A": "B"}, keep_session_running=True
+        )
+
+    def test_run_task_when_called_delegates_to_wrapped_session(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        step_script = MagicMock()
+        task_params = {"TaskParam": "val"}
+
+        adapter.run_task(
+            step_script=step_script,
+            task_parameter_values=task_params,
+            os_env_vars={"X": "Y"},
+            log_task_banner=False,
+        )
+
+        mock_session_instance.run_task.assert_called_once_with(
+            step_script=step_script,
+            task_parameter_values=task_params,
+            os_env_vars={"X": "Y"},
+            log_task_banner=False,
+        )
+
+    def test_run_task_without_session_env_when_called_delegates_to_private_method(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        step_script = MagicMock()
+        task_params = {"P": "v"}
+
+        adapter._run_task_without_session_env(
+            step_script=step_script,
+            task_parameter_values=task_params,
+            os_env_vars=None,
+            log_task_banner=True,
+        )
+
+        mock_session_instance._run_task_without_session_env.assert_called_once_with(
+            step_script=step_script,
+            task_parameter_values=task_params,
+            os_env_vars=None,
+            log_task_banner=True,
+        )
+
+    def test_cancel_action_when_called_delegates_to_wrapped_session(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        limit = timedelta(seconds=30)
+
+        adapter.cancel_action(time_limit=limit, mark_action_failed=True)
+
+        mock_session_instance.cancel_action.assert_called_once_with(
+            time_limit=limit, mark_action_failed=True
+        )
+
+    def test_cleanup_when_called_delegates_to_wrapped_session(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        adapter.cleanup()
+
+        mock_session_instance.cleanup.assert_called_once_with()
+
+
+class TestPythonSessionRuntimeProperties:
+    @pytest.fixture()
+    def adapter(
+        self, runtime_config: SessionRuntimeConfig, mock_openjd_session: MagicMock
+    ) -> PythonSessionRuntime:
+        return PythonSessionRuntime(runtime_config)
+
+    @pytest.fixture()
+    def mock_session_instance(self, mock_openjd_session: MagicMock) -> MagicMock:
+        return mock_openjd_session.return_value
+
+    def test_working_directory_when_accessed_returns_wrapped_session_value(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        mock_session_instance.working_directory = Path("/tmp/work")
+
+        assert adapter.working_directory == Path("/tmp/work")
+
+    def test_action_status_when_accessed_returns_wrapped_session_value(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        fake_status = MagicMock()
+        mock_session_instance.action_status = fake_status
+
+        assert adapter.action_status is fake_status
+
+    def test_action_status_when_none_returns_none(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        mock_session_instance.action_status = None
+
+        assert adapter.action_status is None


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The SessionRuntime ABC (from the prior PR) defines the adapter interface but has no concrete implementation yet. The worker agent needs a v0 adapter that wraps the existing `openjd.sessions.Session` behind this abstraction.

### What was the solution? (How)

Added `PythonSessionRuntime` — a delegation adapter that wraps `openjd.sessions.Session`. The constructor translates `SessionRuntimeConfig` fields into openjd's native types (`SpecificationRevision`, `RevisionExtensions`). All 6 methods + 2 properties forward directly to the wrapped session.

Purely additive. No existing code paths modified.

### What is the impact of this change?

None on existing behavior. New module and test file only. The adapter becomes active in a follow-up PR that wires `Session` through the factory.

### How was this change tested?

- 11 unit tests (construction delegation, str-to-enum conversion, all method/property forwarding, return value flow-through)
- `hatch run test` — 2911 passed
- `hatch run lint` — all pass (ruff + mypy)
- Module coverage: 100% (`sessions/runtime/python.py`)

### Was this change documented?

Class docstring on `PythonSessionRuntime`. No user-facing docs needed.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*