### PR TITLE
chore: add slow-path warning for job attachment sync

### DIFF
--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -1151,11 +1151,24 @@ if __name__ == "__main__":
 
         # Query the session to check for progress percentage
         complete_percentage: float = 0
+        _last_progress: list[float] = [0]
 
         @backoff.on_predicate(
             wait_gen=backoff.constant,
             max_time=240,
             interval=2,
+            on_success=lambda details: (
+                logging.warning(
+                    f"syncInputJobAttachments took {details['elapsed']:.0f}s "
+                    f"(>120s slow-path threshold)"
+                )
+                if details["elapsed"] > 120
+                else None
+            ),
+            on_giveup=lambda details: logging.error(
+                f"syncInputJobAttachments timed out after {details['elapsed']:.0f}s "
+                f"(last progressPercent={_last_progress[0]})"
+            ),
         )
         def check_percentage(complete_percentage) -> bool:
             sessions = deadline_client.list_sessions(
@@ -1174,6 +1187,7 @@ if __name__ == "__main__":
                     if "syncInputJobAttachments" in session_action["definition"]:
                         assert complete_percentage <= session_action["progressPercent"]
                         complete_percentage = session_action["progressPercent"]
+                        _last_progress[0] = complete_percentage
                         return complete_percentage == 100
 
             return False


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `test_worker_uses_job_attachment_sync[hash_script]` E2E test syncs 2,500 files on Windows with a 240s poll budget. When sync takes longer than expected under canary load, there's no visibility into performance degradation until it actually times out and fails, triggering a false canary alarm.

### What was the solution? (How)

Added a `backoff.on_success` callback to the `check_percentage` polling decorator that logs a warning when the sync takes longer than 120s. The test still passes, but slow performance is now visible in canary logs.

### What is the impact of this change?

None on test behavior. Adds observability: engineers can detect performance regressions from canary logs before they become test failures.

### How was this change tested?

This is a logging-only addition to an E2E test decorator. No behavioral change to verify.

### Was this change documented?

No documentation needed.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
