### PR TITLE
chore(deps): bump deadline to 0.59.1 and mypy to 2 (marker-pinned for py3.9)

### DIFF
--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -1,10 +1,11 @@
 backoff == 2.2.*
 boto3 >= 1.34.75
-deadline >= 0.56, < 0.59
+deadline >= 0.59.1, < 0.60
 deadline-job-attachments == 0.1.0
 deadline-cloud-test-fixtures >= 0.18.12, < 0.19
 flaky == 3.8.*
-mypy >= 1.19.1, < 1.20
+mypy >= 2.1.0, < 2.2; python_version >= "3.10"
+mypy >= 1.19.1, < 1.20; python_version < "3.10"
 pytest == 9.0.*
 pytest-cov == 7.1.*
 pytest-timeout == 2.4.*

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -11,7 +11,8 @@ pytest-timeout == 2.4.*
 pytest-xdist == 3.8.*
 rich == 15.0.*
 types-python-dateutil ~= 2.9
-mypy >= 1.19.1, < 1.20
+mypy >= 2.1.0, < 2.2; python_version >= "3.10"
+mypy >= 1.19.1, < 1.20; python_version < "3.10"
 types-requests ~= 2.33; python_version >= "3.10"
 types-requests ~= 2.31; python_version < "3.10"
 ruff ~= 0.15.19


### PR DESCRIPTION
Combining dependabot PRs #977 and #980.

## Changes
- **deadline `>= 0.56, < 0.59` -> `>= 0.59.1, < 0.60`** (#980) in `requirements-e2e.txt`
- **mypy `>= 1.19.1, < 1.20` -> `>= 2.1.0, < 2.2`** (#977) in both `requirements-testing.txt` and `requirements-e2e.txt`

## Older-Python handling
mypy 2 requires Python `>=3.10`, but this package supports `>=3.9` and tests 3.9 in CI. mypy is pinned via environment markers so Python `< 3.10` keeps `mypy >= 1.19.1, < 1.20` while `>= 3.10` gets `mypy >= 2.1.0, < 2.2` — matching the existing `types-requests` / `pytest` marker pattern already in the file.

## Verification
- `ruff check` / `ruff format --check` — pass
- `mypy` (2.1.0) — no issues in 185 source files
- `hatch run test` — 2903 passed, 46 skipped

Closes #977, closes #980.

> Note: dependabot PRs #979 (types-requests) and #975 (deadline-job-attachments) are intentionally excluded from this PR and will be handled separately.