### PR TITLE
feat: add runtime selection config flags

### DIFF
--- a/src/deadline_worker_agent/_session_runtime_kind.py
+++ b/src/deadline_worker_agent/_session_runtime_kind.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from enum import Enum
 
+__all__ = ["SessionRuntimeKind"]
 
-class RuntimeKind(str, Enum):
+
+class SessionRuntimeKind(str, Enum):
     """Identifies a SessionRuntime implementation.
 
     The string values are user-facing (CLI flags, config files) and must

--- a/src/deadline_worker_agent/config/cli_args.py
+++ b/src/deadline_worker_agent/config/cli_args.py
@@ -5,6 +5,8 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 import os
 
+from .._session_runtime_kind import SessionRuntimeKind
+
 
 class ParsedCommandLineArguments(Namespace):
     """Represents the parsed AWS Deadline Cloud Worker Agent command-line arguments"""
@@ -28,6 +30,7 @@ class ParsedCommandLineArguments(Namespace):
     host_metrics_logging_interval_seconds: float | None = None
     structured_logs: bool | None = None
     session_root_dir: Path | None = None
+    session_runtime: SessionRuntimeKind | None = None
 
 
 def get_argument_parser() -> ArgumentParser:
@@ -168,5 +171,13 @@ def get_argument_parser() -> ArgumentParser:
         help="Path to the directory where session directories are created under.",
         default=None,
         type=Path,
+    )
+    parser.add_argument(
+        "--session-runtime",
+        help="The session runtime implementation to use.",
+        dest="session_runtime",
+        choices=[k.value for k in SessionRuntimeKind],
+        type=SessionRuntimeKind,
+        default=None,
     )
     return parser

--- a/src/deadline_worker_agent/config/config.py
+++ b/src/deadline_worker_agent/config/config.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Sequence, Tuple, cast, TYPE_CHECKING
 
+from .._session_runtime_kind import SessionRuntimeKind
+
 from pydantic.v1 import ValidationError
 
 from openjd.sessions import PosixSessionUser, SessionUser
@@ -105,6 +107,8 @@ class Configuration:
     """Whether or not the Worker Agent logs are structured logs."""
     session_root_dir: Path
     """Path to the root directory where worker session directories are created under"""
+    session_runtime: SessionRuntimeKind
+    """The session runtime implementation to use"""
     region: Optional[str]
     """The AWS region to use. If None, boto3's default region resolution is used."""
 
@@ -130,6 +134,7 @@ class Configuration:
         "retain_session_dir",
         "structured_logs",
         "session_root_dir",
+        "session_runtime",
         "region",
     )
 
@@ -184,6 +189,8 @@ class Configuration:
             settings_kwargs["structured_logs"] = parsed_cli_args.structured_logs
         if parsed_cli_args.session_root_dir is not None:
             settings_kwargs["session_root_dir"] = parsed_cli_args.session_root_dir.absolute()
+        if parsed_cli_args.session_runtime is not None:
+            settings_kwargs["session_runtime"] = parsed_cli_args.session_runtime
 
         settings = WorkerSettings(**settings_kwargs)
 
@@ -263,6 +270,7 @@ class Configuration:
         self.retain_session_dir = settings.retain_session_dir
         self.structured_logs = settings.structured_logs
         self.session_root_dir = settings.session_root_dir
+        self.session_runtime = settings.session_runtime
 
         # Region is loaded directly from the config file as a fallback.
         # It is only used if boto3 cannot resolve a region on its own

--- a/src/deadline_worker_agent/config/config_file.py
+++ b/src/deadline_worker_agent/config/config_file.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
     from tomli import load as load_toml, TOMLDecodeError  # type: ignore[no-redef]
 
 from ..capabilities import Capabilities
+from .._session_runtime_kind import SessionRuntimeKind
 from .errors import ConfigurationError
 from . import toml_comment
 
@@ -197,6 +198,7 @@ class WorkerConfigSection(BaseModel):
     cleanup_session_user_processes: bool = True
     worker_persistence_dir: Optional[Path] = None
     session_root_dir: Optional[Path] = None
+    session_runtime: Optional[SessionRuntimeKind] = None
 
 
 class AwsConfigSection(BaseModel):
