### PR TITLE
feat: consume runtimeHint from UpdateWorkerSchedule responses

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -3,6 +3,7 @@ coverage[toml] ~= 7.15; python_version >= "3.10"
 coverage[toml] ~= 7.10; python_version < "3.10"
 coverage-conditional-plugin == 0.9.*
 deadline-cloud-test-fixtures >= 0.18.14, < 0.19
+numpy < 2.2
 flaky == 3.8.*
 pytest == 9.1.*; python_version >= "3.10"
 pytest ~= 8.4; python_version < "3.10"

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -3,7 +3,13 @@ coverage[toml] ~= 7.15; python_version >= "3.10"
 coverage[toml] ~= 7.10; python_version < "3.10"
 coverage-conditional-plugin == 0.9.*
 deadline-cloud-test-fixtures >= 0.18.14, < 0.19
-numpy < 2.2
+# We don't use numpy directly; deadline-cloud-test-fixtures pulls it in.
+# numpy 2.5+ (Python 3.12+ only) ships type stubs using PEP 695 `type`
+# aliases, which mypy rejects while we type-check against
+# python_version = "3.10". Only Python >= 3.12 environments can install
+# numpy 2.5, so the pin is scoped to them. Remove when the mypy target
+# is raised to 3.12.
+numpy < 2.5; python_version >= "3.12"
 flaky == 3.8.*
 pytest == 9.1.*; python_version >= "3.10"
 pytest ~= 8.4; python_version < "3.10"

--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -123,6 +123,7 @@ class AssignedSession(TypedDict):
     jobId: str
     sessionActions: list[EnvironmentAction | TaskRunAction | AttachmentDownloadAction]
     logConfiguration: NotRequired[LogConfiguration]
+    metadata: NotRequired[dict[str, str]]
 
 
 class UpdateWorkerScheduleResponse(TypedDict):

--- a/src/deadline_worker_agent/boto/shim.py
+++ b/src/deadline_worker_agent/boto/shim.py
@@ -214,6 +214,8 @@ class DeadlineClient:
             )
             if log_configuration := session.get("logConfiguration", None):
                 mapped_session["logConfiguration"] = log_configuration
+            if metadata := session.get("metadata", None):
+                mapped_session["metadata"] = metadata
 
             mapped_sessions[session_id] = mapped_session
 

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -194,7 +194,7 @@ class WorkerScheduler:
     _worker_persistence_dir: Path
     _worker_logs_dir: Path | None
     _retain_session_dir: bool
-    _session_runtime: SessionRuntimeKind
+    _session_runtime_kind: SessionRuntimeKind
     _session_root_dir: Path
 
     # Map from queueId -> QueueAwsCredentials.
@@ -217,7 +217,7 @@ class WorkerScheduler:
         worker_logs_dir: Path | None,
         session_root_dir: Path,
         retain_session_dir: bool = False,
-        session_runtime: SessionRuntimeKind = SessionRuntimeKind.PYTHON,
+        session_runtime_kind: SessionRuntimeKind = SessionRuntimeKind.PYTHON,
         stop: Event | None = None,
     ) -> None:
         """Queue of Worker Sessions and their actions
@@ -256,7 +256,7 @@ class WorkerScheduler:
         self._worker_persistence_dir = worker_persistence_dir
         self._worker_logs_dir = worker_logs_dir
         self._retain_session_dir = retain_session_dir
-        self._session_runtime = session_runtime
+        self._session_runtime_kind = session_runtime_kind
         self._windows_credentials_resolver: Optional[WindowsCredentialsResolver]
         self._session_root_dir = session_root_dir
 
@@ -1165,7 +1165,7 @@ class WorkerScheduler:
 
             runtime_hint = (session_spec.get("metadata") or {}).get("runtimeHint")
             try:
-                runtime_kind = select_runtime(self._session_runtime, runtime_hint=runtime_hint)
+                runtime_kind = select_runtime(self._session_runtime_kind, runtime_hint=runtime_hint)
             except ValueError as e:
                 # An unknown runtimeHint indicates version skew or a
                 # service-side bug. Fail this session's actions visibly and
@@ -1183,6 +1183,18 @@ class WorkerScheduler:
                 )
                 continue
 
+            logger.info(
+                SessionLogEvent(
+                    subtype=SessionLogEventSubtype.STARTING,
+                    queue_id=queue_id,
+                    job_id=job_id,
+                    session_id=new_session_id,
+                    message=(
+                        f"Selected session runtime: {runtime_kind.value} (hint={runtime_hint!r})"
+                    ),
+                )
+            )
+
             session = Session(
                 id=new_session_id,
                 queue=queue,
@@ -1193,7 +1205,7 @@ class WorkerScheduler:
                 job_details=job_details,
                 os_user=os_user,
                 retain_session_dir=self._retain_session_dir,
-                runtime_kind=runtime_kind,
+                session_runtime_kind=runtime_kind,
                 action_update_callback=self._handle_session_action_update,
                 action_update_lock=self._action_update_lock,
                 session_root_dir=self._session_root_dir,

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -28,6 +28,8 @@ from deadline.job_attachments.asset_sync import AssetSync
 
 from ..aws.deadline import update_worker
 from ..aws_credentials import QueueBoto3Session, AwsCredentialsRefresher
+from .._session_runtime_kind import SessionRuntimeKind
+from ..sessions.runtime import select_runtime
 from ..boto import DeadlineClient, Session as BotoSession
 from ..errors import ServiceShutdown
 from ..sessions import JobEntities, Session
@@ -192,6 +194,7 @@ class WorkerScheduler:
     _worker_persistence_dir: Path
     _worker_logs_dir: Path | None
     _retain_session_dir: bool
+    _session_runtime: SessionRuntimeKind
     _session_root_dir: Path
 
     # Map from queueId -> QueueAwsCredentials.
@@ -214,6 +217,7 @@ class WorkerScheduler:
         worker_logs_dir: Path | None,
         session_root_dir: Path,
         retain_session_dir: bool = False,
+        session_runtime: SessionRuntimeKind = SessionRuntimeKind.PYTHON,
         stop: Event | None = None,
     ) -> None:
         """Queue of Worker Sessions and their actions
