### PR TITLE
fix: properly capture session action structure errors

### DIFF
--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -406,6 +406,16 @@ class SessionActionQueue:
             action_type = action_queue_entry.definition["actionType"]
             action_definition = action_queue_entry.definition
             action_id = action_definition["sessionActionId"]
+            # Remove the action from the queue up-front. We are committed to
+            # consuming the front action regardless of the outcome below: on
+            # success it is returned to be run; if resolving its job-entity
+            # details raises a terminal SessionActionError, the Session reports
+            # it as FAILED. Leaving it queued would let cancel_all() re-report
+            # it as NEVER_ATTEMPTED and clobber that FAILED status -- and the
+            # service rejects NEVER_ATTEMPTED for the first session action,
+            # which crashes the worker's scheduler.
+            del self._actions[0]
+            del self._actions_by_id[action_id]
             if action_type.startswith("ENV_"):
                 action_queue_entry = cast(EnvironmentQueueEntry, action_queue_entry)
                 action_definition = action_queue_entry.definition
@@ -546,6 +556,4 @@ class SessionActionQueue:
                 raise ValueError(
                     f'Unknown action type "{action_type}". Complete action = {action_definition}'
                 )
-            del self._actions[0]
-            del self._actions_by_id[action_id]
         return next_action

--- a/src/deadline_worker_agent/sessions/errors.py
+++ b/src/deadline_worker_agent/sessions/errors.py
@@ -36,6 +36,8 @@ class SessionActionError(Exception):
         self.action_id = action_id
         self.action_log_kind = action_log_kind
         self.message = message
+        self.step_id = step_id
+        self.task_id = task_id
 
     def __str__(self) -> str:
         return self.message

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -43,6 +43,7 @@ from deadline_worker_agent.sessions.actions import (
 from deadline_worker_agent.sessions.errors import (
     EnvironmentDetailsError,
     JobEntityUnsupportedSchemaError,
+    SessionActionError,
     StepDetailsError,
 )
 from deadline_worker_agent.sessions.job_entities import (
@@ -302,7 +303,7 @@ class TestSessionActionQueueDequeue:
         assert type(next_action) is AttachmentUploadAction
 
     @pytest.mark.parametrize(
-        argnames=("queue_entry", "error_type"),
+        argnames=("queue_entry", "error_type", "expected_step_id", "expected_task_id"),
         argvalues=(
             pytest.param(
                 EnvironmentQueueEntry(
@@ -312,6 +313,8 @@ class TestSessionActionQueueDequeue:
                     ),
                 ),
                 EnvironmentDetailsError,
+                None,
+                None,
                 id="Environment Details Error",
             ),
             pytest.param(
@@ -326,6 +329,8 @@ class TestSessionActionQueueDequeue:
                     ),
                 ),
                 StepDetailsError,
+                "stepId",
+                "taskId",
                 id="Step Details Error",
             ),
         ),
@@ -333,7 +338,9 @@ class TestSessionActionQueueDequeue:
     def test_handle_job_entity_error_on_dequeue(
         self,
         queue_entry: (EnvironmentQueueEntry | TaskRunQueueEntry),
-        error_type: type[Exception],
+        error_type: type[SessionActionError],
+        expected_step_id: str | None,
+        expected_task_id: str | None,
         session_queue: SessionActionQueue,
     ) -> None:
         # GIVEN
@@ -347,9 +354,17 @@ class TestSessionActionQueueDequeue:
         job_entity_mock.job_attachment_details.side_effect = inner_error
         session_queue._job_entities = job_entity_mock
 
-        # WHEN / THEN
-        with pytest.raises(error_type):
+        # WHEN
+        with pytest.raises(error_type) as excinfo:
             session_queue.dequeue()
