### PR TITLE
feat: emit runtime selection and failure telemetry events

### DIFF
--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -847,6 +847,34 @@ def record_uncaught_exception_telemetry_event(exception_type: str) -> None:
     )
 
 
+def record_runtime_selection_telemetry_event(
+    *, runtime_kind: str, selection_reason: str, session_runtime_config: str
+) -> None:
+    """Records a telemetry event capturing which session runtime was selected and why."""
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.runtime_selection",
+        event_details={
+            "runtime_kind": runtime_kind,
+            "selection_reason": selection_reason,
+            "session_runtime_config": session_runtime_config,
+        },
+    )
+
+
+def record_runtime_failure_telemetry_event(
+    *, runtime_kind: str, failure_reason: str, exception_type: str
+) -> None:
+    """Records a telemetry event for a session failure caused by a runtime issue."""
+    _get_deadline_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.worker_agent.runtime_failure",
+        event_details={
+            "runtime_kind": runtime_kind,
+            "failure_reason": failure_reason,
+            "exception_type": exception_type,
+        },
+    )
+
+
 def _record_attachment_download_filesystem_event(queue_id: str, file_system: str) -> None:
     """Calls the telemetry client to record what filesystem was used"""
     details: Dict[str, Any] = {"queue_id": queue_id, "filesystem": file_system}

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -850,7 +850,7 @@ def record_uncaught_exception_telemetry_event(exception_type: str) -> None:
 def record_runtime_selection_telemetry_event(
     *, runtime_kind: str, selection_reason: str, session_runtime_config: str
 ) -> None:
