### PR TITLE
feat: add select_runtime() to resolve session runtime mode

### DIFF
--- a/src/deadline_worker_agent/sessions/runtime/__init__.py
+++ b/src/deadline_worker_agent/sessions/runtime/__init__.py
@@ -3,6 +3,7 @@
 from ._abc import SessionRuntime
 from ._config import ActionCallback, SessionRuntimeConfig
 from ._factory import create_session_runtime
+from ._select import select_runtime
 from ..._session_runtime_kind import SessionRuntimeKind
 
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "SessionRuntime",
     "SessionRuntimeConfig",
     "create_session_runtime",
+    "select_runtime",
 ]

--- a/src/deadline_worker_agent/sessions/runtime/_select.py
+++ b/src/deadline_worker_agent/sessions/runtime/_select.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+from typing import Optional
+
+from ..._session_runtime_kind import SessionRuntimeKind
+
+# Valid values that the service may send as a runtimeHint. The hint is a raw
+# string from the UpdateWorkerSchedule response, so we map it explicitly rather
+# than trusting SessionRuntimeKind(...) — "service-selected" is a valid enum
+# value but NOT a valid hint.
+_RUNTIME_HINT_MAP: dict[str, SessionRuntimeKind] = {
+    SessionRuntimeKind.PYTHON.value: SessionRuntimeKind.PYTHON,
+    SessionRuntimeKind.RUST.value: SessionRuntimeKind.RUST,
+}
+
+
+def select_runtime(
+    configured_kind: SessionRuntimeKind,
+    *,
+    runtime_hint: Optional[str] = None,
+) -> SessionRuntimeKind:
+    """Resolve the worker's configured runtime mode to a concrete runtime kind.
+
+    The worker configuration determines the mode. PYTHON and RUST modes pin the
+    runtime unconditionally and ignore any service-provided hint. SERVICE_SELECTED
+    mode defers to the service's runtimeHint when present, and defaults to PYTHON
+    when absent.
+
+    There is intentionally no capability check, escalation, or fallback here. If
+    the selected runtime cannot support the job's required extensions, runtime
+    construction fails — that is openjd's responsibility, not this function's.
+
+    This function has no callers yet; reading runtimeHint from the
+    UpdateWorkerSchedule response and wiring it into session construction
+    lands in a follow-up change.
+    """
+    if configured_kind == SessionRuntimeKind.PYTHON:
+        return SessionRuntimeKind.PYTHON
+    if configured_kind == SessionRuntimeKind.RUST:
+        return SessionRuntimeKind.RUST
+
+    # SERVICE_SELECTED: the hint decides; no hint means PYTHON.
+    if runtime_hint is None:
+        return SessionRuntimeKind.PYTHON
+    try:
+        return _RUNTIME_HINT_MAP[runtime_hint]
+    except KeyError:
+        raise ValueError(
+            f"Invalid runtimeHint value {runtime_hint!r}; expected one of {sorted(_RUNTIME_HINT_MAP)}"
+        ) from None

--- a/src/deadline_worker_agent/sessions/runtime/_select.py
+++ b/src/deadline_worker_agent/sessions/runtime/_select.py
@@ -5,13 +5,20 @@ from typing import Optional
 
 from ..._session_runtime_kind import SessionRuntimeKind
 
-# Valid values that the service may send as a runtimeHint. The hint is a raw
-# string from the UpdateWorkerSchedule response, so we map it explicitly rather
-# than trusting SessionRuntimeKind(...) — "service-selected" is a valid enum
-# value but NOT a valid hint.
+# Valid values that the service may send as a runtimeHint in the
+# UpdateWorkerSchedule response's session metadata. These are the service's
+# RuntimeMode wire values and intentionally differ from SessionRuntimeKind's
+# config strings: "pythonexpr" denotes the Python session runtime (with the
+# Rust expression engine), "rust" denotes the full Rust session runtime.
+# Unknown values raise ValueError — the map is an explicit allowlist.
+#
+# This map is the single translation point from the service's wire
+# vocabulary to SessionRuntimeKind. Callers pass the raw metadata string
+# through unmodified — no pre-translation — so that the wire contract is
+# defined (and validated) in exactly one place.
 _RUNTIME_HINT_MAP: dict[str, SessionRuntimeKind] = {
-    SessionRuntimeKind.PYTHON.value: SessionRuntimeKind.PYTHON,
-    SessionRuntimeKind.RUST.value: SessionRuntimeKind.RUST,
+    "pythonexpr": SessionRuntimeKind.PYTHON,
+    "rust": SessionRuntimeKind.RUST,
 }
 
 
