### PR TITLE
feat(mrf): Use region from log config options for cross-region CWL ro…

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -34,8 +34,9 @@ from ...api_models import (
     UpdateWorkerResponse,
     WorkerStatus,
 )
-from ...log_sync.cloudwatch import (
+from ...log_sync.log_constants import (
     LOG_CONFIG_OPTION_GROUP_NAME_KEY,
+    LOG_CONFIG_OPTION_REGION_KEY,
     LOG_CONFIG_OPTION_STREAM_NAME_KEY,
 )
 
@@ -131,6 +132,11 @@ class WorkerLogConfig:
 
     cloudwatch_log_stream: str
     """The name of the CloudWatch Log Stream that the Agent log should be streamed to"""
+
+    cloudwatch_region: Optional[str] = None
+    """The AWS region where the CloudWatch Log Group resides. If None, the agent's local region
+    is used. This enables satellite workers in multi-region fleets to write logs to the home
+    region's log groups."""
 
 
 def _get_error_code_from_header(response: dict[str, Any]) -> Optional[str]:
@@ -696,6 +702,7 @@ def construct_worker_log_config(log_config: LogConfiguration) -> Optional[Worker
         return WorkerLogConfig(
             cloudwatch_log_group=log_group_name,
             cloudwatch_log_stream=log_stream_name,
+            cloudwatch_region=log_config_options.get(LOG_CONFIG_OPTION_REGION_KEY),
         )
     else:
         _logger.warning(

--- a/src/deadline_worker_agent/log_sync/cloudwatch.py
+++ b/src/deadline_worker_agent/log_sync/cloudwatch.py
@@ -25,8 +25,11 @@ __all__ = [
     "stream_cloudwatch_logs",
 ]
 
-LOG_CONFIG_OPTION_GROUP_NAME_KEY = "logGroupName"
-LOG_CONFIG_OPTION_STREAM_NAME_KEY = "logStreamName"
+from .log_constants import (
+    LOG_CONFIG_OPTION_GROUP_NAME_KEY,  # noqa: F401 - re-exported for backwards compatibility
+    LOG_CONFIG_OPTION_REGION_KEY,  # noqa: F401
+    LOG_CONFIG_OPTION_STREAM_NAME_KEY,  # noqa: F401
+)
 
 
 class PutLogEventsConstraints(NamedTuple):

--- a/src/deadline_worker_agent/log_sync/log_constants.py
+++ b/src/deadline_worker_agent/log_sync/log_constants.py
@@ -1,0 +1,7 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Constants for log configuration option keys."""
+
+LOG_CONFIG_OPTION_GROUP_NAME_KEY = "logGroupName"
+LOG_CONFIG_OPTION_STREAM_NAME_KEY = "logStreamName"
+LOG_CONFIG_OPTION_REGION_KEY = "region"

--- a/src/deadline_worker_agent/sessions/log_config.py
+++ b/src/deadline_worker_agent/sessions/log_config.py
@@ -14,8 +14,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, ContextManager
 
-from ..log_sync.cloudwatch import (
+from ..log_sync.log_constants import (
     LOG_CONFIG_OPTION_GROUP_NAME_KEY,
+    LOG_CONFIG_OPTION_REGION_KEY,
     LOG_CONFIG_OPTION_STREAM_NAME_KEY,
 )
 from ..api_models import LogConfiguration as BotoSessionLogConfiguration
@@ -314,7 +315,15 @@ class LogConfiguration:
         return CloudWatchHandler(
             log_group_name=log_group,
             log_stream_name=log_stream,
-            logs_client=boto_session.client("logs", config=OTHER_BOTOCORE_CONFIG),
+            logs_client=boto_session.client(
+                "logs",
+                config=OTHER_BOTOCORE_CONFIG,
+                **(
+                    {"region_name": region}
+                    if (region := self.options.get(LOG_CONFIG_OPTION_REGION_KEY))
+                    else {}
+                ),
+            ),
         )
 
     def create_local_file_handler(self) -> logging.FileHandler:

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -12,7 +12,7 @@ from time import sleep
 from botocore.exceptions import NoRegionError
 from logging.handlers import TimedRotatingFileHandler
 from threading import Event
-from typing import Optional
+from typing import Any, Optional
 from pathlib import Path
 
 from ..aws_credentials.worker_boto3_session import WorkerBoto3Session
@@ -130,7 +130,10 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
             config=DEADLINE_BOTOCORE_CONFIG,
         )
         s3_client = session.client("s3", config=OTHER_BOTOCORE_CONFIG)
-        logs_client = session.client("logs", config=OTHER_BOTOCORE_CONFIG)
+        logs_client_kwargs: dict[str, Any] = {"config": OTHER_BOTOCORE_CONFIG}
+        if worker_bootstrap.log_config.cloudwatch_region:
+            logs_client_kwargs["region_name"] = worker_bootstrap.log_config.cloudwatch_region
+        logs_client = session.client("logs", **logs_client_kwargs)
 
         # Shutdown behavior flags set by Worker below
         shutdown_requested_by_service = False

--- a/test/unit/aws/deadline/test_construct_worker_log_config.py
+++ b/test/unit/aws/deadline/test_construct_worker_log_config.py
@@ -13,18 +13,28 @@ from deadline_worker_agent.api_models import (
 )
 
 
-from deadline_worker_agent.log_sync.cloudwatch import (
+from deadline_worker_agent.log_sync.log_constants import (
     LOG_CONFIG_OPTION_GROUP_NAME_KEY,
+    LOG_CONFIG_OPTION_REGION_KEY,
     LOG_CONFIG_OPTION_STREAM_NAME_KEY,
 )
 
 CLOUDWATCH_LOG_GROUP = "log-group"
 CLOUDWATCH_LOG_STREAM = "log-stream"
+CLOUDWATCH_REGION = "us-west-2"
 AWSLOGS_LOG_CONFIGURATION = LogConfiguration(
     logDriver="awslogs",
     options={
         LOG_CONFIG_OPTION_GROUP_NAME_KEY: CLOUDWATCH_LOG_GROUP,
         LOG_CONFIG_OPTION_STREAM_NAME_KEY: CLOUDWATCH_LOG_STREAM,
+    },
+)
+AWSLOGS_LOG_CONFIGURATION_WITH_REGION = LogConfiguration(
+    logDriver="awslogs",
+    options={
+        LOG_CONFIG_OPTION_GROUP_NAME_KEY: CLOUDWATCH_LOG_GROUP,
+        LOG_CONFIG_OPTION_STREAM_NAME_KEY: CLOUDWATCH_LOG_STREAM,
+        LOG_CONFIG_OPTION_REGION_KEY: CLOUDWATCH_REGION,
     },
 )
 AWSLOGS_LOG_CONFIGURATION_MISSING_OPTIONS = LogConfiguration(
@@ -64,7 +74,9 @@ def test_success() -> None:
 
     # GIVEN
     expected_result = WorkerLogConfig(
-        cloudwatch_log_group=CLOUDWATCH_LOG_GROUP, cloudwatch_log_stream=CLOUDWATCH_LOG_STREAM
+        cloudwatch_log_group=CLOUDWATCH_LOG_GROUP,
+        cloudwatch_log_stream=CLOUDWATCH_LOG_STREAM,
+        cloudwatch_region=None,
     )
 
     # WHEN
@@ -72,6 +84,25 @@ def test_success() -> None:
 
     # THEN
     assert result == expected_result
+    assert result.cloudwatch_region is None
+
+
+def test_success_with_region() -> None:
+    # Tests that the region option is correctly extracted from the log configuration
+
+    # GIVEN
+    expected_result = WorkerLogConfig(
+        cloudwatch_log_group=CLOUDWATCH_LOG_GROUP,
+        cloudwatch_log_stream=CLOUDWATCH_LOG_STREAM,
+        cloudwatch_region=CLOUDWATCH_REGION,
+    )
+
+    # WHEN
+    result = construct_worker_log_config(AWSLOGS_LOG_CONFIGURATION_WITH_REGION)
+
+    # THEN
+    assert result == expected_result
+    assert result.cloudwatch_region == CLOUDWATCH_REGION
 
 
 @pytest.mark.parametrize(

--- a/test/unit/sessions/test_log_config.py
+++ b/test/unit/sessions/test_log_config.py
@@ -393,3 +393,62 @@ class TestActionOutputCaptureFilter:
             # Verify the filter returns True but doesn't process the message due to multiple matches
             assert result is True
             mock_callback.assert_not_called()
+
+
+class TestCreateRemoteHandler:
+    """Tests for LogConfiguration.create_remote_handler region handling"""
+
+    def test_create_remote_handler_without_region(self) -> None:
+        """Tests that create_remote_handler does NOT pass region_name when region is absent"""
+        # GIVEN
+        boto_log_configuration = BotoLogConfiguration(
+            logDriver="awslogs",
+            options={
+                "logGroupName": "test-log-group",
+                "logStreamName": "test-log-stream",
+            },
+            parameters={"interval": "15"},
+        )
+        log_config = LogConfiguration.from_boto(
+            loggers=[],
+            log_configuration=boto_log_configuration,
+            session_log_file=None,
+        )
+        mock_boto_session = MagicMock()
+
+        # WHEN
+        log_config.create_remote_handler(boto_session=mock_boto_session)
+
+        # THEN
+        mock_boto_session.client.assert_called_once()
+        call_kwargs = mock_boto_session.client.call_args
+        assert call_kwargs[0][0] == "logs"
+        assert "region_name" not in call_kwargs[1]
+
+    def test_create_remote_handler_with_region(self) -> None:
+        """Tests that create_remote_handler passes region_name when region option is present"""
+        # GIVEN
+        boto_log_configuration = BotoLogConfiguration(
+            logDriver="awslogs",
+            options={
+                "logGroupName": "test-log-group",
+                "logStreamName": "test-log-stream",
+                "region": "us-east-1",
+            },
+            parameters={"interval": "15"},
+        )
+        log_config = LogConfiguration.from_boto(
+            loggers=[],
+            log_configuration=boto_log_configuration,
+            session_log_file=None,
+        )
+        mock_boto_session = MagicMock()
+
+        # WHEN
+        log_config.create_remote_handler(boto_session=mock_boto_session)
+
+        # THEN
+        mock_boto_session.client.assert_called_once()
+        call_kwargs = mock_boto_session.client.call_args
+        assert call_kwargs[0][0] == "logs"
+        assert call_kwargs[1]["region_name"] == "us-east-1"

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -89,7 +89,7 @@ def mock_boto_session(
 ) -> MagicMock:
     mock_session = MagicMock()
 
-    def client_mock(service: str, config: Any) -> MagicMock:
+    def client_mock(service: str, **kwargs: Any) -> MagicMock:
         if service == "deadline":
             return client
         elif service == "s3":
@@ -770,6 +770,49 @@ class TestCloudWatchLogStreaming:
         )
         context_mgr_enter.assert_called_once_with()
         context_mgr_exit.assert_called_once()
+
+    def test_logs_client_created_without_region_when_cloudwatch_region_is_none(
+        self,
+        mock_stream_cloudwatch_logs: MagicMock,
+        mock_boto_session: MagicMock,
+        worker_log_config: WorkerLogConfig,
+        configuration: Configuration,
+    ) -> None:
+        """When cloudwatch_region is None, session.client('logs', ...) is called without region_name"""
+        # GIVEN
+        assert worker_log_config.cloudwatch_region is None
+
+        # WHEN
+        entrypoint_mod.entrypoint()
+
+        # THEN
+        logs_call = [c for c in mock_boto_session.client.call_args_list if c[0][0] == "logs"]
+        assert len(logs_call) == 1
+        assert "region_name" not in logs_call[0][1]
+
+    def test_logs_client_created_with_region_when_cloudwatch_region_is_set(
+        self,
+        mock_stream_cloudwatch_logs: MagicMock,
+        mock_boto_session: MagicMock,
+        configuration: Configuration,
+        bootstrap_worker_mock: MagicMock,
+    ) -> None:
+        """When cloudwatch_region is set, session.client('logs', ..., region_name='us-east-1') is called"""
+        # GIVEN
+        log_config_with_region = WorkerLogConfig(
+            cloudwatch_log_group="test-group",
+            cloudwatch_log_stream="test-stream",
+            cloudwatch_region="us-east-1",
+        )
+        bootstrap_worker_mock.return_value.log_config = log_config_with_region
+
+        # WHEN
+        entrypoint_mod.entrypoint()
+
+        # THEN
+        logs_call = [c for c in mock_boto_session.client.call_args_list if c[0][0] == "logs"]
+        assert len(logs_call) == 1
+        assert logs_call[0][1].get("region_name") == "us-east-1"
 
 
 @patch.object(entrypoint_mod, "record_uncaught_exception_telemetry_event")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Workers may need to write CloudWatch logs to a region different from the one they are running in. Currently the agent infers the CWL target region from local EC2 metadata, which doesn't support this.

### What was the solution? (How)

Read the optional `region` field from `logConfiguration.options` and pass it as `region_name` when creating the CWL boto3 client. Covers both the agent-level log path and session-level log path. Falls back to local region when absent.

### What is the impact of this change?

No change for existing fleets. When the service provides a `region` in the log configuration options, the agent will route logs to that region.

### How was this change tested?

- Unit tests for parsing with/without region, and verifying `region_name` is passed to the CWL client
- Integration: custom wheel deployed via fleet host config, worker reached IDLE, job completed, logs written with 0 errors

### Was this change documented?

No. Internal contract between the data plane and worker agent.

### Is this a breaking change?

No. Backwards compatible. If `region` is absent, existing behavior is preserved.