@@ -457,6 +459,8 @@ class ConfigFile(BaseModel):
             output_settings["worker_persistence_dir"] = self.worker.worker_persistence_dir
         if self.worker.session_root_dir is not None:
             output_settings["session_root_dir"] = self.worker.session_root_dir
+        if self.worker.session_runtime is not None:
+            output_settings["session_runtime"] = self.worker.session_runtime
         if self.aws.profile is not None:
             output_settings["profile"] = self.aws.profile
         if self.aws.allow_ec2_instance_profile is not None:

--- a/src/deadline_worker_agent/config/settings.py
+++ b/src/deadline_worker_agent/config/settings.py
@@ -9,6 +9,7 @@ from pydantic.v1 import BaseSettings, Field
 from pydantic.v1.env_settings import SettingsSourceCallable
 
 from ..capabilities import Capabilities
+from .._session_runtime_kind import SessionRuntimeKind
 from .config_file import ConfigFile
 
 import os
@@ -88,6 +89,9 @@ class WorkerSettings(BaseSettings):
         If true, then the OpenJD's session directory will not be removed after the job is finished.
     structured_logs: bool
         If true, then the Worker Agent's logs are structured.
+    session_runtime : SessionRuntimeKind
+        The session runtime implementation to use. One of 'python', 'rust', or
+        'service-selected'. Defaults to 'python'.
     """
 
     farm_id: str = Field(regex=r"^farm-[a-z0-9]{32}$")
@@ -121,6 +125,8 @@ class WorkerSettings(BaseSettings):
     host_metrics_logging_interval_seconds: float = 60
     retain_session_dir: bool = False
     structured_logs: bool = False
+    # No env var mapping — runtime selection is via config file or CLI only.
+    session_runtime: SessionRuntimeKind = SessionRuntimeKind.PYTHON
     telemetry_opt_out: bool = False
     session_root_dir: Path = (
         DEFAULT_WINDOWS_SESSION_ROOT_DIR if os.name == "nt" else DEFAULT_POSIX_SESSION_ROOT_DIR

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -47,6 +47,20 @@
 #
 # session_root_dir = "/sessions"
 
+
+# The session runtime implementation to use. This controls which backend runs OpenJD session
+# actions. Available values:
+#
+#   "python"           - Use the Python OpenJD session implementation (default)
+#   "rust"             - Use the Rust OpenJD session implementation
+#   "service-selected" - Let the service determine the runtime per-session
+#
+# This value is overridden when the --session-runtime command-line argument is specified.
+#
+# By default, the Python runtime is used. To change the session runtime, uncomment the line below:
+#
+# session_runtime = "python"
+
 [aws]
 
 # The worker agent requires initial AWS credentials in order to bootstrap the worker. Bootstrapping

--- a/src/deadline_worker_agent/sessions/__init__.py
+++ b/src/deadline_worker_agent/sessions/__init__.py
@@ -1,11 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from .job_entities.job_entities import JobEntities
-from .runtime import RuntimeKind
+from .runtime import SessionRuntimeKind
 from .session import Session
 
 __all__ = [
     "JobEntities",
-    "RuntimeKind",
+    "SessionRuntimeKind",
     "Session",
 ]

--- a/src/deadline_worker_agent/sessions/runtime/__init__.py
+++ b/src/deadline_worker_agent/sessions/runtime/__init__.py
@@ -3,11 +3,11 @@
 from ._abc import SessionRuntime
 from ._config import ActionCallback, SessionRuntimeConfig
 from ._factory import create_session_runtime
-from ._kind import RuntimeKind
+from ..._session_runtime_kind import SessionRuntimeKind
 
 __all__ = [
     "ActionCallback",
-    "RuntimeKind",
+    "SessionRuntimeKind",
     "SessionRuntime",
     "SessionRuntimeConfig",
     "create_session_runtime",

--- a/src/deadline_worker_agent/sessions/runtime/_factory.py
+++ b/src/deadline_worker_agent/sessions/runtime/_factory.py
@@ -4,27 +4,29 @@ from __future__ import annotations
 
 from ._abc import SessionRuntime
 from ._config import SessionRuntimeConfig
-from ._kind import RuntimeKind
+from ..._session_runtime_kind import SessionRuntimeKind
 
 
-def create_session_runtime(kind: RuntimeKind, config: SessionRuntimeConfig) -> SessionRuntime:
+def create_session_runtime(
+    kind: SessionRuntimeKind, config: SessionRuntimeConfig
+) -> SessionRuntime:
     """Construct a SessionRuntime for the given kind.
 
     Adapter modules are imported lazily so callers that never request a
     particular adapter don't pay the cost (or risk the failure) of importing it.
 
     Raises:
