### PR TITLE
ci: add Security Scan stub (zizmor via reusable org workflow)

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -7,11 +7,12 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # canonical dependabot auto-approve pattern; the job only has pull-requests: write and runs Dependabot's own metadata action
+    if: ${{ github.actor == 'dependabot[bot]' }} # zizmor: ignore[bot-conditions]
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -11,7 +11,7 @@
 # workflow_run identifiers and the role-ARN secret.
 name: Claude PR Review
 
-on:
+on: # zizmor: ignore[dangerous-triggers] -- workflow_run is intentional and safe here; see the header comment above (runs from default branch, fork PRs cannot alter behavior/secrets)
   workflow_run:
     workflows: ["Claude PR Review (collect)"]
     types:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -39,12 +39,12 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref: ${{ inputs.tag || inputs.branch || github.ref }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/mainline_e2e_canary.yml
+++ b/.github/workflows/mainline_e2e_canary.yml
@@ -16,10 +16,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/mainline_e2e_test.yml
+++ b/.github/workflows/mainline_e2e_test.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,6 +1,9 @@
 name: On Opened PR
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
+  # workflow_run is intentional: it runs from the default branch with this
+  # repo's context (never a fork's copy), and only consumes the PR artifact via
+  # the reusable extract-PR-details workflow. A fork PR cannot alter behavior.
   workflow_run:
     workflows: ["Record PR"]
     types:

--- a/.github/workflows/release_e2e_canary.yml
+++ b/.github/workflows/release_e2e_canary.yml
@@ -16,10 +16,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -85,7 +85,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
@@ -138,12 +138,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.TagRelease.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ needs.TagRelease.outputs.build-python-version }}
       - name: Install dependencies
@@ -153,5 +153,5 @@ jobs:
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,0 +1,21 @@
+name: "Security Scan"
+
+on:
+  push:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  pull_request:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  schedule:
+    - cron: '0 8 * * MON'
+
+jobs:
+  Scan:
+    name: Scan
+    # Central, extensible security-scan workflow (currently zizmor). New checks
+    # added there apply here automatically — no change needed to this stub.
+    uses: aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline
+    permissions:
+      # The reusable workflow checks out this repo and fetches the central
+      # zizmor config, and reports findings to the run log / PR annotations
+      # (not the Security tab), so it only needs read access.
+      contents: read


### PR DESCRIPTION
## What

Adds a thin `.github/workflows/security_scan.yml` stub that calls the central reusable workflow `aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline`, gating PRs on **high**-severity zizmor findings. New checks added centrally apply here automatically.

Replicates what was done in aws-deadline/deadline-cloud (PR #1256).

## High-severity zizmor findings fixed first (so CI is green)

16 high findings resolved:

- **unpinned-uses (13):** pinned third-party actions to full commit SHAs with version comments:
  - `actions/checkout@v7` -> `9c091bb…` # v7.0.0
  - `actions/setup-python@v6` -> `ece7cb0…` # v6.3.0
  - `pypa/gh-action-pypi-publish@release/v1` -> `cef2210…` # v1.14.0
  - `dependabot/fetch-metadata@v3` -> `25dd0e3…` # v3.1.0
  - across code_quality, mainline_e2e_canary, mainline_e2e_test, release_e2e_canary, release_publish, auto_approve.
- **bot-conditions (1):** suppressed on the dependabot actor check in `auto_approve.yml` (job only has `pull-requests: write` and runs Dependabot's own metadata action).
- **dangerous-triggers (2):** suppressed `workflow_run` triggers in `claude_pr_review.yml` and `on_opened_pr.yml` — they run from the default branch with this repo's context; fork PRs cannot alter behavior/secrets.

Internal `aws-deadline/*@mainline` reusable-workflow refs left as-is (allowed by the central config ref-pin policy).

`uvx zizmor --config <central> --min-severity high .github/` now reports **0 findings**.