+
+        # THEN
+        # The Session error handler reads e.step_id/e.task_id when reporting the
+        # failure. They must be populated (not raise AttributeError) so that the
+        # action fails cleanly instead of triggering an unexpected worker error
+        # and reschedule loop.
+        assert excinfo.value.step_id == expected_step_id
+        assert excinfo.value.task_id == expected_task_id
 
     @pytest.mark.parametrize(
         argnames=("queue_entry"),

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -365,6 +365,13 @@ class TestSessionActionQueueDequeue:
         # and reschedule loop.
         assert excinfo.value.step_id == expected_step_id
         assert excinfo.value.task_id == expected_task_id
+        # The failed action must be removed from the queue. If it were left
+        # queued, cancel_all() would re-report it as NEVER_ATTEMPTED and clobber
+        # the FAILED status the Session reports -- which the service rejects for
+        # the first session action, crashing the worker scheduler.
+        action_id = queue_entry.definition["sessionActionId"]
+        assert session_queue._actions == []
+        assert action_id not in session_queue._actions_by_id
 
     @pytest.mark.parametrize(
         argnames=("queue_entry"),

--- a/test/unit/sessions/test_errors.py
+++ b/test/unit/sessions/test_errors.py
@@ -1,0 +1,90 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import pytest
+
+from deadline_worker_agent.log_messages import SessionActionLogKind
+from deadline_worker_agent.sessions.errors import (
+    EnvironmentDetailsError,
+    JobAttachmentDetailsError,
+    JobEntityUnsupportedSchemaError,
+    SessionActionError,
+    StepDetailsError,
+)
+
+
+# All SessionActionError subclasses that share the base (action_id, action_log_kind,
+# message, *, step_id, task_id) constructor signature.
+MESSAGE_ERROR_TYPES: tuple[type[SessionActionError], ...] = (
+    SessionActionError,
+    EnvironmentDetailsError,
+    JobAttachmentDetailsError,
+    StepDetailsError,
+)
+
+
+class TestSessionActionError:
+    """Contract tests for SessionActionError and its subclasses.
+
+    Session._start_action catches SessionActionError raised while dequeueing an
+    action and reports the failure by reading ``e.step_id``/``e.task_id``. If the
+    base ``__init__`` fails to store those attributes, that handler raises an
+    AttributeError; the action is then never attempted and the task
+    reschedule-loops instead of failing cleanly. These tests pin the attribute
+    contract for every subclass so that regression cannot reappear.
+    """
+
+    @pytest.mark.parametrize("error_type", MESSAGE_ERROR_TYPES)
+    def test_stores_step_and_task_id(self, error_type: type[SessionActionError]) -> None:
+        # WHEN
+        err = error_type(
+            "action-id",
+            SessionActionLogKind.TASK_RUN,
+            "something went wrong",
+            step_id="step-123",
+            task_id="task-456",
+        )
+
+        # THEN
+        assert err.step_id == "step-123"
+        assert err.task_id == "task-456"
+        assert err.action_id == "action-id"
+        assert err.action_log_kind == SessionActionLogKind.TASK_RUN
+        assert str(err) == "something went wrong"
+
+    @pytest.mark.parametrize("error_type", MESSAGE_ERROR_TYPES)
+    def test_step_and_task_id_default_to_none(self, error_type: type[SessionActionError]) -> None:
+        # WHEN
+        err = error_type("action-id", SessionActionLogKind.ENV_ENTER, "boom")
+
+        # THEN
+        assert err.step_id is None
+        assert err.task_id is None
+
+    def test_unsupported_schema_error_stores_step_and_task_id(self) -> None:
+        # JobEntityUnsupportedSchemaError has a distinct signature (schema_version
+        # instead of message) but must honor the same step_id/task_id contract.
+        # WHEN
+        err = JobEntityUnsupportedSchemaError(
+            "action-id",
+            SessionActionLogKind.TASK_RUN,
+            "9999-99",
+            step_id="step-123",
+            task_id="task-456",
+        )
+
+        # THEN
+        assert err.step_id == "step-123"
+        assert err.task_id == "task-456"
+        assert err.schema_version == "9999-99"
+
+    def test_unsupported_schema_error_defaults_to_none(self) -> None:
+        # WHEN
+        err = JobEntityUnsupportedSchemaError(
+            "action-id", SessionActionLogKind.ENV_ENTER, "9999-99"
+        )
+
+        # THEN
+        assert err.step_id is None
+        assert err.task_id is None


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

```
'StepDetailsError' object has no attribute 'step_id'
```

This has been a latent bug in the worker agent for a while now, in that was not filling in error information (step/task id) when failing to parse details from the service. This can happen if there's a mismatch in the version of openjd model that validated the submission vs. the version of openjd model that is used by the worker agent.

### What was the solution? (How)

We need to raise the error properly and have it report as a job failure, instead of a re-attempting to parse that information.

### What is the impact of this change?

session actions that fail on parsing should properly be marked as failed.

### How was this change tested?

added tests to the base class and all children. Also ran the worker agent in a container to validate the old and new behaviour.

### Was this change documented?

N/A

### Is this a breaking change?

Fixing

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*