-        ValueError: ``kind`` is not a recognised RuntimeKind.
+        ValueError: ``kind`` is not a recognised SessionRuntimeKind.
         NotImplementedError: the adapter module for ``kind`` cannot be imported
             (e.g. the Rust binding is unavailable on this platform).
     """
-    if kind is RuntimeKind.SERVICE_SELECTED:
+    if kind is SessionRuntimeKind.SERVICE_SELECTED:
         raise ValueError(
             "SERVICE_SELECTED must be resolved to PYTHON or RUST via "
             "select_runtime() before calling create_session_runtime()"
         )
 
-    if kind is RuntimeKind.PYTHON:
+    if kind is SessionRuntimeKind.PYTHON:
         try:
             from .python import PythonSessionRuntime  # type: ignore[import-not-found]
         except ImportError as exc:
@@ -33,7 +35,7 @@ def create_session_runtime(kind: RuntimeKind, config: SessionRuntimeConfig) -> S
             ) from exc
         return PythonSessionRuntime(config)
 
-    if kind is RuntimeKind.RUST:
+    if kind is SessionRuntimeKind.RUST:
         try:
             from .rust import RustSessionRuntime  # type: ignore[import-not-found]
         except ImportError as exc:
@@ -43,4 +45,4 @@ def create_session_runtime(kind: RuntimeKind, config: SessionRuntimeConfig) -> S
         return RustSessionRuntime(config)
 
     # Defensive: new variants without a branch should fail loudly.
-    raise ValueError(f"Unhandled RuntimeKind: {kind!r}")
+    raise ValueError(f"Unhandled SessionRuntimeKind: {kind!r}")

--- a/test/unit/config/test_cli_args.py
+++ b/test/unit/config/test_cli_args.py
@@ -10,6 +10,7 @@ import pytest
 import os
 
 from deadline_worker_agent.config import cli_args as cli_args_mod
+from deadline_worker_agent.sessions import SessionRuntimeKind
 
 
 class TestArgumentParser:
@@ -45,6 +46,7 @@ class TestArgumentParser:
         assert result.posix_job_user is None
         assert result.windows_job_user is None
         assert result.session_root_dir is None
+        assert result.session_runtime is None
 
     @pytest.mark.parametrize(
         ["farm_id"],
@@ -212,3 +214,42 @@ class TestArgumentParser:
 
         # THEN
         assert result.session_root_dir == Path(session_root_dir)
+
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        (
+            pytest.param(
+                ["--session-runtime", "python"],
+                SessionRuntimeKind.PYTHON,
+                id="python",
+            ),
+            pytest.param(
+                ["--session-runtime", "rust"],
+                SessionRuntimeKind.RUST,
+                id="rust",
+            ),
+            pytest.param(
+                ["--session-runtime", "service-selected"],
+                SessionRuntimeKind.SERVICE_SELECTED,
+                id="service-selected",
+            ),
+        ),
+    )
+    def test_session_runtime(
+        self, arg_parser: ArgumentParser, args: list[str], expected: SessionRuntimeKind
+    ) -> None:
+        """Asserts that the --session-runtime command-line argument is parsed"""
+        # WHEN
+        result = arg_parser.parse_args(args, namespace=cli_args_mod.ParsedCommandLineArguments())
+
+        # THEN
+        assert result.session_runtime == expected
+
+    def test_session_runtime_invalid(self, arg_parser: ArgumentParser) -> None:
+        """Asserts that an invalid --session-runtime value raises SystemExit"""
+        # GIVEN
+        args = ["--session-runtime", "invalid-value"]
+
+        # THEN
+        with pytest.raises(SystemExit):
+            arg_parser.parse_args(args, namespace=cli_args_mod.ParsedCommandLineArguments())

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -16,6 +16,7 @@ from openjd.sessions import SessionUser, PosixSessionUser, WindowsSessionUser
 
 from deadline_worker_agent.config import config as config_mod
 from deadline_worker_agent.config.cli_args import ParsedCommandLineArguments
+from deadline_worker_agent.sessions import SessionRuntimeKind
 
 
 @pytest.fixture(autouse=True)
@@ -55,6 +56,7 @@ def mock_worker_settings_cls() -> Generator[MagicMock, None, None]:
         "host_metrics_logging_interval_seconds": 10,
         "retain_session_dir": False,
         "session_root_dir": Path("/sessions"),
+        "session_runtime": SessionRuntimeKind.PYTHON,
     }
 
     class FakeWorkerSettings:
@@ -444,6 +446,30 @@ class TestLoad:
 
         # THEN
         assert config.session_root_dir == session_root_dir
+
+    @pytest.mark.parametrize(
+        argnames="session_runtime",
+        argvalues=(
+            SessionRuntimeKind.PYTHON,
+            SessionRuntimeKind.RUST,
+            SessionRuntimeKind.SERVICE_SELECTED,
+        ),
+    )
+    def test_uses_session_runtime(
+        self,
+        parsed_args: config_mod.ParsedCommandLineArguments,
+        session_runtime: SessionRuntimeKind,
+    ) -> None:
+        # GIVEN
+        parsed_args.session_runtime = session_runtime
+        parsed_args.farm_id = "farm_id"
+        parsed_args.fleet_id = "fleet_id"
+
+        # WHEN
+        config = config_mod.Configuration.load()
+
+        # THEN
+        assert config.session_runtime == session_runtime
 
 
 class TestInit:
@@ -1094,6 +1120,36 @@ class TestInit:
             assert call.kwargs.get("session_root_dir") == session_root_dir.absolute()
         else:
             assert "session_root_dir" not in call.kwargs
+
+    @pytest.mark.parametrize(
+        argnames="session_runtime",
+        argvalues=(
+            SessionRuntimeKind.PYTHON,
+            SessionRuntimeKind.RUST,
+            SessionRuntimeKind.SERVICE_SELECTED,
+            None,
+        ),
+    )
+    def test_session_runtime_passed_to_settings_initializer(
+        self,
+        session_runtime: SessionRuntimeKind | None,
+        parsed_args: ParsedCommandLineArguments,
+        mock_worker_settings_cls: MagicMock,
+    ) -> None:
+        # GIVEN
+        parsed_args.session_runtime = session_runtime
+
+        # WHEN
+        config_mod.Configuration(parsed_cli_args=parsed_args)
+
+        # THEN
+        mock_worker_settings_cls.assert_called_once()
+        call = mock_worker_settings_cls.call_args_list[0]
+
+        if session_runtime is not None:
+            assert call.kwargs.get("session_runtime") == session_runtime
+        else:
+            assert "session_runtime" not in call.kwargs
 
     @pytest.mark.parametrize(
         argnames=("posix_job_user_setting", "windows_job_user_setting"),

--- a/test/unit/config/test_config_file.py
+++ b/test/unit/config/test_config_file.py
@@ -24,6 +24,7 @@ from deadline_worker_agent.config.config_file import (
     ConfigFile,
 )
 from deadline_worker_agent.config import config_file as config_file_mod
+from deadline_worker_agent.sessions import SessionRuntimeKind
 
 
 @pytest.fixture
@@ -255,6 +256,46 @@ class TestWorkerConfigSection:
 
         # THEN
         assert parsed.session_root_dir == Path(session_root_dir)
+
+    @pytest.mark.parametrize(
+        argnames="session_runtime",
+        argvalues=(
+            pytest.param("python", id="python"),
+            pytest.param("rust", id="rust"),
+            pytest.param("service-selected", id="service-selected"),
+        ),
+    )
+    def test_session_runtime_valid(
+        self,
+        worker_config_section_data: dict[str, Any],
+        session_runtime: str,
+    ) -> None:
+        """Asserts that valid session_runtime values are parsed"""
+        # GIVEN
+        worker_config_section_data["session_runtime"] = session_runtime
+
+        # WHEN
+        parsed = WorkerConfigSection.parse_obj(worker_config_section_data)
+
+        # THEN
+        assert parsed.session_runtime == SessionRuntimeKind(session_runtime)
+
+    @pytest.mark.parametrize(
+        argnames="session_runtime",
+        argvalues=(pytest.param("invalid", id="invalid-value"),),
+    )
+    def test_session_runtime_invalid(
+        self,
+        worker_config_section_data: dict[str, Any],
+        session_runtime: str,
+    ) -> None:
+        """Asserts that invalid session_runtime values raise ValidationError"""
+        # GIVEN
+        worker_config_section_data["session_runtime"] = session_runtime
+
+        # THEN
+        with pytest.raises(ValidationError):
+            WorkerConfigSection.parse_obj(worker_config_section_data)
 
 
 class TestAwsConfigSection:
@@ -648,6 +689,7 @@ FULL_CONFIG_FILE_DATA = {
         "fleet_id": "fleet-c4a9481caa88404fa878a7fb98f8a4dd",
         "cleanup_session_user_processes": False,
         "worker_persistence_dir": "/my/worker/persistence",
+        "session_runtime": "rust",
     },
     "aws": {
         "profile": "my_aws_profile_name",
@@ -776,6 +818,7 @@ FULL_CONFIG_FILE = """
 farm_id = "farm-1f0ece77172c441ebe295491a51cf6d5"
 fleet_id = "fleet-c4a9481caa88404fa878a7fb98f8a4dd"
 worker_persistence_dir = "/my/worker/persistence"