@@ -252,6 +256,7 @@ class WorkerScheduler:
         self._worker_persistence_dir = worker_persistence_dir
         self._worker_logs_dir = worker_logs_dir
         self._retain_session_dir = retain_session_dir
+        self._session_runtime = session_runtime
         self._windows_credentials_resolver: Optional[WindowsCredentialsResolver]
         self._session_root_dir = session_root_dir
 
@@ -1158,6 +1163,26 @@ class WorkerScheduler:
 
             logger.debug("env = \n%s", json.dumps(env, indent=2))
 
+            runtime_hint = (session_spec.get("metadata") or {}).get("runtimeHint")
+            try:
+                runtime_kind = select_runtime(self._session_runtime, runtime_hint=runtime_hint)
+            except ValueError as e:
+                # An unknown runtimeHint indicates version skew or a
+                # service-side bug. Fail this session's actions visibly and
+                # continue; it must not take down the scheduler.
+                message = f"Failed to select session runtime: {e}"
+                self._fail_all_actions(session_spec, message)
+                logger.error(
+                    SessionLogEvent(
+                        subtype=SessionLogEventSubtype.FAILED,
+                        queue_id=queue_id,
+                        job_id=job_id,
+                        session_id=new_session_id,
+                        message=message,
+                    )
+                )
+                continue
+
             session = Session(
                 id=new_session_id,
                 queue=queue,
@@ -1168,6 +1193,7 @@ class WorkerScheduler:
                 job_details=job_details,
                 os_user=os_user,
                 retain_session_dir=self._retain_session_dir,
+                runtime_kind=runtime_kind,
                 action_update_callback=self._handle_session_action_update,
                 action_update_lock=self._action_update_lock,
                 session_root_dir=self._session_root_dir,

--- a/src/deadline_worker_agent/sessions/runtime/_select.py
+++ b/src/deadline_worker_agent/sessions/runtime/_select.py
@@ -37,10 +37,6 @@ def select_runtime(
     There is intentionally no capability check, escalation, or fallback here. If
     the selected runtime cannot support the job's required extensions, runtime
     construction fails — that is openjd's responsibility, not this function's.
-
-    This function has no callers yet; reading runtimeHint from the
-    UpdateWorkerSchedule response and wiring it into session construction
-    lands in a follow-up change.
     """
     if configured_kind == SessionRuntimeKind.PYTHON:
         return SessionRuntimeKind.PYTHON

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -171,6 +171,7 @@ class Session:
         asset_sync: Optional[AssetSync],
         os_user: SessionUser | None,
         retain_session_dir: bool = False,
+        runtime_kind: SessionRuntimeKind = SessionRuntimeKind.PYTHON,
         job_details: JobDetails,
         action_update_callback: Callable[[SessionActionStatus], None],
         action_update_lock: RLock,
@@ -198,7 +199,7 @@ class Session:
             self.update_action(action_status)
 
         self._runtime: SessionRuntime = create_session_runtime(
-            SessionRuntimeKind.PYTHON,
+            runtime_kind,
             SessionRuntimeConfig(
                 session_id=self._id,
                 job_parameter_values=self._job_details.parameters,

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -171,7 +171,7 @@ class Session:
         asset_sync: Optional[AssetSync],
         os_user: SessionUser | None,
         retain_session_dir: bool = False,
-        runtime_kind: SessionRuntimeKind = SessionRuntimeKind.PYTHON,
+        session_runtime_kind: SessionRuntimeKind = SessionRuntimeKind.PYTHON,
         job_details: JobDetails,
         action_update_callback: Callable[[SessionActionStatus], None],
         action_update_lock: RLock,
@@ -199,7 +199,7 @@ class Session:
             self.update_action(action_status)
 
         self._runtime: SessionRuntime = create_session_runtime(
-            runtime_kind,
+            session_runtime_kind,
             SessionRuntimeConfig(
                 session_id=self._id,
                 job_parameter_values=self._job_details.parameters,

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -200,6 +200,7 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
                 host_metrics_logging=config.host_metrics_logging,
                 host_metrics_logging_interval_seconds=config.host_metrics_logging_interval_seconds,
                 retain_session_dir=config.retain_session_dir,
+                session_runtime=config.session_runtime,
                 stop=stop,
                 session_root_dir=config.session_root_dir,
             )

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -200,7 +200,7 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
                 host_metrics_logging=config.host_metrics_logging,
                 host_metrics_logging_interval_seconds=config.host_metrics_logging_interval_seconds,
                 retain_session_dir=config.retain_session_dir,
-                session_runtime=config.session_runtime,
+                session_runtime_kind=config.session_runtime,
                 stop=stop,
                 session_root_dir=config.session_root_dir,
             )

--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -94,7 +94,7 @@ class Worker:
         host_metrics_logging: bool,
         host_metrics_logging_interval_seconds: float | None = None,
         retain_session_dir: bool = False,
-        session_runtime: SessionRuntimeKind = SessionRuntimeKind.PYTHON,
+        session_runtime_kind: SessionRuntimeKind = SessionRuntimeKind.PYTHON,
         stop: Event | None = None,
     ) -> None:
         self._deadline_client = deadline_client
@@ -118,7 +118,7 @@ class Worker:
             worker_persistence_dir=worker_persistence_dir,
             worker_logs_dir=worker_logs_dir,
             retain_session_dir=retain_session_dir,
-            session_runtime=session_runtime,
+            session_runtime_kind=session_runtime_kind,
             stop=stop,
             session_root_dir=session_root_dir,
         )

--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -22,6 +22,7 @@ import requests
 from .aws_credentials import WorkerBoto3Session, AwsCredentialsRefresher
 from .boto import DeadlineClient
 from .config import JobsRunAsUserOverride
+from ._session_runtime_kind import SessionRuntimeKind
 from .errors import ServiceShutdown
 from .log_messages import AwsCredentialsLogEvent, AwsCredentialsLogEventOp
 from .metrics import HostMetricsLogger
@@ -93,6 +94,7 @@ class Worker:
         host_metrics_logging: bool,
         host_metrics_logging_interval_seconds: float | None = None,
         retain_session_dir: bool = False,
+        session_runtime: SessionRuntimeKind = SessionRuntimeKind.PYTHON,
         stop: Event | None = None,
     ) -> None:
         self._deadline_client = deadline_client
@@ -116,6 +118,7 @@ class Worker:
             worker_persistence_dir=worker_persistence_dir,
             worker_logs_dir=worker_logs_dir,
             retain_session_dir=retain_session_dir,
+            session_runtime=session_runtime,
             stop=stop,
             session_root_dir=session_root_dir,
         )

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -1479,6 +1479,264 @@ class TestCreateNewSessions:
         assert result == expected_result
 
 
+class TestCreateNewSessionsRuntimeHint:
+    """Tests for runtime hint consumption in WorkerScheduler._create_new_sessions"""
+
+    @pytest.fixture
+    def mock_job_entities(self) -> Generator[MagicMock, None, None]:
+        with patch.object(scheduler_mod, "JobEntities") as job_entities_mock:
+            job_entity_instance = MagicMock()
+            job_entity_instance.job_details.return_value = JobDetails(
+                log_group_name="/aws/deadline/queue-0000",
+                schema_version=SpecificationRevision.v2023_09,
+                job_run_as_user=JobRunAsUser(
+                    posix=(
+                        PosixSessionUser(user="username", group="group")
+                        if os.name == "posix"
+                        else None
+                    ),
+                    windows=(
+                        WindowsSessionUser(user="username", password="password")
+                        if os.name == "nt"
+                        else None
+                    ),
+                    windows_settings=None,
+                ),
+            )
+            job_entities_mock.return_value = job_entity_instance
+            yield job_entities_mock
+
+    @pytest.fixture
+    def scheduler_service_selected(
+        self,
+        farm_id: str,
+        fleet_id: str,
+        worker_id: str,
+        client: MagicMock,
+        job_run_as_user_overrides: JobsRunAsUserOverride,
+        boto_session: Mock,
+        worker_logs_dir: Path,
+        session_root_dir: Path,
+        log_translation_filter: None,
+    ) -> WorkerScheduler:
+        from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
+
+        return WorkerScheduler(
+            farm_id=farm_id,
+            fleet_id=fleet_id,
+            worker_id=worker_id,
+            deadline=client,
+            job_run_as_user_override=job_run_as_user_overrides,
+            boto_session=boto_session,
+            cleanup_session_user_processes=True,
+            worker_persistence_dir=Path("/var/lib/deadline"),
+            worker_logs_dir=worker_logs_dir,
+            session_root_dir=session_root_dir,
+            session_runtime=SessionRuntimeKind.SERVICE_SELECTED,
+        )
+
+    @pytest.mark.parametrize(
+        argnames=("session_runtime_kind", "metadata", "expected_runtime_kind"),
+        argvalues=(
+            pytest.param(
+                "SERVICE_SELECTED",
+                {"runtimeHint": "rust"},
+                "RUST",
+                id="service_selected_with_rust_hint",
+            ),
+            pytest.param(
+                "SERVICE_SELECTED",
+                {"runtimeHint": "pythonexpr"},
+                "PYTHON",
+                id="service_selected_with_pythonexpr_hint",
+            ),
+            pytest.param(
+                "SERVICE_SELECTED",
+                {},
+                "PYTHON",
+                id="service_selected_empty_metadata",
+            ),
+            pytest.param(
+                "SERVICE_SELECTED",
+                None,
+                "PYTHON",
+                id="service_selected_no_metadata_key",
+            ),
+            pytest.param(
+                "PYTHON",
+                {"runtimeHint": "rust"},
+                "PYTHON",
+                id="python_configured_ignores_hint",
+            ),
+        ),
+    )
+    def test_runtime_hint_selection(
+        self,
+        farm_id: str,
+        fleet_id: str,
+        worker_id: str,
+        client: MagicMock,
+        job_run_as_user_overrides: JobsRunAsUserOverride,
+        boto_session: Mock,
+        worker_logs_dir: Path,
+        session_root_dir: Path,
+        log_translation_filter: None,
+        mock_session: MagicMock,
+        mock_job_entities: MagicMock,
+        session_runtime_kind: str,
+        metadata: Optional[dict[str, str]],
+        expected_runtime_kind: str,
+    ) -> None:
+        """Tests that select_runtime is called correctly and the result is passed to Session."""
+        from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
+
+        configured_kind = SessionRuntimeKind[session_runtime_kind]
+        expected_kind = SessionRuntimeKind[expected_runtime_kind]
+
+        sched = WorkerScheduler(
+            farm_id=farm_id,
+            fleet_id=fleet_id,
+            worker_id=worker_id,
+            deadline=client,
+            job_run_as_user_override=job_run_as_user_overrides,
+            boto_session=boto_session,
+            cleanup_session_user_processes=True,
+            worker_persistence_dir=Path("/var/lib/deadline"),
+            worker_logs_dir=worker_logs_dir,
+            session_root_dir=session_root_dir,
+            session_runtime=configured_kind,
+        )
+
+        session_id = "session-abcdef0123456789abcdef0123456789"
+        assigned_session = AssignedSession(
+            queueId="queue-abcdef0123456789abcdef0123456789",
+            jobId="job-abcdef0123456789abcdef0123456789",
+            logConfiguration=LogConfiguration(
+                logDriver="awslogs",
+                options={},
+                parameters={"interval": "15"},
+            ),
+            sessionActions=[
+                EnvironmentAction(
+                    actionType="ENV_ENTER",
+                    environmentId="env-1",
+                    sessionActionId="action-1",
+                ),
+            ],
+        )
+        if metadata is not None:
+            assigned_session["metadata"] = metadata
+        assigned_sessions: dict[str, AssignedSession] = {session_id: assigned_session}
+
+        with patch.object(sched, "_executor"):
+            sched._create_new_sessions(assigned_sessions=assigned_sessions)
+
+        mock_session.assert_called_once()
+        assert mock_session.call_args.kwargs["runtime_kind"] == expected_kind
+
+    def test_invalid_runtime_hint_fails_session(
+        self,
+        scheduler_service_selected: WorkerScheduler,
+        mock_job_entities: MagicMock,
+    ) -> None:
+        """Tests that an unknown runtimeHint causes the session actions to be failed
+        without raising an exception."""
+        session_id = "session-abcdef0123456789abcdef0123456789"
+        assigned_sessions: dict[str, AssignedSession] = {
+            session_id: AssignedSession(
+                queueId="queue-abcdef0123456789abcdef0123456789",
+                jobId="job-abcdef0123456789abcdef0123456789",
+                logConfiguration=LogConfiguration(
+                    logDriver="awslogs",
+                    options={},
+                    parameters={"interval": "15"},
+                ),
+                sessionActions=[
+                    EnvironmentAction(
+                        actionType="ENV_ENTER",
+                        environmentId="env-1",
+                        sessionActionId="action-1",
+                    ),
+                    TaskRunAction(
+                        actionType="TASK_RUN",
+                        parameters={},
+                        sessionActionId="action-2",
+                        stepId="step-1",
+                        taskId="task-1",
+                    ),
+                ],
+                metadata={"runtimeHint": "bogus"},
+            ),
+        }
+
+        with patch.object(scheduler_mod, "Session") as mock_session:
+            # No exception should escape
+            scheduler_service_selected._create_new_sessions(assigned_sessions=assigned_sessions)
+
+        # Session must NOT have been constructed for this session
+        mock_session.assert_not_called()
+
+        # Actions should be failed via _action_updates_map
+        action_update = scheduler_service_selected._action_updates_map.get("action-1")
+        assert action_update is not None
+        assert action_update.completed_status == "FAILED"
+        assert action_update.status is not None
+        assert action_update.status.state == ActionState.FAILED
+        assert action_update.status.fail_message is not None
+        assert "Failed to select session runtime" in action_update.status.fail_message
+
+    def test_empty_string_runtime_hint_fails_session(
+        self,
+        scheduler_service_selected: WorkerScheduler,
+        mock_job_entities: MagicMock,
+    ) -> None:
+        """Tests that an empty-string runtimeHint is not a valid wire value and fails
+        the session without raising an exception."""
+        session_id = "session-abcdef0123456789abcdef0123456789"
+        assigned_sessions: dict[str, AssignedSession] = {
+            session_id: AssignedSession(
+                queueId="queue-abcdef0123456789abcdef0123456789",
+                jobId="job-abcdef0123456789abcdef0123456789",
+                logConfiguration=LogConfiguration(
+                    logDriver="awslogs",
+                    options={},
+                    parameters={"interval": "15"},
+                ),
+                sessionActions=[
+                    EnvironmentAction(
+                        actionType="ENV_ENTER",
+                        environmentId="env-1",
+                        sessionActionId="action-1",
+                    ),
+                    TaskRunAction(
+                        actionType="TASK_RUN",
+                        parameters={},
+                        sessionActionId="action-2",
+                        stepId="step-1",
+                        taskId="task-1",
+                    ),
+                ],
+                metadata={"runtimeHint": ""},
+            ),
+        }
+
+        with patch.object(scheduler_mod, "Session") as mock_session:
+            # No exception should escape
+            scheduler_service_selected._create_new_sessions(assigned_sessions=assigned_sessions)
+
+        # Session must NOT have been constructed for this session
+        mock_session.assert_not_called()
+
+        # Actions should be failed via _action_updates_map
+        action_update = scheduler_service_selected._action_updates_map.get("action-1")
+        assert action_update is not None
+        assert action_update.completed_status == "FAILED"
+        assert action_update.status is not None
+        assert action_update.status.state == ActionState.FAILED
+        assert action_update.status.fail_message is not None
+        assert "Failed to select session runtime" in action_update.status.fail_message
+
+
 class TestQueueAwsCredentialsManagement:
     """Tests that validate that we are constructing and destroying credentials objects
     as appropriate."""

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -41,6 +41,7 @@ from deadline_worker_agent.sessions.job_entities.job_details import (
     JobRunAsWindowsUser,
 )
 from deadline_worker_agent.config import JobsRunAsUserOverride
+from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
 from deadline_worker_agent.errors import ServiceShutdown
 from deadline_worker_agent.log_messages import LogRecordStringTranslationFilter
 import deadline_worker_agent.scheduler.scheduler as scheduler_mod
@@ -1519,8 +1520,6 @@ class TestCreateNewSessionsRuntimeHint:
         session_root_dir: Path,
         log_translation_filter: None,
     ) -> WorkerScheduler:
-        from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
-
         return WorkerScheduler(
             farm_id=farm_id,
             fleet_id=fleet_id,
@@ -1532,7 +1531,7 @@ class TestCreateNewSessionsRuntimeHint:
             worker_persistence_dir=Path("/var/lib/deadline"),
             worker_logs_dir=worker_logs_dir,
             session_root_dir=session_root_dir,
-            session_runtime=SessionRuntimeKind.SERVICE_SELECTED,
+            session_runtime_kind=SessionRuntimeKind.SERVICE_SELECTED,
         )
 
     @pytest.mark.parametrize(
@@ -1588,8 +1587,6 @@ class TestCreateNewSessionsRuntimeHint:
         expected_runtime_kind: str,
     ) -> None:
         """Tests that select_runtime is called correctly and the result is passed to Session."""
-        from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
-
         configured_kind = SessionRuntimeKind[session_runtime_kind]
         expected_kind = SessionRuntimeKind[expected_runtime_kind]
 
@@ -1604,7 +1601,7 @@ class TestCreateNewSessionsRuntimeHint:
             worker_persistence_dir=Path("/var/lib/deadline"),
             worker_logs_dir=worker_logs_dir,
             session_root_dir=session_root_dir,
-            session_runtime=configured_kind,
+            session_runtime_kind=configured_kind,
         )
 
         session_id = "session-abcdef0123456789abcdef0123456789"
@@ -1632,15 +1629,23 @@ class TestCreateNewSessionsRuntimeHint:
             sched._create_new_sessions(assigned_sessions=assigned_sessions)
 
         mock_session.assert_called_once()
-        assert mock_session.call_args.kwargs["runtime_kind"] == expected_kind
+        assert mock_session.call_args.kwargs["session_runtime_kind"] == expected_kind
 
-    def test_invalid_runtime_hint_fails_session(
+    @pytest.mark.parametrize(
+        "bad_hint",
+        [
+            pytest.param("bogus", id="unknown_value"),
+            pytest.param("", id="empty_string"),
+        ],
+    )
+    def test_bad_runtime_hint_fails_session(
         self,
         scheduler_service_selected: WorkerScheduler,
         mock_job_entities: MagicMock,
+        bad_hint: str,
     ) -> None:
-        """Tests that an unknown runtimeHint causes the session actions to be failed
-        without raising an exception."""
+        """Tests that an invalid runtimeHint (unknown or empty) causes the session actions
+        to be failed without raising an exception."""
         session_id = "session-abcdef0123456789abcdef0123456789"
         assigned_sessions: dict[str, AssignedSession] = {
             session_id: AssignedSession(
@@ -1665,58 +1670,7 @@ class TestCreateNewSessionsRuntimeHint:
                         taskId="task-1",
                     ),
                 ],
-                metadata={"runtimeHint": "bogus"},
-            ),
-        }
-
-        with patch.object(scheduler_mod, "Session") as mock_session:
-            # No exception should escape
-            scheduler_service_selected._create_new_sessions(assigned_sessions=assigned_sessions)
-
-        # Session must NOT have been constructed for this session
-        mock_session.assert_not_called()
-
-        # Actions should be failed via _action_updates_map
-        action_update = scheduler_service_selected._action_updates_map.get("action-1")
-        assert action_update is not None
-        assert action_update.completed_status == "FAILED"
-        assert action_update.status is not None
-        assert action_update.status.state == ActionState.FAILED
-        assert action_update.status.fail_message is not None
-        assert "Failed to select session runtime" in action_update.status.fail_message
-
-    def test_empty_string_runtime_hint_fails_session(
-        self,
-        scheduler_service_selected: WorkerScheduler,
-        mock_job_entities: MagicMock,
-    ) -> None:
-        """Tests that an empty-string runtimeHint is not a valid wire value and fails
-        the session without raising an exception."""
-        session_id = "session-abcdef0123456789abcdef0123456789"
-        assigned_sessions: dict[str, AssignedSession] = {
-            session_id: AssignedSession(
-                queueId="queue-abcdef0123456789abcdef0123456789",
-                jobId="job-abcdef0123456789abcdef0123456789",
-                logConfiguration=LogConfiguration(
-                    logDriver="awslogs",
-                    options={},
-                    parameters={"interval": "15"},
-                ),
-                sessionActions=[
-                    EnvironmentAction(
-                        actionType="ENV_ENTER",
-                        environmentId="env-1",
-                        sessionActionId="action-1",
-                    ),
-                    TaskRunAction(
-                        actionType="TASK_RUN",
-                        parameters={},
-                        sessionActionId="action-2",
-                        stepId="step-1",
-                        taskId="task-1",
-                    ),
-                ],
-                metadata={"runtimeHint": ""},
+                metadata={"runtimeHint": bad_hint},
             ),
         }
 

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -494,6 +494,75 @@ class TestSessionInit:
         assert config.session_root_directory == session_root_dir
 
 
+class TestSessionRuntimeKind:
+    """Tests that Session passes the correct runtime_kind to create_session_runtime."""
+
+    def test_explicit_runtime_kind_passed(
+        self,
+        asset_sync: MagicMock,
+        job_details: "JobDetails",
+        os_user: "SessionUser | None",
+        mock_create_runtime: MagicMock,
+        queue_id: str,
+        session_action_queue: MagicMock,
+        action_update_callback: MagicMock,
+        action_update_lock: MagicMock,
+        session_root_dir: Path,
+    ) -> None:
+        """When runtime_kind=RUST is passed, RUST is forwarded to create_session_runtime."""
+        from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
+
+        Session(
+            id="session-test-rust",
+            asset_sync=asset_sync,
+            env=None,
+            job_details=job_details,
+            os_user=os_user,
+            queue=session_action_queue,
+            queue_id=queue_id,
+            job_id="job-1234",
+            action_update_callback=action_update_callback,
+            action_update_lock=action_update_lock,
+            session_root_dir=session_root_dir,
+            runtime_kind=SessionRuntimeKind.RUST,
+        )
+
+        mock_create_runtime.assert_called_once()
+        assert mock_create_runtime.call_args[0][0] == SessionRuntimeKind.RUST
+
+    def test_default_runtime_kind_is_python(
+        self,
+        asset_sync: MagicMock,
+        job_details: "JobDetails",
+        os_user: "SessionUser | None",
+        mock_create_runtime: MagicMock,
+        queue_id: str,
+        session_action_queue: MagicMock,
+        action_update_callback: MagicMock,
+        action_update_lock: MagicMock,
+        session_root_dir: Path,
+    ) -> None:
+        """When runtime_kind is omitted, PYTHON is forwarded to create_session_runtime."""
+        from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
+
+        Session(
+            id="session-test-default",
+            asset_sync=asset_sync,
+            env=None,
+            job_details=job_details,
+            os_user=os_user,
+            queue=session_action_queue,
+            queue_id=queue_id,
+            job_id="job-1234",
+            action_update_callback=action_update_callback,
+            action_update_lock=action_update_lock,
+            session_root_dir=session_root_dir,
+        )
+
+        mock_create_runtime.assert_called_once()
+        assert mock_create_runtime.call_args[0][0] == SessionRuntimeKind.PYTHON
+
+
 class TestSessionOuterRun:
     """Test cases for Session.run()"""
 

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -46,6 +46,7 @@ from deadline_worker_agent.api_models import (
 )
 from deadline_worker_agent.sessions import Session
 from deadline_worker_agent.sessions.runtime import SessionRuntime
+from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
 import deadline_worker_agent.sessions.session as session_mod
 from deadline_worker_agent.sessions.session import (
     CurrentAction,
@@ -495,7 +496,7 @@ class TestSessionInit:
 
 
 class TestSessionRuntimeKind:
-    """Tests that Session passes the correct runtime_kind to create_session_runtime."""
+    """Tests that Session passes the correct session_runtime_kind to create_session_runtime."""
 
     def test_explicit_runtime_kind_passed(
         self,
@@ -509,9 +510,7 @@ class TestSessionRuntimeKind:
         action_update_lock: MagicMock,
         session_root_dir: Path,
     ) -> None:
-        """When runtime_kind=RUST is passed, RUST is forwarded to create_session_runtime."""
-        from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
-
+        """When session_runtime_kind=RUST is passed, RUST is forwarded to create_session_runtime."""
         Session(
             id="session-test-rust",
             asset_sync=asset_sync,
@@ -524,7 +523,7 @@ class TestSessionRuntimeKind:
             action_update_callback=action_update_callback,
             action_update_lock=action_update_lock,
             session_root_dir=session_root_dir,
-            runtime_kind=SessionRuntimeKind.RUST,
+            session_runtime_kind=SessionRuntimeKind.RUST,
         )
 
         mock_create_runtime.assert_called_once()
@@ -542,9 +541,7 @@ class TestSessionRuntimeKind:
         action_update_lock: MagicMock,
         session_root_dir: Path,
     ) -> None:
-        """When runtime_kind is omitted, PYTHON is forwarded to create_session_runtime."""
-        from deadline_worker_agent._session_runtime_kind import SessionRuntimeKind
-
+        """When session_runtime_kind is omitted, PYTHON is forwarded to create_session_runtime."""
         Session(
             id="session-test-default",
             asset_sync=asset_sync,


### PR DESCRIPTION
Read the service's runtimeHint from AssignedSession.metadata and resolve it through select_runtime() when the scheduler creates sessions. The resolved concrete runtime kind is passed into Session, which no longer hardcodes the Python runtime. Absent metadata or an absent runtimeHint key means no hint, preserving the Python default. An unknown hint value fails that session's actions only and never takes down the scheduler.

### What was the problem/requirement? (What/Why)

#1009 added `select_runtime()`, but nothing calls it yet: the scheduler is unaware of runtime selection and `Session` hardcodes `SessionRuntimeKind.PYTHON` when constructing its runtime. Meanwhile the service already stamps a per-session `runtimeHint` (`"pythonexpr"` / `"rust"`) into the `AssignedSession.metadata` map of `UpdateWorkerSchedule` responses for allowlisted accounts. This change wires the two ends together so the `service-selected` mode becomes functional end-to-end.

### What was the solution? (How)

- `api_models.py`: add `metadata: NotRequired[dict[str, str]]` to `AssignedSession`, mirroring the service model (an optional free-form string map; `runtimeHint` is a convention key, deliberately not modeled).
- `scheduler/scheduler.py`: `WorkerScheduler` now takes a `session_runtime: SessionRuntimeKind` parameter (the worker's configured mode, threaded from config the same way as `retain_session_dir`). In `_create_new_sessions`, the hint is read via `session_spec.get("metadata", {}).get("runtimeHint")` — absent map or absent key yields `None` (no hint) — and resolved with `select_runtime()`.
- **Error containment**: the `select_runtime()` call is wrapped in a try/except matching the function's existing per-session failure blocks. A `ValueError` (unknown hint value — version skew or a service-side bug) marks that session's actions as FAILED via `_fail_all_actions()` and continues to the next session. It never propagates into the scheduler's update loop.
- `sessions/session.py`: `Session.__init__` accepts `runtime_kind: SessionRuntimeKind = SessionRuntimeKind.PYTHON` and passes it to `create_session_runtime()` instead of the hardcoded `PYTHON`. The default keeps every existing constructor call and test valid.
- `worker.py` + `startup/entrypoint.py`: thread `configuration.session_runtime` from the entrypoint through `Worker` into `WorkerScheduler`.
- `boto/shim.py`: forward the `metadata` field when mapping assigned sessions (previously silently dropped).
- `sessions/runtime/_select.py`: remove the now-stale "this function has no callers yet" docstring note.

### What is the impact of this change?

No behavior change by default. Workers configured as `python` (the default) or `rust` ignore hints entirely; in `service-selected` mode, no hint still resolves to Python. The hint only takes effect for accounts allowlisted on the service side. The one new failure mode — an unrecognized hint value — is contained to that single session's actions (reported FAILED to the service) and cannot crash the worker.

### How was this change tested?

- New unit tests in `test/unit/scheduler/test_scheduler.py` (`TestCreateNewSessionsRuntimeHint`): `service-selected` + `"rust"` hint → Session receives `RUST`; `service-selected` + `"pythonexpr"` hint → `PYTHON`; no metadata key → `PYTHON`; `python`-configured worker ignores a `"rust"` hint; an invalid hint (`"bogus"`) and an empty-string hint each fail that session's actions (asserted against `_action_updates_map` contents) with no exception escaping the scheduler, while `Session` is never constructed.
- New unit tests in `test/unit/sessions/test_session.py` (`TestSessionRuntimeKind`): `runtime_kind=RUST` is passed through to `create_session_runtime`; omitting the parameter defaults to `PYTHON`.
- Full unit suite: `hatch run test` — 2956 passed, 0 failed.
- `hatch run lint` (ruff check, ruff format, mypy) — clean.
- E2E: 
```
===Flaky Test Report===

test_worker_reports_canceled_sync_input_actions_as_canceled passed 1 out of the required 1 times. Success!

===End Flaky Test Report===

========================================================================= slowest 5 durations =========================================================================
633.98s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
280.97s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
279.98s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_local_session_logs_can_be_turned_off
265.59s setup    test/e2e/test_cap_kill.py::test_cap_kill_not_inherited_by_running_jobs
245.31s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[linux]
============================================================= 49 passed, 23 skipped in 4806.54s (1:20:06) =============================================================
cmd [4] | echo pytest done
pytest done

```

### Was this change documented?

Inline comments in the scheduler document the hint semantics (absent map/key = no hint) and the error-containment rationale. No user-facing documentation changes: default behavior is unchanged, and the `session-runtime` config option was already documented in #982.

### Is this a breaking change?

No. The new `metadata` field is optional (`NotRequired`), and every new parameter defaults to `SessionRuntimeKind.PYTHON`, preserving existing behavior for all callers.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*