### PR TITLE
fix: retry transient network errors in UpdateWorkerSchedule

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -9,7 +9,12 @@ from functools import wraps
 import random
 
 from botocore.retries.standard import RetryContext
-from botocore.exceptions import ClientError
+from botocore.exceptions import (
+    ClientError,
+    # Aliased to avoid shadowing the Python builtin ConnectionError.
+    ConnectionError as BotocoreConnectionError,
+    HTTPClientError,
+)
 
 from deadline.job_attachments import version as deadline_job_attachments_version
 from deadline.job_attachments.progress_tracker import SummaryStatistics
@@ -41,6 +46,21 @@ from ...log_sync.log_constants import (
 )
 
 _logger = logging.getLogger(__name__)
+
+# Transport-level errors that indicate transient connectivity issues and should be retried.
+# We catch botocore's two transport base classes rather than enumerating leaf types, which
+# mirrors how botocore itself classifies retryable connection errors and covers cases like
+# ConnectionClosedError, ReadTimeoutError, ResponseStreamingError (HTTPClientError) and
+# EndpointConnectionError, ConnectTimeoutError, ProxyConnectionError, SSLError (ConnectionError).
+# These are distinct from ClientError (service responses), so they don't overlap with the
+# error-code handling above.
+_TRANSIENT_NETWORK_EXCEPTIONS = (BotocoreConnectionError, HTTPClientError)
+
+# Maximum retries for transient network errors before treating as unrecoverable.
+# Uses the same exponential backoff as throttle retries (base 2, per-retry delay
+# randomized up to ~0.5s, 1s, 2s, 4s, 8s and capped at 30s), so 5 retries gives
+# roughly 15s of worst-case tolerance before giving up.
+_MAX_TRANSIENT_NETWORK_RETRIES = 5
 
 # Generic function return type.
 F = TypeVar("F", bound=Callable[..., Any])
