### PR TITLE
refactor: route Session through SessionRuntime adapter and migrate ca…

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/openjd_action.py
+++ b/src/deadline_worker_agent/sessions/actions/openjd_action.py
@@ -18,9 +18,9 @@ class OpenjdAction(SessionActionDefinition):
             return
 
         try:
-            session._session.cancel_action(time_limit=time_limit)
+            session.runtime.cancel_action(time_limit=time_limit)
         except RuntimeError:
-            if action_status := session._session.action_status:
+            if action_status := session.runtime.action_status:
                 action_state = action_status.state
                 raise CancelationError(
                     f"Could not cancel {self.id}. It completed as {action_state.name}"

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -292,23 +292,8 @@ class AttachmentDownloadAction(OpenjdAction):
         dynamic_mapping_rules.update(generated_path_mapping)
         job_attachment_path_mappings = list([asdict(r) for r in dynamic_mapping_rules.values()])
 
-        # Open Job Description session implementation details -- path mappings are sorted.
-        # bisect.insort only supports the 'key' arg in 3.10 or later, so
-        # we first extend the list and sort it afterwards.
-        if session.openjd_session._path_mapping_rules:
-            session.openjd_session._path_mapping_rules.extend(
-                OpenjdPathMapping.from_dict(r) for r in job_attachment_path_mappings
-            )
-        else:
-            session.openjd_session._path_mapping_rules = [
-                OpenjdPathMapping.from_dict(r) for r in job_attachment_path_mappings
-            ]
-
-        # Open Job Description Sessions sort the path mapping rules based on length of the parts make
-        # rules that are subsets of each other behave in a predictable manner. We must
-        # sort here since we're modifying that internal list appending to the list.
-        session.openjd_session._path_mapping_rules.sort(
-            key=lambda rule: -len(rule.source_path.parts)
+        session.runtime.extend_path_mapping_rules(
+            [OpenjdPathMapping.from_dict(r) for r in job_attachment_path_mappings]
         )
 
         manifest_paths_by_root = session._asset_sync._check_and_write_local_manifests(

--- a/src/deadline_worker_agent/sessions/runtime/_abc.py
+++ b/src/deadline_worker_agent/sessions/runtime/_abc.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
         ActionStatus,
         EnvironmentIdentifier,
         EnvironmentModel,
+        PathMappingRule,
         StepScriptModel,
     )
 
@@ -66,6 +67,15 @@ class SessionRuntime(ABC):
         log_task_banner: bool = True,
     ) -> None:
         """Run a task without entering a session environment (attachment-sync path)."""
+        ...
+
+    @abstractmethod
+    def extend_path_mapping_rules(self, rules: list[PathMappingRule]) -> None:
+        """Add path mapping rules to the session mid-flight.
+
+        The Rust runtime (v1) exposes this as a public API. The Python runtime
+        (v0) lacks it, so the adapter encapsulates the direct attribute access.
+        """
         ...
 
     @abstractmethod

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
         ActionStatus,
         EnvironmentIdentifier,
         EnvironmentModel,
+        PathMappingRule,
         StepScriptModel,
     )
 
@@ -102,16 +103,24 @@ class PythonSessionRuntime(SessionRuntime):
             log_task_banner=log_task_banner,
         )
 
+    def extend_path_mapping_rules(self, rules: list[PathMappingRule]) -> None:
+        # bisect.insort only supports the 'key' arg in 3.10 or later, so
+        # we first extend the list and sort it afterwards.
+        if self._session._path_mapping_rules:
+            self._session._path_mapping_rules.extend(rules)
+        else:
+            self._session._path_mapping_rules = list(rules)
+        # openjd sorts path mapping rules by descending source path length so that
+        # rules that are subsets of each other match in a predictable (most-specific-first) manner.
+        self._session._path_mapping_rules.sort(key=lambda rule: -len(rule.source_path.parts))
+
     def cancel_action(
         self,
         *,
         time_limit: Optional[timedelta] = None,
         mark_action_failed: bool = False,
     ) -> None:
