### PR TITLE
feat: add RustSessionRuntime adapter for OpenJD v1 sessions

### DIFF
--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -1,0 +1,420 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import tempfile
+from datetime import timedelta
+from logging import getLogger
+from pathlib import Path
+from shutil import chown
+from typing import TYPE_CHECKING, Any, Optional
+
+from openjd._openjd_rs import create_environment, deserialize_step
+from openjd.expr import PathFormat, PathMappingRule as RustPathMappingRule
+from openjd.model._v1 import decode_environment_template
+from openjd.model._v1.types import (
+    JobParameterType,
+    JobParameterValue,
+    ModelExtension,
+    ModelProfile,
+    SpecificationRevision,
+    TaskParameterType,
+    TaskParameterValue,
+)
+from openjd.sessions import (
+    ActionState,
+    ActionStatus,
+    PathMappingRule,
+    PosixSessionUser,
+    WindowsSessionUser,
+)
+from openjd.sessions._v1 import (
+    ActionState as RustActionState,
+    ActionStatus as RustActionStatus,
+    PosixSessionUser as RustPosixSessionUser,
+    Session as OpenJDRustSession,
+    WindowsSessionUser as RustWindowsSessionUser,
+)
+
+from . import SessionRuntime, SessionRuntimeConfig
+
+if TYPE_CHECKING:
+    from openjd.sessions import (
+        EnvironmentIdentifier,
+        EnvironmentModel,
+        SessionUser,
+        StepScriptModel,
+    )
+
+__all__ = ["RustSessionRuntime"]
+
+logger = getLogger(__name__)
+
+
+# Deliberate allowlist of the OpenJD specification revisions this adapter
+# supports. Adding a revision is not just adding a map entry: the adapter
+# hardcodes 2023-09 wire strings elsewhere (e.g. enter_environment's
+# "environment-2023-09" envelope), which must be audited for a new revision.
+_SPEC_REVISIONS: dict[str, SpecificationRevision] = {
+    SpecificationRevision.v2023_09.value: SpecificationRevision.v2023_09,
+}
+
+
+# openjd.expr.PathFormat is a non-constructable Rust enum, so map the v0
+# rule's format string to the member by its value.
+_PATH_FORMATS: dict[str, PathFormat] = {
+    "POSIX": PathFormat.POSIX,
+    "WINDOWS": PathFormat.WINDOWS,
+}
+
+
+# The _v1 ActionState is a non-iterable pyo3 enum, so map each member to the
+# v0 enum explicitly (same pattern as _SPEC_REVISIONS/_PATH_FORMATS). A state
+# added on the Rust side must be mapped here deliberately — failing loud beats
+# silently mis-reporting an action's state to the service.
+_ACTION_STATES: dict[str, ActionState] = {
+    str(RustActionState.RUNNING): ActionState.RUNNING,
+    str(RustActionState.CANCELED): ActionState.CANCELED,
+    str(RustActionState.TIMEOUT): ActionState.TIMEOUT,
+    str(RustActionState.FAILED): ActionState.FAILED,
+    str(RustActionState.SUCCESS): ActionState.SUCCESS,
+}
+
+
+def _to_v0_action_state(state: RustActionState) -> ActionState:
+    """Convert a _v1 ActionState into the v0 enum member, failing loud on
+    states this adapter does not recognize."""
+    try:
+        return _ACTION_STATES[str(state)]
+    except KeyError:
+        raise ValueError(f"Unrecognized _v1 ActionState: {state!r}") from None
+
+
+def _to_rust_session_user(
+    user: Optional[SessionUser],
+) -> Optional[RustPosixSessionUser | RustWindowsSessionUser]:
+    """Convert a worker (v0) SessionUser into the equivalent _v1 type.
+
+    The worker builds v0 ``openjd.sessions`` user objects, but the Rust session
+    only accepts its own ``openjd.sessions._v1`` user classes — structurally
+    identical but distinct at the type level. None passes through unchanged
+    (the session runs as the agent's own user in that case).
+    """
+    if user is None:
+        return None
+    if isinstance(user, PosixSessionUser):
+        return RustPosixSessionUser(user.user, group=user.group)
+    if isinstance(user, WindowsSessionUser):
+        return RustWindowsSessionUser(
+            user.user, password=user.password, logon_token=user.logon_token
+        )
+    raise TypeError(f"Unsupported SessionUser type: {type(user).__name__}")
+
+
+def _to_rust_parameter_values(
+    values: dict[str, Any],
+    *,
+    value_cls: type,
+    type_cls: type,
+) -> dict[str, Any]:
+    """Convert worker (v0) parameter values into native _v1 parameter values.
+
+    The worker supplies ``openjd.model`` ParameterValue objects; the Rust
+    session accepts the native pyo3 value types exported from
+    ``openjd.model._v1.types``, which are constructable from Python. Values
+    already in the ``{"type", "value"}`` dict form pass through unchanged.
+    Parameter types the binding does not define fail loud rather than being
+    silently re-encoded.
+    """
+    converted: dict[str, Any] = {}
+    for name, value in values.items():
+        if isinstance(value, dict):
+            converted[name] = value
+            continue
+        native_type = getattr(type_cls, value.type.value, None)
+        if native_type is None:
+            raise ValueError(
+                f"Parameter {name!r} has type {value.type.value!r}, which the "
+                f"_v1 binding's {type_cls.__name__} does not define."
+            )
+        converted[name] = value_cls(type=native_type, value=value.value)
+    return converted
+
+
+def _to_rust_job_parameter_values(values: dict[str, Any]) -> dict[str, Any]:
+    """Convert worker (v0) job parameter values into native _v1 JobParameterValues."""
+    return _to_rust_parameter_values(values, value_cls=JobParameterValue, type_cls=JobParameterType)
+
+
+def _to_rust_task_parameter_values(values: dict[str, Any]) -> dict[str, Any]:
+    """Convert worker (v0) task parameter values into native _v1 TaskParameterValues."""
+    return _to_rust_parameter_values(
+        values, value_cls=TaskParameterValue, type_cls=TaskParameterType
+    )
+
+
+def _to_rust_path_mapping_rule(rule: PathMappingRule) -> RustPathMappingRule:
+    """Convert one worker (v0) PathMappingRule into the _v1 (openjd.expr) type.
+
+    The worker builds ``openjd.sessions`` path-mapping rules, but the Rust
+    session only accepts ``openjd.expr.PathMappingRule`` — a distinct class with
+    the same shape. Paths are coerced to strings, which the _v1 rule stores.
+    """
+    return RustPathMappingRule(
+        source_path_format=_PATH_FORMATS[rule.source_path_format.value],
+        source_path=str(rule.source_path),
+        destination_path=str(rule.destination_path),
+    )
+
+
+def _to_rust_path_mapping_rules(
+    rules: Optional[list[PathMappingRule]],
+) -> Optional[list[RustPathMappingRule]]:
+    """Convert worker (v0) PathMappingRule lists into the _v1 type, passing None through."""
+    if rules is None:
+        return None
+    return [_to_rust_path_mapping_rule(rule) for rule in rules]
+
+
+def _to_v0_action_status(status: RustActionStatus) -> ActionStatus:
+    """Convert a _v1 ActionStatus back into the v0 type the worker consumes.
+
+    The Rust session reports status with its own ``openjd.sessions._v1``
+    ActionStatus/ActionState, but the worker's scheduler compares against the v0
+    ActionState enum. The state is remapped through the explicit _ACTION_STATES
+    table and the remaining fields are copied across.
+    """
+    return ActionStatus(
+        state=_to_v0_action_state(status.state),
+        progress=status.progress,
+        status_message=status.status_message,
+        fail_message=status.fail_message,
+        exit_code=status.exit_code,
+    )
+
+
+class RustSessionRuntime(SessionRuntime):
+    """SessionRuntime backed by openjd.sessions._v1 (Rust implementation)."""
+
+    _session: OpenJDRustSession
+    _user: Optional[SessionUser]
+
+    def __init__(self, config: SessionRuntimeConfig) -> None:
+        try:
+            revision = _SPEC_REVISIONS[config.spec_revision]
+        except KeyError:
+            raise ValueError(
+                f"Unsupported OpenJD specification revision: {config.spec_revision!r}"
+            ) from None
+
+        # The extensions to enable are supplied by the config as strings
+        # (sourced from the OpenJD model library). The v1 API needs native
+        # ModelExtension enums, so convert each name to its enum member.
+        #
+        # The Python openjd.model library may know extensions the Rust crate
+        # doesn't yet (e.g. WRAP_ACTIONS). Skip those rather than fail: a job
+        # template that actually requires a skipped extension is rejected at
+        # decode time with a clear error, matching how the v0 session
+        # tolerates extension names it doesn't recognize.
+        extensions: list[ModelExtension] = []
+        for name in config.supported_extensions:
+            extension = ModelExtension.from_str(name)
+            if extension is None:
+                logger.warning(
+                    "OpenJD model extension %r is not supported by the Rust session runtime; ignoring it.",
+                    name,
+                )
+                continue
+            extensions.append(extension)
+
+        # Kept for the attachment-sync path: on POSIX it grants the files it
+        # writes group-read access for the session user's group, so the job
+        # (which runs as that user) can read them.
+        self._user = config.user
+
+        # The _v1 session reports status with _v1 ActionStatus/ActionState, but
+        # the worker's callback expects the v0 types, so translate on the way out.
+        v0_callback = config.action_callback
+
+        def _rust_action_callback(session_id: str, status: RustActionStatus) -> None:
+            v0_callback(session_id, _to_v0_action_status(status))
+
+        self._session = OpenJDRustSession(
+            session_id=config.session_id,
+            job_parameter_values=_to_rust_job_parameter_values(config.job_parameter_values),
+            path_mapping_rules=_to_rust_path_mapping_rules(config.path_mapping_rules),
+            retain_working_dir=config.retain_working_dir,
+            user=_to_rust_session_user(config.user),
+            callback=_rust_action_callback,
+            os_env_vars=config.os_env_vars,
+            session_root_directory=config.session_root_directory,
+            profile=ModelProfile(revision=revision, extensions=extensions),
+        )
+
+    def enter_environment(
+        self,
+        *,
+        environment: EnvironmentModel,
+        identifier: Optional[EnvironmentIdentifier] = None,
+        os_env_vars: Optional[dict[str, str]] = None,
+    ) -> EnvironmentIdentifier:
+        # The shared action layer hands a pydantic v2023_09 environment, but the
+        # Rust session needs a native _v1 environment. Serialize to the OpenJD
+        # wire shape and rebuild it natively. exclude_none=True is required, not
+        # cosmetic: the Rust decoder rejects explicit nulls (OpenJD treats
+        # absent and null as equivalent).
+        native_environment = create_environment(
+            decode_environment_template(
+                {
+                    "specificationVersion": "environment-2023-09",
+                    "environment": environment.model_dump(
+                        mode="json", by_alias=True, exclude_none=True
+                    ),
+                }
+            )
+        )
+        return self._session.enter_environment(
+            environment=native_environment,
+            identifier=identifier,
+            os_env_vars=os_env_vars,
+        )
+
+    def exit_environment(
+        self,
+        *,
+        identifier: EnvironmentIdentifier,
+        os_env_vars: Optional[dict[str, str]] = None,
+        keep_session_running: bool = False,
+    ) -> None:
+        self._session.exit_environment(
+            identifier=identifier,
+            os_env_vars=os_env_vars,
+            keep_session_running=keep_session_running,
+        )
+
+    def run_task(
+        self,
+        *,
+        step_script: StepScriptModel,
+        task_parameter_values: dict[str, Any],
+        os_env_vars: Optional[dict[str, str]] = None,
+        log_task_banner: bool = True,
+    ) -> None:
+        # The shared action layer hands a pydantic v2023_09 StepScript, but the
+        # Rust session needs a native _v1 step. Serialize to the OpenJD wire
+        # shape and rebuild it natively. deserialize_step requires a named step
+        # and the binding has no bare step-script deserializer (tracked in
+        # OpenJobDescription/openjd-sessions-for-python#334), so wrap the script
+        # as ``{"name": ..., "script": ...}`` and unwrap it after decoding.
+        # exclude_none=True is required, not cosmetic: the Rust decoder rejects
+        # explicit nulls (OpenJD treats absent and null as equivalent).
+        native_step_script = deserialize_step(
+            {
+                "name": "Placeholder",
+                "script": step_script.model_dump(mode="json", by_alias=True, exclude_none=True),
+            }
+        ).script
+        self._session.run_task(
+            step_script=native_step_script,
+            task_parameter_values=_to_rust_task_parameter_values(task_parameter_values),
+            os_env_vars=os_env_vars,
+            log_task_banner=log_task_banner,
+        )
+
+    def _run_task_without_session_env(
+        self,
+        *,
+        step_script: StepScriptModel,
+        task_parameter_values: dict[str, Any],
+        os_env_vars: Optional[dict[str, str]] = None,
+        log_task_banner: bool = True,
+    ) -> None:
+        # Attachment-sync path: the native run_task's embedded-file handling is
+        # unavailable here, so materialize the script's embedded files to the
+        # session's files directory ourselves, resolve ``Task.File.*`` argument
+        # references to those paths, and run the command as a bare subprocess.
+        #
+        # STOPGAP — tracked in OpenJobDescription/openjd-sessions-for-python#332.
+        # Remove this block and delegate once the _v1 wrapper exposes a
+        # ``run_task(..., use_session_env_vars=False)``-style API (which would
+        # also restore the library's cross-platform file permission handling).
+        file_paths: dict[str, str] = {}
+        if step_script.embeddedFiles:
+            for embedded_file in step_script.embeddedFiles:
+                if embedded_file.data is None:
+                    continue
+                fd, path = tempfile.mkstemp(
+                    dir=str(self._session.files_directory),
+                    prefix=f"{embedded_file.name}_",
+                )
+                # UTF-8 explicitly: the platform default (e.g. cp1252 on
+                # Windows) can corrupt or reject non-ASCII paths in the
+                # manifest JSON, which the reader script decodes as UTF-8.
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(str(embedded_file.data))
+                # Owner read/write. On POSIX, also grant the session user's group
+                # read access so the job user can read the materialized file.
+                mode = stat.S_IRUSR | stat.S_IWUSR
+                if self._user is not None and os.name == "posix":
+                    group = getattr(self._user, "group", None)
+                    if group is not None:
+                        chown(path, group=group)
+                        mode |= stat.S_IRGRP
+                os.chmod(path, mode)
+                file_paths[embedded_file.name] = path
+
+        command = str(step_script.actions.onRun.command)
+        args: list[str] = []
+        if step_script.actions.onRun.args:
+            for arg in step_script.actions.onRun.args:
+                # Resolve {{ Task.File.<name> }} references with any interior
+                # whitespace, matching the format-string parser's tolerance.
+                # References to files that were not materialized (unknown name
+                # or no data) are left untouched.
+                resolved = re.sub(
+                    r"\{\{\s*Task\.File\.(\w+)\s*\}\}",
+                    lambda m: file_paths.get(m.group(1), m.group(0)),
+                    str(arg),
+                )
+                args.append(resolved)
+
+        # use_session_env_vars=False bypasses the session environment (e.g. a
+        # conda env) so attachment-sync scripts run in a clean environment.
+        subprocess_env = {"PYTHONUNBUFFERED": "1", **(os_env_vars or {})}
+        self._session.run_subprocess(
+            command=command,
+            args=args,
+            os_env_vars=subprocess_env,
+            use_session_env_vars=False,
+            log_banner_message="Running Task" if log_task_banner else None,
+        )
+
+    def extend_path_mapping_rules(self, rules: list[PathMappingRule]) -> None:
+        # The Rust session exposes this as a public method and sorts the rules
+        # by source-path length internally, so no pre-sorting is needed here.
+        self._session.extend_path_mapping_rules(
+            [_to_rust_path_mapping_rule(rule) for rule in rules]
+        )
+
+    def cancel_action(
+        self,
+        *,
+        time_limit: Optional[timedelta] = None,
+        mark_action_failed: bool = False,
+    ) -> None:
+        self._session.cancel_action(time_limit=time_limit, mark_action_failed=mark_action_failed)
+
+    def cleanup(self) -> None:
+        self._session.cleanup()
+
+    @property
+    def working_directory(self) -> Path:
+        return self._session.working_directory
+
+    @property
+    def action_status(self) -> Optional[ActionStatus]:
+        status = self._session.action_status
+        return _to_v0_action_status(status) if status is not None else None

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -1,0 +1,890 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from datetime import timedelta
+from pathlib import Path, PurePosixPath
+from typing import Any, Generator
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from openjd.model._types import ParameterValue, ParameterValueType
+from openjd.model._v1.types import ModelProfile, SpecificationRevision
+
+from deadline_worker_agent.sessions.runtime import SessionRuntime, SessionRuntimeConfig
+from deadline_worker_agent.sessions.runtime import rust as rust_module
+from deadline_worker_agent.sessions.runtime.rust import RustSessionRuntime
+from deadline_worker_agent.sessions.runtime.rust import _to_rust_task_parameter_values
+
+
+@pytest.fixture()
+def runtime_config() -> SessionRuntimeConfig:
+    """Minimal valid SessionRuntimeConfig for testing."""
+    return SessionRuntimeConfig(
+        session_id="session-1",
+        job_parameter_values={"Param1": {"type": "STRING", "value": "value1"}},
+        path_mapping_rules=None,
+        retain_working_dir=False,
+        user=None,
+        action_callback=lambda session_id, status: None,
+        os_env_vars=None,
+        session_root_directory=Path("/tmp/sessions/session-1"),
+    )
+
+
+@pytest.fixture()
+def mock_rust_session() -> Generator[MagicMock, None, None]:
+    with patch.object(rust_module, "OpenJDRustSession") as mock_cls:
+        yield mock_cls
+
+
+class TestRustSessionRuntimeConstruction:
+    def test_construction_when_default_config_maps_kwargs_to_v1_session(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
+    ) -> None:
+        RustSessionRuntime(runtime_config)
+
+        mock_rust_session.assert_called_once()
+        call_kwargs = mock_rust_session.call_args.kwargs
+        assert call_kwargs["session_id"] == "session-1"
+        assert call_kwargs["job_parameter_values"] == {
+            "Param1": {"type": "STRING", "value": "value1"}
+        }
+        assert call_kwargs["path_mapping_rules"] is None
+        assert call_kwargs["retain_working_dir"] is False
+        assert call_kwargs["user"] is None
+        assert callable(call_kwargs["callback"])
+        assert call_kwargs["os_env_vars"] is None
+        assert call_kwargs["session_root_directory"] == Path("/tmp/sessions/session-1")
+        profile = call_kwargs["profile"]
+        assert isinstance(profile, ModelProfile)
+
+    def test_construction_when_no_extensions_configured_wires_empty_list(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
+    ) -> None:
+        # Proves the extensions are NOT hardcoded: an empty config yields an
+        # empty extensions list rather than a fixed set.
+        with (
+            patch.object(rust_module, "ModelProfile") as mock_profile,
+            patch.object(rust_module, "ModelExtension") as mock_extension,
+        ):
+            RustSessionRuntime(runtime_config)
+
+        mock_extension.from_str.assert_not_called()
+        profile_kwargs = mock_profile.call_args.kwargs
+        assert profile_kwargs["extensions"] == []
+        assert profile_kwargs["revision"] == SpecificationRevision.v2023_09
+
+    def test_construction_when_extensions_configured_wires_them_from_config(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        config = SessionRuntimeConfig(
+            session_id="session-2",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda session_id, status: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-2"),
+            supported_extensions=("EXPR", "TASK_CHUNKING"),
+        )
+
+        with (
+            patch.object(rust_module, "ModelProfile") as mock_profile,
+            patch.object(rust_module, "ModelExtension") as mock_extension,
+        ):
+            mock_extension.from_str.side_effect = lambda name: f"EXT::{name}"
+            RustSessionRuntime(config)
+
+        # Each configured extension identifier is coerced via from_str, in order.
+        assert mock_extension.from_str.call_args_list == [call("EXPR"), call("TASK_CHUNKING")]
+        profile_kwargs = mock_profile.call_args.kwargs
+        assert profile_kwargs["extensions"] == ["EXT::EXPR", "EXT::TASK_CHUNKING"]
+
+    def test_construction_when_unknown_extension_warns_and_skips(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        config = SessionRuntimeConfig(
+            session_id="session-3",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda session_id, status: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-3"),
+            supported_extensions=("NOT_A_REAL_EXTENSION",),
+        )
+
+        with patch.object(rust_module, "logger") as mock_logger:
+            RustSessionRuntime(config)
+
+        mock_logger.warning.assert_called_once()
+        assert "NOT_A_REAL_EXTENSION" in mock_logger.warning.call_args[0][1]
+        profile = mock_rust_session.call_args.kwargs["profile"]
+        assert profile.extensions == []
+
+    def test_construction_when_unknown_spec_revision_raises_value_error(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        config = SessionRuntimeConfig(
+            session_id="session-4",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda session_id, status: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-4"),
+            spec_revision="9999-99",
+        )
+
+        with pytest.raises(ValueError, match="Unsupported OpenJD specification revision"):
+            RustSessionRuntime(config)
+
+    @pytest.mark.skipif(os.name == "nt", reason="PosixSessionUser is only constructible on POSIX")
+    def test_construction_when_posix_user_converts_v0_to_v1(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
+    ) -> None:
+        """A real v0 PosixSessionUser must be converted to the _v1 type before
+        passing it to the Rust session — they are distinct classes with the same
+        fields.  Without the conversion the Rust binding raises TypeError."""
+        from openjd.sessions import PosixSessionUser
+        from openjd.sessions._v1 import PosixSessionUser as RustPosixSessionUser
+
+        v0_user = PosixSessionUser(user="job-user", group="job-group")
+        config = replace(runtime_config, user=v0_user)
+        RustSessionRuntime(config)
+
+        passed_user = mock_rust_session.call_args.kwargs["user"]
+        assert isinstance(passed_user, RustPosixSessionUser)
+        assert passed_user.user == "job-user"
+        assert passed_user.group == "job-group"
+
+    @pytest.mark.skipif(os.name != "nt", reason="WindowsSessionUser only available on Windows")
+    def test_construction_when_windows_user_converts_v0_to_v1(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
+    ) -> None:
+        """Same as the POSIX test but for WindowsSessionUser.
+
+        The _v1 WindowsSessionUser constructor performs a real Win32 logon to
+        validate the credentials, so it is mocked out — the adapter's
+        responsibility under test is only that it converts the v0 user to the
+        _v1 type and forwards the fields.
+        """
+        from openjd.sessions import WindowsSessionUser
+
+        v0_user = WindowsSessionUser(user="job-user", password="secret")
+        config = replace(runtime_config, user=v0_user)
+        with patch.object(rust_module, "RustWindowsSessionUser") as mock_v1_user_cls:
+            RustSessionRuntime(config)
+
+        mock_v1_user_cls.assert_called_once_with(
+            "job-user", password="secret", logon_token=v0_user.logon_token
+        )
+        assert mock_rust_session.call_args.kwargs["user"] is mock_v1_user_cls.return_value
+
+    def test_construction_when_user_is_none_passes_none_through(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
+    ) -> None:
+        """None means run-as-agent-user — it passes through without conversion."""
+        config = replace(runtime_config, user=None)
+        RustSessionRuntime(config)
+
+        assert mock_rust_session.call_args.kwargs["user"] is None
+
+    def test_construction_when_unsupported_user_type_raises_type_error(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
+    ) -> None:
+        """An unrecognized SessionUser subtype should fail loud."""
+        fake_user = MagicMock()
+        fake_user.__class__.__name__ = "AlienUser"
+        config = replace(runtime_config, user=fake_user)
+
+        with pytest.raises(TypeError, match="Unsupported SessionUser type"):
+            RustSessionRuntime(config)
+
+
+class TestRustSessionRuntimeDelegation:
+    @pytest.fixture()
+    def adapter(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
+    ) -> RustSessionRuntime:
+        return RustSessionRuntime(runtime_config)
+
+    @pytest.fixture()
+    def mock_session_instance(self, mock_rust_session: MagicMock) -> MagicMock:
+        return mock_rust_session.return_value
+
+    def test_enter_environment_when_called_converts_env_and_delegates(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        environment = MagicMock()
+        identifier = "job-env-1"
+        os_env = {"KEY": "VAL"}
+
+        with (
+            patch.object(rust_module, "decode_environment_template") as mock_decode,
+            patch.object(rust_module, "create_environment") as mock_create,
+        ):
+            result = adapter.enter_environment(
+                environment=environment, identifier=identifier, os_env_vars=os_env
+            )
+
+        # The pydantic environment is serialized and rebuilt natively before
+        # being handed to the session.
+        mock_decode.assert_called_once_with(
+            {
+                "specificationVersion": "environment-2023-09",
+                "environment": environment.model_dump.return_value,
+            }
+        )
+        environment.model_dump.assert_called_once_with(
+            mode="json", by_alias=True, exclude_none=True
+        )
+        mock_create.assert_called_once_with(mock_decode.return_value)
+        mock_session_instance.enter_environment.assert_called_once_with(
+            environment=mock_create.return_value,
+            identifier=identifier,
+            os_env_vars=os_env,
+        )
+        assert result is mock_session_instance.enter_environment.return_value
+
+    def test_exit_environment_when_called_delegates_to_wrapped_session(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        adapter.exit_environment(
+            identifier="job-env-1", os_env_vars={"A": "B"}, keep_session_running=True
+        )
+
+        mock_session_instance.exit_environment.assert_called_once_with(
+            identifier="job-env-1", os_env_vars={"A": "B"}, keep_session_running=True
+        )
+
+    def test_run_task_when_called_converts_step_script_and_delegates(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        step_script = MagicMock()
+        task_params: dict[str, Any] = {
+            "TaskParam": ParameterValue(type=ParameterValueType.STRING, value="val"),
+        }
+
+        with patch.object(rust_module, "deserialize_step") as mock_deserialize:
+            adapter.run_task(
+                step_script=step_script,
+                task_parameter_values=task_params,
+                os_env_vars={"X": "Y"},
+                log_task_banner=False,
+            )
+
+        # The pydantic step script is serialized, wrapped as a named step, and
+        # rebuilt natively; the native ``.script`` is forwarded to the session.
+        step_script.model_dump.assert_called_once_with(
+            mode="json", by_alias=True, exclude_none=True
+        )
+        mock_deserialize.assert_called_once_with(
+            {"name": "Placeholder", "script": step_script.model_dump.return_value}
+        )
+        mock_session_instance.run_task.assert_called_once()
+        run_kwargs = mock_session_instance.run_task.call_args.kwargs
+        assert run_kwargs["step_script"] is mock_deserialize.return_value.script
+        # The v0 ParameterValue is rebuilt as a native _v1 TaskParameterValue.
+        passed_param = run_kwargs["task_parameter_values"]["TaskParam"]
+        assert isinstance(passed_param, rust_module.TaskParameterValue)
+        assert passed_param.value == "val"
+        assert run_kwargs["os_env_vars"] == {"X": "Y"}
+        assert run_kwargs["log_task_banner"] is False
+
+    def test_run_task_without_session_env_materializes_files_and_runs_subprocess(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_session_instance.files_directory = tmp_path
+
+        embedded_file = MagicMock()
+        embedded_file.name = "WorkerManifest"
+        embedded_file.data = "file-contents"
+
+        step_script = MagicMock()
+        step_script.embeddedFiles = [embedded_file]
+        step_script.actions.onRun.command = "python"
+        step_script.actions.onRun.args = [
+            "{{ Task.File.WorkerManifest }}",
+            "{{Task.File.WorkerManifest}}",
+            "{{ Task.File.WorkerManifest}}",
+            "{{Task.File.WorkerManifest }}",
+            "{{  Task.File.WorkerManifest  }}",
+            "literal-arg",
+        ]
+
+        adapter._run_task_without_session_env(
+            step_script=step_script,
+            task_parameter_values={},
+            os_env_vars={"EXTRA": "1"},
+            log_task_banner=True,
+        )
+
+        mock_session_instance.run_subprocess.assert_called_once()
+        run_kwargs = mock_session_instance.run_subprocess.call_args.kwargs
+        assert run_kwargs["command"] == "python"
+        # All whitespace spellings of the Task.File reference resolve to the
+        # same materialized path; the literal arg is untouched.
+        materialized_path = run_kwargs["args"][0]
+        assert run_kwargs["args"] == [*([materialized_path] * 5), "literal-arg"]
+        assert os.path.dirname(materialized_path) == str(tmp_path)
+        with open(materialized_path) as f:
+            assert f.read() == "file-contents"
+        # Attachment-sync bypasses the session environment and forces unbuffered output.
+        assert run_kwargs["use_session_env_vars"] is False
+        assert run_kwargs["os_env_vars"] == {"PYTHONUNBUFFERED": "1", "EXTRA": "1"}
+        assert run_kwargs["log_banner_message"] == "Running Task"
+
+    def test_run_task_without_session_env_when_no_banner_passes_none(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_session_instance.files_directory = tmp_path
+        step_script = MagicMock()
+        step_script.embeddedFiles = None
+        step_script.actions.onRun.command = "echo"
+        step_script.actions.onRun.args = None
+
+        adapter._run_task_without_session_env(
+            step_script=step_script,
+            task_parameter_values={},
+            log_task_banner=False,
+        )
+
+        run_kwargs = mock_session_instance.run_subprocess.call_args.kwargs
+        assert run_kwargs["args"] == []
+        assert run_kwargs["log_banner_message"] is None
+
+    @pytest.mark.skipif(os.name != "posix", reason="chown group semantics are POSIX-only")
+    def test_run_task_without_session_env_when_posix_user_chowns_group(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock, tmp_path: Path
+    ) -> None:
+        from openjd.sessions import PosixSessionUser
+
+        user = PosixSessionUser(user="job-user", group="job-group")
+        config = replace(runtime_config, session_id="session-5", user=user)
+        adapter = RustSessionRuntime(config)
+        mock_rust_session.return_value.files_directory = tmp_path
+
+        embedded_file = MagicMock()
+        embedded_file.name = "Manifest"
+        embedded_file.data = "data"
+        step_script = MagicMock()
+        step_script.embeddedFiles = [embedded_file]
+        step_script.actions.onRun.command = "cmd"
+        step_script.actions.onRun.args = None
+
+        with (
+            patch.object(rust_module, "chown") as mock_chown,
+            patch.object(rust_module.os, "chmod") as mock_chmod,
+        ):
+            adapter._run_task_without_session_env(step_script=step_script, task_parameter_values={})
+
+        mock_chown.assert_called_once()
+        assert mock_chown.call_args.kwargs["group"] == "job-group"
+        # With a group present, the chmod grants owner rw + group-read (0o640).
+        mock_chmod.assert_called_once()
+        assert mock_chmod.call_args.args[1] == 0o640
+
+    def test_run_task_without_session_env_when_embedded_file_data_none_is_skipped(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_session_instance.files_directory = tmp_path
+
+        none_file = MagicMock()
+        none_file.name = "EmptyFile"
+        none_file.data = None
+        real_file = MagicMock()
+        real_file.name = "RealFile"
+        real_file.data = "real-contents"
+
+        step_script = MagicMock()
+        step_script.embeddedFiles = [none_file, real_file]
+        step_script.actions.onRun.command = "python"
+        step_script.actions.onRun.args = [
+            "{{ Task.File.EmptyFile }}",
+            "{{ Task.File.RealFile }}",
+        ]
+
+        adapter._run_task_without_session_env(
+            step_script=step_script,
+            task_parameter_values={},
+        )
+
+        # The None-data embedded file is skipped: only the real-data file is
+        # materialized into the session files directory.
+        materialized = list(tmp_path.iterdir())
+        assert len(materialized) == 1
+        materialized_path = str(materialized[0])
+
+        mock_session_instance.run_subprocess.assert_called_once()
+        run_kwargs = mock_session_instance.run_subprocess.call_args.kwargs
+        # The skipped file's reference is never added to file_paths, so it is
+        # left unresolved; only the real file's reference resolves to a path.
+        assert run_kwargs["args"] == ["{{ Task.File.EmptyFile }}", materialized_path]
+        with open(materialized_path) as f:
+            assert f.read() == "real-contents"
+
+    @pytest.mark.skipif(os.name != "posix", reason="chown group semantics are POSIX-only")
+    def test_run_task_without_session_env_when_posix_user_without_group_skips_chown(
+        self, mock_rust_session: MagicMock, tmp_path: Path
+    ) -> None:
+        # When no user is configured (run-as-agent-user path), self._user is
+        # None and no group ownership or group-read is granted; the
+        # materialized file stays owner rw only.
+        config = SessionRuntimeConfig(
+            session_id="session-6",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda session_id, status: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-6"),
+        )
+        adapter = RustSessionRuntime(config)
+        mock_rust_session.return_value.files_directory = tmp_path
+
+        embedded_file = MagicMock()
+        embedded_file.name = "Manifest"
+        embedded_file.data = "data"
+        step_script = MagicMock()
+        step_script.embeddedFiles = [embedded_file]
+        step_script.actions.onRun.command = "cmd"
+        step_script.actions.onRun.args = None
+
+        with (
+            patch.object(rust_module, "chown") as mock_chown,
+            patch.object(rust_module.os, "chmod") as mock_chmod,
+        ):
+            adapter._run_task_without_session_env(step_script=step_script, task_parameter_values={})
+
+        # No group → no chown, and the chmod mode carries no group-read bit
+        # (0o600), leaving the file owner read/write only.
+        mock_chown.assert_not_called()
+        mock_chmod.assert_called_once()
+        assert mock_chmod.call_args.args[1] == 0o600
+        mock_rust_session.return_value.run_subprocess.assert_called_once()
+
+    def test_extend_path_mapping_rules_delegates_without_presorting(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        from openjd.expr import PathFormat as ExprPathFormat
+        from openjd.expr import PathMappingRule as ExprPathMappingRule
+        from openjd.sessions import PathFormat, PathMappingRule as V0PathMappingRule
+
+        rule_short = V0PathMappingRule(
+            source_path_format=PathFormat.POSIX,
+            source_path=PurePosixPath("/a"),
+            destination_path=PurePosixPath("/b"),
+        )
+        rule_long = V0PathMappingRule(
+            source_path_format=PathFormat.POSIX,
+            source_path=PurePosixPath("/longer/path"),
+            destination_path=PurePosixPath("/dest/path"),
+        )
+        rules: list[V0PathMappingRule] = [rule_short, rule_long]
+
+        adapter.extend_path_mapping_rules(rules)
+
+        # The public method is called with the rules in their original order —
+        # the session sorts internally, so the adapter must not pre-sort.
+        mock_session_instance.extend_path_mapping_rules.assert_called_once()
+        passed = mock_session_instance.extend_path_mapping_rules.call_args.args[0]
+        assert len(passed) == 2
+        assert isinstance(passed[0], ExprPathMappingRule)
+        assert passed[0].source_path_format == ExprPathFormat.POSIX
+        assert passed[0].source_path == "/a"
+        assert passed[0].destination_path == "/b"
+        assert passed[1].source_path == "/longer/path"
+
+    def test_cancel_action_when_called_delegates_to_wrapped_session(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        limit = timedelta(seconds=30)
+
+        adapter.cancel_action(time_limit=limit, mark_action_failed=True)
+
+        mock_session_instance.cancel_action.assert_called_once_with(
+            time_limit=limit, mark_action_failed=True
+        )
+
+    def test_cancel_action_when_defaults_passes_none_and_false(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """Default kwargs are None time_limit and mark_action_failed=False."""
+        adapter.cancel_action()
+
+        mock_session_instance.cancel_action.assert_called_once_with(
+            time_limit=None, mark_action_failed=False
+        )
+
+    def test_cancel_action_when_rust_session_raises_runtime_error_propagates(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """RuntimeError from the Rust session (e.g. 'Cannot cancel: session is
+        busy with an action') must propagate to the caller — the openjd_action
+        layer catches it and wraps as CancelationError."""
+        mock_session_instance.cancel_action.side_effect = RuntimeError(
+            "Cannot cancel: session is busy with an action"
+        )
+
+        with pytest.raises(RuntimeError, match="Cannot cancel"):
+            adapter.cancel_action(time_limit=timedelta(seconds=5))
+
+    def test_cleanup_when_called_delegates_to_wrapped_session(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        adapter.cleanup()
+
+        mock_session_instance.cleanup.assert_called_once_with()
+
+
+class TestRustSessionRuntimeProperties:
+    @pytest.fixture()
+    def adapter(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
+    ) -> RustSessionRuntime:
+        return RustSessionRuntime(runtime_config)
+
+    @pytest.fixture()
+    def mock_session_instance(self, mock_rust_session: MagicMock) -> MagicMock:
+        return mock_rust_session.return_value
+
+    def test_working_directory_when_accessed_returns_wrapped_session_value(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        mock_session_instance.working_directory = Path("/tmp/work")
+
+        assert adapter.working_directory == Path("/tmp/work")
+
+    def test_action_status_when_accessed_returns_converted_v0_status(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        from openjd.sessions import ActionState, ActionStatus
+
+        v1_state = MagicMock(**{"__str__.return_value": "running"})
+        v1_status = SimpleNamespace(
+            state=v1_state,
+            progress=42,
+            status_message="working",
+            fail_message=None,
+            exit_code=None,
+        )
+        mock_session_instance.action_status = v1_status
+
+        result = adapter.action_status
+        assert isinstance(result, ActionStatus)
+        assert result.state == ActionState.RUNNING
+        assert result.progress == 42
+        assert result.status_message == "working"
+        assert result.fail_message is None
+        assert result.exit_code is None
+
+    def test_action_status_when_none_returns_none(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        mock_session_instance.action_status = None
+
+        assert adapter.action_status is None
+
+
+class TestRustSessionRuntimeTypeConversions:
+    """Tests for v0 ↔ v1 type conversion helpers."""
+
+    @pytest.fixture()
+    def mock_rust_session(self) -> Generator[MagicMock, None, None]:
+        with patch.object(rust_module, "OpenJDRustSession") as mock_cls:
+            yield mock_cls
+
+    def test_job_parameter_values_when_v0_parameter_value_converts_to_native(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """A v0 openjd.model ParameterValue is rebuilt as a native _v1 JobParameterValue."""
+        config = SessionRuntimeConfig(
+            session_id="session-conv-1",
+            job_parameter_values={
+                "P": ParameterValue(type=ParameterValueType.STRING, value="hello"),
+            },
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-conv-1"),
+        )
+
+        RustSessionRuntime(config)
+
+        passed = mock_rust_session.call_args.kwargs["job_parameter_values"]["P"]
+        assert isinstance(passed, rust_module.JobParameterValue)
+        assert passed.value == "hello"
+
+    def test_parameter_values_when_type_unknown_to_binding_raises(self) -> None:
+        """A parameter type the _v1 binding does not define fails loud."""
+        bogus = SimpleNamespace(type=SimpleNamespace(value="HOLOGRAM"), value="x")
+        with pytest.raises(ValueError, match="HOLOGRAM.*JobParameterType does not define"):
+            rust_module._to_rust_job_parameter_values({"P": bogus})
+
+    def test_every_v1_action_state_maps_to_v0(self) -> None:
+        """Every member of the REAL _v1 ActionState enum maps to a v0 member.
+
+        The pyo3 enum is not iterable, so members are collected via dir(). The
+        member-count assertion is the drift tripwire: a state added on the Rust
+        side must be added to _ACTION_STATES deliberately.
+        """
+        from openjd.sessions import ActionState
+        from openjd.sessions._v1 import ActionState as RustActionState
+
+        members = [getattr(RustActionState, n) for n in dir(RustActionState) if n.isupper()]
+        assert len(members) == 5
+        for member in members:
+            assert isinstance(rust_module._to_v0_action_state(member), ActionState)
+
+    def test_unrecognized_v1_action_state_raises(self) -> None:
+        """A _v1 state missing from _ACTION_STATES fails loud instead of drifting."""
+
+        class _FakeState:
+            def __str__(self) -> str:
+                return "warp-speed"
+
+        with pytest.raises(ValueError, match="Unrecognized _v1 ActionState"):
+            rust_module._to_v0_action_state(_FakeState())  # type: ignore[arg-type]
+
+    def test_job_parameter_values_when_dict_passes_through_unchanged(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """A dict value is passed through without modification."""
+        config = SessionRuntimeConfig(
+            session_id="session-conv-2",
+            job_parameter_values={
+                "D": {"type": "INT", "value": "42"},
+            },
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-conv-2"),
+        )
+
+        RustSessionRuntime(config)
+
+        passed = mock_rust_session.call_args.kwargs["job_parameter_values"]
+        assert passed == {"D": {"type": "INT", "value": "42"}}
+
+    def test_path_mapping_rules_when_v0_rules_converts_to_expr_type(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """v0 PathMappingRule objects are converted to openjd.expr.PathMappingRule."""
+        from openjd.expr import PathFormat as ExprPathFormat
+        from openjd.expr import PathMappingRule as ExprPathMappingRule
+        from openjd.sessions import PathFormat, PathMappingRule as V0PathMappingRule
+
+        v0_rule = V0PathMappingRule(
+            source_path_format=PathFormat.POSIX,
+            source_path=PurePosixPath("/source"),
+            destination_path=PurePosixPath("/dest"),
+        )
+        config = SessionRuntimeConfig(
+            session_id="session-conv-3",
+            job_parameter_values={},
+            path_mapping_rules=[v0_rule],
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-conv-3"),
+        )
+
+        RustSessionRuntime(config)
+
+        passed = mock_rust_session.call_args.kwargs["path_mapping_rules"]
+        assert len(passed) == 1
+        assert isinstance(passed[0], ExprPathMappingRule)
+        assert passed[0].source_path_format == ExprPathFormat.POSIX
+        assert passed[0].source_path == "/source"
+        assert passed[0].destination_path == "/dest"
+
+    def test_path_mapping_rules_when_none_passes_none(self, mock_rust_session: MagicMock) -> None:
+        config = SessionRuntimeConfig(
+            session_id="session-conv-4",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-conv-4"),
+        )
+
+        RustSessionRuntime(config)
+
+        assert mock_rust_session.call_args.kwargs["path_mapping_rules"] is None
+
+    def test_callback_when_invoked_converts_v1_status_to_v0(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """The callback wrapper converts _v1 ActionStatus to v0 ActionStatus."""
+        from openjd.sessions import ActionState, ActionStatus
+
+        original_callback = MagicMock()
+        config = SessionRuntimeConfig(
+            session_id="session-conv-5",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=original_callback,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-conv-5"),
+        )
+
+        RustSessionRuntime(config)
+
+        # Grab the wrapped callback that was passed to the Rust session.
+        wrapped_callback = mock_rust_session.call_args.kwargs["callback"]
+
+        # Simulate a v1 ActionStatus with a state whose str() == "success"
+        v1_state = MagicMock(**{"__str__.return_value": "success"})
+        v1_status = SimpleNamespace(
+            state=v1_state,
+            progress=100,
+            status_message="done",
+            fail_message=None,
+            exit_code=0,
+        )
+
+        wrapped_callback("session-conv-5", v1_status)
+
+        original_callback.assert_called_once()
+        call_args = original_callback.call_args
+        assert call_args[0][0] == "session-conv-5"
+        v0_status = call_args[0][1]
+        assert isinstance(v0_status, ActionStatus)
+        assert v0_status.state == ActionState.SUCCESS
+        assert v0_status.progress == 100
+        assert v0_status.status_message == "done"
+        assert v0_status.fail_message is None
+        assert v0_status.exit_code == 0
+
+    def test_action_status_property_when_v1_status_present_returns_v0(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """The action_status property converts _v1 status to v0."""
+        from openjd.sessions import ActionState, ActionStatus
+
+        config = SessionRuntimeConfig(
+            session_id="session-conv-6",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-conv-6"),
+        )
+        adapter = RustSessionRuntime(config)
+
+        v1_state = MagicMock(**{"__str__.return_value": "failed"})
+        mock_rust_session.return_value.action_status = SimpleNamespace(
+            state=v1_state,
+            progress=0,
+            status_message=None,
+            fail_message="something broke",
+            exit_code=1,
+        )
+
+        result = adapter.action_status
+        assert isinstance(result, ActionStatus)
+        assert result.state == ActionState.FAILED
+        assert result.fail_message == "something broke"
+        assert result.exit_code == 1
+
+    def test_action_status_property_when_none_returns_none(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        config = SessionRuntimeConfig(
+            session_id="session-conv-7",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-conv-7"),
+        )
+        adapter = RustSessionRuntime(config)
+        mock_rust_session.return_value.action_status = None
+
+        assert adapter.action_status is None
+
+
+class TestToRustTaskParameterValues:
+    """Tests for _to_rust_task_parameter_values conversion helper."""
+
+    def test_converts_parameter_value_objects_to_native(self) -> None:
+        """ParameterValue objects convert to native _v1 TaskParameterValues of the right type."""
+        from openjd.model._v1.types import TaskParameterType
+
+        values: dict[str, Any] = {
+            "StringParam": ParameterValue(type=ParameterValueType.STRING, value="hello"),
+            "IntParam": ParameterValue(type=ParameterValueType.INT, value="42"),
+            "FloatParam": ParameterValue(type=ParameterValueType.FLOAT, value="3.14"),
+            "PathParam": ParameterValue(type=ParameterValueType.PATH, value="/tmp/out"),
+        }
+
+        result = _to_rust_task_parameter_values(values)
+
+        expected: dict[str, tuple[Any, str]] = {
+            "StringParam": (TaskParameterType.STRING, "hello"),
+            "IntParam": (TaskParameterType.INT, "42"),
+            "FloatParam": (TaskParameterType.FLOAT, "3.14"),
+            "PathParam": (TaskParameterType.PATH, "/tmp/out"),
+        }
+        assert result.keys() == expected.keys()
+        for name, (expected_type, expected_value) in expected.items():
+            converted = result[name]
+            assert isinstance(converted, rust_module.TaskParameterValue), name
+            assert str(converted.type) == str(expected_type), name
+            assert converted.value == expected_value, name
+
+    def test_dict_values_pass_through_unchanged(self) -> None:
+        """Values already in dict form are not modified."""
+        values: dict[str, Any] = {
+            "AlreadyDict": {"type": "STRING", "value": "existing"},
+        }
+
+        result = _to_rust_task_parameter_values(values)
+
+        assert result == {"AlreadyDict": {"type": "STRING", "value": "existing"}}
+
+    def test_empty_dict_returns_empty_dict(self) -> None:
+        """An empty input produces an empty output."""
+        assert _to_rust_task_parameter_values({}) == {}
+
+    def test_mixed_parameter_values_and_dicts(self) -> None:
+        """ParameterValue objects convert to native types; plain dicts pass through."""
+        values: dict[str, Any] = {
+            "Obj": ParameterValue(type=ParameterValueType.INT, value="7"),
+            "Dict": {"type": "FLOAT", "value": "2.5"},
+        }
+
+        result = _to_rust_task_parameter_values(values)
+
+        assert isinstance(result["Obj"], rust_module.TaskParameterValue)
+        assert result["Obj"].value == "7"
+        assert result["Dict"] == {"type": "FLOAT", "value": "2.5"}
+
+
+def test_rust_session_runtime_is_session_runtime_subclass() -> None:
+    # Smoke test: the module imports cleanly against the installed _v1 binding
+    # and the adapter satisfies the ABC contract.
+    assert issubclass(RustSessionRuntime, SessionRuntime)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

This change adds the Rust-backed implementation of our SessionRuntime ABC. It must be a behaviorally-faithful drop-in for the existing Python runtime, and it must keep the rest of the worker on the pydantic `v2023_09` models it already uses.

### What was the solution? (How)

Add `RustSessionRuntime`, an adapter implementing the existing `SessionRuntime` ABC and backed by `openjd.sessions._v1`. Highlights:

- `run_task` and `enter_environment` serialize the pydantic model to the OpenJD wire shape and rebuild it natively
- `_run_task_without_session_env` (the attachment-sync path) materializes the step's embedded files to the session's files directory, resolves `Task.File.*` argument references, and runs the command with `use_session_env_vars=False`.
- The enabled openjd model extensions are wired from the session config rather than a hardcoded list.


### What is the impact of this change?

Additive only. Nothing selects `RustSessionRuntime` at runtime yet. The worker still constructs the Python runtime, so there is no behavioral change to existing sessions. 

### How was this change tested?

- New unit tests (`test/unit/sessions/runtime/test_rust.py`), passing
```
Required test coverage of 78.0% reached. Total coverage: 84.57%
=============================================================== slowest 5 durations ===============================================================
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[spot-shutdown-1-min]
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_spot_interruption[spot-shutdown-15-sec]
1.00s call     test/unit/test_worker.py::TestMonitorEc2Shutdown::test_asg_termination
0.60s call     test/unit/startup/test_host_config_timer.py::TestHostConfigTimer::test_no_further_logs_after_timeout_reached
0.50s call     test/unit/startup/test_host_config_timer.py::TestHostConfigTimer::test_accelerates_interval_when_remaining_low
================================================== 2950 passed, 38 skipped, 8 warnings in 23.37s ==================================================
```
- Integ tests passing
```
================================================================ warnings summary =================================================================
test/integ/startup/test_host_configuration.py:116
  /local/home/stangch/github/deadline-cloud-worker-agent/test/integ/startup/test_host_configuration.py:116: PytestCollectionWarning: cannot collect test class 'TestOS' because it has a __new__ constructor (from: test/integ/startup/test_host_configuration.py)
    class TestOS(Enum):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== slowest 5 durations ===============================================================
3.01s call     test/integ/startup/test_host_configuration.py::TestHostConfigurationScriptRunner::test_timer_timeout_expiration_log_appears
2.01s call     test/integ/startup/test_host_configuration.py::TestHostConfigurationScriptRunner::test_host_configuration_script_runner[Timed out test case]
1.01s call     test/integ/startup/test_host_configuration.py::TestHostConfigurationScriptRunner::test_timer_ticker_logs_appear_during_script_execution
0.69s call     test/integ/config/test_config_cli.py::TestMissingExistingCommented::test[ModifiableSetting.FARM_ID-missing]
0.69s call     test/integ/config/test_config_cli.py::TestMissingExistingCommented::test[ModifiableSetting.FLEET_ID-missing]
============================================== 84 passed, 4 skipped, 1 xfailed, 1 warning in 24.53s ===============================================

```
- Ran E2E tests, hardcoding testing with `SessionRuntimeKind.RUST`
```
============================= slowest 5 durations ==============================
617.10s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
340.63s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_local_session_logs_can_be_turned_off
298.11s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
293.99s setup    test/e2e/test_override_job_user.py::TestLinuxJobUserOverride::test_no_user_override
254.97s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_session_root_dir
=========================== short test summary info ============================
FAILED test/e2e/test_cap_kill.py::test_worker_only_has_cap_kill - AssertionEr...
============ 1 failed, 48 passed, 23 skipped in 4614.16s (1:16:54) =============
```
One remaining failure to be fixed

### Was this change documented?

No customer facing changes yet.

### Is this a breaking change?

No. The change is purely additive and no code path constructs `RustSessionRuntime` yet, so runtime behavior is unchanged.