@@ -165,6 +185,44 @@ def _get_resource_id_and_status_from_conflictexception_header(
     context = response.get("context", {})
     resourceId = response.get("resourceId")
     return resourceId, context.get("status")
+
+
+def _handle_transient_network_error(
+    e: Exception,
+    transient_retries: int,
+    backoff: Backoff,
+    interrupt_event: Optional[Event],
+    api_name: str,
+) -> None:
+    """Handles a transient network error raised during a Deadline Cloud API call by logging
+    and performing an interruptible backoff wait before the caller retries.
+
+    Transient network errors (connection reset, timeout, etc.) commonly occur due to VPN
+    reconnection, load balancer rotation, or brief network blips, and should be retried
+    rather than treated as fatal.
+
+    Note: The caller owns the ``transient_retries`` counter and is responsible for
+    incrementing it after this function returns.
+
+    Raises:
+        DeadlineRequestUnrecoverableError -- When ``transient_retries`` has reached
+            ``_MAX_TRANSIENT_NETWORK_RETRIES``, i.e. the error has persisted past the retry limit.
+    """
+    if transient_retries >= _MAX_TRANSIENT_NETWORK_RETRIES:
+        _logger.error(
+            f"Transient network error persisted after {_MAX_TRANSIENT_NETWORK_RETRIES} "
+            f"retries ({type(e).__name__}: {e}). Giving up."
+        )
+        raise DeadlineRequestUnrecoverableError(e)
+    delay = backoff.delay_amount(RetryContext(transient_retries))
+    _logger.warning(
+        f"Transient network error during {api_name} ({type(e).__name__}: {e}). "
+        f"Retrying in {delay} seconds..."
+    )
+    if interrupt_event:
+        interrupt_event.wait(delay)
+    else:
+        sleep(delay)
 
 
 def assume_fleet_role_for_worker(
@@ -747,6 +805,7 @@ def update_worker_schedule(
     # Retry API call when being throttled
     backoff = Backoff(max_backoff=30)
     retry = 0
+    transient_retries = 0
     while True:
         if interrupt_event is not None and interrupt_event.is_set():
             raise DeadlineRequestInterrupted("UpdateWorkerSchedule interrupted")
@@ -796,6 +855,11 @@ def update_worker_schedule(
             else:
                 sleep(delay)
             retry += 1
+        except _TRANSIENT_NETWORK_EXCEPTIONS as e:
+            _handle_transient_network_error(
+                e, transient_retries, backoff, interrupt_event, "UpdateWorkerSchedule"
+            )
+            transient_retries += 1
         except Exception as e:
             # General catch-all for the unexpected, so that the agent can try to handle it gracefully.
             _logger.critical(

--- a/test/unit/aws/deadline/test_update_worker_schedule.py
+++ b/test/unit/aws/deadline/test_update_worker_schedule.py
@@ -3,7 +3,16 @@
 from typing import Generator, Optional
 from unittest.mock import MagicMock, patch
 import pytest
-from botocore.exceptions import ClientError
+from botocore.exceptions import (
+    ClientError,
+    ConnectionClosedError,
+    ConnectTimeoutError,
+    EndpointConnectionError,
+    ReadTimeoutError,
+    ProxyConnectionError,
+    ResponseStreamingError,
+    SSLError,
+)
 
 
 from deadline_worker_agent.api_models import UpdateWorkerScheduleResponse, UpdatedSessionActionInfo
@@ -13,6 +22,7 @@ from deadline_worker_agent.aws.deadline import (
     DeadlineRequestUnrecoverableError,
     DeadlineRequestWorkerNotFound,
     DeadlineRequestWorkerOfflineError,
+    _MAX_TRANSIENT_NETWORK_RETRIES,
 )
 import deadline_worker_agent.aws.deadline as deadline_mod
 
@@ -345,3 +355,126 @@ def test_raises_worker_offline(
     # THEN
     assert exc_context.value.inner_exc is status_conflict
     sleep_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(
+            ConnectionClosedError(
+                endpoint_url="https://scheduling.deadline.us-west-2.amazonaws.com"
+            ),
+            id="ConnectionClosed",
+        ),
+        pytest.param(
+            ConnectTimeoutError(endpoint_url="https://scheduling.deadline.us-west-2.amazonaws.com"),
+            id="ConnectTimeout",
+        ),
+        pytest.param(
+            ReadTimeoutError(endpoint_url="https://scheduling.deadline.us-west-2.amazonaws.com"),
+            id="ReadTimeout",
+        ),
+        pytest.param(
+            EndpointConnectionError(
+                endpoint_url="https://scheduling.deadline.us-west-2.amazonaws.com"
+            ),
+            id="EndpointConnection",
+        ),
+        # The following are covered by catching botocore's transport base classes
+        # (HTTPClientError / ConnectionError) rather than enumerated leaf types.
+        pytest.param(
+            SSLError(
+                endpoint_url="https://scheduling.deadline.us-west-2.amazonaws.com",
+                error="handshake failure",
+            ),
+            id="SSLError",
+        ),
+        pytest.param(
+            ProxyConnectionError(proxy_url="https://proxy.internal:8080"),
+            id="ProxyConnection",
+        ),
+        pytest.param(
+            ResponseStreamingError(error="connection reset mid-stream"),
+            id="ResponseStreaming",
+        ),
+    ],
+)
+def test_retries_transient_network_errors(
+    client: MagicMock,
+    farm_id: str,
+    fleet_id: str,
+    worker_id: str,
+    exception: Exception,
+    sleep_mock: MagicMock,
+) -> None:
+    # GIVEN
+    client.update_worker_schedule.side_effect = [exception, SAMPLE_UPDATE_WORKER_SCHEDULE_RESPONSE]
+
+    # WHEN
+    response = update_worker_schedule(
+        deadline_client=client, farm_id=farm_id, fleet_id=fleet_id, worker_id=worker_id
+    )
+
+    # THEN
+    assert response == SAMPLE_UPDATE_WORKER_SCHEDULE_RESPONSE
+    assert client.update_worker_schedule.call_count == 2
+    sleep_mock.assert_called_once()
+
+
+def test_transient_network_error_raises_after_max_retries(
+    client: MagicMock,
+    farm_id: str,
+    fleet_id: str,
+    worker_id: str,
+    sleep_mock: MagicMock,
+) -> None:
+    # GIVEN - network error persists beyond max retries
+    client.update_worker_schedule.side_effect = ConnectionClosedError(
+        endpoint_url="https://scheduling.deadline.us-west-2.amazonaws.com"
+    )
+
+    # WHEN
+    with pytest.raises(DeadlineRequestUnrecoverableError):
+        update_worker_schedule(
+            deadline_client=client, farm_id=farm_id, fleet_id=fleet_id, worker_id=worker_id
+        )
+
+    # THEN - retried max times then gave up
+    assert client.update_worker_schedule.call_count == _MAX_TRANSIENT_NETWORK_RETRIES + 1
+    assert sleep_mock.call_count == _MAX_TRANSIENT_NETWORK_RETRIES
+
+
+def test_transient_network_error_wait_is_interruptible(
+    client: MagicMock,
+    farm_id: str,
+    fleet_id: str,
+    worker_id: str,
+    sleep_mock: MagicMock,
+) -> None:
+    # Test that a transient network error backoff uses the interruptible wait
+    # (interrupt_event.wait) rather than an uninterruptible sleep, and that a set
+    # interrupt_event breaks out of the retry loop with DeadlineRequestInterrupted.
+
+    # GIVEN - a persistent network error, and an interrupt_event that becomes set
+    # after the first backoff wait (simulating a shutdown/drain during the wait).
+    client.update_worker_schedule.side_effect = ConnectionClosedError(
+        endpoint_url="https://scheduling.deadline.us-west-2.amazonaws.com"
+    )
+    interrupt_event = MagicMock()
+    # Not set on the initial loop check, then set after the first wait() returns.
+    interrupt_event.is_set.side_effect = [False, True]
+
+    # WHEN
+    with pytest.raises(DeadlineRequestInterrupted):
+        update_worker_schedule(
+            deadline_client=client,
+            farm_id=farm_id,
+            fleet_id=fleet_id,
+            worker_id=worker_id,
+            interrupt_event=interrupt_event,
+        )
+
+    # THEN - the interruptible wait was used (not the plain sleep), and we bailed out.
+    interrupt_event.wait.assert_called_once()
+    sleep_mock.assert_not_called()
+    assert client.update_worker_schedule.call_count == 1


### PR DESCRIPTION
## fix: retry transient network errors in UpdateWorkerSchedule

Add retry handling for transient network errors in UpdateWorkerSchedule. These errors were previously caught by the generic `except Exception` handler and raised as `DeadlineRequestUnrecoverableError`, causing the agent to terminate on brief network blips. Now they are retried with exponential backoff, matching the existing retry behavior for throttling and internal server errors.

### What was the problem/requirement? (What/Why)

Any transient network error (connection reset, timeout, endpoint unreachable) during an `UpdateWorkerSchedule` heartbeat call caused the worker agent to immediately terminate. The generic `except Exception` handler wrapped these as `DeadlineRequestUnrecoverableError` without any retry attempt. This affected customers with momentary network instability (VPN reconnection, load balancer rotation, NIC flap) — their agents would die and lose in-progress sessions. It was reported from the field and corroborated by simultaneous CloudWatch Logs upload failures observed during brief network interruptions.

### What was the solution? (How)

Added an `except _TRANSIENT_NETWORK_EXCEPTIONS` block before the generic `except Exception` catch-all in `update_worker_schedule`. Rather than enumerating individual leaf exceptions, it catches botocore's two transport base classes, `ConnectionError` and `HTTPClientError`. This covers `ConnectionClosedError`, `ConnectTimeoutError`, `EndpointConnectionError`, and `ReadTimeoutError`, and also `SSLError`, `ProxyConnectionError`, and `ResponseStreamingError`, mirroring how botocore itself classifies retryable connection errors. The shared handling was extracted into a `_handle_transient_network_error` helper that logs, performs an interruptible backoff wait, and raises `DeadlineRequestUnrecoverableError` once the retry limit is reached. Retries use the existing exponential backoff (capped at 30s); the limit is 5 retries, which is roughly 15s of worst-case tolerance before giving up.

### What is the impact of this change?

Workers now survive brief network blips during `UpdateWorkerSchedule` calls instead of terminating. There is no behavior change for actual unrecoverable errors (4xx responses, validation errors, etc.) — those still terminate as before. On a sustained outage the agent still gives up after the retry limit and exits.

### How was this change tested?

Note: the full `hatch run test` suite was not run in this environment (the local hatch env could not be provisioned), so full-suite pass counts and coverage should be taken from CI. The following were performed and verified directly:

- Unit tests: ran `test/unit/aws/deadline/test_update_worker_schedule.py` against the branch source — 25 passed. This includes parametrized cases for all seven covered transient exception types (verifying a retry occurs and the call succeeds on the second attempt), a test that the call raises `DeadlineRequestUnrecoverableError` after the max retry count, and a test that the backoff wait is interruptible and a set interrupt breaks the loop with `DeadlineRequestInterrupted`.
- Lint: `ruff check` passed on the changed source and test files. `ruff format` and `mypy` were not run locally and should be confirmed by CI.
- Live worker test: installed the branch as an editable install and ran a real worker against a customer-managed fleet. Confirmed the running code was the branch source (module resolved to the working tree, `_handle_transient_network_error` present, transient tuple = `ConnectionError, HTTPClientError`). With the worker heartbeating `UpdateWorkerSchedule` successfully, a real network fault was injected by adding a host firewall outbound rule scoped only to the endpoint IPs on port 443 (remote access and all other traffic unaffected). The agent logged `Transient network error during UpdateWorkerSchedule (EndpointConnectionError: ...). Retrying in N seconds...` across five retries with increasing exponential backoff, then logged `Transient network error persisted after 5 retries (...). Giving up.` and exited cleanly with `DeadlineRequestUnrecoverableError`. The firewall rule was removed afterward and connectivity confirmed restored.

### Was this change documented?

No external documentation changes required. The fix is internal retry behavior, with a warning log per retry and an error log on give-up for observability.

### Is this a breaking change?

No. This only adds retry behavior where the agent would previously crash. No API, config, or interface changes.