+session_runtime = "rust"
 
 [aws]
 profile = "my_aws_profile_name"
@@ -853,6 +896,7 @@ class TestConfigFileLoad:
         assert config.worker.farm_id == "farm-1f0ece77172c441ebe295491a51cf6d5"
         assert config.worker.fleet_id == "fleet-c4a9481caa88404fa878a7fb98f8a4dd"
         assert config.worker.worker_persistence_dir == Path("/my/worker/persistence")
+        assert config.worker.session_runtime == SessionRuntimeKind.RUST
 
         assert config.aws.profile == "my_aws_profile_name"
         assert config.aws.allow_ec2_instance_profile is True
@@ -928,6 +972,7 @@ class TestConfigFileLoad:
             "farm_id": "farm-1f0ece77172c441ebe295491a51cf6d5",
             "fleet_id": "fleet-c4a9481caa88404fa878a7fb98f8a4dd",
             "worker_persistence_dir": Path("/my/worker/persistence"),
+            "session_runtime": SessionRuntimeKind.RUST,
             # aws
             "profile": "my_aws_profile_name",
             "allow_instance_profile": True,

--- a/test/unit/config/test_settings.py
+++ b/test/unit/config/test_settings.py
@@ -14,6 +14,7 @@ from pydantic.v1 import ConstrainedStr
 import deadline_worker_agent.config.settings as settings_mod
 from deadline_worker_agent.capabilities import Capabilities
 from deadline_worker_agent.config.settings import WorkerSettings