-    """Records a telemetry event capturing which session runtime was selected and why."""
+    """Records a com.amazon.rum.deadline.worker_agent.runtime_selection telemetry event capturing which session runtime was selected and why."""
     _get_deadline_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.worker_agent.runtime_selection",
         event_details={
@@ -864,7 +864,7 @@ def record_runtime_selection_telemetry_event(
 def record_runtime_failure_telemetry_event(
     *, runtime_kind: str, failure_reason: str, exception_type: str
 ) -> None:
-    """Records a telemetry event for a session failure caused by a runtime issue."""
+    """Records a com.amazon.rum.deadline.worker_agent.runtime_failure telemetry event for a session failure caused by a runtime issue."""
     _get_deadline_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.worker_agent.runtime_failure",
         event_details={

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -860,6 +860,8 @@ def record_runtime_selection_telemetry_event(
     runtime_hint: Optional[str],
     session_id: str,
     queue_id: str,
+    farm_id: str,
+    region: Optional[str],
 ) -> None:
     """Records a com.amazon.rum.deadline.worker_agent.runtime_selection telemetry event capturing which session runtime was selected and why."""
     _get_deadline_telemetry_client().record_event(
@@ -871,6 +873,8 @@ def record_runtime_selection_telemetry_event(
             "runtime_hint": runtime_hint,
             "session_id": session_id,
             "queue_id": queue_id,
+            "farm_id": farm_id,
+            "region": region,
         },
     )
 
@@ -883,6 +887,8 @@ def record_runtime_failure_telemetry_event(
     runtime_hint: Optional[str],
     session_id: str,
     queue_id: str,
+    farm_id: str,
+    region: Optional[str],
 ) -> None:
     """Records a com.amazon.rum.deadline.worker_agent.runtime_failure telemetry event for a session failure caused by a runtime issue."""
     _get_deadline_telemetry_client().record_event(
@@ -894,6 +900,8 @@ def record_runtime_failure_telemetry_event(
             "runtime_hint": runtime_hint,
             "session_id": session_id,
             "queue_id": queue_id,
+            "farm_id": farm_id,
+            "region": region,
         },
     )
 

--- a/src/deadline_worker_agent/aws/deadline/__init__.py
+++ b/src/deadline_worker_agent/aws/deadline/__init__.py
@@ -809,6 +809,11 @@ def update_worker_schedule(
 
 _telemetry_client: Optional[TelemetryClient] = None
 
+# Exception messages can be arbitrarily long (e.g. validation errors); RUM
+# rejects oversized events, which would silently drop the failure report.
+# The head of an exception message carries the diagnostic essence.
+_FAILURE_REASON_MAX_LEN = 200
+
 
 def _get_deadline_telemetry_client() -> TelemetryClient:
     """Wrapper around the telemetry client, in order to set package-specific information.
@@ -848,7 +853,13 @@ def record_uncaught_exception_telemetry_event(exception_type: str) -> None:
 
 
 def record_runtime_selection_telemetry_event(
-    *, runtime_kind: str, selection_reason: str, session_runtime_config: str
+    *,
+    runtime_kind: str,
+    selection_reason: str,
+    session_runtime_config: str,
+    runtime_hint: Optional[str],
+    session_id: str,
+    queue_id: str,
 ) -> None:
     """Records a com.amazon.rum.deadline.worker_agent.runtime_selection telemetry event capturing which session runtime was selected and why."""
     _get_deadline_telemetry_client().record_event(
@@ -857,20 +868,32 @@ def record_runtime_selection_telemetry_event(
             "runtime_kind": runtime_kind,
             "selection_reason": selection_reason,
             "session_runtime_config": session_runtime_config,
+            "runtime_hint": runtime_hint,
+            "session_id": session_id,
+            "queue_id": queue_id,
         },
     )
 
 
 def record_runtime_failure_telemetry_event(
-    *, runtime_kind: str, failure_reason: str, exception_type: str
+    *,
+    runtime_kind: str,
+    failure_reason: str,
+    exception_type: str,
+    runtime_hint: Optional[str],
+    session_id: str,
+    queue_id: str,
 ) -> None:
     """Records a com.amazon.rum.deadline.worker_agent.runtime_failure telemetry event for a session failure caused by a runtime issue."""
     _get_deadline_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.worker_agent.runtime_failure",
         event_details={
             "runtime_kind": runtime_kind,
-            "failure_reason": failure_reason,
+            "failure_reason": failure_reason[:_FAILURE_REASON_MAX_LEN],
             "exception_type": exception_type,
+            "runtime_hint": runtime_hint,
+            "session_id": session_id,
+            "queue_id": queue_id,
         },
     )
 

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -54,6 +54,8 @@
 #   "python"           - Use the Python OpenJD session implementation (default)
 #   "rust"             - Use the Rust OpenJD session implementation
 #   "service-selected" - Let the service determine the runtime per-session
+#                       (follows the service's per-session runtimeHint; defaults to python when
+#                       no hint is provided)
 #
 # This value is overridden when the --session-runtime command-line argument is specified.
 #

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -1189,6 +1189,9 @@ class WorkerScheduler:
                     runtime_kind="unknown",
                     failure_reason=str(e),
                     exception_type=type(e).__name__,
+                    runtime_hint=runtime_hint,
+                    session_id=new_session_id,
+                    queue_id=queue_id,
                 )
                 continue
 
@@ -1212,6 +1215,9 @@ class WorkerScheduler:
                     else "config-default"
                 ),
                 session_runtime_config=self._session_runtime_kind.value,
+                runtime_hint=runtime_hint,
+                session_id=new_session_id,
+                queue_id=queue_id,
             )
 
             try:
@@ -1248,8 +1254,16 @@ class WorkerScheduler:
                 )
                 record_runtime_failure_telemetry_event(
                     runtime_kind=runtime_kind.value,
-                    failure_reason=str(e),
+                    # OSError messages embed filesystem paths (potential PII on Windows);
+                    # strerror carries the error class without the path. Full detail
+                    # remains in the worker log.
+                    failure_reason=(
+                        e.strerror if isinstance(e, OSError) and e.strerror else str(e)
+                    ),
                     exception_type=type(e).__name__,
+                    runtime_hint=runtime_hint,
+                    session_id=new_session_id,
+                    queue_id=queue_id,
                 )
                 continue
 

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -1214,21 +1214,44 @@ class WorkerScheduler:
                 session_runtime_config=self._session_runtime_kind.value,
             )
 
-            session = Session(
-                id=new_session_id,
-                queue=queue,
-                queue_id=queue_id,
-                job_id=job_id,
-                env=env,
-                asset_sync=asset_sync,
-                job_details=job_details,
-                os_user=os_user,
-                retain_session_dir=self._retain_session_dir,
-                session_runtime_kind=runtime_kind,
-                action_update_callback=self._handle_session_action_update,
-                action_update_lock=self._action_update_lock,
-                session_root_dir=self._session_root_dir,
-            )
+            try:
+                session = Session(
+                    id=new_session_id,
+                    queue=queue,
+                    queue_id=queue_id,
+                    job_id=job_id,
+                    env=env,
+                    asset_sync=asset_sync,
+                    job_details=job_details,
+                    os_user=os_user,
+                    retain_session_dir=self._retain_session_dir,
+                    session_runtime_kind=runtime_kind,
+                    action_update_callback=self._handle_session_action_update,
+                    action_update_lock=self._action_update_lock,
+                    session_root_dir=self._session_root_dir,
+                )
+            except (ValueError, NotImplementedError, OSError) as e:
+                # Runtime construction can fail per-session (e.g. the selected runtime's
+                # adapter is unavailable on this host). Fail this session's actions visibly
+                # and continue; do not take down the scheduler. Unexpected exception types
+                # still propagate.
+                message = f"Failed to create session: {e}"
+                self._fail_all_actions(session_spec, message)
+                logger.error(
+                    SessionLogEvent(
+                        subtype=SessionLogEventSubtype.FAILED,
+                        queue_id=queue_id,
+                        job_id=job_id,
+                        session_id=new_session_id,
+                        message=message,
+                    )
+                )
+                record_runtime_failure_telemetry_event(
+                    runtime_kind=runtime_kind.value,
+                    failure_reason=str(e),
+                    exception_type=type(e).__name__,
+                )
+                continue
 
             def run_session(
                 session: Session, queue_credentials: QueueAwsCredentials | None

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -1254,11 +1254,16 @@ class WorkerScheduler:
                 )
                 record_runtime_failure_telemetry_event(
                     runtime_kind=runtime_kind.value,
-                    # OSError messages embed filesystem paths (potential PII on Windows);
-                    # strerror carries the error class without the path. Full detail
-                    # remains in the worker log.
+                    # Exception messages are free text and can embed filesystem paths
+                    # (potential PII) — e.g. hand-raised OSError(f"...{path}") has
+                    # strerror=None. Never forward str(e): send OS-level strerror when
+                    # present (error class, no path), otherwise a coarse constant.
+                    # exception_type carries the class; full detail remains in the
+                    # worker log, reachable via session_id.
                     failure_reason=(
-                        e.strerror if isinstance(e, OSError) and e.strerror else str(e)
+                        e.strerror
+                        if isinstance(e, OSError) and e.strerror
+                        else "session construction failed"
                     ),
                     exception_type=type(e).__name__,
                     runtime_hint=runtime_hint,

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -26,7 +26,11 @@ from openjd.sessions import ActionState, ActionStatus, SessionUser
 from openjd.sessions import LOG as OPENJD_SESSION_LOG
 from deadline.job_attachments.asset_sync import AssetSync
 
-from ..aws.deadline import update_worker
+from ..aws.deadline import (
+    update_worker,
+    record_runtime_selection_telemetry_event,
+    record_runtime_failure_telemetry_event,
+)
 from ..aws_credentials import QueueBoto3Session, AwsCredentialsRefresher
 from .._session_runtime_kind import SessionRuntimeKind
 from ..sessions.runtime import select_runtime
@@ -1181,6 +1185,11 @@ class WorkerScheduler:
                         message=message,
                     )
                 )
+                record_runtime_failure_telemetry_event(
+                    runtime_kind="unknown",
+                    failure_reason=str(e),
+                    exception_type=type(e).__name__,
+                )
                 continue
 
             logger.info(
@@ -1193,6 +1202,16 @@ class WorkerScheduler:
                         f"Selected session runtime: {runtime_kind.value} (hint={runtime_hint!r})"
                     ),
                 )
+            )
+            record_runtime_selection_telemetry_event(
+                runtime_kind=runtime_kind.value,
+                selection_reason=(
+                    "hint"
+                    if self._session_runtime_kind is SessionRuntimeKind.SERVICE_SELECTED
+                    and runtime_hint is not None
+                    else "config-default"
+                ),
+                session_runtime_config=self._session_runtime_kind.value,
             )
 
             session = Session(

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -1192,6 +1192,8 @@ class WorkerScheduler:
                     runtime_hint=runtime_hint,
                     session_id=new_session_id,
                     queue_id=queue_id,
+                    farm_id=self._farm_id,
+                    region=self._boto_session.region_name,
                 )
                 continue
 
@@ -1218,6 +1220,8 @@ class WorkerScheduler:
                 runtime_hint=runtime_hint,
                 session_id=new_session_id,
                 queue_id=queue_id,
+                farm_id=self._farm_id,
+                region=self._boto_session.region_name,
             )
 
             try:
@@ -1269,6 +1273,8 @@ class WorkerScheduler:
                     runtime_hint=runtime_hint,
                     session_id=new_session_id,
                     queue_id=queue_id,
+                    farm_id=self._farm_id,
+                    region=self._boto_session.region_name,
                 )
                 continue
 

--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -1187,7 +1187,10 @@ class WorkerScheduler:
                 )
                 record_runtime_failure_telemetry_event(
                     runtime_kind="unknown",
-                    failure_reason=str(e),
+                    # Constant reason: the offending value is already carried
+                    # verbatim in the runtime_hint field, and free exception
+                    # text must not reach telemetry.
+                    failure_reason="invalid runtimeHint",
                     exception_type=type(e).__name__,
                     runtime_hint=runtime_hint,
                     session_id=new_session_id,

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -309,6 +309,8 @@ def test_record_runtime_selection_telemetry_event():
             runtime_hint="rust",
             session_id="session-abc123",
             queue_id="queue-xyz789",
+            farm_id="farm-abc123",
+            region="us-west-2",
         )
 
     # THEN
@@ -321,6 +323,8 @@ def test_record_runtime_selection_telemetry_event():
             "runtime_hint": "rust",
             "session_id": "session-abc123",
             "queue_id": "queue-xyz789",
+            "farm_id": "farm-abc123",
+            "region": "us-west-2",
         },
     )
 
@@ -344,6 +348,8 @@ def test_record_runtime_failure_telemetry_event():
             runtime_hint="bogus",
             session_id="session-abc123",
             queue_id="queue-xyz789",
+            farm_id="farm-abc123",
+            region="us-west-2",
         )
 
     # THEN
@@ -356,6 +362,8 @@ def test_record_runtime_failure_telemetry_event():
             "runtime_hint": "bogus",
             "session_id": "session-abc123",
             "queue_id": "queue-xyz789",
+            "farm_id": "farm-abc123",
+            "region": "us-west-2",
         },
     )
 
@@ -376,6 +384,8 @@ def test_record_runtime_failure_telemetry_event_truncates_long_failure_reason():
             runtime_hint=None,
             session_id="session-123",
             queue_id="queue-456",
+            farm_id="farm-abc123",
+            region="us-west-2",
         )
 
     call_details = mock_telemetry_client.record_event.call_args[1]["event_details"]

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -306,6 +306,9 @@ def test_record_runtime_selection_telemetry_event():
             runtime_kind="RUST",
             selection_reason="hint",
             session_runtime_config="SERVICE_SELECTED",
+            runtime_hint="rust",
+            session_id="session-abc123",
+            queue_id="queue-xyz789",
         )
 
     # THEN
@@ -315,6 +318,9 @@ def test_record_runtime_selection_telemetry_event():
             "runtime_kind": "RUST",
             "selection_reason": "hint",
             "session_runtime_config": "SERVICE_SELECTED",
+            "runtime_hint": "rust",
+            "session_id": "session-abc123",
+            "queue_id": "queue-xyz789",
         },
     )
 
@@ -335,6 +341,9 @@ def test_record_runtime_failure_telemetry_event():
             runtime_kind="unknown",
             failure_reason="No runtime named 'bogus'",
             exception_type="ValueError",
+            runtime_hint="bogus",
+            session_id="session-abc123",
+            queue_id="queue-xyz789",
         )
 
     # THEN
@@ -344,5 +353,31 @@ def test_record_runtime_failure_telemetry_event():
             "runtime_kind": "unknown",
             "failure_reason": "No runtime named 'bogus'",
             "exception_type": "ValueError",
+            "runtime_hint": "bogus",
+            "session_id": "session-abc123",
+            "queue_id": "queue-xyz789",
         },
     )
+
+
+def test_record_runtime_failure_telemetry_event_truncates_long_failure_reason():
+    """Tests that failure_reason is truncated to _FAILURE_REASON_MAX_LEN (200) characters."""
+
+    mock_telemetry_client = MagicMock()
+    long_reason = "x" * 1000
+
+    with patch.object(deadline_mod, "_get_deadline_telemetry_client") as mock_get_telemetry_client:
+        mock_get_telemetry_client.return_value = mock_telemetry_client
+
+        record_runtime_failure_telemetry_event(
+            runtime_kind="RUST",
+            failure_reason=long_reason,
+            exception_type="OSError",
+            runtime_hint=None,
+            session_id="session-123",
+            queue_id="queue-456",
+        )
+
+    call_details = mock_telemetry_client.record_event.call_args[1]["event_details"]
+    assert len(call_details["failure_reason"]) == 200
+    assert call_details["failure_reason"] == "x" * 200

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -286,3 +286,63 @@ def test_get_deadline_telemetry_client_sets_service_name():
             package_name="deadline-cloud-worker-agent",
             package_ver=".".join(deadline_mod.version.split(".")[:3]),
         )
+
+
+def test_record_runtime_selection_telemetry_event():
+    """
+    Tests that when record_runtime_selection_telemetry_event() is called, the correct
+    event type and details are passed to the telemetry client's record_event() method.
+    """
+    from deadline_worker_agent.aws.deadline import record_runtime_selection_telemetry_event
+
+    mock_telemetry_client = MagicMock()
+
+    with patch.object(deadline_mod, "_get_deadline_telemetry_client") as mock_get_telemetry_client:
+        mock_get_telemetry_client.return_value = mock_telemetry_client
+
+        # WHEN
+        record_runtime_selection_telemetry_event(
+            runtime_kind="RUST",
+            selection_reason="hint",
+            session_runtime_config="SERVICE_SELECTED",
+        )
+
+    # THEN
+    mock_telemetry_client.record_event.assert_called_with(
+        event_type="com.amazon.rum.deadline.worker_agent.runtime_selection",
+        event_details={
+            "runtime_kind": "RUST",
+            "selection_reason": "hint",
+            "session_runtime_config": "SERVICE_SELECTED",
+        },
+    )
+
+
+def test_record_runtime_failure_telemetry_event():
+    """
+    Tests that when record_runtime_failure_telemetry_event() is called, the correct
+    event type and details are passed to the telemetry client's record_event() method.
+    """
+    from deadline_worker_agent.aws.deadline import record_runtime_failure_telemetry_event
+
+    mock_telemetry_client = MagicMock()
+
+    with patch.object(deadline_mod, "_get_deadline_telemetry_client") as mock_get_telemetry_client:
+        mock_get_telemetry_client.return_value = mock_telemetry_client
+
+        # WHEN
+        record_runtime_failure_telemetry_event(
+            runtime_kind="unknown",
+            failure_reason="No runtime named 'bogus'",
+            exception_type="ValueError",
+        )
+
+    # THEN
+    mock_telemetry_client.record_event.assert_called_with(
+        event_type="com.amazon.rum.deadline.worker_agent.runtime_failure",
+        event_details={
+            "runtime_kind": "unknown",
+            "failure_reason": "No runtime named 'bogus'",
+            "exception_type": "ValueError",
+        },
+    )

--- a/test/unit/aws/deadline/test_client_telemetry.py
+++ b/test/unit/aws/deadline/test_client_telemetry.py
@@ -12,6 +12,8 @@ from deadline_worker_agent.aws.deadline import (
     record_sync_inputs_telemetry_event,
     record_sync_outputs_telemetry_event,
     record_uncaught_exception_telemetry_event,
+    record_runtime_selection_telemetry_event,
+    record_runtime_failure_telemetry_event,
     _get_deadline_telemetry_client,
 )
 from deadline_worker_agent.capabilities import Capabilities
@@ -293,7 +295,6 @@ def test_record_runtime_selection_telemetry_event():
     Tests that when record_runtime_selection_telemetry_event() is called, the correct
     event type and details are passed to the telemetry client's record_event() method.
     """
-    from deadline_worker_agent.aws.deadline import record_runtime_selection_telemetry_event
 
     mock_telemetry_client = MagicMock()
 
@@ -323,7 +324,6 @@ def test_record_runtime_failure_telemetry_event():
     Tests that when record_runtime_failure_telemetry_event() is called, the correct
     event type and details are passed to the telemetry client's record_event() method.
     """
-    from deadline_worker_agent.aws.deadline import record_runtime_failure_telemetry_event
 
     mock_telemetry_client = MagicMock()
 

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -1789,6 +1789,8 @@ class TestCreateNewSessionsRuntimeHint:
         assert call_kwargs["runtime_hint"] == metadata.get("runtimeHint")
         assert call_kwargs["session_id"] == session_id
         assert call_kwargs["queue_id"] == "queue-abcdef0123456789abcdef0123456789"
+        assert call_kwargs["farm_id"] == sched._farm_id
+        assert call_kwargs["region"] == sched._boto_session.region_name
 
     @pytest.mark.parametrize(
         "bad_hint",
@@ -1841,6 +1843,8 @@ class TestCreateNewSessionsRuntimeHint:
         assert call_kwargs["runtime_hint"] == bad_hint
         assert call_kwargs["session_id"] == session_id
         assert call_kwargs["queue_id"] == "queue-abcdef0123456789abcdef0123456789"
+        assert call_kwargs["farm_id"] == scheduler_service_selected._farm_id
+        assert call_kwargs["region"] == scheduler_service_selected._boto_session.region_name
 
 
 class TestCreateNewSessionsConstructionFailure:
@@ -1973,6 +1977,8 @@ class TestCreateNewSessionsConstructionFailure:
         assert call_kwargs["runtime_hint"] == "rust"
         assert call_kwargs["session_id"] == session_id
         assert call_kwargs["queue_id"] == "queue-abcdef0123456789abcdef0123456789"
+        assert call_kwargs["farm_id"] == scheduler_service_selected._farm_id
+        assert call_kwargs["region"] == scheduler_service_selected._boto_session.region_name
 
         # Actions should be failed
         action_update = scheduler_service_selected._action_updates_map.get("action-1")

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -1837,6 +1837,171 @@ class TestCreateNewSessionsRuntimeHint:
         assert call_kwargs["exception_type"] == "ValueError"
 
 
+class TestCreateNewSessionsConstructionFailure:
+    """Tests that Session(...) construction failures are caught per-session
+    and do not crash the scheduler loop."""
+
+    @pytest.fixture
+    def mock_job_entities(self) -> Generator[MagicMock, None, None]:
+        with patch.object(scheduler_mod, "JobEntities") as job_entities_mock:
+            job_entity_instance = MagicMock()
+            job_entity_instance.job_details.return_value = JobDetails(
+                log_group_name="/aws/deadline/queue-0000",
+                schema_version=SpecificationRevision.v2023_09,
+                job_run_as_user=JobRunAsUser(
+                    posix=(
+                        PosixSessionUser(user="username", group="group")
+                        if os.name == "posix"
+                        else None
+                    ),
+                    windows=(
+                        WindowsSessionUser(user="username", password="password")
+                        if os.name == "nt"
+                        else None
+                    ),
+                    windows_settings=None,
+                ),
+            )
+            job_entities_mock.return_value = job_entity_instance
+            yield job_entities_mock
+
+    @pytest.fixture
+    def scheduler_service_selected(
+        self,
+        farm_id: str,
+        fleet_id: str,
+        worker_id: str,
+        client: MagicMock,
+        job_run_as_user_overrides: JobsRunAsUserOverride,
+        boto_session: Mock,
+        worker_logs_dir: Path,
+        session_root_dir: Path,
+        log_translation_filter: None,
+    ) -> WorkerScheduler:
+        return WorkerScheduler(
+            farm_id=farm_id,
+            fleet_id=fleet_id,
+            worker_id=worker_id,
+            deadline=client,
+            job_run_as_user_override=job_run_as_user_overrides,
+            boto_session=boto_session,
+            cleanup_session_user_processes=True,
+            worker_persistence_dir=Path("/var/lib/deadline"),
+            worker_logs_dir=worker_logs_dir,
+            session_root_dir=session_root_dir,
+            session_runtime_kind=SessionRuntimeKind.SERVICE_SELECTED,
+        )
+
+    @pytest.mark.parametrize(
+        argnames=("exc_type", "exc_msg"),
+        argvalues=(
+            pytest.param(
+                NotImplementedError,
+                "RustSessionRuntime adapter is not available on this host",
+                id="not_implemented",
+            ),
+            pytest.param(
+                ValueError,
+                "Invalid session configuration parameter",
+                id="value_error",
+            ),
+            pytest.param(
+                OSError,
+                "Permission denied: /var/lib/deadline/sessions/session-abc",
+                id="os_error",
+            ),
+        ),
+    )
+    def test_session_construction_failure_is_handled(
+        self,
+        scheduler_service_selected: WorkerScheduler,
+        mock_job_entities: MagicMock,
+        exc_type: type[Exception],
+        exc_msg: str,
+    ) -> None:
+        """Tests that Session(...) raising a known exception type causes the session
+        actions to be failed with telemetry, without raising."""
+        session_id = "session-abcdef0123456789abcdef0123456789"
+        assigned_sessions: dict[str, AssignedSession] = {
+            session_id: AssignedSession(
+                queueId="queue-abcdef0123456789abcdef0123456789",
+                jobId="job-abcdef0123456789abcdef0123456789",
+                logConfiguration=LogConfiguration(
+                    logDriver="awslogs",
+                    options={},
+                    parameters={"interval": "15"},
+                ),
+                sessionActions=[
+                    EnvironmentAction(
+                        actionType="ENV_ENTER",
+                        environmentId="env-1",
+                        sessionActionId="action-1",
+                    ),
+                ],
+                metadata={"runtimeHint": "rust"},
+            ),
+        }
+
+        with (
+            patch.object(scheduler_mod, "Session", side_effect=exc_type(exc_msg)),
+            patch.object(
+                scheduler_mod, "record_runtime_failure_telemetry_event"
+            ) as mock_failure_telemetry,
+        ):
+            # Must not raise
+            scheduler_service_selected._create_new_sessions(assigned_sessions=assigned_sessions)
+
+        # Telemetry emitted with correct details
+        mock_failure_telemetry.assert_called_once()
+        call_kwargs = mock_failure_telemetry.call_args.kwargs
+        assert call_kwargs["runtime_kind"] == "rust"
+        assert call_kwargs["failure_reason"] == exc_msg
+        assert call_kwargs["exception_type"] == exc_type.__name__
+
+        # Actions should be failed
+        action_update = scheduler_service_selected._action_updates_map.get("action-1")
+        assert action_update is not None
+        assert action_update.completed_status == "FAILED"
+        assert action_update.status is not None
+        assert action_update.status.state == ActionState.FAILED
+        assert action_update.status.fail_message is not None
+        assert "Failed to create session" in action_update.status.fail_message
+
+    def test_unexpected_session_construction_exception_propagates(
+        self,
+        scheduler_service_selected: WorkerScheduler,
+        mock_job_entities: MagicMock,
+    ) -> None:
+        """Tests that an unexpected exception type from Session(...) is NOT caught
+        and propagates up, preserving narrow-catch design."""
+        session_id = "session-abcdef0123456789abcdef0123456789"
+        assigned_sessions: dict[str, AssignedSession] = {
+            session_id: AssignedSession(
+                queueId="queue-abcdef0123456789abcdef0123456789",
+                jobId="job-abcdef0123456789abcdef0123456789",
+                logConfiguration=LogConfiguration(
+                    logDriver="awslogs",
+                    options={},
+                    parameters={"interval": "15"},
+                ),
+                sessionActions=[
+                    EnvironmentAction(
+                        actionType="ENV_ENTER",
+                        environmentId="env-1",
+                        sessionActionId="action-1",
+                    ),
+                ],
+                metadata={"runtimeHint": "rust"},
+            ),
+        }
+
+        with (
+            patch.object(scheduler_mod, "Session", side_effect=TypeError("unexpected failure")),
+            pytest.raises(TypeError, match="unexpected failure"),
+        ):
+            scheduler_service_selected._create_new_sessions(assigned_sessions=assigned_sessions)
+
+
 class TestQueueAwsCredentialsManagement:
     """Tests that validate that we are constructing and destroying credentials objects
     as appropriate."""

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -1690,6 +1690,152 @@ class TestCreateNewSessionsRuntimeHint:
         assert action_update.status.fail_message is not None
         assert "Failed to select session runtime" in action_update.status.fail_message
 
+    @pytest.mark.parametrize(
+        argnames=("session_runtime_kind", "metadata", "expected_reason", "expected_runtime_kind"),
+        argvalues=(
+            pytest.param(
+                "SERVICE_SELECTED",
+                {"runtimeHint": "rust"},
+                "hint",
+                "rust",
+                id="service_selected_hint_present",
+            ),
+            pytest.param(
+                "SERVICE_SELECTED",
+                {},
+                "config-default",
+                "python",
+                id="service_selected_no_hint",
+            ),
+            pytest.param(
+                "PYTHON",
+                {"runtimeHint": "rust"},
+                "config-default",
+                "python",
+                id="python_configured",
+            ),
+        ),
+    )
+    def test_runtime_selection_telemetry_event(
+        self,
+        farm_id: str,
+        fleet_id: str,
+        worker_id: str,
+        client: MagicMock,
+        job_run_as_user_overrides: JobsRunAsUserOverride,
+        boto_session: Mock,
+        worker_logs_dir: Path,
+        session_root_dir: Path,
+        log_translation_filter: None,
+        mock_session: MagicMock,
+        mock_job_entities: MagicMock,
+        session_runtime_kind: str,
+        metadata: dict,
+        expected_reason: str,
+        expected_runtime_kind: str,
+    ) -> None:
+        """Tests that the runtime selection telemetry event is emitted with the correct
+        selection_reason after successful runtime selection."""
+        configured_kind = SessionRuntimeKind[session_runtime_kind]
+
+        sched = WorkerScheduler(
+            farm_id=farm_id,
+            fleet_id=fleet_id,
+            worker_id=worker_id,
+            deadline=client,
+            job_run_as_user_override=job_run_as_user_overrides,
+            boto_session=boto_session,
+            cleanup_session_user_processes=True,
+            worker_persistence_dir=Path("/var/lib/deadline"),
+            worker_logs_dir=worker_logs_dir,
+            session_root_dir=session_root_dir,
+            session_runtime_kind=configured_kind,
+        )
+
+        session_id = "session-abcdef0123456789abcdef0123456789"
+        assigned_session = AssignedSession(
+            queueId="queue-abcdef0123456789abcdef0123456789",
+            jobId="job-abcdef0123456789abcdef0123456789",
+            logConfiguration=LogConfiguration(
+                logDriver="awslogs",
+                options={},
+                parameters={"interval": "15"},
+            ),
+            sessionActions=[
+                EnvironmentAction(
+                    actionType="ENV_ENTER",
+                    environmentId="env-1",
+                    sessionActionId="action-1",
+                ),
+            ],
+        )
+        if metadata:
+            assigned_session["metadata"] = metadata
+        assigned_sessions: dict[str, AssignedSession] = {session_id: assigned_session}
+
+        with (
+            patch.object(sched, "_executor"),
+            patch.object(
+                scheduler_mod, "record_runtime_selection_telemetry_event"
+            ) as mock_telemetry,
+        ):
+            sched._create_new_sessions(assigned_sessions=assigned_sessions)
+
+        mock_telemetry.assert_called_once()
+        call_kwargs = mock_telemetry.call_args.kwargs
+        assert call_kwargs["runtime_kind"] == expected_runtime_kind
+        assert call_kwargs["selection_reason"] == expected_reason
+        assert call_kwargs["session_runtime_config"] == configured_kind.value
+
+    @pytest.mark.parametrize(
+        "bad_hint",
+        [
+            pytest.param("bogus", id="unknown_value"),
+            pytest.param("", id="empty_string"),
+        ],
+    )
+    def test_runtime_failure_telemetry_event_on_bad_hint(
+        self,
+        scheduler_service_selected: WorkerScheduler,
+        mock_job_entities: MagicMock,
+        bad_hint: str,
+    ) -> None:
+        """Tests that a runtime failure telemetry event is emitted when select_runtime
+        raises ValueError due to an invalid hint."""
+        session_id = "session-abcdef0123456789abcdef0123456789"
+        assigned_sessions: dict[str, AssignedSession] = {
+            session_id: AssignedSession(
+                queueId="queue-abcdef0123456789abcdef0123456789",
+                jobId="job-abcdef0123456789abcdef0123456789",
+                logConfiguration=LogConfiguration(
+                    logDriver="awslogs",
+                    options={},
+                    parameters={"interval": "15"},
+                ),
+                sessionActions=[
+                    EnvironmentAction(
+                        actionType="ENV_ENTER",
+                        environmentId="env-1",
+                        sessionActionId="action-1",
+                    ),
+                ],
+                metadata={"runtimeHint": bad_hint},
+            ),
+        }
+
+        with (
+            patch.object(scheduler_mod, "Session"),
+            patch.object(
+                scheduler_mod, "record_runtime_failure_telemetry_event"
+            ) as mock_failure_telemetry,
+        ):
+            scheduler_service_selected._create_new_sessions(assigned_sessions=assigned_sessions)
+
+        mock_failure_telemetry.assert_called_once()
+        call_kwargs = mock_failure_telemetry.call_args.kwargs
+        assert call_kwargs["runtime_kind"] == "unknown"
+        assert call_kwargs["exception_type"] == "ValueError"
+
 
 class TestQueueAwsCredentialsManagement:
     """Tests that validate that we are constructing and destroying credentials objects

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -1839,6 +1839,9 @@ class TestCreateNewSessionsRuntimeHint:
         mock_failure_telemetry.assert_called_once()
         call_kwargs = mock_failure_telemetry.call_args.kwargs
         assert call_kwargs["runtime_kind"] == "unknown"
+        # Constant reason: the offending value is already carried verbatim in
+        # runtime_hint, and free exception text must not reach telemetry.
+        assert call_kwargs["failure_reason"] == "invalid runtimeHint"
         assert call_kwargs["exception_type"] == "ValueError"
         assert call_kwargs["runtime_hint"] == bad_hint
         assert call_kwargs["session_id"] == session_id

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -1786,6 +1786,9 @@ class TestCreateNewSessionsRuntimeHint:
         assert call_kwargs["runtime_kind"] == expected_runtime_kind
         assert call_kwargs["selection_reason"] == expected_reason
         assert call_kwargs["session_runtime_config"] == configured_kind.value
+        assert call_kwargs["runtime_hint"] == metadata.get("runtimeHint")
+        assert call_kwargs["session_id"] == session_id
+        assert call_kwargs["queue_id"] == "queue-abcdef0123456789abcdef0123456789"
 
     @pytest.mark.parametrize(
         "bad_hint",
@@ -1835,6 +1838,9 @@ class TestCreateNewSessionsRuntimeHint:
         call_kwargs = mock_failure_telemetry.call_args.kwargs
         assert call_kwargs["runtime_kind"] == "unknown"
         assert call_kwargs["exception_type"] == "ValueError"
+        assert call_kwargs["runtime_hint"] == bad_hint
+        assert call_kwargs["session_id"] == session_id
+        assert call_kwargs["queue_id"] == "queue-abcdef0123456789abcdef0123456789"
 
 
 class TestCreateNewSessionsConstructionFailure:
@@ -1893,22 +1899,22 @@ class TestCreateNewSessionsConstructionFailure:
         )
 
     @pytest.mark.parametrize(
-        argnames=("exc_type", "exc_msg"),
+        argnames=("exc", "expected_failure_reason"),
         argvalues=(
             pytest.param(
-                NotImplementedError,
+                NotImplementedError("RustSessionRuntime adapter is not available on this host"),
                 "RustSessionRuntime adapter is not available on this host",
                 id="not_implemented",
             ),
             pytest.param(
-                ValueError,
+                ValueError("Invalid session configuration parameter"),
                 "Invalid session configuration parameter",
                 id="value_error",
             ),
             pytest.param(
-                OSError,
-                "Permission denied: /var/lib/deadline/sessions/session-abc",
-                id="os_error",
+                OSError(13, "Permission denied", "/some/user/path"),
+                "Permission denied",
+                id="os_error_with_path",
             ),
         ),
     )
@@ -1916,8 +1922,8 @@ class TestCreateNewSessionsConstructionFailure:
         self,
         scheduler_service_selected: WorkerScheduler,
         mock_job_entities: MagicMock,
-        exc_type: type[Exception],
-        exc_msg: str,
+        exc: Exception,
+        expected_failure_reason: str,
     ) -> None:
         """Tests that Session(...) raising a known exception type causes the session
         actions to be failed with telemetry, without raising."""
@@ -1943,7 +1949,7 @@ class TestCreateNewSessionsConstructionFailure:
         }
 
         with (
-            patch.object(scheduler_mod, "Session", side_effect=exc_type(exc_msg)),
+            patch.object(scheduler_mod, "Session", side_effect=exc),
             patch.object(
                 scheduler_mod, "record_runtime_failure_telemetry_event"
             ) as mock_failure_telemetry,
@@ -1955,8 +1961,11 @@ class TestCreateNewSessionsConstructionFailure:
         mock_failure_telemetry.assert_called_once()
         call_kwargs = mock_failure_telemetry.call_args.kwargs
         assert call_kwargs["runtime_kind"] == "rust"
-        assert call_kwargs["failure_reason"] == exc_msg
-        assert call_kwargs["exception_type"] == exc_type.__name__
+        assert call_kwargs["failure_reason"] == expected_failure_reason
+        assert call_kwargs["exception_type"] == type(exc).__name__
+        assert call_kwargs["runtime_hint"] == "rust"
+        assert call_kwargs["session_id"] == session_id
+        assert call_kwargs["queue_id"] == "queue-abcdef0123456789abcdef0123456789"
 
         # Actions should be failed
         action_update = scheduler_service_selected._action_updates_map.get("action-1")

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -1903,18 +1903,25 @@ class TestCreateNewSessionsConstructionFailure:
         argvalues=(
             pytest.param(
                 NotImplementedError("RustSessionRuntime adapter is not available on this host"),
-                "RustSessionRuntime adapter is not available on this host",
+                "session construction failed",
                 id="not_implemented",
             ),
             pytest.param(
                 ValueError("Invalid session configuration parameter"),
-                "Invalid session configuration parameter",
+                "session construction failed",
                 id="value_error",
             ),
             pytest.param(
                 OSError(13, "Permission denied", "/some/user/path"),
                 "Permission denied",
-                id="os_error_with_path",
+                id="os_error_with_strerror",
+            ),
+            pytest.param(
+                # Hand-raised OSError has strerror=None; its free-text message can
+                # embed filesystem paths which must never reach telemetry.
+                OSError("failed to write /Users/jdoe/some/private/path"),
+                "session construction failed",
+                id="os_error_no_strerror",
             ),
         ),
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

#1009/#1016 gave the worker agent per-session runtime selection (`select_runtime()` + `runtimeHint` consumption), but no fleet-wide visibility: during the upcoming Rust runtime canary bake, the service team needs to see which runtime sessions actually select, why (service hint vs worker config), and how often a selected runtime fails — without logging into individual workers. Per-worker logs can't answer "what is the Rust failure rate across the fleet right now".

Additionally, `Session()` construction was the only unguarded step in the scheduler's per-session creation loop: a runtime construction failure (e.g. the selected runtime's adapter unavailable on that host) would propagate out of `_create_new_sessions` and take down the whole worker instead of failing just that session — turning a per-session problem into a crash-looping machine with no telemetry record.

### What was the solution? (How)

Five commits:

1. **feat: emit runtime selection and failure telemetry events** — two anonymous RUM events via the existing `TelemetryClient` pattern: `runtime_selection` on every session start (runtime_kind, selection_reason, session_runtime_config) and `runtime_failure` on an invalid `runtimeHint`.
2. **fix: fail session actions when runtime construction fails** — narrow `except (ValueError, NotImplementedError, OSError)` around `Session()` construction: fails that session's actions, emits `runtime_failure`, and continues instead of crashing the worker. Unexpected exception types still propagate (pinned by a test).
3. **feat: add correlation fields** — `runtime_hint`, `session_id`, `queue_id` on both events; `failure_reason` truncated to 200 chars.
4. **fix: never forward free-text exception messages as failure_reason** (review finding) — `strerror` when present, otherwise a coarse constant, so filesystem paths (potential PII) never reach telemetry; full detail stays in the worker log via `session_id`.
5. **feat: add farm_id and region** — so dashboard findings can be localized without an all-region search.


### What is the impact of this change?

- No change to job execution or scheduling behavior on the happy path; the telemetry calls are non-blocking (queued, sent by a background thread) and failure-proof (`@_swallow_exceptions`).
- One behavior improvement on an error path: a per-session runtime construction failure now fails that session's actions visibly instead of crashing the worker.
- New telemetry respects the existing opt-out: both events go through `TelemetryClient.record_event()`, which short-circuits when `opt_out = true` is set in the `[telemetry]` section of worker.toml (or via `DEADLINE_CLOUD_TELEMETRY_OPT_OUT`).

### How was this change tested?

- **Unit tests:** 7 new test functions (13 cases with parametrization) written red-first, covering both helpers' event types/payloads, `selection_reason` resolution for every configured-kind × hint combination, failure emission on invalid hint, per-session handling of construction failures (parametrized over the three caught exception types, including a hand-raised OSError with `strerror=None`), a pinned test that unexpected types (e.g. `TypeError`) still propagate, truncation, and free-text sanitization. Full suite: 3009 passed, 47 skipped.
- **E2E:** full Linux e2e suite: 49 passed, 23 skipped (1:13:30).

### Was this change documented?

Docstrings on both helpers name the full event type strings for greppability; the exception-handling block and the sanitization/truncation each carry comments explaining intent; `worker.toml.example` now documents the `service-selected` fallback behavior. No user-facing docs needed: the events are internal observability and the config surface is unchanged.

### Is this a breaking change?

No. Purely additive; existing telemetry events, configuration, and scheduling behavior are unchanged.

**Scope note:** the failure event covers runtime *selection* and *construction* failures. Failures during session execution (e.g. a panic crossing the PyO3 boundary from the Rust runtime) are not yet instrumented — a follow-up PR will catch those at the runtime adapter boundary and emit the same failure event with runtime attribution.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*