-        self._session.cancel_action(
-            time_limit=time_limit,
-            mark_action_failed=mark_action_failed,
-        )
+        self._session.cancel_action(time_limit=time_limit, mark_action_failed=mark_action_failed)
 
     def cleanup(self) -> None:
         self._session.cleanup()

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -39,8 +39,6 @@ if TYPE_CHECKING:
 
 from openjd.model import (
     TaskParameterSet,
-    RevisionExtensions,
-    SpecificationRevision,
 )
 from openjd.model.v2023_09 import ExtensionName
 from openjd.sessions import (
@@ -50,7 +48,6 @@ from openjd.sessions import (
     EnvironmentModel,
     LOG as OPENJD_LOG,
     StepScriptModel,
-    Session as OPENJDSession,
     SessionUser,
 )
 
@@ -62,6 +59,12 @@ from deadline.job_attachments.progress_tracker import ProgressReportMetadata
 
 from ..scheduler.session_action_status import SessionActionStatus
 from ..sessions.errors import SessionActionError
+from .runtime import (
+    SessionRuntimeKind,
+    SessionRuntime,
+    SessionRuntimeConfig,
+    create_session_runtime,
+)
 from ..log_messages import (
     SessionLogEvent,
     SessionLogEventSubtype,
@@ -194,21 +197,22 @@ class Session:
         def openjd_session_action_callback(session_id: str, action_status: ActionStatus) -> None:
             self.update_action(action_status)
 
-        self._session = OPENJDSession(
-            session_id=self._id,
-            job_parameter_values=self._job_details.parameters,
-            path_mapping_rules=self._job_details.path_mapping_rules,
-            retain_working_dir=self._retain_session_dir,
-            user=self._os_user,
-            callback=openjd_session_action_callback,
-            os_env_vars=self._env,
-            session_root_directory=session_root_dir,
-            # Currently for simplicity request that our session allow all extensions
-            # This does not obey the spec.  It should be changed at a later date to the list of requested
-            # extensions once those are returned by BatchGetJobEntity
-            revision_extensions=RevisionExtensions(
-                spec_rev=SpecificationRevision.v2023_09,
-                supported_extensions=[v.value for v in ExtensionName],
+        self._runtime: SessionRuntime = create_session_runtime(
+            SessionRuntimeKind.PYTHON,
+            SessionRuntimeConfig(
+                session_id=self._id,
+                job_parameter_values=self._job_details.parameters,
+                path_mapping_rules=self._job_details.path_mapping_rules,
+                retain_working_dir=self._retain_session_dir,
+                user=self._os_user,
+                action_callback=openjd_session_action_callback,
+                os_env_vars=self._env,
+                session_root_directory=session_root_dir,
+                spec_revision="2023-09",
+                # Currently for simplicity request that our session allow all extensions
+                # This does not obey the spec.  It should be changed at a later date to the list of requested
+                # extensions once those are returned by BatchGetJobEntity
+                supported_extensions=tuple(v.value for v in ExtensionName),
             ),
         )
 
@@ -225,14 +229,14 @@ class Session:
         self._action_output_log_filter = None
 
     @property
-    def openjd_session(self) -> OPENJDSession:
-        """The openjd session for this session"""
-        return self._session
+    def runtime(self) -> SessionRuntime:
+        """The session runtime adapter for this session"""
+        return self._runtime
 
     @property
     def working_directory(self) -> Path:
         """The working directory for this session"""
-        return self._session.working_directory
+        return self._runtime.working_directory
 
     @property
     def id(self) -> str:
@@ -453,7 +457,7 @@ class Session:
         # After canceling the running action, we exit any active environments
         actions.extend(
             (
-                partial(self._session.exit_environment, identifier=env.session_env_id),
+                partial(self._runtime.exit_environment, identifier=env.session_env_id),
                 f"exit environment {env.job_env_id}",
             )
             for env in reversed(self._active_envs)
@@ -486,7 +490,7 @@ class Session:
                 except TimeoutError:
                     # Log, cancel the cleanup action and break the loop if we've run out of grace time
                     logger.warning("%s timed out", desc)
-                    self._session.cancel_action()
+                    self._runtime.cancel_action()
                     break
                 else:
                     logger.info("%s successful", desc)
@@ -495,12 +499,12 @@ class Session:
             if self._asset_sync is not None and self._job_attachment_details is not None:
                 # Perform any cleanup the job attachments system needs to do
                 self._asset_sync.cleanup_session(
-                    session_dir=self._session.working_directory,
+                    session_dir=self._runtime.working_directory,
                     file_system=self._job_attachment_details.job_attachments_file_system,
                     os_user=self._os_user.user if self._os_user else None,
                 )
             # Clean-up the Open Job Description session
-            self._session.cleanup()
+            self._runtime.cleanup()
 
     def replace_assigned_actions(
         self,
@@ -809,7 +813,7 @@ class Session:
                 f"yield_frequency must be a positive timedelta or None, but got {frequency}"
             )
 
-        if self._session.action_status is None:
+        if self._runtime.action_status is None:
             raise RuntimeError("No action is running")
 
         start_time = monotonic()
@@ -817,24 +821,24 @@ class Session:
         remaining_time: timedelta | None = timeout
         if timeout:
             while (
-                self._session.action_status.state
+                self._runtime.action_status.state
                 not in OPENJD_ACTION_STATE_TO_DEADLINE_COMPLETED_STATUS
             ):
                 elapsed_time = timedelta(seconds=cur_time - start_time)
                 remaining_time = timeout - elapsed_time
 
                 if elapsed_time > TIME_DELTA_ZERO:
-                    yield self._session.action_status
+                    yield self._runtime.action_status
 
                 if remaining_time <= TIME_DELTA_ZERO:
                     raise TimeoutError()
                 sleep(min(frequency, remaining_time).total_seconds())
                 cur_time = monotonic()
         else:
-            if self._session.action_status.state == ActionState.RUNNING:
+            if self._runtime.action_status.state == ActionState.RUNNING:
                 sleep(frequency.total_seconds())
-            while self._session.action_status.state == ActionState.RUNNING:
-                yield self._session.action_status
+            while self._runtime.action_status.state == ActionState.RUNNING:
+                yield self._runtime.action_status
                 sleep(frequency.total_seconds())
 
     def enter_environment(
@@ -844,7 +848,7 @@ class Session:
         environment: EnvironmentModel,
         os_env_vars: Optional[dict[str, str]] = None,
     ) -> None:
-        session_env_id = self._session.enter_environment(
+        session_env_id = self._runtime.enter_environment(
             environment=environment, identifier=job_env_id, os_env_vars=os_env_vars
         )
         self._active_envs.append(
@@ -867,7 +871,7 @@ class Session:
                 f"Active environments from outer-most to inner-most are: {env_stack_str}"
             )
         active_env = self._active_envs[-1]
-        self._session.exit_environment(
+        self._runtime.exit_environment(
             identifier=active_env.session_env_id, os_env_vars=os_env_vars
         )
         self._active_envs.pop()
@@ -1176,7 +1180,7 @@ class Session:
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
-        self._session.run_task(
+        self._runtime.run_task(
             step_script=step_script,
             task_parameter_values=task_parameter_values,
             os_env_vars=os_env_vars,
@@ -1191,7 +1195,7 @@ class Session:
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
-        self._session._run_task_without_session_env(
+        self._runtime._run_task_without_session_env(
             step_script=step_script,
             task_parameter_values=task_parameter_values,
             os_env_vars=os_env_vars,

--- a/test/unit/sessions/actions/test_openjd_action.py
+++ b/test/unit/sessions/actions/test_openjd_action.py
@@ -65,7 +65,7 @@ class TestCancel:
         action.cancel(session=session, time_limit=time_limit)
 
         # THEN
-        session._session.cancel_action.assert_called_once_with(time_limit=time_limit)
+        session.runtime.cancel_action.assert_called_once_with(time_limit=time_limit)
 
     @pytest.mark.parametrize(
         argnames="action_status",
@@ -92,15 +92,15 @@ class TestCancel:
         # GIVEN
         action = DerivedOpenjdAction(id="my-id")
         error_msg = "error msg"
-        session._session.cancel_action.side_effect = RuntimeError(error_msg)
-        session._session.action_status = action_status
+        session.runtime.cancel_action.side_effect = RuntimeError(error_msg)
+        session.runtime.action_status = action_status
 
         with pytest.raises(CancelationError) as raise_ctx:
             # WHEN
             action.cancel(session=session, time_limit=time_limit)
 
         # THEN
-        session._session.cancel_action.assert_called_once()
+        session.runtime.cancel_action.assert_called_once()
         if action_status:
             raise_ctx.match(
                 re.escape(

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -69,11 +69,12 @@ def session_dir(session_id: str):
 
 
 @pytest.fixture
-def mock_openjd_session_cls(session_dir: str) -> Generator[MagicMock, None, None]:
-    """Mocks the Worker Agent Session module's import of the Open Job Description Session class"""
-    with patch.object(session_mod, "OPENJDSession") as mock_openjd_session:
-        mock_openjd_session.working_directory = session_dir
-        yield mock_openjd_session
+def mock_runtime(session_dir: str) -> Generator[MagicMock, None, None]:
+    """Patches create_session_runtime and yields a runtime mock with working_directory set."""
+    runtime = MagicMock()
+    runtime.working_directory = session_dir
+    with patch.object(session_mod, "create_session_runtime", return_value=runtime):
+        yield runtime
 
 
 @pytest.fixture
@@ -100,14 +101,14 @@ def session(
     job_details: JobDetails,
     job_user: SessionUser,
     job_attachment_details: JobAttachmentDetails,
-    mock_openjd_session_cls: Mock,
+    mock_runtime: Mock,
 ) -> Mock:
     session = Mock()
     session.id = session_id
     session._job_details = job_details
     session._job_attachment_details = job_attachment_details
     session._os_user = job_user
-    session.openjd_session = mock_openjd_session_cls
+    session.runtime = mock_runtime
     session.working_directory = session_dir
     session._queue_id = TestStart.QUEUE_ID
     session._queue._job_id = TestStart.JOB_ID

--- a/test/unit/sessions/actions/test_run_attachment_upload.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload.py
@@ -59,11 +59,12 @@ def diff_dir(session_dir: str):
 
 
 @pytest.fixture
-def mock_openjd_session_cls(session_dir: str) -> Generator[MagicMock, None, None]:
-    """Mocks the Worker Agent Session module's import of the Open Job Description Session class"""
-    with patch.object(session_mod, "OPENJDSession") as mock_openjd_session:
-        mock_openjd_session.working_directory = session_dir
-        yield mock_openjd_session
+def mock_runtime(session_dir: str) -> Generator[MagicMock, None, None]:
+    """Patches create_session_runtime and yields a runtime mock with working_directory set."""
+    runtime = MagicMock()
+    runtime.working_directory = session_dir
+    with patch.object(session_mod, "create_session_runtime", return_value=runtime):
+        yield runtime
 
 
 @pytest.fixture
@@ -99,14 +100,14 @@ class TestStart:
         job_details: JobDetails,
         job_user: SessionUser,
         job_attachment_details: JobAttachmentDetails,
-        mock_openjd_session_cls: Mock,
+        mock_runtime: Mock,
     ) -> Mock:
         session = Mock()
         session.id = session_id
         session._job_details = job_details
         session._job_attachment_details = job_attachment_details
         session._os_user = job_user
-        session.openjd_session = mock_openjd_session_cls
+        session.runtime = mock_runtime
         session._queue_id = TestStart.QUEUE_ID
         session._queue._job_id = TestStart.JOB_ID
         session.get_worker_manifest_properties_list = Mock(return_value=[])

--- a/test/unit/sessions/runtime/conftest.py
+++ b/test/unit/sessions/runtime/conftest.py
@@ -71,6 +71,9 @@ def _make_stub_runtime_class() -> type[SessionRuntime]:
         ) -> None:
             return None
 
+        def extend_path_mapping_rules(self, rules: list[Any]) -> None:
+            return None
+
         def cancel_action(
             self,
             *,

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -45,6 +45,7 @@ from deadline_worker_agent.api_models import (
     ManifestInfo,
 )
 from deadline_worker_agent.sessions import Session
+from deadline_worker_agent.sessions.runtime import SessionRuntime
 import deadline_worker_agent.sessions.session as session_mod
 from deadline_worker_agent.sessions.session import (
     CurrentAction,
@@ -122,16 +123,18 @@ def action_complete_time() -> datetime:
 
 
 @pytest.fixture
-def mock_openjd_session_cls() -> Generator[MagicMock, None, None]:
-    """Mocks the Worker Agent Session module's import of the Open Job Description Session class"""
-    with patch.object(session_mod, "OPENJDSession") as mock_openjd_session:
-        yield mock_openjd_session
+def mock_create_runtime() -> Generator[MagicMock, None, None]:
+    """Patches create_session_runtime in the session module and yields the mock factory."""
+    with patch.object(session_mod, "create_session_runtime") as mock_create:
+        yield mock_create
 
 
 @pytest.fixture
-def mock_openjd_session(mock_openjd_session_cls: MagicMock) -> MagicMock:
-    """The mocked Open Job Description Session class instance"""
-    return mock_openjd_session_cls.return_value
+def mock_runtime(mock_create_runtime: MagicMock) -> MagicMock:
+    """A MagicMock standing in for the SessionRuntime created by Session.__init__."""
+    runtime = MagicMock(spec=SessionRuntime)
+    mock_create_runtime.return_value = runtime
+    return runtime
 
 
 @pytest.fixture
@@ -152,7 +155,7 @@ def session(
     env: dict[str, str] | None,
     job_details: JobDetails,
     os_user: SessionUser | None,
-    mock_openjd_session_cls: MagicMock,
+    mock_runtime: MagicMock,
     queue_id: str,
     session_action_queue: MagicMock,
     session_id: str,
@@ -355,19 +358,19 @@ class TestSessionInit:
     def test_uses_action_updated_callback(
         self,
         session: Session,
-        mock_openjd_session_cls: MagicMock,
+        mock_create_runtime: MagicMock,
     ) -> None:
         """Asserts that the Session.update_action method is called by the callback supplied to the
         Open Job Description session initializer."""
         # GIVEN
-        mock_openjd_session_cls.assert_called_once()
-        call = mock_openjd_session_cls.call_args_list[0]
+        mock_create_runtime.assert_called_once()
+        config = mock_create_runtime.call_args[0][1]
         action_status = ActionStatus(state=ActionState.SUCCESS)
 
         # THEN
         with patch.object(session, "update_action") as mock_update_action:
             # WHEN
-            call.kwargs["callback"](session.id, action_status)
+            config.action_callback(session.id, action_status)
             mock_update_action.assert_called_once_with(action_status)
 
     def test_creates_current_action_lock(
@@ -419,19 +422,18 @@ class TestSessionInit:
     def test_has_path_mapping_rules(
         self,
         session: Session,
-        mock_openjd_session_cls: MagicMock,
+        mock_create_runtime: MagicMock,
         path_mapping_rules: list[PathMappingRule],
     ):
         """Ensure that when we have path mapping rules that we're passing them to the Open Job Description session"""
         # GIVEN / WHEN / THEN
         assert session is not None
-        mock_openjd_session_cls.assert_called_once()
+        mock_create_runtime.assert_called_once()
+        config = mock_create_runtime.call_args[0][1]
         if path_mapping_rules:
-            assert (
-                path_mapping_rules == mock_openjd_session_cls.call_args.kwargs["path_mapping_rules"]
-            )
+            assert path_mapping_rules == config.path_mapping_rules
         else:
-            assert not mock_openjd_session_cls.call_args.kwargs.get("path_mapping_rules", False)
+            assert not config.path_mapping_rules
 
     @pytest.mark.parametrize(
         "env",
@@ -459,17 +461,18 @@ class TestSessionInit:
     def test_has_env_variables(
         self,
         session: Session,
-        mock_openjd_session_cls: MagicMock,
+        mock_create_runtime: MagicMock,
         env: dict[str, str],
     ):
         """Ensure that when we have env variables that we're passing them to the Open Job Description session"""
         # GIVEN / WHEN / THEN
         assert session is not None
-        mock_openjd_session_cls.assert_called_once()
+        mock_create_runtime.assert_called_once()
+        config = mock_create_runtime.call_args[0][1]
         if env:
-            assert env == mock_openjd_session_cls.call_args.kwargs["os_env_vars"]
+            assert env == config.os_env_vars
         else:
-            assert not mock_openjd_session_cls.call_args.kwargs.get("os_env_vars", False)
+            assert not config.os_env_vars
 
     @pytest.mark.parametrize(
         argnames="session_root_dir",
@@ -481,15 +484,14 @@ class TestSessionInit:
     def test_has_session_root_dir(
         self,
         session: Session,
-        mock_openjd_session_cls: MagicMock,
+        mock_create_runtime: MagicMock,
         session_root_dir: Path,
     ) -> None:
         """Ensure that Session passes session_root_dir when creating the Open Job Description session"""
         # THEN
-        mock_openjd_session_cls.assert_called_once()
-        assert (
-            mock_openjd_session_cls.call_args.kwargs["session_root_directory"] == session_root_dir
-        )
+        mock_create_runtime.assert_called_once()
+        config = mock_create_runtime.call_args[0][1]
+        assert config.session_root_directory == session_root_dir
 
 
 class TestSessionOuterRun:
@@ -811,13 +813,13 @@ class TestSessionCancelActionsImpl:
     def test_cancels_current_action(
         self,
         session: Session,
-        mock_openjd_session: MagicMock,
+        mock_runtime: MagicMock,
         current_action: CurrentAction,
     ) -> None:
         """Asserts that the current action is canceled if cancel_actions() is called with the
         corresponding action ID in the action_ids argument."""
         # GIVEN
-        openjd_cancel_action: MagicMock = mock_openjd_session.cancel_action
+        openjd_cancel_action: MagicMock = mock_runtime.cancel_action
 
         # WHEN
         session._cancel_actions_impl(action_ids=[current_action.definition.id])
@@ -1669,7 +1671,7 @@ class TestSessionActionUpdatedImpl:
         )
 
 
-@pytest.mark.usefixtures("mock_openjd_session")
+@pytest.mark.usefixtures("mock_runtime")
 class TestStartCancelingCurrentAction:
     """Test cases for Session._start_canceling_current_action()"""
 
@@ -1920,10 +1922,10 @@ class TestSessionCleanup:
     def test_calls_openjd_cleanup(
         self,
         session: Session,
-        mock_openjd_session: MagicMock,
+        mock_runtime: MagicMock,
     ) -> None:
         # GIVEN
-        openjd_session_cleanup: MagicMock = mock_openjd_session.cleanup
+        openjd_session_cleanup: MagicMock = mock_runtime.cleanup
 
         # Mock Session._monitor_action which is used to poll the Open Job Description session status
         with patch.object(session, "_monitor_action", return_value=[]):
@@ -1943,7 +1945,7 @@ class TestSessionCleanup:
         session: Session,
         job_attachment_details: JobAttachmentDetails,
         mock_asset_sync: MagicMock,
-        mock_openjd_session: MagicMock,
+        mock_runtime: MagicMock,
     ) -> None:
         # GIVEN
         mock_asset_sync_cleanup: MagicMock = mock_asset_sync.cleanup_session
@@ -1955,7 +1957,7 @@ class TestSessionCleanup:
 
         # THEN
         mock_asset_sync_cleanup.assert_called_once_with(
-            session_dir=mock_openjd_session.working_directory,
+            session_dir=mock_runtime.working_directory,
             file_system=job_attachment_details.job_attachments_file_system,
             os_user=session._os_user.user,
         )
@@ -1965,7 +1967,7 @@ class TestSessionCleanup:
         session: Session,
         job_attachment_details: JobAttachmentDetails,
         mock_asset_sync: MagicMock,
-        mock_openjd_session: MagicMock,
+        mock_runtime: MagicMock,
     ) -> None:
         # GIVEN
         mock_asset_sync_cleanup: MagicMock = mock_asset_sync.cleanup_session
@@ -1977,7 +1979,7 @@ class TestSessionCleanup:
 
         # THEN
         mock_asset_sync_cleanup.assert_called_once_with(
-            session_dir=mock_openjd_session.working_directory,
+            session_dir=mock_runtime.working_directory,
             file_system=job_attachment_details.job_attachments_file_system,
             os_user=None,
         )
@@ -2169,7 +2171,7 @@ class TestSessionStartAction:
         from deadline_worker_agent.sessions.session import Session
 
         # WHEN
-        with patch("deadline_worker_agent.sessions.session.OPENJDSession") as mock_openjd_session:
+        with patch("deadline_worker_agent.sessions.session.create_session_runtime") as mock_create:
             _ = Session(
                 id=session_id,
                 job_details=job_details,
@@ -2186,12 +2188,10 @@ class TestSessionStartAction:
 
         # THEN
         # Verify that the REDACTED_ENV_VARS extension is included in the supported extensions
-        mock_openjd_session.assert_called_once()
-        _, kwargs = mock_openjd_session.call_args
-        assert "revision_extensions" in kwargs
-        revision_extensions = kwargs["revision_extensions"]
+        mock_create.assert_called_once()
+        config = mock_create.call_args[0][1]
         # Check that REDACTED_ENV_VARS is in the list of extensions
-        assert ExtensionName.REDACTED_ENV_VARS.value in revision_extensions.extensions
+        assert ExtensionName.REDACTED_ENV_VARS.value in config.supported_extensions
 
 
 class TestSessionWorkerManifestProperties:
@@ -2482,7 +2482,7 @@ class TestRunAttachmentSyncTask:
     def test_delegates_to_run_task_without_session_env(
         self,
         session: Session,
-        mock_openjd_session: MagicMock,
+        mock_runtime: MagicMock,
         os_env_vars: dict[str, str] | None,
         log_task_banner: bool,
     ) -> None:
@@ -2499,7 +2499,7 @@ class TestRunAttachmentSyncTask:
         )
 
         # THEN
-        mock_openjd_session._run_task_without_session_env.assert_called_once_with(
+        mock_runtime._run_task_without_session_env.assert_called_once_with(
             step_script=step_script_model,
             task_parameter_values=dict[str, ParameterValue](),
             os_env_vars=os_env_vars,
@@ -2509,12 +2509,12 @@ class TestRunAttachmentSyncTask:
     def test_propagates_exception_from_openjd_session(
         self,
         session: Session,
-        mock_openjd_session: MagicMock,
+        mock_runtime: MagicMock,
     ) -> None:
         """Tests that exceptions from the underlying Open Job Description session are propagated."""
         # GIVEN
         expected_exception = RuntimeError("Task execution failed")
-        mock_openjd_session._run_task_without_session_env.side_effect = expected_exception
+        mock_runtime._run_task_without_session_env.side_effect = expected_exception
 
         # WHEN / THEN
         with pytest.raises(RuntimeError) as exc_info:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Session directly constructed and held an `openjd.sessions.Session` object,
tightly coupling it to one runtime implementation. This prevented plugging in
alternative runtimes (e.g., Rust-backed) without invasive changes to session.py.


One other patch to note of: `run_attachment_download.py` reached into openjd's private
`_path_mapping_rules` attribute to inject path mappings mid-session. Added another abstract func to the ABC pattern. Rust version has a public API version of this, so will be clean when that gets implemented in the future


### What was the solution? (How)

Route all Session → openjd interactions through the `SessionRuntime` adapter
(ABC + factory introduced in previous PRs):

- `Session.__init__` now calls `create_session_runtime()` to obtain a
  `PythonSessionRuntime` adapter instead of constructing openjd directly
- All `self._session.<method>` calls renamed to `self._runtime.<method>`
- Added `extend_path_mapping_rules()` to the `SessionRuntime` ABC for
  mid-session path mapping injection. The Python adapter encapsulates the
  direct attribute access internally; the Rust runtime (v1) exposes this
  as a public API.
- Migrated `run_attachment_download.py` to use the new ABC method
- Deleted the `openjd_session` back-compat property (zero callers remain)

### What is the impact of this change?

The same openjd Session is constructed with the same parameters. Path
mappings are injected identically. This is a pure structural refactor to use the new ABC factory pattern

### How was this change tested?

- `hatch run lint` (ruff check + ruff format + mypy): clean
- `hatch run test` (2927 unit tests): all pass
```
Required test coverage of 78.0% reached. Total coverage: 84.33%
============================================================================= slowest 5 durations ==============================================================================
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[spot-shutdown-15-sec]
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_asg_termination
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[spot-shutdown-1-min]
0.60s call     test/unit/startup/test_host_config_timer.py::TestHostConfigTimer::test_no_further_logs_after_timeout_reached
0.50s call     test/unit/startup/test_host_config_timer.py::TestHostConfigTimer::test_accelerates_interval_when_remaining_low
====================================================================== 2927 passed, 38 skipped in 21.25s =======================================================================
```
- `hatch run integ-test` (73 integration tests): all pass
```
================================================================================================== slowest 5 durations ===================================================================================================
3.01s call     test/integ/startup/test_host_configuration.py::TestHostConfigurationScriptRunner::test_timer_timeout_expiration_log_appears
2.01s call     test/integ/startup/test_host_configuration.py::TestHostConfigurationScriptRunner::test_host_configuration_script_runner[Timed out test case]
1.01s call     test/integ/startup/test_host_configuration.py::TestHostConfigurationScriptRunner::test_timer_ticker_logs_appear_during_script_execution
0.77s call     test/integ/config/test_config_cli.py::TestMissingExistingCommented::test[ModifiableSetting.ALLOW_EC2_INSTANCE_PROFILE-commented]
0.76s call     test/integ/config/test_config_cli.py::TestMissingExistingCommented::test[ModifiableSetting.REGION-missing]
======================================================================================= 73 passed, 4 skipped, 1 warning in 25.15s ========================================================================================

```
- E2E tests with real Deadline Cloud farm: (CURRENTLY RERUNNING)
Linux:
```
================================================================================================== slowest 5 durations ===================================================================================================
629.44s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
269.09s setup    test/e2e/test_cap_kill.py::test_cap_kill_not_inherited_by_running_jobs
260.03s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_local_session_logs_can_be_turned_off
253.78s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
213.41s setup    test/e2e/test_worker_status.py::TestWorkerStatus::test_linux_worker_restarts_process
====================================================================================== 49 passed, 23 skipped in 4318.74s (1:11:58) =======================================================================================
```
WIndows:
```
================================================================================== short test summary info ==================================================================================
XFAIL test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_queue_user[ddl] - AD DS install on EC2 is unreliable
XFAIL test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_config_override_user[ddl] - AD DS install on EC2 is unreliable
XFAIL test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_queue_user[upn] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_local_queue_user[ddl] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_service_identity[ddl] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_local_queue_user[upn] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_service_identity[upn] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_config_override_user[upn] - AD DS install on EC2 is unreliable
============================================================= 47 passed, 17 skipped, 3 xfailed, 5 xpassed in 7055.37s (1:57:35) =============================================================
```
- Test mocks migrated from patching `OPENJDSession` to patching
  `create_session_runtime`, asserting on `SessionRuntimeConfig` fields

### Was this change documented?

Inline docstrings on new `extend_path_mapping_rules` ABC method explain the
Python/Rust asymmetry. 

### Is this a breaking change?

No. Internal refactor with no public API changes.