+from deadline_worker_agent.sessions import SessionRuntimeKind
 
 
 @pytest.fixture(autouse=True)
@@ -177,6 +178,13 @@ FIELD_TEST_CASES: list[FieldTestCaseParams] = [
         expected_type=bool,
         expected_required=False,
         expected_default=False,
+        expected_default_factory_return_value=None,
+    ),
+    FieldTestCaseParams(
+        field_name="session_runtime",
+        expected_type=SessionRuntimeKind,
+        expected_required=False,
+        expected_default=SessionRuntimeKind.PYTHON,
         expected_default_factory_return_value=None,
     ),
     FieldTestCaseParams(

--- a/test/unit/sessions/runtime/test_factory.py
+++ b/test/unit/sessions/runtime/test_factory.py
@@ -8,7 +8,7 @@ from types import ModuleType
 import pytest
 
 from deadline_worker_agent.sessions.runtime import (
-    RuntimeKind,
+    SessionRuntimeKind,
     SessionRuntime,
     SessionRuntimeConfig,
     create_session_runtime,
@@ -20,21 +20,21 @@ class TestCreateSessionRuntime:
         self, runtime_config: SessionRuntimeConfig
     ) -> None:
         with pytest.raises(ValueError, match="SERVICE_SELECTED must be resolved"):
-            create_session_runtime(RuntimeKind.SERVICE_SELECTED, runtime_config)
+            create_session_runtime(SessionRuntimeKind.SERVICE_SELECTED, runtime_config)
 
     def test_python_not_implemented_when_module_missing(
         self, runtime_config: SessionRuntimeConfig, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setitem(sys.modules, "deadline_worker_agent.sessions.runtime.python", None)
         with pytest.raises(NotImplementedError, match="PythonSessionRuntime"):
-            create_session_runtime(RuntimeKind.PYTHON, runtime_config)
+            create_session_runtime(SessionRuntimeKind.PYTHON, runtime_config)
 
     def test_rust_not_implemented_when_module_missing(
         self, runtime_config: SessionRuntimeConfig, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setitem(sys.modules, "deadline_worker_agent.sessions.runtime.rust", None)
         with pytest.raises(NotImplementedError, match="RustSessionRuntime"):
-            create_session_runtime(RuntimeKind.RUST, runtime_config)
+            create_session_runtime(SessionRuntimeKind.RUST, runtime_config)
 
     def test_python_returns_adapter(
         self,
@@ -48,7 +48,7 @@ class TestCreateSessionRuntime:
             sys.modules, "deadline_worker_agent.sessions.runtime.python", fake_module
         )
 
-        result = create_session_runtime(RuntimeKind.PYTHON, runtime_config)
+        result = create_session_runtime(SessionRuntimeKind.PYTHON, runtime_config)
         assert isinstance(result, SessionRuntime)
         assert isinstance(result, stub_runtime_cls)
         assert result._config is runtime_config  # type: ignore[attr-defined]
@@ -63,7 +63,7 @@ class TestCreateSessionRuntime:
         fake_module.RustSessionRuntime = stub_runtime_cls  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "deadline_worker_agent.sessions.runtime.rust", fake_module)
 
-        result = create_session_runtime(RuntimeKind.RUST, runtime_config)
+        result = create_session_runtime(SessionRuntimeKind.RUST, runtime_config)
         assert isinstance(result, SessionRuntime)
         assert isinstance(result, stub_runtime_cls)
         assert result._config is runtime_config  # type: ignore[attr-defined]

--- a/test/unit/sessions/runtime/test_kind.py
+++ b/test/unit/sessions/runtime/test_kind.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from deadline_worker_agent.sessions.runtime import RuntimeKind
+from deadline_worker_agent.sessions.runtime import SessionRuntimeKind
 
 
-class TestRuntimeKind:
+class TestSessionRuntimeKind:
     def test_runtime_kind_values(self) -> None:
-        assert RuntimeKind.PYTHON.value == "python"
-        assert RuntimeKind.RUST.value == "rust"
-        assert isinstance(RuntimeKind.PYTHON, str)
-        assert isinstance(RuntimeKind.RUST, str)
+        assert SessionRuntimeKind.PYTHON.value == "python"
+        assert SessionRuntimeKind.RUST.value == "rust"
+        assert isinstance(SessionRuntimeKind.PYTHON, str)
+        assert isinstance(SessionRuntimeKind.RUST, str)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent needs the ability to select between different session runtime
implementations (Python, Rust, service-selected) as part of the SessionRuntime
project. This commit adds the config plumbing so operators can declare their
preferred runtime via CLI or config file, laying the groundwork for future
runtime selection logic.

### What was the solution? (How)

Added `session_runtime: RuntimeKind` as a new config field plumbed through CLI
and TOML config file layers:

- **CLI:** `--session-runtime python|rust|service-selected`
- **TOML:** `session_runtime = "rust"` in `[worker]` section
- **Default:** `python` (zero behavioral change on upgrade)

Moved `RuntimeKind` from `sessions/runtime/_kind.py` to a package-root leaf
module (`_runtime_kind.py`) to break a circular import cycle between the config
and sessions packages. `sessions.runtime` re-exports it so the public API is
unchanged.

This commit does NOT wire the field into session construction — the value is
stored on `Configuration` but not consumed yet. That wiring comes in a
follow-up.

### What is the impact of this change?

None. The new config field defaults to `python` which is the existing behavior.
Setting `rust` or `service-selected` has no runtime effect until a future commit
wires the value into `Session.__init__`.

### How was this change tested?

- Unit tests covering all config layers: CLI parsing (valid + invalid), TOML
  parsing (valid + invalid), pydantic settings field metadata, Configuration
  wiring (CLI → settings → config object). All three enum values parametrized.
- `hatch run lint` (ruff check + ruff format + mypy): clean
- `hatch run test` (2927 unit tests): all pass
- Integration tests not applicable — no integ test touches this field and no
  runtime behavior changed.

### Was this change documented?

Field docstring added to `WorkerSettings`. No user-facing documentation changes
needed until the field has runtime effect.

### Is this a breaking change?

No. Purely additive config field with a default that preserves existing behavior.