@@ -24,8 +31,8 @@ def select_runtime(
 
     The worker configuration determines the mode. PYTHON and RUST modes pin the
     runtime unconditionally and ignore any service-provided hint. SERVICE_SELECTED
-    mode defers to the service's runtimeHint when present, and defaults to PYTHON
-    when absent.
+    mode defers to the service's runtimeHint ("pythonexpr" or "rust") when present,
+    and defaults to PYTHON when absent.
 
     There is intentionally no capability check, escalation, or fallback here. If
     the selected runtime cannot support the job's required extensions, runtime

--- a/test/unit/sessions/runtime/test_select.py
+++ b/test/unit/sessions/runtime/test_select.py
@@ -1,0 +1,82 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
+from deadline_worker_agent.sessions.runtime import select_runtime
+
+
+@pytest.mark.parametrize(
+    ("configured", "hint", "expected"),
+    [
+        pytest.param(
+            SessionRuntimeKind.PYTHON,
+            "rust",
+            SessionRuntimeKind.PYTHON,
+            id="python-mode-ignores-hint",
+        ),
+        pytest.param(
+            SessionRuntimeKind.PYTHON, None, SessionRuntimeKind.PYTHON, id="python-mode-no-hint"
+        ),
+        pytest.param(
+            SessionRuntimeKind.RUST, "python", SessionRuntimeKind.RUST, id="rust-mode-ignores-hint"
+        ),
+        pytest.param(
+            SessionRuntimeKind.RUST, None, SessionRuntimeKind.RUST, id="rust-mode-no-hint"
+        ),
+        pytest.param(
+            SessionRuntimeKind.SERVICE_SELECTED,
+            "rust",
+            SessionRuntimeKind.RUST,
+            id="service-selected-follows-rust-hint",
+        ),
+        pytest.param(
+            SessionRuntimeKind.SERVICE_SELECTED,
+            "python",
+            SessionRuntimeKind.PYTHON,
+            id="service-selected-follows-python-hint",
+        ),
+        pytest.param(
+            SessionRuntimeKind.SERVICE_SELECTED,
+            None,
+            SessionRuntimeKind.PYTHON,
+            id="service-selected-defaults-to-python",
+        ),
+    ],
+)
+def test_select_runtime(
+    configured: SessionRuntimeKind, hint: Optional[str], expected: SessionRuntimeKind
+) -> None:
+    assert select_runtime(configured, runtime_hint=hint) is expected
+
+
+@pytest.mark.parametrize(
+    "bad_hint",
+    [
+        pytest.param("service-selected", id="service-selected-is-not-a-valid-hint"),
+        pytest.param("RUST", id="wrong-case"),
+        pytest.param("", id="empty-string"),
+        pytest.param("cobol", id="unknown-runtime"),
+    ],
+)
+def test_select_runtime_invalid_hint_errors(bad_hint: str) -> None:
+    with pytest.raises(ValueError, match="Invalid runtimeHint"):
+        select_runtime(SessionRuntimeKind.SERVICE_SELECTED, runtime_hint=bad_hint)
+
+
+def test_pinned_mode_does_not_validate_hint() -> None:
+    # In python/rust mode the hint is ignored entirely — even a garbage value
+    # must not raise, because pinned fleets shouldn't break on bad service data.
+    assert (
+        select_runtime(SessionRuntimeKind.PYTHON, runtime_hint="garbage")
+        is SessionRuntimeKind.PYTHON
+    )
+
+
+def test_hint_whitespace_is_not_stripped() -> None:
+    # The wire value must match exactly; " rust " is treated as invalid, not trimmed.
+    with pytest.raises(ValueError, match="Invalid runtimeHint"):
+        select_runtime(SessionRuntimeKind.SERVICE_SELECTED, runtime_hint=" rust ")

--- a/test/unit/sessions/runtime/test_select.py
+++ b/test/unit/sessions/runtime/test_select.py
@@ -22,7 +22,10 @@ from deadline_worker_agent.sessions.runtime import select_runtime
             SessionRuntimeKind.PYTHON, None, SessionRuntimeKind.PYTHON, id="python-mode-no-hint"
         ),
         pytest.param(
-            SessionRuntimeKind.RUST, "python", SessionRuntimeKind.RUST, id="rust-mode-ignores-hint"
+            SessionRuntimeKind.RUST,
+            "pythonexpr",
+            SessionRuntimeKind.RUST,
+            id="rust-mode-ignores-hint",
         ),
         pytest.param(
             SessionRuntimeKind.RUST, None, SessionRuntimeKind.RUST, id="rust-mode-no-hint"
@@ -35,9 +38,9 @@ from deadline_worker_agent.sessions.runtime import select_runtime
         ),
         pytest.param(
             SessionRuntimeKind.SERVICE_SELECTED,
-            "python",
+            "pythonexpr",
             SessionRuntimeKind.PYTHON,
-            id="service-selected-follows-python-hint",
+            id="service-selected-follows-pythonexpr-hint",
         ),
         pytest.param(
             SessionRuntimeKind.SERVICE_SELECTED,
@@ -56,6 +59,7 @@ def test_select_runtime(
 @pytest.mark.parametrize(
     "bad_hint",
     [
+        pytest.param("python", id="config-string-not-a-wire-value"),
         pytest.param("service-selected", id="service-selected-is-not-a-valid-hint"),
         pytest.param("RUST", id="wrong-case"),
         pytest.param("", id="empty-string"),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent now has a pluggable `SessionRuntime` abstraction (#972, #976, #982, #992) with a `service-selected` mode in the `SessionRuntimeKind` enum, but no way to resolve that mode to a concrete runtime. `create_session_runtime()` already rejects `SERVICE_SELECTED` with an error message referencing a `select_runtime()` function that did not exist yet.

Operators need two ways to control which runtime a session uses:
1. Pin it per worker via config (`python` / `rust`)
2. Defer to the service (`service-selected`), letting a per-job `runtimeHint` steer the choice — enabling service-side rollout and rollback of the Rust runtime without touching customer worker configs

### What was the solution? (How)

Add `select_runtime()` in `sessions/runtime/_select.py` implementing simple mode dispatch:

- `python` mode: always `PYTHON`, service signals ignored
- `rust` mode: always `RUST`, service signals ignored
- `service-selected` mode: follow the service `runtimeHint` when present, default to `PYTHON` when absent; invalid hint values raise `ValueError`

There is intentionally no capability check, escalation, or fallback: if the selected runtime cannot support the job's required extensions, runtime construction fails (openjd's responsibility, not routing's).

`select_runtime()` has no callers yet by design; reading `runtimeHint` from the `UpdateWorkerSchedule` response and wiring it into session construction lands in a follow-up change.

### What is the impact of this change?

None at runtime. This is a leaf addition: a new pure function plus its export. No existing code path calls it yet, and no behavior of the worker agent changes.

### How was this change tested?

- 13 new unit tests in `test/unit/sessions/runtime/test_select.py` covering: each pinned mode ignoring hints, `service-selected` following python/rust hints, defaulting to Python when the hint is absent, and rejection of invalid hints (unknown values, wrong case, empty string, whitespace, `"service-selected"` as a hint).
- Full unit suite: `hatch run test` — 2947 passed, 0 failed.
- `hatch run lint` (ruff check, ruff format, mypy) — clean.
- E2E test:

```
========================================================================= slowest 5 durations =========================================================================
705.77s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
300.74s setup    test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_enters_stopping_state_while_draining
260.11s setup    test/e2e/test_override_job_user.py::TestLinuxJobUserOverride::test_no_user_override
224.24s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
214.50s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[linux]
============================================================= 49 passed, 23 skipped in 4501.35s (1:15:01) =============================================================
cmd [4] | echo pytest done
pytest done
```

### Was this change documented?

Docstring on `select_runtime()` describing the selection rules and the deliberate absence of capability checks/fallback. No user-facing docs needed until the follow-up wires it into session construction.

### Is this a breaking change?

No. Purely additive.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*