### PR TITLE
ci: Add macOS integration coverage

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/mainline_e2e_canary.yml
+++ b/.github/workflows/mainline_e2e_canary.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/mainline_e2e_test.yml
+++ b/.github/workflows/mainline_e2e_test.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release_e2e_canary.yml
+++ b/.github/workflows/release_e2e_canary.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Integration tests ran on Ubuntu and Windows, but not macOS. This left macOS compatibility unverified across the supported Python versions.

### What was the solution? (How)

Add `macos-latest` to every integration-test operating-system matrix while keeping the existing Python 3.9 through 3.13 coverage.

### What is the impact of this change?

Pull requests, mainline runs, and scheduled mainline/release canaries now run integration tests on macOS. Runtime behavior is unchanged.

### How was this change tested?

* `hatch run fmt`
* `hatch run lint`
* `hatch run integ-test` on macOS: 73 passed, 4 skipped
* `hatch build`
* Parsed all GitHub workflow YAML files
* `git diff --check`

### Was this change documented?

No documentation change is required for CI-only coverage.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*