### PR TITLE
fix(credentials): Retry with bootstrap creds on hibernate/sleep expiry

### DIFF
--- a/src/deadline_worker_agent/aws_credentials/worker_boto3_session.py
+++ b/src/deadline_worker_agent/aws_credentials/worker_boto3_session.py
@@ -89,17 +89,37 @@ class WorkerBoto3Session(BaseBoto3Session):
             )
         )
 
-        deadline_client = session.client("deadline", config=DEADLINE_BOTOCORE_CONFIG)
-        try:
-            response = assume_fleet_role_for_worker(
+        def _assume(boto_session: Session) -> Any:
+            deadline_client = boto_session.client("deadline", config=DEADLINE_BOTOCORE_CONFIG)
+            return assume_fleet_role_for_worker(
                 deadline_client=deadline_client,
                 farm_id=self._farm_id,
                 fleet_id=self._fleet_id,
                 worker_id=self._worker_id,
             )
+
+        try:
+            response = _assume(session)
         except DeadlineRequestUnrecoverableError as e:
-            # Re-raise to let the caller know, and handle the exception.
-            raise e from None
+            # If credentials expired during the call (e.g. machine hibernated/slept between
+            # the are_expired() check and the API call), retry with bootstrap credentials.
+            #
+            # NOTE: are_expired() is a heuristic, not proof of the failure's cause. We can't tell
+            # from the error alone whether it was caused by expiry, so we infer it from the clock.
+            # A genuine AccessDeniedException (e.g. policy change, role deletion) that happens to
+            # coincide with expiry will also be retried here rather than surfacing immediately.
+            if credentials_object.are_expired() and session is not self._bootstrap_session:
+                _logger.warning(
+                    AwsCredentialsLogEvent(
+                        op=AwsCredentialsLogEventOp.QUERY,
+                        resource=self._worker_id,
+                        message="Credentials expired during refresh (possible hibernate/sleep). Retrying with bootstrap credentials.",
+                    )
+                )
+                response = _assume(self._bootstrap_session)
+            else:
+                # Re-raise to let the caller know, and handle the exception.
+                raise e from None
 
         try:
             temporary_creds = TemporaryCredentials.from_deadline_assume_role_response(

--- a/test/unit/aws_credentials/test_worker_boto3_session.py
+++ b/test/unit/aws_credentials/test_worker_boto3_session.py
@@ -374,3 +374,206 @@ class TestRefreshCredentials:
 
             # THEN
             assert exc_context.value.inner_exc is exception
+
+    def test_retries_with_bootstrap_on_hibernate_expired_credentials(
+        self,
+        bootstrap_session: MagicMock,
+        config: Configuration,
+        worker_id: str,
+        file_cache_cls_mock: MagicMock,
+        temporary_credentials_cls_mock: MagicMock,
+    ) -> None:
+        # Test that if credentials appear valid before the API call but expire during the call
+        # (e.g. machine hibernated/slept), then the retry uses bootstrap credentials.
+
+        # GIVEN
+        with (
+            patch.object(WorkerBoto3Session, "get_credentials", MagicMock()) as mock_get_creds,
+            patch.object(WorkerBoto3Session, "client", MagicMock()),
+            patch.object(
+                worker_boto3_session_mod, "assume_fleet_role_for_worker"
+            ) as assume_role_mock,
+        ):
+            # Mocks to get through WorkerBoto3Session.__init__
+            mock_creds_object = MagicMock()
+            mock_creds_object.are_expired.return_value = False
+            mock_get_creds.return_value = mock_creds_object
+            temporary_credentials_cls_mock.from_cache.return_value = None
+
+            session = WorkerBoto3Session(
+                bootstrap_session=bootstrap_session, config=config, worker_id=worker_id
+            )
+
+            # First call fails (simulates 403 after hibernate), second call succeeds
+            assume_role_mock.side_effect = [
+                DeadlineRequestUnrecoverableError(Exception("AccessDeniedException")),
+                SAMPLE_ASSUME_ROLE_RESPONSE,
+            ]
+            mock_temporary_credentials = MagicMock()
+            temporary_credentials_cls_mock.from_deadline_assume_role_response.return_value = (
+                mock_temporary_credentials
+            )
+
+            # After the first failure, are_expired() returns True (time jumped during sleep)
+            mock_creds_object.are_expired.side_effect = [False, True]
+
+            # WHEN
+            session.refresh_credentials()
+
+            # THEN
+            # Bootstrap session was used for the retry
+            bootstrap_session.client.assert_called_once_with(
+                "deadline", config=DEADLINE_BOTOCORE_CONFIG
+            )
+            # assume_fleet_role_for_worker was called twice (first with self, then with bootstrap)
+            assert assume_role_mock.call_count == 2
+            # Credentials were updated with the successful response
+            mock_creds_object.set_credentials.assert_called_once_with(
+                mock_temporary_credentials.to_deadline.return_value
+            )
+
+    def test_reraises_when_not_expired_after_failure(
+        self,
+        bootstrap_session: MagicMock,
+        config: Configuration,
+        worker_id: str,
+        file_cache_cls_mock: MagicMock,
+        temporary_credentials_cls_mock: MagicMock,
+    ) -> None:
+        # Test that if the API call fails but credentials are NOT expired (not a hibernate case),
+        # the error is re-raised without retrying.
+
+        # GIVEN
+        with (
+            patch.object(WorkerBoto3Session, "get_credentials", MagicMock()) as mock_get_creds,
+            patch.object(WorkerBoto3Session, "client", MagicMock()),
+            patch.object(
+                worker_boto3_session_mod, "assume_fleet_role_for_worker"
+            ) as assume_role_mock,
+        ):
+            # Mocks to get through WorkerBoto3Session.__init__
+            mock_creds_object = MagicMock()
+            mock_creds_object.are_expired.return_value = False
+            mock_get_creds.return_value = mock_creds_object
+            temporary_credentials_cls_mock.from_cache.return_value = None
+
+            # Mocks to get to where we want in refresh_credentials()
+            error = DeadlineRequestUnrecoverableError(Exception("AccessDeniedException"))
+            assume_role_mock.side_effect = error
+
+            session = WorkerBoto3Session(
+                bootstrap_session=bootstrap_session, config=config, worker_id=worker_id
+            )
+
+            # Credentials are NOT expired after the failure (not a hibernate scenario)
+            mock_creds_object.are_expired.return_value = False
+
+            # WHEN
+            with pytest.raises(DeadlineRequestUnrecoverableError) as exc_context:
+                session.refresh_credentials()
+
+            # THEN
+            assert exc_context.value is error
+            # Bootstrap was never used for a retry
+            bootstrap_session.client.assert_not_called()
+            # Only one call attempt was made
+            assert assume_role_mock.call_count == 1
+
+    def test_reraises_when_already_using_bootstrap(
+        self,
+        bootstrap_session: MagicMock,
+        config: Configuration,
+        worker_id: str,
+        file_cache_cls_mock: MagicMock,
+        temporary_credentials_cls_mock: MagicMock,
+    ) -> None:
+        # Test that if we're already using bootstrap credentials and the call fails,
+        # we don't retry (avoid infinite loop).
+
+        # GIVEN
+        with (
+            patch.object(WorkerBoto3Session, "get_credentials", MagicMock()) as mock_get_creds,
+            patch.object(WorkerBoto3Session, "client", MagicMock()),
+            patch.object(
+                worker_boto3_session_mod, "assume_fleet_role_for_worker"
+            ) as assume_role_mock,
+        ):
+            # Mocks to get through WorkerBoto3Session.__init__
+            mock_creds_object = MagicMock()
+            mock_creds_object.are_expired.return_value = False
+            mock_get_creds.return_value = mock_creds_object
+            temporary_credentials_cls_mock.from_cache.return_value = None
+
+            session = WorkerBoto3Session(
+                bootstrap_session=bootstrap_session, config=config, worker_id=worker_id
+            )
+
+            # Credentials are expired (so bootstrap is chosen initially)
+            mock_creds_object.are_expired.return_value = True
+
+            # Bootstrap call also fails
+            error = DeadlineRequestUnrecoverableError(Exception("AccessDeniedException"))
+            assume_role_mock.side_effect = error
+
+            # WHEN
+            with pytest.raises(DeadlineRequestUnrecoverableError) as exc_context:
+                session.refresh_credentials()
+
+            # THEN
+            assert exc_context.value is error
+            # Only one call attempt (no retry since already using bootstrap)
+            assert assume_role_mock.call_count == 1
+
+    def test_reraises_when_bootstrap_retry_also_fails(
+        self,
+        bootstrap_session: MagicMock,
+        config: Configuration,
+        worker_id: str,
+        file_cache_cls_mock: MagicMock,
+        temporary_credentials_cls_mock: MagicMock,
+    ) -> None:
+        # Test that if creds expire mid-call (hibernate) AND the bootstrap retry also fails
+        # (e.g. static bootstrap creds were revoked, or bootstrap is otherwise unrecoverable),
+        # then the error from the retry is propagated rather than swallowed.
+
+        # GIVEN
+        with (
+            patch.object(WorkerBoto3Session, "get_credentials", MagicMock()) as mock_get_creds,
+            patch.object(WorkerBoto3Session, "client", MagicMock()),
+            patch.object(
+                worker_boto3_session_mod, "assume_fleet_role_for_worker"
+            ) as assume_role_mock,
+        ):
+            # Mocks to get through WorkerBoto3Session.__init__
+            mock_creds_object = MagicMock()
+            mock_creds_object.are_expired.return_value = False
+            mock_get_creds.return_value = mock_creds_object
+            temporary_credentials_cls_mock.from_cache.return_value = None
+
+            session = WorkerBoto3Session(
+                bootstrap_session=bootstrap_session, config=config, worker_id=worker_id
+            )
+
+            # Creds appear valid at the initial check (use self), then expire during the call.
+            mock_creds_object.are_expired.side_effect = [False, True]
+
+            # First call fails (hibernate), bootstrap retry also fails.
+            first_error = DeadlineRequestUnrecoverableError(Exception("AccessDeniedException"))
+            bootstrap_error = DeadlineRequestUnrecoverableError(Exception("ExpiredTokenException"))
+            assume_role_mock.side_effect = [first_error, bootstrap_error]
+
+            # WHEN
+            with pytest.raises(DeadlineRequestUnrecoverableError) as exc_context:
+                session.refresh_credentials()
+
+            # THEN
+            # The bootstrap retry's error is what propagates.
+            assert exc_context.value is bootstrap_error
+            # Bootstrap was used for the retry.
+            bootstrap_session.client.assert_called_once_with(
+                "deadline", config=DEADLINE_BOTOCORE_CONFIG
+            )
+            # Two attempts were made (self, then bootstrap).
+            assert assume_role_mock.call_count == 2
+            # Credentials were never updated since both attempts failed.
+            mock_creds_object.set_credentials.assert_not_called()


### PR DESCRIPTION
## Problem

Fleet-role credentials are held in a non-auto-refreshing session (a `PassThroughCredentialProvider` wrapping `SettableCredentials`), so they're only rotated by our explicit `refresh_credentials()` call.

`refresh_credentials()` picks which session to call `AssumeFleetRoleForWorker` with based on `are_expired()`: if the current fleet-role creds look valid, it uses them; otherwise it falls back to the bootstrap session.

There's a race: if the machine hibernates/sleeps between the `are_expired()` check and the API call completing, the fleet-role creds expire mid-flight. The resulting 403 was mapped to `DeadlineRequestUnrecoverableError` and caused the worker to exit.

## Fix

After catching `DeadlineRequestUnrecoverableError`, we re-check `are_expired()`. If the creds expired during the call and we weren't already using bootstrap, we retry once with the bootstrap session. Non-hibernate failures are unaffected (re-raised as before), and we never retry bootstrap→bootstrap, so there's no loop.

## Notes for reviewers

- **Why bootstrap is the fallback:** you can't refresh expired fleet-role creds using those same expired creds. The bootstrap session is a plain boto3 `Session` whose credentials come from the standard chain (instance role/IMDS, profile, env).

- **"What if bootstrap is also expired?"** For refreshable sources (IMDS, etc.) botocore auto-refreshes the bootstrap creds on demand, so the retry self-heals after a long hibernate. The only unrecoverable case is revoked static creds, which correctly propagates. No extra code needed — verified and covered by a test.

- **`are_expired()` is a heuristic:** we can't tell from the error alone whether expiry caused it, so we infer it from the clock. A genuine AccessDenied that coincides with expiry will also be retried. The blast radius is small (bootstrap is the more-privileged path, timing overlap is narrow) and there's an inline comment calling this out.

## Testing

Unit tests cover all branches:
- expiry mid-call → retry with bootstrap succeeds
- non-expiry failure → re-raised, no retry
- already on bootstrap → re-raised, no retry (no loop)
- expiry mid-call → bootstrap retry also fails → error propagates, no creds set
