### PR TITLE
refactor: make the SessionRuntime interface v1-native

### DIFF
--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -22,7 +22,8 @@ import stat
 import sys
 import getpass
 
-from openjd.sessions import ActionState, ActionStatus, SessionUser
+from openjd.sessions import SessionUser
+from openjd.sessions._v1 import ActionState, ActionStatus
 from openjd.sessions import LOG as OPENJD_SESSION_LOG
 from deadline.job_attachments.asset_sync import AssetSync
 
@@ -586,12 +587,6 @@ class WorkerScheduler:
     ) -> UpdatedSessionActionInfo:
         updated_action = UpdatedSessionActionInfo()
 
-        def _exit_code_to_32bit_signed(exitcode: int) -> int:
-            # Workaround to ensure that the process exit code is returned in range of
-            # a 32-bit signed integer as expected by the UpdateWorkerSchedule API.
-            as_uint32_bytes = (exitcode & 0xFFFFFFFF).to_bytes(4, "big", signed=False)
-            return int.from_bytes(as_uint32_bytes, "big", signed=True)
-
         # Optional fields
         if action_updated.start_time:
             updated_action["startedAt"] = action_updated.start_time
@@ -601,9 +596,7 @@ class WorkerScheduler:
             updated_action["updatedAt"] = action_updated.update_time
         if action_updated.status:
             if action_updated.status.exit_code is not None:
-                updated_action["processExitCode"] = _exit_code_to_32bit_signed(
-                    action_updated.status.exit_code
-                )
+                updated_action["processExitCode"] = action_updated.status.exit_code
             if action_updated.completed_status:
                 if action_updated.status.fail_message:
                     updated_action["progressMessage"] = action_updated.status.fail_message

--- a/src/deadline_worker_agent/scheduler/session_action_status.py
+++ b/src/deadline_worker_agent/scheduler/session_action_status.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from openjd.sessions import ActionStatus
+from openjd.sessions._v1 import ActionStatus
 
 if TYPE_CHECKING:
     from ..api_models import CompletedActionStatus, ManifestInfo

--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -9,7 +9,7 @@ from threading import Event
 from typing import Any, Callable, Iterable, Generic, Literal, TypeVar, TYPE_CHECKING, cast
 
 from openjd.model import UnsupportedSchema
-from openjd.sessions import ActionState, ActionStatus
+from openjd.sessions._v1 import ActionState, ActionStatus
 
 from ..api_models import (
     EnvironmentAction as EnvironmentActionApiModel,

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_download.py
@@ -41,19 +41,9 @@ from openjd.sessions import (
     PosixSessionUser,
     WindowsSessionUser,
 )
-from openjd.model.v2023_09 import (
-    EmbeddedFileTypes as EmbeddedFileTypes_2023_09,
-    EmbeddedFileText as EmbeddedFileText_2023_09,
-    Action as Action_2023_09,
-    StepScript as StepScript_2023_09,
-    StepActions as StepActions_2023_09,
-    CommandString,
-    ArgString,
-    DataString,
-)
-from openjd.model import ParameterValue
 
 from ...log_messages import SessionActionLogKind
+from ..runtime._v0_compat import to_interface_path_mapping_rule
 from .openjd_action import OpenjdAction
 from ..attachment_models import WorkerManifestProperties
 
@@ -73,7 +63,7 @@ class AttachmentDownloadAction(OpenjdAction):
 
     _job_attachment_details: Optional[JobAttachmentDetails]
     _step_details: Optional[StepDetails]
-    _step_script: Optional[StepScript_2023_09]
+    _step_script: Optional[dict[str, Any]]
 
     def __init__(
         self,
@@ -120,21 +110,21 @@ class AttachmentDownloadAction(OpenjdAction):
 
         worker_props_json = json.dumps(worker_props_data, indent=2)
         embedded_files.append(
-            EmbeddedFileText_2023_09(
-                name="WorkerManifestProperties",
-                type=EmbeddedFileTypes_2023_09.TEXT,
-                data=DataString(worker_props_json),
-            )
+            {
+                "name": "WorkerManifestProperties",
+                "type": "TEXT",
+                "data": worker_props_json,
+            }
         )
 
         # Build the command arguments
         download_script_path = Path(__file__).parent / "scripts" / "attachment_download.py"
         args = [
-            ArgString(str(download_script_path)),
-            ArgString("-s3"),
-            ArgString(s3_settings.to_s3_root_uri()),
-            ArgString("-wp"),
-            ArgString("{{ Task.File.WorkerManifestProperties }}"),
+            str(download_script_path),
+            "-s3",
+            s3_settings.to_s3_root_uri(),
+            "-wp",
+            "{{ Task.File.WorkerManifestProperties }}",
         ]
 
         executable_path = Path(sys.executable)
@@ -142,15 +132,17 @@ class AttachmentDownloadAction(OpenjdAction):
             "pythonservice.exe", "python.exe"
         )
 
-        self._step_script = StepScript_2023_09(
-            actions=StepActions_2023_09(
-                onRun=Action_2023_09(
-                    command=CommandString(str(python_path)),
-                    args=args,
-                )
-            ),
-            embeddedFiles=embedded_files,
-        )
+        # Wire-format OpenJD step script: the SessionRuntime interface carries
+        # wire JSON and each runtime decodes (and validates) it natively.
+        self._step_script = {
+            "actions": {
+                "onRun": {
+                    "command": str(python_path),
+                    "args": args,
+                }
+            },
+            "embeddedFiles": embedded_files,
+        }
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -293,7 +285,10 @@ class AttachmentDownloadAction(OpenjdAction):
         job_attachment_path_mappings = list([asdict(r) for r in dynamic_mapping_rules.values()])
 
         session.runtime.extend_path_mapping_rules(
-            [OpenjdPathMapping.from_dict(r) for r in job_attachment_path_mappings]
+            [
+                to_interface_path_mapping_rule(OpenjdPathMapping.from_dict(r))
+                for r in job_attachment_path_mappings
+            ]
         )
 
         manifest_paths_by_root = session._asset_sync._check_and_write_local_manifests(
@@ -342,15 +337,15 @@ class AttachmentDownloadAction(OpenjdAction):
             # for the session to proceed to the next action
             # LINUX and VIRTUAL only
             session._run_attachment_sync_task(
-                step_script=StepScript_2023_09(
-                    actions=StepActions_2023_09(
-                        onRun=Action_2023_09(
-                            command=CommandString("echo"),
-                            args=[ArgString("Job Attachments mode VIRTUAL, VFS launched")],
-                        )
-                    ),
-                ),
-                task_parameter_values=dict[str, ParameterValue](),
+                step_script={
+                    "actions": {
+                        "onRun": {
+                            "command": "echo",
+                            "args": ["Job Attachments mode VIRTUAL, VFS launched"],
+                        }
+                    },
+                },
+                task_parameter_values={},
                 log_task_banner=False,
             )
         else:
@@ -361,7 +356,7 @@ class AttachmentDownloadAction(OpenjdAction):
             assert self._step_script is not None
             session._run_attachment_sync_task(
                 step_script=self._step_script,
-                task_parameter_values=dict[str, ParameterValue](),
+                task_parameter_values={},
                 os_env_vars={
                     "DEADLINE_QUEUE_ID": session._queue_id,
                     # Ensure UTF-8 encoding for stdout/stderr to prevent UnicodeEncodeError

--- a/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
+++ b/src/deadline_worker_agent/sessions/actions/run_attachment_upload.py
@@ -13,17 +13,6 @@ from deadline.job_attachments.models import (
     JobAttachmentS3Settings,
 )
 from openjd.sessions import LOG as OPENJD_LOG, LogContent
-from openjd.model.v2023_09 import (
-    EmbeddedFileTypes as EmbeddedFileTypes_2023_09,
-    EmbeddedFileText as EmbeddedFileText_2023_09,
-    Action as Action_2023_09,
-    StepScript as StepScript_2023_09,
-    StepActions as StepActions_2023_09,
-    ArgString,
-    CommandString,
-    DataString,
-)
-from openjd.model import ParameterValue
 
 from ...log_messages import SessionActionLogKind
 from ..attachment_models import WorkerManifestProperties
@@ -48,7 +37,7 @@ class AttachmentUploadAction(OpenjdAction):
         The task identifier that the action belongs to
     """
 
-    _step_script: Optional[StepScript_2023_09]
+    _step_script: Optional[dict[str, Any]]
     _step_id: str
     _task_id: Optional[str]
     _start_time: float
@@ -97,32 +86,34 @@ class AttachmentUploadAction(OpenjdAction):
         # Build the command arguments
         upload_script_path = Path(__file__).parent / "scripts" / "attachment_upload.py"
         args = [
-            ArgString(str(upload_script_path)),
-            ArgString("-s3"),
-            ArgString(s3_settings.to_s3_root_uri()),
-            ArgString("-wp"),
-            ArgString("{{ Task.File.WorkerManifestProperties }}"),
+            str(upload_script_path),
+            "-s3",
+            s3_settings.to_s3_root_uri(),
+            "-wp",
+            "{{ Task.File.WorkerManifestProperties }}",
         ]
 
         executable_path = Path(sys.executable)
         python_path = executable_path.parent / executable_path.name.lower().replace(
             "pythonservice.exe", "python.exe"
         )
-        self._step_script = StepScript_2023_09(
-            actions=StepActions_2023_09(
-                onRun=Action_2023_09(
-                    command=CommandString(str(python_path)),
-                    args=args,
-                )
-            ),
-            embeddedFiles=[
-                EmbeddedFileText_2023_09(
-                    name="WorkerManifestProperties",
-                    type=EmbeddedFileTypes_2023_09.TEXT,
-                    data=DataString(worker_props_json),
-                ),
+        # Wire-format OpenJD step script: the SessionRuntime interface carries
+        # wire JSON and each runtime decodes (and validates) it natively.
+        self._step_script = {
+            "actions": {
+                "onRun": {
+                    "command": str(python_path),
+                    "args": args,
+                }
+            },
+            "embeddedFiles": [
+                {
+                    "name": "WorkerManifestProperties",
+                    "type": "TEXT",
+                    "data": worker_props_json,
+                },
             ],
-        )
+        }
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -199,7 +190,7 @@ class AttachmentUploadAction(OpenjdAction):
 
         session._run_attachment_sync_task(
             step_script=self._step_script,
-            task_parameter_values=dict[str, ParameterValue](),
+            task_parameter_values={},
             os_env_vars=env_vars,
             log_task_banner=False,
         )

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from concurrent.futures import Executor
-from typing import Any, Optional, TYPE_CHECKING, cast
+from typing import Any, Optional, TYPE_CHECKING
 
 from openjd.model import TaskParameterSet
 
@@ -10,8 +10,6 @@ from ...log_messages import SessionActionLogKind
 from .openjd_action import OpenjdAction
 
 if TYPE_CHECKING:
-    from openjd.model.v2023_09 import StepScript
-
     from ..job_entities import StepDetails
     from ..session import Session
 
@@ -81,7 +79,7 @@ class RunStepTaskAction(OpenjdAction):
 
         # The service resolves step template syntax sugar, so script is always present.
         session.run_task(
-            step_script=cast("StepScript", self._details.step_template.script),
+            step_script=self._details.step_script,
             task_parameter_values=self._task_parameter_values,
             os_env_vars=env_vars,
         )

--- a/src/deadline_worker_agent/sessions/job_entities/environment_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/environment_details.py
@@ -6,7 +6,6 @@ from typing import Any, cast
 
 from openjd.model import parse_model, TemplateSpecificationVersion, UnsupportedSchema
 from openjd.model.v2023_09 import Environment as Environment_2023_09
-from openjd.sessions import EnvironmentModel
 
 from ...api_models import EnvironmentDetailsData
 from .job_entity_type import JobEntityType
@@ -20,7 +19,7 @@ class EnvironmentDetails:
     ENTITY_TYPE = JobEntityType.ENVIRONMENT_DETAILS.value
     """The JobEntityType handled by this class"""
 
-    environment: EnvironmentModel
+    environment: dict[str, Any]
     """The environment"""
 
     @classmethod
@@ -50,13 +49,14 @@ class EnvironmentDetails:
             TemplateSpecificationVersion.JOBTEMPLATE_v2023_09,
             TemplateSpecificationVersion.ENVIRONMENT_v2023_09,
         ):
-            environment = parse_model(
-                model=Environment_2023_09, obj=environment_details_data["template"]
-            )
+            # Validate the document, but store the wire-format dict: the
+            # SessionRuntime interface carries wire JSON and each runtime
+            # decodes it with its own library.
+            parse_model(model=Environment_2023_09, obj=environment_details_data["template"])
         else:
             raise UnsupportedSchema(schema_version.value)
 
-        return EnvironmentDetails(environment=environment)
+        return EnvironmentDetails(environment=dict(environment_details_data["template"]))
 
     @classmethod
     def validate_entity_data(cls, entity_data: dict[str, Any]) -> EnvironmentDetailsData:

--- a/src/deadline_worker_agent/sessions/job_entities/step_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/step_details.py
@@ -36,6 +36,11 @@ class StepDetails:
     dependencies: list[str] = field(default_factory=list)
     """The dependencies (a list of IDs) that the step depends on"""
 
+    step_script: dict[str, Any] = field(default_factory=dict)
+    """The wire-format JSON of the step's script. The SessionRuntime interface
+    carries wire JSON and each runtime decodes it with its own library.
+    """
+
     @classmethod
     def from_boto(cls, step_details_data: StepDetailsData) -> StepDetails:
         """Converts an stepDetails entity received from BatchGetJobEntity API response into a
@@ -66,17 +71,20 @@ class StepDetails:
             if "name" in details_data:
                 # New API shape -- 'template' contains a StepTemplate
                 step_template = parse_model(model=StepTemplate_2023_09, obj=details_data)
+                step_script = dict(details_data["script"])
             else:
                 # Old API shape -- 'template' contains a StepScript.
                 # If we're GA and you're reading this, then delete this code path.
                 step_template = parse_model(
                     model=StepTemplate_2023_09, obj={"name": "Placeholder", "script": details_data}
                 )
+                step_script = dict(details_data)
         else:
             raise UnsupportedSchema(schema_version.value)
 
         return StepDetails(
             step_template=step_template,
+            step_script=step_script,
             step_id=step_details_data["stepId"],
             dependencies=step_details_data["dependencies"],
         )

--- a/src/deadline_worker_agent/sessions/runtime/__init__.py
+++ b/src/deadline_worker_agent/sessions/runtime/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from ._abc import SessionRuntime
+from ._abc import SessionRuntime, SessionRuntimeDecodeError
 from ._config import ActionCallback, SessionRuntimeConfig
 from ._factory import create_session_runtime
 from ._select import select_runtime
@@ -11,6 +11,7 @@ __all__ = [
     "SessionRuntimeKind",
     "SessionRuntime",
     "SessionRuntimeConfig",
+    "SessionRuntimeDecodeError",
     "create_session_runtime",
     "select_runtime",
 ]

--- a/src/deadline_worker_agent/sessions/runtime/_abc.py
+++ b/src/deadline_worker_agent/sessions/runtime/_abc.py
@@ -8,30 +8,34 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
-    from openjd.sessions import (
-        ActionStatus,
-        EnvironmentIdentifier,
-        EnvironmentModel,
-        PathMappingRule,
-        StepScriptModel,
-    )
+    from openjd.expr import PathMappingRule
+    from openjd.sessions import EnvironmentIdentifier
+    from openjd.sessions._v1 import ActionStatus
 
 
 class SessionRuntime(ABC):
     """Abstract surface every session backend implements.
 
-    Mirrors ``openjd.sessions.Session``'s public surface 1:1.
+    Environments and step scripts cross this interface as OpenJD wire-format
+    JSON dicts (the service's own vocabulary) rather than as decoded models:
+    each backend decodes with its native library, so no decoded object ever
+    needs translating between the v0 and _v1 type systems. Scalar values
+    (parameters, path-mapping rules, action statuses) are the _v1 native types.
     """
 
     @abstractmethod
     def enter_environment(
         self,
         *,
-        environment: EnvironmentModel,
+        environment: dict[str, Any],
         identifier: Optional[EnvironmentIdentifier] = None,
         os_env_vars: Optional[dict[str, str]] = None,
     ) -> EnvironmentIdentifier:
-        """Enter an environment; returns its identifier."""
+        """Enter an environment; returns its identifier.
+
+        ``environment`` is the wire-format JSON dict of the OpenJD environment
+        (the value of a template's ``environment`` key).
+        """
         ...
 
     @abstractmethod
@@ -49,20 +53,24 @@ class SessionRuntime(ABC):
     def run_task(
         self,
         *,
-        step_script: StepScriptModel,
-        task_parameter_values: dict[str, Any],
+        step_script: dict[str, Any],
+        task_parameter_values: dict[str, dict[str, Any]],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
-        """Run a task within the session's active environment(s)."""
+        """Run a task within the session's active environment(s).
+
+        ``step_script`` is the wire-format JSON dict of the OpenJD step script
+        (the value of a step template's ``script`` key).
+        """
         ...
 
     @abstractmethod
     def _run_task_without_session_env(
         self,
         *,
-        step_script: StepScriptModel,
-        task_parameter_values: dict[str, Any],
+        step_script: dict[str, Any],
+        task_parameter_values: dict[str, dict[str, Any]],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
@@ -104,3 +112,18 @@ class SessionRuntime(ABC):
     def action_status(self) -> Optional[ActionStatus]:
         """Status of the most recent action; ``None`` if no action has run yet."""
         ...
+
+
+class SessionRuntimeDecodeError(Exception):
+    """A wire-format JSON document failed to decode at a runtime boundary.
+
+    Raised by adapters when the environment or step-script JSON handed across
+    the SessionRuntime interface is rejected by the backend's decoder. Names
+    the boundary so the failure is diagnosable from a session log without a
+    traceback (decode failures otherwise surface in customer-visible progress
+    messages with nothing pointing at the conversion hop).
+    """
+
+    def __init__(self, *, boundary: str, cause: Exception) -> None:
+        self.boundary = boundary
+        super().__init__(f"Failed to decode OpenJD document at {boundary}: {cause}")

--- a/src/deadline_worker_agent/sessions/runtime/_config.py
+++ b/src/deadline_worker_agent/sessions/runtime/_config.py
@@ -7,13 +7,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 if TYPE_CHECKING:
-    from openjd.sessions import (
-        ActionStatus,
-        PathMappingRule,
-        SessionUser,
-    )
+    from openjd.expr import PathMappingRule
+    from openjd.sessions import SessionUser
+    from openjd.sessions._v1 import ActionStatus
 
-# Matches openjd.sessions.SessionCallbackType: Callable[[session_id, ActionStatus], None]
+# Matches the _v1 session callback shape: Callable[[session_id, ActionStatus], None]
 ActionCallback = Callable[[str, "ActionStatus"], None]
 
 
@@ -21,14 +19,27 @@ ActionCallback = Callable[[str, "ActionStatus"], None]
 class SessionRuntimeConfig:
     """Construction arguments for a SessionRuntime.
 
-    Mirrors ``openjd.sessions.Session``'s constructor surface but expressed in
-    primitives that any backend (Python, Rust) can translate at its boundary.
-    ``spec_revision`` and ``supported_extensions`` carry OpenJD revision info
-    that each adapter converts into its native types.
+    The interface is expressed in OpenJD _v1 (native) types and wire-format
+    values: the Rust runtime consumes them directly, and the Python runtime
+    bridges them to the v0 library types at its boundary. When the Python
+    runtime is retired, the bridge is deleted with it and no conversion layer
+    remains.
+
+    ``job_parameter_values`` carries wire-format ``{"type", "value"}`` dicts
+    rather than _v1 parameter-value objects: the wire form is total over the
+    v0 type domain (e.g. CHUNK_INT, which the _v1 parameter-type enums do not
+    define), so no parameter that works today changes behavior.
+
+    ``user`` is the one deliberate v0 hold-over and still carries
+    ``openjd.sessions.SessionUser``: the worker's OS-user machinery is
+    v0-native and the _v1 ``WindowsSessionUser`` validates the logon at
+    construction, so converting at the producer and back in the Python adapter
+    would round-trip live credentials through a third type system for no
+    benefit. It moves to the _v1 type when the worker's user handling does.
     """
 
     session_id: str
-    job_parameter_values: dict[str, Any]
+    job_parameter_values: dict[str, dict[str, Any]]
     path_mapping_rules: Optional[list[PathMappingRule]]
     retain_working_dir: bool
     user: Optional[SessionUser]

--- a/src/deadline_worker_agent/sessions/runtime/_v0_compat.py
+++ b/src/deadline_worker_agent/sessions/runtime/_v0_compat.py
@@ -1,0 +1,88 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Transitional producer-side conversions from worker (v0) values to the
+SessionRuntime interface's native (_v1 / wire-format) vocabulary.
+
+The worker's job-entity layer still decodes and stores OpenJD v0 types. Until
+it produces interface-native values directly, these helpers convert at the
+point where a ``SessionRuntimeConfig`` is built. Delete this module when the
+job-entity layer moves off the v0 library.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from openjd.expr import PathFormat, PathMappingRule
+
+if TYPE_CHECKING:
+    from openjd.model import ParameterValue
+    from openjd.sessions import PathMappingRule as V0PathMappingRule
+
+__all__ = [
+    "to_interface_parameter_values",
+    "to_interface_path_mapping_rule",
+    "to_interface_path_mapping_rules",
+]
+
+
+# openjd.expr.PathFormat is a non-constructable Rust enum, so map the v0
+# rule's format string to the member by its value.
+_PATH_FORMATS: dict[str, PathFormat] = {
+    "POSIX": PathFormat.POSIX,
+    "WINDOWS": PathFormat.WINDOWS,
+}
+
+
+def to_interface_parameter_values(
+    parameter_values: dict[str, ParameterValue],
+) -> dict[str, dict[str, Any]]:
+    """Convert v0 ParameterValue objects into wire-format ``{"type", "value"}`` dicts.
+
+    The wire dict form is total over the v0 type domain (including types like
+    CHUNK_INT that the _v1 binding's parameter-type enums do not define), so no
+    parameter that works today changes behavior. Each runtime decodes the dict
+    with its own library.
+    """
+    return {
+        name: {"type": value.type.value, "value": value.value}
+        for name, value in parameter_values.items()
+    }
+
+
+def to_interface_path_mapping_rule(rule: V0PathMappingRule) -> PathMappingRule:
+    """Convert one v0 PathMappingRule into the interface's _v1 type. Paths are
+    coerced to strings, which the _v1 rule stores."""
+    try:
+        source_path_format = _PATH_FORMATS[rule.source_path_format.value]
+    except KeyError:
+        raise ValueError(
+            f"Unrecognized v0 path format: {rule.source_path_format.value!r}"
+        ) from None
+    return PathMappingRule(
+        source_path_format=source_path_format,
+        source_path=str(rule.source_path),
+        destination_path=str(rule.destination_path),
+    )
+
+
+def to_interface_path_mapping_rules(
+    rules: Optional[list[V0PathMappingRule]],
+) -> Optional[list[PathMappingRule]]:
+    """Convert v0 PathMappingRule lists into the interface's _v1 type, passing
+    None through."""
+    if rules is None:
+        return None
+    return [to_interface_path_mapping_rule(rule) for rule in rules]
+
+
+def _exit_code_to_i32(exitcode: int) -> int:
+    """Reinterpret an exit code as a 32-bit signed integer.
+
+    On Windows, subprocess exit codes are commonly unsigned 32-bit values
+    (e.g. 0xC0000005 for access violation).  The v1 ActionStatus (backed by
+    Rust i32) and the UpdateWorkerSchedule API both require a signed 32-bit
+    value, so we truncate to the low 32 bits and reinterpret as signed.
+    """
+    as_uint32_bytes = (exitcode & 0xFFFFFFFF).to_bytes(4, "big", signed=False)
+    return int.from_bytes(as_uint32_bytes, "big", signed=True)

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -3,39 +3,155 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, Optional
 
-from openjd.model import RevisionExtensions, SpecificationRevision
-from openjd.sessions import Session as OpenJDSession
+from openjd.expr import PathFormat as V1PathFormat, PathMappingRule as V1PathMappingRule
+from openjd.model import (
+    DecodeValidationError,
+    ParameterValue,
+    ParameterValueType,
+    RevisionExtensions,
+    SpecificationRevision,
+    parse_model,
+)
+from openjd.model.v2023_09 import (
+    Environment as Environment_2023_09,
+    StepScript as StepScript_2023_09,
+)
+from openjd.sessions import (
+    ActionState,
+    ActionStatus,
+    PathFormat,
+    PathMappingRule,
+    Session as OpenJDSession,
+)
+from openjd.sessions._v1 import (
+    ActionState as V1ActionState,
+    ActionStatus as V1ActionStatus,
+)
 
-from . import SessionRuntime, SessionRuntimeConfig
+from . import SessionRuntime, SessionRuntimeConfig, SessionRuntimeDecodeError
+from ._v0_compat import _exit_code_to_i32
 
 if TYPE_CHECKING:
-    from openjd.sessions import (
-        ActionStatus,
-        EnvironmentIdentifier,
-        EnvironmentModel,
-        PathMappingRule,
-        StepScriptModel,
-    )
+    from openjd.sessions import EnvironmentIdentifier
 
 __all__ = ["PythonSessionRuntime"]
 
 
+# This adapter is the v1->v0 bridge: the SessionRuntime interface speaks the
+# _v1 native types, and everything below converts them to the v0 library's
+# types (and back, for statuses). When the Python runtime is retired, this
+# module is deleted and no v0 conversion code remains in the worker.
+
+
+# The v0 ActionState -> _v1 ActionState translation. Keyed off the real v0
+# members so a rename on either side surfaces here. A state added on the v0
+# side must be mapped deliberately -- failing loud beats silently
+# mis-reporting an action's state to the service.
+_V1_ACTION_STATES: dict[ActionState, V1ActionState] = {
+    ActionState.RUNNING: V1ActionState.RUNNING,
+    ActionState.CANCELED: V1ActionState.CANCELED,
+    ActionState.TIMEOUT: V1ActionState.TIMEOUT,
+    ActionState.FAILED: V1ActionState.FAILED,
+    ActionState.SUCCESS: V1ActionState.SUCCESS,
+}
+
+# openjd.expr.PathFormat (the _v1 rule's format) mapped to the v0 enum. The
+# _v1 enum is non-iterable, so keys are computed from its members at import.
+_V0_PATH_FORMATS: dict[str, PathFormat] = {
+    str(V1PathFormat.POSIX): PathFormat.POSIX,
+    str(V1PathFormat.WINDOWS): PathFormat.WINDOWS,
+}
+
+
+def _to_v1_action_status(status: ActionStatus) -> V1ActionStatus:
+    """Convert a v0 ActionStatus into the _v1 type the interface reports."""
+    try:
+        state = _V1_ACTION_STATES[status.state]
+    except KeyError:
+        raise ValueError(f"Unrecognized v0 ActionState: {status.state!r}") from None
+    return V1ActionStatus(
+        state=state,
+        progress=status.progress,
+        status_message=status.status_message,
+        fail_message=status.fail_message,
+        exit_code=_exit_code_to_i32(status.exit_code) if status.exit_code is not None else None,
+    )
+
+
+def _to_v0_parameter_values(values: dict[str, dict[str, Any]]) -> dict[str, ParameterValue]:
+    """Convert wire-format ``{"type", "value"}`` dicts into v0 ParameterValues."""
+    converted: dict[str, ParameterValue] = {}
+    for name, value in values.items():
+        try:
+            value_type = ParameterValueType(value["type"])
+        except ValueError:
+            raise ValueError(
+                f"Parameter {name!r} has type {value['type']!r}, which the "
+                "v0 ParameterValueType enum does not define."
+            ) from None
+        converted[name] = ParameterValue(type=value_type, value=value["value"])
+    return converted
+
+
+def _to_v0_path_mapping_rule(rule: V1PathMappingRule) -> PathMappingRule:
+    """Convert one _v1 (openjd.expr) PathMappingRule into the v0 type.
+
+    The source path is rebuilt as the pure-path class matching its declared
+    format, mirroring how the worker's entity layer constructs v0 rules.
+    """
+    try:
+        source_path_format = _V0_PATH_FORMATS[str(rule.source_path_format)]
+    except KeyError:
+        raise ValueError(f"Unrecognized _v1 path format: {rule.source_path_format!r}") from None
+    source_path = (
+        PureWindowsPath(rule.source_path)
+        if source_path_format == PathFormat.WINDOWS
+        else PurePosixPath(rule.source_path)
+    )
+    return PathMappingRule(
+        source_path_format=source_path_format,
+        source_path=source_path,
+        destination_path=Path(rule.destination_path),
+    )
+
+
+def _to_v0_path_mapping_rules(
+    rules: Optional[list[V1PathMappingRule]],
+) -> Optional[list[PathMappingRule]]:
+    """Convert _v1 PathMappingRule lists into the v0 type, passing None through."""
+    if rules is None:
+        return None
+    return [_to_v0_path_mapping_rule(rule) for rule in rules]
+
+
 class PythonSessionRuntime(SessionRuntime):
-    """SessionRuntime backed by openjd.sessions (v0 Python implementation)."""
+    """SessionRuntime backed by openjd.sessions (v0 Python implementation).
+
+    Bridges the interface's _v1/wire-format vocabulary to the v0 library:
+    wire-JSON documents are decoded with the v0 pydantic models, and scalar
+    values are converted at the boundary.
+    """
 
     _session: OpenJDSession
 
     def __init__(self, config: SessionRuntimeConfig) -> None:
+        # The v0 session reports v0 ActionStatus; the interface's callback
+        # expects the _v1 type, so translate on the way out.
+        v1_callback = config.action_callback
+
+        def _action_callback(session_id: str, status: ActionStatus) -> None:
+            v1_callback(session_id, _to_v1_action_status(status))
+
         self._session = OpenJDSession(
             session_id=config.session_id,
-            job_parameter_values=config.job_parameter_values,
-            path_mapping_rules=config.path_mapping_rules,
+            job_parameter_values=_to_v0_parameter_values(config.job_parameter_values),
+            path_mapping_rules=_to_v0_path_mapping_rules(config.path_mapping_rules),
             retain_working_dir=config.retain_working_dir,
             user=config.user,
-            callback=config.action_callback,
+            callback=_action_callback,
             os_env_vars=config.os_env_vars,
             session_root_directory=config.session_root_directory,
             revision_extensions=RevisionExtensions(
@@ -50,12 +166,19 @@ class PythonSessionRuntime(SessionRuntime):
     def enter_environment(
         self,
         *,
-        environment: EnvironmentModel,
+        environment: dict[str, Any],
         identifier: Optional[EnvironmentIdentifier] = None,
         os_env_vars: Optional[dict[str, str]] = None,
     ) -> EnvironmentIdentifier:
+        try:
+            environment_model = parse_model(model=Environment_2023_09, obj=environment)
+        except DecodeValidationError as exc:
+            raise SessionRuntimeDecodeError(
+                boundary="PythonSessionRuntime.enter_environment (v0 environment decode)",
+                cause=exc,
+            ) from exc
         return self._session.enter_environment(
-            environment=environment,
+            environment=environment_model,
             identifier=identifier,
             os_env_vars=os_env_vars,
         )
@@ -73,17 +196,26 @@ class PythonSessionRuntime(SessionRuntime):
             keep_session_running=keep_session_running,
         )
 
+    def _decode_step_script(self, step_script: dict[str, Any]) -> StepScript_2023_09:
+        try:
+            return parse_model(model=StepScript_2023_09, obj=step_script)
+        except DecodeValidationError as exc:
+            raise SessionRuntimeDecodeError(
+                boundary="PythonSessionRuntime.run_task (v0 step script decode)",
+                cause=exc,
+            ) from exc
+
     def run_task(
         self,
         *,
-        step_script: StepScriptModel,
-        task_parameter_values: dict[str, Any],
+        step_script: dict[str, Any],
+        task_parameter_values: dict[str, dict[str, Any]],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
         self._session.run_task(
-            step_script=step_script,
-            task_parameter_values=task_parameter_values,
+            step_script=self._decode_step_script(step_script),
+            task_parameter_values=_to_v0_parameter_values(task_parameter_values),
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
         )
@@ -91,25 +223,26 @@ class PythonSessionRuntime(SessionRuntime):
     def _run_task_without_session_env(
         self,
         *,
-        step_script: StepScriptModel,
-        task_parameter_values: dict[str, Any],
+        step_script: dict[str, Any],
+        task_parameter_values: dict[str, dict[str, Any]],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
         self._session._run_task_without_session_env(
-            step_script=step_script,
-            task_parameter_values=task_parameter_values,
+            step_script=self._decode_step_script(step_script),
+            task_parameter_values=_to_v0_parameter_values(task_parameter_values),
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
         )
 
-    def extend_path_mapping_rules(self, rules: list[PathMappingRule]) -> None:
+    def extend_path_mapping_rules(self, rules: list[V1PathMappingRule]) -> None:
+        v0_rules = [_to_v0_path_mapping_rule(rule) for rule in rules]
         # bisect.insort only supports the 'key' arg in 3.10 or later, so
         # we first extend the list and sort it afterwards.
         if self._session._path_mapping_rules:
-            self._session._path_mapping_rules.extend(rules)
+            self._session._path_mapping_rules.extend(v0_rules)
         else:
-            self._session._path_mapping_rules = list(rules)
+            self._session._path_mapping_rules = list(v0_rules)
         # openjd sorts path mapping rules by descending source path length so that
         # rules that are subsets of each other match in a predictable (most-specific-first) manner.
         self._session._path_mapping_rules.sort(key=lambda rule: -len(rule.source_path.parts))
@@ -130,5 +263,6 @@ class PythonSessionRuntime(SessionRuntime):
         return self._session.working_directory
 
     @property
-    def action_status(self) -> Optional[ActionStatus]:
-        return self._session.action_status
+    def action_status(self) -> Optional[V1ActionStatus]:
+        status = self._session.action_status
+        return _to_v1_action_status(status) if status is not None else None

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -12,42 +12,30 @@ from pathlib import Path
 from shutil import chown
 from typing import TYPE_CHECKING, Any, Optional
 
-from openjd._openjd_rs import create_environment, deserialize_step
-from openjd.expr import PathFormat, PathMappingRule as RustPathMappingRule
+from openjd._openjd_rs import StepScript as V1StepScript, create_environment, deserialize_step
 from openjd.model._v1 import decode_environment_template
+from openjd.model._v1.errors import DecodeValidationError
 from openjd.model._v1.types import (
-    JobParameterType,
-    JobParameterValue,
     ModelExtension,
     ModelProfile,
     SpecificationRevision,
-    TaskParameterType,
-    TaskParameterValue,
 )
 from openjd.sessions import (
-    ActionState,
-    ActionStatus,
-    PathMappingRule,
     PosixSessionUser,
     WindowsSessionUser,
 )
 from openjd.sessions._v1 import (
-    ActionState as RustActionState,
-    ActionStatus as RustActionStatus,
-    PosixSessionUser as RustPosixSessionUser,
+    PosixSessionUser as V1PosixSessionUser,
     Session as OpenJDRustSession,
-    WindowsSessionUser as RustWindowsSessionUser,
+    WindowsSessionUser as V1WindowsSessionUser,
 )
 
-from . import SessionRuntime, SessionRuntimeConfig
+from . import SessionRuntime, SessionRuntimeConfig, SessionRuntimeDecodeError
 
 if TYPE_CHECKING:
-    from openjd.sessions import (
-        EnvironmentIdentifier,
-        EnvironmentModel,
-        SessionUser,
-        StepScriptModel,
-    )
+    from openjd.expr import PathMappingRule
+    from openjd.sessions import EnvironmentIdentifier, SessionUser
+    from openjd.sessions._v1 import ActionStatus
 
 __all__ = ["RustSessionRuntime"]
 
@@ -63,141 +51,32 @@ _SPEC_REVISIONS: dict[str, SpecificationRevision] = {
 }
 
 
-# openjd.expr.PathFormat is a non-constructable Rust enum, so map the v0
-# rule's format string to the member by its value.
-_PATH_FORMATS: dict[str, PathFormat] = {
-    "POSIX": PathFormat.POSIX,
-    "WINDOWS": PathFormat.WINDOWS,
-}
-
-
-# The _v1 ActionState is a non-iterable pyo3 enum, so map each member to the
-# v0 enum explicitly (same pattern as _SPEC_REVISIONS/_PATH_FORMATS). A state
-# added on the Rust side must be mapped here deliberately — failing loud beats
-# silently mis-reporting an action's state to the service.
-_ACTION_STATES: dict[str, ActionState] = {
-    str(RustActionState.RUNNING): ActionState.RUNNING,
-    str(RustActionState.CANCELED): ActionState.CANCELED,
-    str(RustActionState.TIMEOUT): ActionState.TIMEOUT,
-    str(RustActionState.FAILED): ActionState.FAILED,
-    str(RustActionState.SUCCESS): ActionState.SUCCESS,
-}
-
-
-def _to_v0_action_state(state: RustActionState) -> ActionState:
-    """Convert a _v1 ActionState into the v0 enum member, failing loud on
-    states this adapter does not recognize."""
-    try:
-        return _ACTION_STATES[str(state)]
-    except KeyError:
-        raise ValueError(f"Unrecognized _v1 ActionState: {state!r}") from None
-
-
-def _to_rust_session_user(
+def _to_v1_session_user(
     user: Optional[SessionUser],
-) -> Optional[RustPosixSessionUser | RustWindowsSessionUser]:
+) -> Optional[V1PosixSessionUser | V1WindowsSessionUser]:
     """Convert a worker (v0) SessionUser into the equivalent _v1 type.
 
-    The worker builds v0 ``openjd.sessions`` user objects, but the Rust session
-    only accepts its own ``openjd.sessions._v1`` user classes — structurally
-    identical but distinct at the type level. None passes through unchanged
-    (the session runs as the agent's own user in that case).
+    The session user is the interface's one deliberate v0 hold-over (see
+    SessionRuntimeConfig): the worker's OS-user machinery is v0-native, so this
+    adapter converts at its boundary. None passes through unchanged (the
+    session runs as the agent's own user in that case).
     """
     if user is None:
         return None
     if isinstance(user, PosixSessionUser):
-        return RustPosixSessionUser(user.user, group=user.group)
+        return V1PosixSessionUser(user.user, group=user.group)
     if isinstance(user, WindowsSessionUser):
-        return RustWindowsSessionUser(
-            user.user, password=user.password, logon_token=user.logon_token
-        )
+        return V1WindowsSessionUser(user.user, password=user.password, logon_token=user.logon_token)
     raise TypeError(f"Unsupported SessionUser type: {type(user).__name__}")
 
 
-def _to_rust_parameter_values(
-    values: dict[str, Any],
-    *,
-    value_cls: type,
-    type_cls: type,
-) -> dict[str, Any]:
-    """Convert worker (v0) parameter values into native _v1 parameter values.
-
-    The worker supplies ``openjd.model`` ParameterValue objects; the Rust
-    session accepts the native pyo3 value types exported from
-    ``openjd.model._v1.types``, which are constructable from Python. Values
-    already in the ``{"type", "value"}`` dict form pass through unchanged.
-    Parameter types the binding does not define fail loud rather than being
-    silently re-encoded.
-    """
-    converted: dict[str, Any] = {}
-    for name, value in values.items():
-        if isinstance(value, dict):
-            converted[name] = value
-            continue
-        native_type = getattr(type_cls, value.type.value, None)
-        if native_type is None:
-            raise ValueError(
-                f"Parameter {name!r} has type {value.type.value!r}, which the "
-                f"_v1 binding's {type_cls.__name__} does not define."
-            )
-        converted[name] = value_cls(type=native_type, value=value.value)
-    return converted
-
-
-def _to_rust_job_parameter_values(values: dict[str, Any]) -> dict[str, Any]:
-    """Convert worker (v0) job parameter values into native _v1 JobParameterValues."""
-    return _to_rust_parameter_values(values, value_cls=JobParameterValue, type_cls=JobParameterType)
-
-
-def _to_rust_task_parameter_values(values: dict[str, Any]) -> dict[str, Any]:
-    """Convert worker (v0) task parameter values into native _v1 TaskParameterValues."""
-    return _to_rust_parameter_values(
-        values, value_cls=TaskParameterValue, type_cls=TaskParameterType
-    )
-
-
-def _to_rust_path_mapping_rule(rule: PathMappingRule) -> RustPathMappingRule:
-    """Convert one worker (v0) PathMappingRule into the _v1 (openjd.expr) type.
-
-    The worker builds ``openjd.sessions`` path-mapping rules, but the Rust
-    session only accepts ``openjd.expr.PathMappingRule`` — a distinct class with
-    the same shape. Paths are coerced to strings, which the _v1 rule stores.
-    """
-    return RustPathMappingRule(
-        source_path_format=_PATH_FORMATS[rule.source_path_format.value],
-        source_path=str(rule.source_path),
-        destination_path=str(rule.destination_path),
-    )
-
-
-def _to_rust_path_mapping_rules(
-    rules: Optional[list[PathMappingRule]],
-) -> Optional[list[RustPathMappingRule]]:
-    """Convert worker (v0) PathMappingRule lists into the _v1 type, passing None through."""
-    if rules is None:
-        return None
-    return [_to_rust_path_mapping_rule(rule) for rule in rules]
-
-
-def _to_v0_action_status(status: RustActionStatus) -> ActionStatus:
-    """Convert a _v1 ActionStatus back into the v0 type the worker consumes.
-
-    The Rust session reports status with its own ``openjd.sessions._v1``
-    ActionStatus/ActionState, but the worker's scheduler compares against the v0
-    ActionState enum. The state is remapped through the explicit _ACTION_STATES
-    table and the remaining fields are copied across.
-    """
-    return ActionStatus(
-        state=_to_v0_action_state(status.state),
-        progress=status.progress,
-        status_message=status.status_message,
-        fail_message=status.fail_message,
-        exit_code=status.exit_code,
-    )
-
-
 class RustSessionRuntime(SessionRuntime):
-    """SessionRuntime backed by openjd.sessions._v1 (Rust implementation)."""
+    """SessionRuntime backed by openjd.sessions._v1 (Rust implementation).
+
+    The interface speaks the _v1 native types and wire-format JSON, so this
+    adapter passes scalar values straight through and decodes the JSON
+    documents with the _v1 decoders directly.
+    """
 
     _session: OpenJDRustSession
     _user: Optional[SessionUser]
@@ -235,20 +114,13 @@ class RustSessionRuntime(SessionRuntime):
         # (which runs as that user) can read them.
         self._user = config.user
 
-        # The _v1 session reports status with _v1 ActionStatus/ActionState, but
-        # the worker's callback expects the v0 types, so translate on the way out.
-        v0_callback = config.action_callback
-
-        def _rust_action_callback(session_id: str, status: RustActionStatus) -> None:
-            v0_callback(session_id, _to_v0_action_status(status))
-
         self._session = OpenJDRustSession(
             session_id=config.session_id,
-            job_parameter_values=_to_rust_job_parameter_values(config.job_parameter_values),
-            path_mapping_rules=_to_rust_path_mapping_rules(config.path_mapping_rules),
+            job_parameter_values=config.job_parameter_values,
+            path_mapping_rules=config.path_mapping_rules,
             retain_working_dir=config.retain_working_dir,
-            user=_to_rust_session_user(config.user),
-            callback=_rust_action_callback,
+            user=_to_v1_session_user(config.user),
+            callback=config.action_callback,
             os_env_vars=config.os_env_vars,
             session_root_directory=config.session_root_directory,
             profile=ModelProfile(revision=revision, extensions=extensions),
@@ -257,25 +129,26 @@ class RustSessionRuntime(SessionRuntime):
     def enter_environment(
         self,
         *,
-        environment: EnvironmentModel,
+        environment: dict[str, Any],
         identifier: Optional[EnvironmentIdentifier] = None,
         os_env_vars: Optional[dict[str, str]] = None,
     ) -> EnvironmentIdentifier:
-        # The shared action layer hands a pydantic v2023_09 environment, but the
-        # Rust session needs a native _v1 environment. Serialize to the OpenJD
-        # wire shape and rebuild it natively. exclude_none=True is required, not
-        # cosmetic: the Rust decoder rejects explicit nulls (OpenJD treats
-        # absent and null as equivalent).
-        native_environment = create_environment(
-            decode_environment_template(
-                {
-                    "specificationVersion": "environment-2023-09",
-                    "environment": environment.model_dump(
-                        mode="json", by_alias=True, exclude_none=True
-                    ),
-                }
+        # The interface hands the wire-format environment JSON; wrap it in the
+        # template envelope the _v1 decoder expects and decode natively.
+        try:
+            native_environment = create_environment(
+                decode_environment_template(
+                    {
+                        "specificationVersion": "environment-2023-09",
+                        "environment": environment,
+                    }
+                )
             )
-        )
+        except DecodeValidationError as exc:
+            raise SessionRuntimeDecodeError(
+                boundary="RustSessionRuntime.enter_environment (_v1 environment decode)",
+                cause=exc,
+            ) from exc
         return self._session.enter_environment(
             environment=native_environment,
             identifier=identifier,
@@ -295,31 +168,30 @@ class RustSessionRuntime(SessionRuntime):
             keep_session_running=keep_session_running,
         )
 
+    def _decode_step_script(self, step_script: dict[str, Any]) -> V1StepScript:
+        # deserialize_step requires a named step and the binding has no bare
+        # step-script deserializer (tracked in
+        # OpenJobDescription/openjd-sessions-for-python#334), so wrap the script
+        # as ``{"name": ..., "script": ...}`` and unwrap it after decoding.
+        try:
+            return deserialize_step({"name": "Placeholder", "script": step_script}).script
+        except (DecodeValidationError, ValueError) as exc:
+            raise SessionRuntimeDecodeError(
+                boundary="RustSessionRuntime.run_task (_v1 step script decode)",
+                cause=exc,
+            ) from exc
+
     def run_task(
         self,
         *,
-        step_script: StepScriptModel,
-        task_parameter_values: dict[str, Any],
+        step_script: dict[str, Any],
+        task_parameter_values: dict[str, dict[str, Any]],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
-        # The shared action layer hands a pydantic v2023_09 StepScript, but the
-        # Rust session needs a native _v1 step. Serialize to the OpenJD wire
-        # shape and rebuild it natively. deserialize_step requires a named step
-        # and the binding has no bare step-script deserializer (tracked in
-        # OpenJobDescription/openjd-sessions-for-python#334), so wrap the script
-        # as ``{"name": ..., "script": ...}`` and unwrap it after decoding.
-        # exclude_none=True is required, not cosmetic: the Rust decoder rejects
-        # explicit nulls (OpenJD treats absent and null as equivalent).
-        native_step_script = deserialize_step(
-            {
-                "name": "Placeholder",
-                "script": step_script.model_dump(mode="json", by_alias=True, exclude_none=True),
-            }
-        ).script
         self._session.run_task(
-            step_script=native_step_script,
-            task_parameter_values=_to_rust_task_parameter_values(task_parameter_values),
+            step_script=self._decode_step_script(step_script),
+            task_parameter_values=task_parameter_values,
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
         )
@@ -327,59 +199,63 @@ class RustSessionRuntime(SessionRuntime):
     def _run_task_without_session_env(
         self,
         *,
-        step_script: StepScriptModel,
-        task_parameter_values: dict[str, Any],
+        step_script: dict[str, Any],
+        task_parameter_values: dict[str, dict[str, Any]],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
         # Attachment-sync path: the native run_task's embedded-file handling is
         # unavailable here, so materialize the script's embedded files to the
-        # session's files directory ourselves, resolve ``Task.File.*`` argument
+        # session's files directory ourselves, resolve ``Task.File.*``
         # references to those paths, and run the command as a bare subprocess.
         #
         # STOPGAP — tracked in OpenJobDescription/openjd-sessions-for-python#332.
         # Remove this block and delegate once the _v1 wrapper exposes a
         # ``run_task(..., use_session_env_vars=False)``-style API (which would
         # also restore the library's cross-platform file permission handling).
-        file_paths: dict[str, str] = {}
-        if step_script.embeddedFiles:
-            for embedded_file in step_script.embeddedFiles:
-                if embedded_file.data is None:
-                    continue
-                fd, path = tempfile.mkstemp(
-                    dir=str(self._session.files_directory),
-                    prefix=f"{embedded_file.name}_",
-                )
-                # UTF-8 explicitly: the platform default (e.g. cp1252 on
-                # Windows) can corrupt or reject non-ASCII paths in the
-                # manifest JSON, which the reader script decodes as UTF-8.
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    f.write(str(embedded_file.data))
-                # Owner read/write. On POSIX, also grant the session user's group
-                # read access so the job user can read the materialized file.
-                mode = stat.S_IRUSR | stat.S_IWUSR
-                if self._user is not None and os.name == "posix":
-                    group = getattr(self._user, "group", None)
-                    if group is not None:
-                        chown(path, group=group)
-                        mode |= stat.S_IRGRP
-                os.chmod(path, mode)
-                file_paths[embedded_file.name] = path
+        script = self._decode_step_script(step_script)
 
-        command = str(step_script.actions.onRun.command)
-        args: list[str] = []
-        if step_script.actions.onRun.args:
-            for arg in step_script.actions.onRun.args:
-                # Resolve {{ Task.File.<name> }} references with any interior
-                # whitespace, matching the format-string parser's tolerance.
-                # References to files that were not materialized (unknown name
-                # or no data) are left untouched.
-                resolved = re.sub(
-                    r"\{\{\s*Task\.File\.(\w+)\s*\}\}",
-                    lambda m: file_paths.get(m.group(1), m.group(0)),
-                    str(arg),
-                )
-                args.append(resolved)
+        file_paths: dict[str, str] = {}
+        for embedded_file in script.embeddedFiles or []:
+            if embedded_file.data is None:
+                continue
+            fd, path = tempfile.mkstemp(
+                dir=str(self._session.files_directory),
+                prefix=f"{embedded_file.name}_",
+            )
+            # UTF-8 explicitly: the platform default (e.g. cp1252 on
+            # Windows) can corrupt or reject non-ASCII paths in the
+            # manifest JSON, which the reader script decodes as UTF-8.
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(str(embedded_file.data))
+            # Owner read/write. On POSIX, also grant the session user's group
+            # read access so the job user can read the materialized file.
+            mode = stat.S_IRUSR | stat.S_IWUSR
+            if self._user is not None and os.name == "posix":
+                group = getattr(self._user, "group", None)
+                if group is not None:
+                    chown(path, group=group)
+                    mode |= stat.S_IRGRP
+            os.chmod(path, mode)
+            file_paths[embedded_file.name] = path
+
+        def _resolve_task_file_refs(value: str) -> str:
+            # Resolve {{ Task.File.<name> }} references with any interior
+            # whitespace, matching the format-string parser's tolerance.
+            # References to files that were not materialized (unknown name
+            # or no data) are left untouched.
+            return re.sub(
+                r"\{\{\s*Task\.File\.(\w+)\s*\}\}",
+                lambda m: file_paths.get(m.group(1), m.group(0)),
+                value,
+            )
+
+        # The command gets the same Task.File resolution as the args: the v0
+        # session and the Rust engine's own runner resolve both identically,
+        # and attachment scripts may reference an embedded file as the command
+        # itself (e.g. ``command: "{{ Task.File.syncScript }}"``).
+        command = _resolve_task_file_refs(str(script.actions.onRun.command))
+        args = [_resolve_task_file_refs(str(arg)) for arg in script.actions.onRun.args or []]
 
         # use_session_env_vars=False bypasses the session environment (e.g. a
         # conda env) so attachment-sync scripts run in a clean environment.
@@ -395,9 +271,7 @@ class RustSessionRuntime(SessionRuntime):
     def extend_path_mapping_rules(self, rules: list[PathMappingRule]) -> None:
         # The Rust session exposes this as a public method and sorts the rules
         # by source-path length internally, so no pre-sorting is needed here.
-        self._session.extend_path_mapping_rules(
-            [_to_rust_path_mapping_rule(rule) for rule in rules]
-        )
+        self._session.extend_path_mapping_rules(rules)
 
     def cancel_action(
         self,
@@ -416,5 +290,4 @@ class RustSessionRuntime(SessionRuntime):
 
     @property
     def action_status(self) -> Optional[ActionStatus]:
-        status = self._session.action_status
-        return _to_v0_action_status(status) if status is not None else None
+        return self._session.action_status

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -42,14 +42,13 @@ from openjd.model import (
 )
 from openjd.model.v2023_09 import ExtensionName
 from openjd.sessions import (
-    ActionState,
-    ActionStatus,
     EnvironmentIdentifier,
-    EnvironmentModel,
     LOG as OPENJD_LOG,
-    StepScriptModel,
     SessionUser,
 )
+
+# The SessionRuntime interface reports action status with the _v1 native types.
+from openjd.sessions._v1 import ActionState, ActionStatus
 
 from deadline.job_attachments.asset_sync import AssetSync
 from deadline.job_attachments.models import (
@@ -64,6 +63,10 @@ from .runtime import (
     SessionRuntime,
     SessionRuntimeConfig,
     create_session_runtime,
+)
+from .runtime._v0_compat import (
+    to_interface_parameter_values,
+    to_interface_path_mapping_rules,
 )
 from ..log_messages import (
     SessionLogEvent,
@@ -202,8 +205,10 @@ class Session:
             session_runtime_kind,
             SessionRuntimeConfig(
                 session_id=self._id,
-                job_parameter_values=self._job_details.parameters,
-                path_mapping_rules=self._job_details.path_mapping_rules,
+                job_parameter_values=to_interface_parameter_values(self._job_details.parameters),
+                path_mapping_rules=to_interface_path_mapping_rules(
+                    self._job_details.path_mapping_rules
+                ),
                 retain_working_dir=self._retain_session_dir,
                 user=self._os_user,
                 action_callback=openjd_session_action_callback,
@@ -846,7 +851,7 @@ class Session:
         self,
         *,
         job_env_id: str,
-        environment: EnvironmentModel,
+        environment: dict[str, Any],
         os_env_vars: Optional[dict[str, str]] = None,
     ) -> None:
         session_env_id = self._runtime.enter_environment(
@@ -1176,14 +1181,14 @@ class Session:
     def run_task(
         self,
         *,
-        step_script: StepScriptModel,
+        step_script: dict[str, Any],
         task_parameter_values: TaskParameterSet,
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
         self._runtime.run_task(
             step_script=step_script,
-            task_parameter_values=task_parameter_values,
+            task_parameter_values=to_interface_parameter_values(task_parameter_values),
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
         )
@@ -1191,14 +1196,14 @@ class Session:
     def _run_attachment_sync_task(
         self,
         *,
-        step_script: StepScriptModel,
+        step_script: dict[str, Any],
         task_parameter_values: TaskParameterSet,
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
     ) -> None:
         self._runtime._run_task_without_session_env(
             step_script=step_script,
-            task_parameter_values=task_parameter_values,
+            task_parameter_values=to_interface_parameter_values(task_parameter_values),
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
         )

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -11,12 +11,11 @@ import logging
 from deadline_worker_agent.api_models import ManifestInfo
 
 from openjd.sessions import (
-    ActionState,
-    ActionStatus,
     SessionUser,
     PosixSessionUser,
     WindowsSessionUser,
 )
+from openjd.sessions._v1 import ActionState, ActionStatus
 from botocore.exceptions import ClientError
 import pytest
 import os
@@ -687,18 +686,14 @@ class TestSchedulerSync:
             pytest.param(0, 0, id="Zero"),
             pytest.param(0x7FFFFFFF, 0x7FFFFFFF, id="maxint"),
             pytest.param(-2147483648, -2147483648, id="minint_decimal"),
-            pytest.param(0x80000000, -2147483648, id="minint_hex"),
-            pytest.param(0xFFFD0000, -196608, id="out-of-range-32bit"),
-            pytest.param(0xFFFFFFFD0000, -196608, id="out-of-range-big"),
         ],
     )
     def test_updated_action_to_boto_exitcode(
         self, scheduler: WorkerScheduler, exitcode: Optional[int], expected_result: Optional[int]
     ) -> None:
         # GIVEN
-        action_status = SessionActionStatus(
-            id="1234", status=ActionStatus(state=ActionState.FAILED, exit_code=exitcode)
-        )
+        status = ActionStatus(state=ActionState.FAILED, exit_code=exitcode)
+        action_status = SessionActionStatus(id="1234", status=status)
 
         # WHEN
         status_as_boto = scheduler._updated_action_to_boto(action_status)

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -13,7 +13,6 @@ from openjd.model import (
     UnsupportedSchema,
 )
 from openjd.model.v2023_09 import (
-    Environment,
     EnvironmentScript,
     EnvironmentActions,
     Action,
@@ -116,7 +115,10 @@ class TestSessionActionQueueDequeue:
                     id="id",
                     job_env_id="envid",
                     details=EnvironmentDetails(
-                        environment=Environment(name="TestEnv", script=_TEST_ENVIRONMENT_SCRIPT)
+                        environment={
+                            "name": "TestEnv",
+                            "script": {"actions": {"onEnter": {"command": "test"}}},
+                        }
                     ),
                 ),
                 id="env enter",

--- a/test/unit/sessions/actions/test_run_attachment_download.py
+++ b/test/unit/sessions/actions/test_run_attachment_download.py
@@ -14,17 +14,6 @@ import pytest
 import deadline_worker_agent.sessions.actions as actions_module
 from deadline_worker_agent.sessions.job_entities.job_details import JobDetails
 from openjd.sessions import SessionUser, PosixSessionUser
-from openjd.model import ParameterValue
-from openjd.model.v2023_09 import (
-    EmbeddedFileTypes as EmbeddedFileTypes_2023_09,
-    EmbeddedFileText as EmbeddedFileText_2023_09,
-    Action as Action_2023_09,
-    StepScript as StepScript_2023_09,
-    StepActions as StepActions_2023_09,
-    ArgString,
-    CommandString,
-    DataString,
-)
 
 import deadline_worker_agent.sessions.session as session_mod
 from deadline.job_attachments.models import (
@@ -209,39 +198,24 @@ class TestStart:
         download_script_path = (
             Path(os.path.dirname(actions_module.__file__)) / "scripts" / "attachment_download.py"
         )
-        expected_script = StepScript_2023_09(
-            actions=StepActions_2023_09(
-                onRun=Action_2023_09(
-                    command=CommandString(python_path),
-                    args=[
-                        ArgString(str(download_script_path)),
-                        ArgString("-s3"),
-                        ArgString(s3_settings.to_s3_root_uri()),
-                        ArgString("-wp"),
-                        ArgString("{{ Task.File.WorkerManifestProperties }}"),
-                    ],
-                )
-            ),
-            embeddedFiles=[
-                EmbeddedFileText_2023_09(
-                    name="WorkerManifestProperties",
-                    type=EmbeddedFileTypes_2023_09.TEXT,
-                    data=DataString(ANY),  # JSON data will vary
-                ),
-            ],
-        )
 
-        # Check the basic structure
+        # Check the basic structure — step_script is now a wire-format dict
         assert action._step_script is not None
-        assert action._step_script.actions.onRun.command == expected_script.actions.onRun.command
-        assert action._step_script.actions.onRun.args == expected_script.actions.onRun.args
-        assert action._step_script.embeddedFiles is not None
-        assert len(action._step_script.embeddedFiles) == 1
-        assert action._step_script.embeddedFiles[0].name == "WorkerManifestProperties"
+        assert action._step_script["actions"]["onRun"]["command"] == python_path
+        assert action._step_script["actions"]["onRun"]["args"] == [
+            str(download_script_path),
+            "-s3",
+            s3_settings.to_s3_root_uri(),
+            "-wp",
+            "{{ Task.File.WorkerManifestProperties }}",
+        ]
+        assert "embeddedFiles" in action._step_script
+        assert len(action._step_script["embeddedFiles"]) == 1
+        assert action._step_script["embeddedFiles"][0]["name"] == "WorkerManifestProperties"
 
         session._run_attachment_sync_task.assert_called_once_with(
             step_script=action._step_script,
-            task_parameter_values=dict[str, ParameterValue](),
+            task_parameter_values={},
             os_env_vars={
                 "DEADLINE_QUEUE_ID": TestStart.QUEUE_ID,
                 "PYTHONIOENCODING": "utf-8",
@@ -380,31 +354,31 @@ class TestSetStepScript:
         assert action._step_script is not None
 
         # Check command and args
-        assert action._step_script.actions.onRun.command == CommandString(python_path)
+        assert action._step_script["actions"]["onRun"]["command"] == python_path
         # The actual path is calculated from the actions module location
         download_script_path = (
             Path(actions_module.__file__).parent / "scripts" / "attachment_download.py"
         )
         expected_args = [
-            ArgString(str(download_script_path)),
-            ArgString("-s3"),
-            ArgString(s3_settings.to_s3_root_uri()),
-            ArgString("-wp"),
-            ArgString("{{ Task.File.WorkerManifestProperties }}"),
+            str(download_script_path),
+            "-s3",
+            s3_settings.to_s3_root_uri(),
+            "-wp",
+            "{{ Task.File.WorkerManifestProperties }}",
         ]
-        assert action._step_script.actions.onRun.args == expected_args
+        assert action._step_script["actions"]["onRun"]["args"] == expected_args
 
         # Check embedded files
-        assert action._step_script.embeddedFiles is not None
-        assert len(action._step_script.embeddedFiles) == 1
+        assert "embeddedFiles" in action._step_script
+        assert len(action._step_script["embeddedFiles"]) == 1
 
         # Check WorkerManifestProperties file
-        worker_props_file = action._step_script.embeddedFiles[0]
-        assert worker_props_file.name == "WorkerManifestProperties"
-        assert worker_props_file.type == EmbeddedFileTypes_2023_09.TEXT
+        worker_props_file = action._step_script["embeddedFiles"][0]
+        assert worker_props_file["name"] == "WorkerManifestProperties"
+        assert worker_props_file["type"] == "TEXT"
 
         # Verify the worker properties JSON contains expected data
-        worker_props_data = json.loads(worker_props_file.data)
+        worker_props_data = json.loads(worker_props_file["data"])
         assert len(worker_props_data) == 1
         assert worker_props_data[0]["localRootPath"] == "/local/root"
         assert worker_props_data[0]["localManifestPaths"] == ["/local/manifest.json"]
@@ -433,13 +407,13 @@ class TestSetStepScript:
         assert action._step_script is not None
 
         # Check that embedded files still exist but WorkerManifestProperties is empty
-        assert action._step_script.embeddedFiles is not None
-        assert len(action._step_script.embeddedFiles) == 1
+        assert "embeddedFiles" in action._step_script
+        assert len(action._step_script["embeddedFiles"]) == 1
 
-        worker_props_file = action._step_script.embeddedFiles[0]
-        assert worker_props_file.name == "WorkerManifestProperties"
+        worker_props_file = action._step_script["embeddedFiles"][0]
+        assert worker_props_file["name"] == "WorkerManifestProperties"
 
-        worker_props_data = json.loads(worker_props_file.data)
+        worker_props_data = json.loads(worker_props_file["data"])
         assert worker_props_data == []
 
 

--- a/test/unit/sessions/actions/test_run_attachment_upload.py
+++ b/test/unit/sessions/actions/test_run_attachment_upload.py
@@ -13,11 +13,6 @@ import pytest
 import deadline_worker_agent.sessions.actions as actions_module
 from deadline_worker_agent.sessions.job_entities.job_details import JobDetails
 from openjd.sessions import SessionUser
-from openjd.model import ParameterValue
-from openjd.model.v2023_09 import (
-    EmbeddedFileTypes as EmbeddedFileTypes_2023_09,
-    CommandString,
-)
 
 import deadline_worker_agent.sessions.session as session_mod
 from deadline.job_attachments.models import JobAttachmentS3Settings
@@ -148,28 +143,28 @@ class TestStart:
 
         # THEN - Verify the step script is created with new format
         assert action._step_script is not None
-        assert action._step_script.actions.onRun.command == CommandString(python_path)
+        assert action._step_script["actions"]["onRun"]["command"] == python_path
 
         # Check that the arguments use the new format (no embedded file, direct script path)
-        args = action._step_script.actions.onRun.args
+        args = action._step_script["actions"]["onRun"]["args"]
         assert args is not None
         assert len(args) == 5  # script_path, -s3, s3_uri, -wp, worker_properties_file
-        assert str(args[1]) == "-s3"
-        assert str(args[2]) == s3_settings.to_s3_root_uri()
-        assert str(args[3]) == "-wp"
-        assert str(args[4]) == "{{ Task.File.WorkerManifestProperties }}"
+        assert args[1] == "-s3"
+        assert args[2] == s3_settings.to_s3_root_uri()
+        assert args[3] == "-wp"
+        assert args[4] == "{{ Task.File.WorkerManifestProperties }}"
 
         # Check embedded files contain WorkerManifestProperties
-        embedded_files = action._step_script.embeddedFiles
+        embedded_files = action._step_script["embeddedFiles"]
         assert embedded_files is not None
         assert len(embedded_files) == 1
         embedded_file = embedded_files[0]
-        assert embedded_file.name == "WorkerManifestProperties"
-        assert embedded_file.type == EmbeddedFileTypes_2023_09.TEXT
+        assert embedded_file["name"] == "WorkerManifestProperties"
+        assert embedded_file["type"] == "TEXT"
 
         session._run_attachment_sync_task.assert_called_once_with(
             step_script=action._step_script,
-            task_parameter_values=dict[str, ParameterValue](),
+            task_parameter_values={},
             os_env_vars={
                 "DEADLINE_SESSIONACTION_ID": action_id,
                 "DEADLINE_STEP_ID": step_id,
@@ -221,22 +216,22 @@ class TestStart:
         assert action._step_script is not None
 
         # Check embedded files contain WorkerManifestProperties with expected data
-        embedded_files = action._step_script.embeddedFiles
+        embedded_files = action._step_script["embeddedFiles"]
         assert embedded_files is not None
         assert len(embedded_files) == 1
         embedded_file = embedded_files[0]
-        assert embedded_file.name == "WorkerManifestProperties"
+        assert embedded_file["name"] == "WorkerManifestProperties"
 
         # Verify the embedded data contains the worker properties
         import json
 
-        embedded_data = json.loads(str(embedded_file.data))
+        embedded_data = json.loads(embedded_file["data"])
         assert len(embedded_data) == 1
         assert embedded_data[0]["root_path"] == "/test/path"
 
         session._run_attachment_sync_task.assert_called_once_with(
             step_script=action._step_script,
-            task_parameter_values=dict[str, ParameterValue](),
+            task_parameter_values={},
             os_env_vars={
                 "DEADLINE_SESSIONACTION_ID": action_id,
                 "DEADLINE_STEP_ID": step_id,

--- a/test/unit/sessions/actions/test_run_step_task.py
+++ b/test/unit/sessions/actions/test_run_step_task.py
@@ -13,6 +13,7 @@ def mock_step_details():
     mock.step_id = "step-123"
     mock.step_template = Mock()
     mock.step_template.script = Mock()
+    mock.step_script = {"actions": {"onRun": {"command": "test.exe"}}}
     return mock
 
 

--- a/test/unit/sessions/job_entities/test_job_entities.py
+++ b/test/unit/sessions/job_entities/test_job_entities.py
@@ -13,9 +13,6 @@ from openjd.model import (
 )
 from openjd.model.v2023_09 import (
     Action,
-    Environment,
-    EnvironmentActions,
-    EnvironmentScript,
     StepActions,
     StepScript,
     StepTemplate,
@@ -447,12 +444,16 @@ class TestDetails:
             "errors": [],
         }
         expected_details = EnvironmentDetails(
-            environment=Environment(
-                name=env_name,
-                script=EnvironmentScript(
-                    actions=EnvironmentActions(onEnter=Action(command=CommandString("test")))
-                ),
-            )
+            environment={
+                "name": env_name,
+                "script": {
+                    "actions": {
+                        "onEnter": {
+                            "command": "test",
+                        },
+                    }
+                },
+            }
         )
         deadline_client.batch_get_job_entity.return_value = response
         job_entities = JobEntities(
@@ -543,6 +544,7 @@ class TestDetails:
             ),
             step_id=step_id,
             dependencies=[dependency],
+            step_script={"actions": {"onRun": {"command": "test.exe"}}},
         )
         deadline_client.batch_get_job_entity.return_value = response
         job_entities = JobEntities(
@@ -599,6 +601,7 @@ class TestDetails:
             ),
             step_id=step_id,
             dependencies=[dependency],
+            step_script={"actions": {"onRun": {"command": "test.exe"}}},
         )
         deadline_client.batch_get_job_entity.return_value = response
         job_entities = JobEntities(

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -3,17 +3,28 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from pathlib import Path
-from typing import Generator
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Generator
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from openjd.model import SpecificationRevision
 
-from deadline_worker_agent.sessions.runtime import SessionRuntimeConfig
+from deadline_worker_agent.sessions.runtime import (
+    SessionRuntimeConfig,
+    SessionRuntimeDecodeError,
+)
 from deadline_worker_agent.sessions.runtime import python as python_module
-from deadline_worker_agent.sessions.runtime.python import PythonSessionRuntime
+from deadline_worker_agent.sessions.runtime.python import (
+    PythonSessionRuntime,
+    _to_v0_parameter_values,
+    _to_v0_path_mapping_rule,
+    _to_v0_path_mapping_rules,
+    _to_v1_action_status,
+)
+from deadline_worker_agent.sessions.runtime._v0_compat import _exit_code_to_i32
 
 
 @pytest.fixture()
@@ -21,7 +32,7 @@ def runtime_config() -> SessionRuntimeConfig:
     """Minimal valid SessionRuntimeConfig for testing."""
     return SessionRuntimeConfig(
         session_id="session-1",
-        job_parameter_values={"Param1": "value1"},
+        job_parameter_values={"Param1": {"type": "STRING", "value": "value1"}},
         path_mapping_rules=None,
         retain_working_dir=False,
         user=None,
@@ -46,11 +57,16 @@ class TestPythonSessionRuntimeConstruction:
         mock_openjd_session.assert_called_once()
         call_kwargs = mock_openjd_session.call_args.kwargs
         assert call_kwargs["session_id"] == "session-1"
-        assert call_kwargs["job_parameter_values"] == {"Param1": "value1"}
+        # Wire-format dicts are converted to v0 ParameterValue objects.
+        from openjd.model import ParameterValue, ParameterValueType
+
+        expected_param = ParameterValue(type=ParameterValueType.STRING, value="value1")
+        assert call_kwargs["job_parameter_values"] == {"Param1": expected_param}
         assert call_kwargs["path_mapping_rules"] is None
         assert call_kwargs["retain_working_dir"] is False
         assert call_kwargs["user"] is None
-        assert call_kwargs["callback"] is runtime_config.action_callback
+        # The callback is wrapped (v0→v1 conversion), so it's NOT the same object.
+        assert callable(call_kwargs["callback"])
         assert call_kwargs["os_env_vars"] is None
         assert call_kwargs["session_root_directory"] == Path("/tmp/sessions/session-1")
         rev_ext = call_kwargs["revision_extensions"]
@@ -80,6 +96,38 @@ class TestPythonSessionRuntimeConstruction:
         assert rev_ext.spec_rev == SpecificationRevision.v2023_09
         assert rev_ext.extensions == {"WRAP_ACTIONS"}
 
+    def test_construction_when_path_mapping_rules_converts_v1_to_v0(
+        self, mock_openjd_session: MagicMock
+    ) -> None:
+        """_v1 PathMappingRules from the config are converted to v0 types."""
+        from openjd.expr import PathFormat as V1PathFormat, PathMappingRule as V1PathMappingRule
+        from openjd.sessions import PathFormat, PathMappingRule as V0PathMappingRule
+
+        v1_rule = V1PathMappingRule(
+            source_path_format=V1PathFormat.POSIX,
+            source_path="/source",
+            destination_path="/dest",
+        )
+        config = SessionRuntimeConfig(
+            session_id="session-pmr",
+            job_parameter_values={},
+            path_mapping_rules=[v1_rule],
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-pmr"),
+        )
+
+        PythonSessionRuntime(config)
+
+        passed = mock_openjd_session.call_args.kwargs["path_mapping_rules"]
+        assert len(passed) == 1
+        assert isinstance(passed[0], V0PathMappingRule)
+        assert passed[0].source_path_format == PathFormat.POSIX
+        assert passed[0].source_path == PurePosixPath("/source")
+        assert passed[0].destination_path == Path("/dest")
+
 
 class TestPythonSessionRuntimeDelegation:
     @pytest.fixture()
@@ -92,23 +140,43 @@ class TestPythonSessionRuntimeDelegation:
     def mock_session_instance(self, mock_openjd_session: MagicMock) -> MagicMock:
         return mock_openjd_session.return_value
 
-    def test_enter_environment_when_called_delegates_to_wrapped_session(
+    def test_enter_environment_when_called_decodes_and_delegates(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        env = MagicMock()
+        env: dict[str, Any] = {
+            "name": "TestEnv",
+            "script": {"actions": {"onEnter": {"command": "echo"}}},
+        }
         identifier = MagicMock()
         os_env = {"KEY": "VAL"}
 
-        result = adapter.enter_environment(
-            environment=env, identifier=identifier, os_env_vars=os_env
-        )
+        with patch.object(python_module, "parse_model") as mock_parse:
+            result = adapter.enter_environment(
+                environment=env, identifier=identifier, os_env_vars=os_env
+            )
 
+        # The wire-format dict is decoded via parse_model into a v0 pydantic model.
+        mock_parse.assert_called_once()
+        assert mock_parse.call_args.kwargs["obj"] == env
         mock_session_instance.enter_environment.assert_called_once_with(
-            environment=env, identifier=identifier, os_env_vars=os_env
+            environment=mock_parse.return_value,
+            identifier=identifier,
+            os_env_vars=os_env,
         )
-        # enter_environment is the only non-void method — verify the return value
-        # (EnvironmentIdentifier) flows through the adapter.
         assert result is mock_session_instance.enter_environment.return_value
+
+    def test_enter_environment_when_decode_fails_raises_session_runtime_decode_error(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """F3: DecodeValidationError from parse_model is wrapped."""
+        from openjd.model import DecodeValidationError
+
+        with patch.object(python_module, "parse_model") as mock_parse:
+            mock_parse.side_effect = DecodeValidationError("bad env")
+            with pytest.raises(
+                SessionRuntimeDecodeError, match="PythonSessionRuntime.enter_environment"
+            ):
+                adapter.enter_environment(environment={"bad": "data"})
 
     def test_exit_environment_when_called_delegates_to_wrapped_session(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
@@ -123,45 +191,67 @@ class TestPythonSessionRuntimeDelegation:
             identifier=identifier, os_env_vars={"A": "B"}, keep_session_running=True
         )
 
-    def test_run_task_when_called_delegates_to_wrapped_session(
+    def test_run_task_when_called_decodes_and_converts_then_delegates(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        step_script = MagicMock()
-        task_params = {"TaskParam": "val"}
+        step_script: dict[str, Any] = {"actions": {"onRun": {"command": "echo"}}}
+        task_params: dict[str, dict[str, Any]] = {"TaskParam": {"type": "STRING", "value": "val"}}
 
-        adapter.run_task(
-            step_script=step_script,
-            task_parameter_values=task_params,
-            os_env_vars={"X": "Y"},
-            log_task_banner=False,
-        )
+        with patch.object(python_module, "parse_model") as mock_parse:
+            adapter.run_task(
+                step_script=step_script,
+                task_parameter_values=task_params,
+                os_env_vars={"X": "Y"},
+                log_task_banner=False,
+            )
 
-        mock_session_instance.run_task.assert_called_once_with(
-            step_script=step_script,
-            task_parameter_values=task_params,
-            os_env_vars={"X": "Y"},
-            log_task_banner=False,
-        )
+        mock_parse.assert_called_once()
+        assert mock_parse.call_args.kwargs["obj"] == step_script
+        mock_session_instance.run_task.assert_called_once()
+        run_kwargs = mock_session_instance.run_task.call_args.kwargs
+        assert run_kwargs["step_script"] is mock_parse.return_value
+        # Wire-format task params are converted to v0 ParameterValue objects.
+        from openjd.model import ParameterValue, ParameterValueType
 
-    def test_run_task_without_session_env_when_called_delegates_to_private_method(
+        expected = ParameterValue(type=ParameterValueType.STRING, value="val")
+        assert run_kwargs["task_parameter_values"] == {"TaskParam": expected}
+        assert run_kwargs["os_env_vars"] == {"X": "Y"}
+        assert run_kwargs["log_task_banner"] is False
+
+    def test_run_task_when_decode_fails_raises_session_runtime_decode_error(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        step_script = MagicMock()
-        task_params = {"P": "v"}
+        """F3: DecodeValidationError from parse_model is wrapped."""
+        from openjd.model import DecodeValidationError
 
-        adapter._run_task_without_session_env(
-            step_script=step_script,
-            task_parameter_values=task_params,
-            os_env_vars=None,
-            log_task_banner=True,
-        )
+        with patch.object(python_module, "parse_model") as mock_parse:
+            mock_parse.side_effect = DecodeValidationError("bad script")
+            with pytest.raises(SessionRuntimeDecodeError, match="PythonSessionRuntime.run_task"):
+                adapter.run_task(step_script={"bad": "script"}, task_parameter_values={})
 
-        mock_session_instance._run_task_without_session_env.assert_called_once_with(
-            step_script=step_script,
-            task_parameter_values=task_params,
-            os_env_vars=None,
-            log_task_banner=True,
-        )
+    def test_run_task_without_session_env_when_called_decodes_and_delegates(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        step_script: dict[str, Any] = {"actions": {"onRun": {"command": "echo"}}}
+        task_params: dict[str, dict[str, Any]] = {"P": {"type": "INT", "value": "7"}}
+
+        with patch.object(python_module, "parse_model") as mock_parse:
+            adapter._run_task_without_session_env(
+                step_script=step_script,
+                task_parameter_values=task_params,
+                os_env_vars=None,
+                log_task_banner=True,
+            )
+
+        mock_parse.assert_called_once()
+        assert mock_parse.call_args.kwargs["obj"] == step_script
+        mock_session_instance._run_task_without_session_env.assert_called_once()
+        run_kwargs = mock_session_instance._run_task_without_session_env.call_args.kwargs
+        assert run_kwargs["step_script"] is mock_parse.return_value
+        from openjd.model import ParameterValue, ParameterValueType
+
+        expected = ParameterValue(type=ParameterValueType.INT, value="7")
+        assert run_kwargs["task_parameter_values"] == {"P": expected}
 
     def test_cancel_action_when_called_delegates_to_wrapped_session(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
@@ -180,6 +270,35 @@ class TestPythonSessionRuntimeDelegation:
         adapter.cleanup()
 
         mock_session_instance.cleanup.assert_called_once_with()
+
+    def test_extend_path_mapping_rules_when_called_converts_and_sorts(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """_v1 rules are converted to v0 and sorted by descending source path length."""
+        from openjd.expr import PathFormat as V1PathFormat, PathMappingRule as V1PathMappingRule
+
+        rule_short = V1PathMappingRule(
+            source_path_format=V1PathFormat.POSIX,
+            source_path="/a",
+            destination_path="/b",
+        )
+        rule_long = V1PathMappingRule(
+            source_path_format=V1PathFormat.POSIX,
+            source_path="/longer/path",
+            destination_path="/dest/path",
+        )
+
+        # Set up the mock session's _path_mapping_rules as an empty list.
+        mock_session_instance._path_mapping_rules = []
+
+        adapter.extend_path_mapping_rules([rule_short, rule_long])
+
+        # The rules are converted to v0 and sorted by descending source path length.
+        rules = mock_session_instance._path_mapping_rules
+        assert len(rules) == 2
+        # Longer path should be first after sort.
+        assert rules[0].source_path == PurePosixPath("/longer/path")
+        assert rules[1].source_path == PurePosixPath("/a")
 
 
 class TestPythonSessionRuntimeProperties:
@@ -200,13 +319,24 @@ class TestPythonSessionRuntimeProperties:
 
         assert adapter.working_directory == Path("/tmp/work")
 
-    def test_action_status_when_accessed_returns_wrapped_session_value(
+    def test_action_status_when_v0_status_present_returns_v1(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        fake_status = MagicMock()
-        mock_session_instance.action_status = fake_status
+        """The action_status property converts the v0 session's status to _v1."""
+        from openjd.sessions import ActionState, ActionStatus
+        from openjd.sessions._v1 import ActionState as V1ActionState, ActionStatus as V1ActionStatus
 
-        assert adapter.action_status is fake_status
+        mock_session_instance.action_status = ActionStatus(
+            state=ActionState.RUNNING,
+            progress=42,
+            status_message="working",
+        )
+
+        result = adapter.action_status
+        assert isinstance(result, V1ActionStatus)
+        assert result.state == V1ActionState.RUNNING
+        assert result.progress == 42
+        assert result.status_message == "working"
 
     def test_action_status_when_none_returns_none(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
@@ -214,3 +344,242 @@ class TestPythonSessionRuntimeProperties:
         mock_session_instance.action_status = None
 
         assert adapter.action_status is None
+
+    def test_callback_when_invoked_converts_v0_status_to_v1(
+        self, mock_openjd_session: MagicMock
+    ) -> None:
+        """The wrapped callback converts v0 ActionStatus to _v1 ActionStatus."""
+        from openjd.sessions import ActionState, ActionStatus
+        from openjd.sessions._v1 import ActionState as V1ActionState, ActionStatus as V1ActionStatus
+
+        original_callback = MagicMock()
+        config = SessionRuntimeConfig(
+            session_id="session-cb",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=original_callback,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-cb"),
+        )
+
+        PythonSessionRuntime(config)
+
+        # Grab the wrapped callback that was passed to the v0 session.
+        wrapped_callback = mock_openjd_session.call_args.kwargs["callback"]
+
+        # Simulate a v0 ActionStatus
+        v0_status = ActionStatus(
+            state=ActionState.SUCCESS,
+            progress=100,
+            status_message="done",
+            exit_code=0,
+        )
+        wrapped_callback("session-cb", v0_status)
+
+        original_callback.assert_called_once()
+        call_args = original_callback.call_args
+        assert call_args[0][0] == "session-cb"
+        v1_status = call_args[0][1]
+        assert isinstance(v1_status, V1ActionStatus)
+        assert v1_status.state == V1ActionState.SUCCESS
+        assert v1_status.progress == 100
+        assert v1_status.status_message == "done"
+        assert v1_status.exit_code == 0
+
+
+class TestV0CompatConversions:
+    """Tests for the v1→v0 conversion helpers in python.py."""
+
+    def test_to_v0_parameter_values_when_valid_type_converts(self) -> None:
+        from openjd.model import ParameterValue, ParameterValueType
+
+        values: dict[str, dict[str, Any]] = {
+            "StringParam": {"type": "STRING", "value": "hello"},
+            "IntParam": {"type": "INT", "value": "42"},
+            "FloatParam": {"type": "FLOAT", "value": "3.14"},
+            "PathParam": {"type": "PATH", "value": "/tmp/out"},
+        }
+
+        result = _to_v0_parameter_values(values)
+
+        assert result == {
+            "StringParam": ParameterValue(type=ParameterValueType.STRING, value="hello"),
+            "IntParam": ParameterValue(type=ParameterValueType.INT, value="42"),
+            "FloatParam": ParameterValue(type=ParameterValueType.FLOAT, value="3.14"),
+            "PathParam": ParameterValue(type=ParameterValueType.PATH, value="/tmp/out"),
+        }
+
+    def test_to_v0_parameter_values_when_unknown_type_raises(self) -> None:
+        """A parameter type the v0 enum does not define fails loud."""
+        values: dict[str, dict[str, Any]] = {
+            "P": {"type": "HOLOGRAM", "value": "x"},
+        }
+        with pytest.raises(ValueError, match="HOLOGRAM.*ParameterValueType enum does not define"):
+            _to_v0_parameter_values(values)
+
+    def test_to_v0_parameter_values_when_empty_returns_empty(self) -> None:
+        assert _to_v0_parameter_values({}) == {}
+
+    def test_to_v0_path_mapping_rule_when_posix_converts(self) -> None:
+        from openjd.expr import PathFormat as V1PathFormat, PathMappingRule as V1PathMappingRule
+        from openjd.sessions import PathFormat, PathMappingRule as V0PathMappingRule
+
+        v1_rule = V1PathMappingRule(
+            source_path_format=V1PathFormat.POSIX,
+            source_path="/source/path",
+            destination_path="/dest/path",
+        )
+
+        result = _to_v0_path_mapping_rule(v1_rule)
+
+        assert isinstance(result, V0PathMappingRule)
+        assert result.source_path_format == PathFormat.POSIX
+        assert result.source_path == PurePosixPath("/source/path")
+        assert result.destination_path == Path("/dest/path")
+
+    def test_to_v0_path_mapping_rule_when_windows_uses_pure_windows_path(self) -> None:
+        from openjd.expr import PathFormat as V1PathFormat, PathMappingRule as V1PathMappingRule
+        from openjd.sessions import PathFormat
+
+        v1_rule = V1PathMappingRule(
+            source_path_format=V1PathFormat.WINDOWS,
+            source_path="C:\\Users\\source",
+            destination_path="/dest",
+        )
+
+        result = _to_v0_path_mapping_rule(v1_rule)
+
+        assert result.source_path_format == PathFormat.WINDOWS
+        assert isinstance(result.source_path, PureWindowsPath)
+        assert str(result.source_path) == "C:\\Users\\source"
+
+    def test_to_v0_path_mapping_rules_when_none_returns_none(self) -> None:
+        assert _to_v0_path_mapping_rules(None) is None
+
+    def test_to_v0_path_mapping_rules_when_list_converts_all(self) -> None:
+        from openjd.expr import PathFormat as V1PathFormat, PathMappingRule as V1PathMappingRule
+
+        rules = [
+            V1PathMappingRule(
+                source_path_format=V1PathFormat.POSIX,
+                source_path="/a",
+                destination_path="/b",
+            ),
+            V1PathMappingRule(
+                source_path_format=V1PathFormat.POSIX,
+                source_path="/c",
+                destination_path="/d",
+            ),
+        ]
+
+        result = _to_v0_path_mapping_rules(rules)
+
+        assert result is not None
+        assert len(result) == 2
+        assert result[0].source_path == PurePosixPath("/a")
+        assert result[1].source_path == PurePosixPath("/c")
+
+    def test_to_v1_action_status_when_all_states_map(self) -> None:
+        """Every member of the REAL v0 ActionState maps to a _v1 member.
+
+        The member-count assertion is the drift tripwire: a state added on
+        the v0 side must be added to _V1_ACTION_STATES deliberately.
+        """
+        from openjd.sessions import ActionState, ActionStatus
+        from openjd.sessions._v1 import ActionStatus as V1ActionStatus
+
+        # v0 ActionState is a standard Python enum — iterable.
+        members = list(ActionState)
+        assert len(members) == 5
+        for member in members:
+            v0_status = ActionStatus(state=member)
+            v1_status = _to_v1_action_status(v0_status)
+            assert isinstance(v1_status, V1ActionStatus)
+
+    def test_to_v1_action_status_when_unrecognized_state_raises(self) -> None:
+        """A v0 state missing from _V1_ACTION_STATES fails loud."""
+
+        class _FakeState:
+            pass
+
+        fake_status = SimpleNamespace(state=_FakeState())
+
+        with pytest.raises(ValueError, match="Unrecognized v0 ActionState"):
+            _to_v1_action_status(fake_status)  # type: ignore[arg-type]
+
+    def test_to_v1_action_status_when_all_fields_carried(self) -> None:
+        """All ActionStatus fields are carried across the conversion."""
+        from openjd.sessions import ActionState, ActionStatus
+        from openjd.sessions._v1 import ActionState as V1ActionState
+
+        v0_status = ActionStatus(
+            state=ActionState.FAILED,
+            progress=50,
+            status_message="half done",
+            fail_message="oops",
+            exit_code=1,
+        )
+
+        result = _to_v1_action_status(v0_status)
+
+        assert result.state == V1ActionState.FAILED
+        assert result.progress == 50
+        assert result.status_message == "half done"
+        assert result.fail_message == "oops"
+        assert result.exit_code == 1
+
+
+class TestExitCodeToI32:
+    """Tests for _exit_code_to_i32 — the 32-bit signed reinterpretation helper."""
+
+    @pytest.mark.parametrize(
+        "exitcode, expected_result",
+        [
+            pytest.param(0x80000000, -2147483648, id="minint_hex"),
+            pytest.param(0xFFFD0000, -196608, id="out-of-range-32bit"),
+            pytest.param(0xFFFFFFFD0000, -196608, id="out-of-range-big"),
+            pytest.param(0xC0000005, -1073741819, id="windows-access-violation"),
+        ],
+    )
+    def test_exit_code_to_i32_when_out_of_range_truncates(
+        self, exitcode: int, expected_result: int
+    ) -> None:
+        assert _exit_code_to_i32(exitcode) == expected_result
+
+    @pytest.mark.parametrize(
+        "exitcode, expected_result",
+        [
+            pytest.param(0, 0, id="zero"),
+            pytest.param(1, 1, id="one"),
+            pytest.param(-1, -1, id="minus-one"),
+            pytest.param(0x7FFFFFFF, 0x7FFFFFFF, id="maxint"),
+            pytest.param(-2147483648, -2147483648, id="minint"),
+        ],
+    )
+    def test_exit_code_to_i32_when_in_range_passes_through(
+        self, exitcode: int, expected_result: int
+    ) -> None:
+        assert _exit_code_to_i32(exitcode) == expected_result
+
+
+class TestV0BridgeExitCodeOverflow:
+    """Integration test: the v0→v1 bridge does not raise OverflowError for
+    large unsigned exit codes (e.g. Windows 0xC0000005)."""
+
+    def test_to_v1_action_status_when_exit_code_overflows_i32_reinterprets(self) -> None:
+        from openjd.sessions import ActionState, ActionStatus
+        from openjd.sessions._v1 import ActionState as V1ActionState
+
+        # 0xC0000005 (3221225477) exceeds i32 max — would crash without the fix.
+        v0_status = ActionStatus(
+            state=ActionState.FAILED,
+            exit_code=3221225477,
+        )
+
+        result = _to_v1_action_status(v0_status)
+
+        assert result.state == V1ActionState.FAILED
+        # Reinterpreted as signed 32-bit: 0xC0000005 → -1073741819
+        assert result.exit_code == -1073741819

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -5,20 +5,21 @@ from __future__ import annotations
 import os
 from dataclasses import replace
 from datetime import timedelta
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any, Generator
-from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from openjd.model._types import ParameterValue, ParameterValueType
 from openjd.model._v1.types import ModelProfile, SpecificationRevision
 
-from deadline_worker_agent.sessions.runtime import SessionRuntime, SessionRuntimeConfig
+from deadline_worker_agent.sessions.runtime import (
+    SessionRuntime,
+    SessionRuntimeConfig,
+    SessionRuntimeDecodeError,
+)
 from deadline_worker_agent.sessions.runtime import rust as rust_module
 from deadline_worker_agent.sessions.runtime.rust import RustSessionRuntime
-from deadline_worker_agent.sessions.runtime.rust import _to_rust_task_parameter_values
 
 
 @pytest.fixture()
@@ -51,6 +52,7 @@ class TestRustSessionRuntimeConstruction:
         mock_rust_session.assert_called_once()
         call_kwargs = mock_rust_session.call_args.kwargs
         assert call_kwargs["session_id"] == "session-1"
+        # Wire-format dicts pass straight through without conversion.
         assert call_kwargs["job_parameter_values"] == {
             "Param1": {"type": "STRING", "value": "value1"}
         }
@@ -155,14 +157,14 @@ class TestRustSessionRuntimeConstruction:
         passing it to the Rust session — they are distinct classes with the same
         fields.  Without the conversion the Rust binding raises TypeError."""
         from openjd.sessions import PosixSessionUser
-        from openjd.sessions._v1 import PosixSessionUser as RustPosixSessionUser
+        from openjd.sessions._v1 import PosixSessionUser as V1PosixSessionUser
 
         v0_user = PosixSessionUser(user="job-user", group="job-group")
         config = replace(runtime_config, user=v0_user)
         RustSessionRuntime(config)
 
         passed_user = mock_rust_session.call_args.kwargs["user"]
-        assert isinstance(passed_user, RustPosixSessionUser)
+        assert isinstance(passed_user, V1PosixSessionUser)
         assert passed_user.user == "job-user"
         assert passed_user.group == "job-group"
 
@@ -181,7 +183,7 @@ class TestRustSessionRuntimeConstruction:
 
         v0_user = WindowsSessionUser(user="job-user", password="secret")
         config = replace(runtime_config, user=v0_user)
-        with patch.object(rust_module, "RustWindowsSessionUser") as mock_v1_user_cls:
+        with patch.object(rust_module, "V1WindowsSessionUser") as mock_v1_user_cls:
             RustSessionRuntime(config)
 
         mock_v1_user_cls.assert_called_once_with(
@@ -209,6 +211,43 @@ class TestRustSessionRuntimeConstruction:
         with pytest.raises(TypeError, match="Unsupported SessionUser type"):
             RustSessionRuntime(config)
 
+    def test_construction_when_callback_is_passed_through_directly(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
+    ) -> None:
+        """The callback passes through without wrapping — no v1→v0 conversion
+        exists in the Rust adapter after the interface moved to _v1 types."""
+        RustSessionRuntime(runtime_config)
+
+        assert mock_rust_session.call_args.kwargs["callback"] is runtime_config.action_callback
+
+    def test_construction_when_path_mapping_rules_passes_through_directly(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """_v1 path mapping rules pass straight through without conversion."""
+        from openjd.expr import PathFormat as ExprPathFormat
+        from openjd.expr import PathMappingRule as ExprPathMappingRule
+
+        rule = ExprPathMappingRule(
+            source_path_format=ExprPathFormat.POSIX,
+            source_path="/source",
+            destination_path="/dest",
+        )
+        config = SessionRuntimeConfig(
+            session_id="session-pass",
+            job_parameter_values={},
+            path_mapping_rules=[rule],
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-pass"),
+        )
+
+        RustSessionRuntime(config)
+
+        passed = mock_rust_session.call_args.kwargs["path_mapping_rules"]
+        assert passed == [rule]
+
 
 class TestRustSessionRuntimeDelegation:
     @pytest.fixture()
@@ -221,10 +260,10 @@ class TestRustSessionRuntimeDelegation:
     def mock_session_instance(self, mock_rust_session: MagicMock) -> MagicMock:
         return mock_rust_session.return_value
 
-    def test_enter_environment_when_called_converts_env_and_delegates(
+    def test_enter_environment_when_called_decodes_wire_json_and_delegates(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        environment = MagicMock()
+        environment = {"name": "TestEnv", "script": {"actions": {"onEnter": {"command": "echo"}}}}
         identifier = "job-env-1"
         os_env = {"KEY": "VAL"}
 
@@ -236,16 +275,12 @@ class TestRustSessionRuntimeDelegation:
                 environment=environment, identifier=identifier, os_env_vars=os_env
             )
 
-        # The pydantic environment is serialized and rebuilt natively before
-        # being handed to the session.
+        # The wire-format dict is wrapped in the template envelope and decoded.
         mock_decode.assert_called_once_with(
             {
                 "specificationVersion": "environment-2023-09",
-                "environment": environment.model_dump.return_value,
+                "environment": environment,
             }
-        )
-        environment.model_dump.assert_called_once_with(
-            mode="json", by_alias=True, exclude_none=True
         )
         mock_create.assert_called_once_with(mock_decode.return_value)
         mock_session_instance.enter_environment.assert_called_once_with(
@@ -254,6 +289,20 @@ class TestRustSessionRuntimeDelegation:
             os_env_vars=os_env,
         )
         assert result is mock_session_instance.enter_environment.return_value
+
+    def test_enter_environment_when_decode_fails_raises_session_runtime_decode_error(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """F3: DecodeValidationError from the _v1 decoder is wrapped in
+        SessionRuntimeDecodeError with the boundary named."""
+        from openjd.model._v1.errors import DecodeValidationError
+
+        with patch.object(rust_module, "decode_environment_template") as mock_decode:
+            mock_decode.side_effect = DecodeValidationError("bad template")
+            with pytest.raises(
+                SessionRuntimeDecodeError, match="RustSessionRuntime.enter_environment"
+            ):
+                adapter.enter_environment(environment={"bad": "data"})
 
     def test_exit_environment_when_called_delegates_to_wrapped_session(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
@@ -266,12 +315,12 @@ class TestRustSessionRuntimeDelegation:
             identifier="job-env-1", os_env_vars={"A": "B"}, keep_session_running=True
         )
 
-    def test_run_task_when_called_converts_step_script_and_delegates(
+    def test_run_task_when_called_decodes_step_script_and_delegates(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        step_script = MagicMock()
-        task_params: dict[str, Any] = {
-            "TaskParam": ParameterValue(type=ParameterValueType.STRING, value="val"),
+        step_script: dict[str, Any] = {"actions": {"onRun": {"command": "echo", "args": ["hi"]}}}
+        task_params: dict[str, dict[str, Any]] = {
+            "TaskParam": {"type": "STRING", "value": "val"},
         }
 
         with patch.object(rust_module, "deserialize_step") as mock_deserialize:
@@ -282,23 +331,42 @@ class TestRustSessionRuntimeDelegation:
                 log_task_banner=False,
             )
 
-        # The pydantic step script is serialized, wrapped as a named step, and
-        # rebuilt natively; the native ``.script`` is forwarded to the session.
-        step_script.model_dump.assert_called_once_with(
-            mode="json", by_alias=True, exclude_none=True
-        )
-        mock_deserialize.assert_called_once_with(
-            {"name": "Placeholder", "script": step_script.model_dump.return_value}
-        )
+        # The wire-format step script dict is wrapped as a named step and decoded.
+        mock_deserialize.assert_called_once_with({"name": "Placeholder", "script": step_script})
         mock_session_instance.run_task.assert_called_once()
         run_kwargs = mock_session_instance.run_task.call_args.kwargs
         assert run_kwargs["step_script"] is mock_deserialize.return_value.script
-        # The v0 ParameterValue is rebuilt as a native _v1 TaskParameterValue.
-        passed_param = run_kwargs["task_parameter_values"]["TaskParam"]
-        assert isinstance(passed_param, rust_module.TaskParameterValue)
-        assert passed_param.value == "val"
+        # Wire-format task params pass through unchanged.
+        assert run_kwargs["task_parameter_values"] == task_params
         assert run_kwargs["os_env_vars"] == {"X": "Y"}
         assert run_kwargs["log_task_banner"] is False
+
+    def test_run_task_when_decode_fails_raises_session_runtime_decode_error(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """F3: DecodeValidationError from deserialize_step is wrapped in
+        SessionRuntimeDecodeError with the boundary named."""
+        from openjd.model._v1.errors import DecodeValidationError
+
+        with patch.object(rust_module, "deserialize_step") as mock_deserialize:
+            mock_deserialize.side_effect = DecodeValidationError("bad script")
+            with pytest.raises(SessionRuntimeDecodeError, match="RustSessionRuntime.run_task"):
+                adapter.run_task(
+                    step_script={"bad": "script"},
+                    task_parameter_values={},
+                )
+
+    def test_run_task_when_value_error_raises_session_runtime_decode_error(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """F3: ValueError from deserialize_step is also wrapped."""
+        with patch.object(rust_module, "deserialize_step") as mock_deserialize:
+            mock_deserialize.side_effect = ValueError("invalid step")
+            with pytest.raises(SessionRuntimeDecodeError, match="RustSessionRuntime.run_task"):
+                adapter.run_task(
+                    step_script={"bad": "script"},
+                    task_parameter_values={},
+                )
 
     def test_run_task_without_session_env_materializes_files_and_runs_subprocess(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock, tmp_path: Path
@@ -309,10 +377,10 @@ class TestRustSessionRuntimeDelegation:
         embedded_file.name = "WorkerManifest"
         embedded_file.data = "file-contents"
 
-        step_script = MagicMock()
-        step_script.embeddedFiles = [embedded_file]
-        step_script.actions.onRun.command = "python"
-        step_script.actions.onRun.args = [
+        mock_script = MagicMock()
+        mock_script.embeddedFiles = [embedded_file]
+        mock_script.actions.onRun.command = "python"
+        mock_script.actions.onRun.args = [
             "{{ Task.File.WorkerManifest }}",
             "{{Task.File.WorkerManifest}}",
             "{{ Task.File.WorkerManifest}}",
@@ -321,12 +389,16 @@ class TestRustSessionRuntimeDelegation:
             "literal-arg",
         ]
 
-        adapter._run_task_without_session_env(
-            step_script=step_script,
-            task_parameter_values={},
-            os_env_vars={"EXTRA": "1"},
-            log_task_banner=True,
-        )
+        step_script: dict[str, Any] = {"actions": {"onRun": {"command": "python"}}}
+
+        with patch.object(rust_module, "deserialize_step") as mock_deserialize:
+            mock_deserialize.return_value.script = mock_script
+            adapter._run_task_without_session_env(
+                step_script=step_script,
+                task_parameter_values={},
+                os_env_vars={"EXTRA": "1"},
+                log_task_banner=True,
+            )
 
         mock_session_instance.run_subprocess.assert_called_once()
         run_kwargs = mock_session_instance.run_subprocess.call_args.kwargs
@@ -343,20 +415,50 @@ class TestRustSessionRuntimeDelegation:
         assert run_kwargs["os_env_vars"] == {"PYTHONUNBUFFERED": "1", "EXTRA": "1"}
         assert run_kwargs["log_banner_message"] == "Running Task"
 
+    def test_run_task_without_session_env_when_command_has_task_file_ref_resolves_it(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock, tmp_path: Path
+    ) -> None:
+        """F2: Task.File references in the command itself are resolved, not only args."""
+        mock_session_instance.files_directory = tmp_path
+
+        embedded_file = MagicMock()
+        embedded_file.name = "syncScript"
+        embedded_file.data = "#!/bin/bash\necho sync"
+
+        mock_script = MagicMock()
+        mock_script.embeddedFiles = [embedded_file]
+        mock_script.actions.onRun.command = "{{ Task.File.syncScript }}"
+        mock_script.actions.onRun.args = None
+
+        with patch.object(rust_module, "deserialize_step") as mock_deserialize:
+            mock_deserialize.return_value.script = mock_script
+            adapter._run_task_without_session_env(
+                step_script={"actions": {"onRun": {"command": "placeholder"}}},
+                task_parameter_values={},
+            )
+
+        run_kwargs = mock_session_instance.run_subprocess.call_args.kwargs
+        # The command was resolved from the Task.File reference.
+        assert "syncScript_" in run_kwargs["command"]
+        assert os.path.exists(run_kwargs["command"])
+
     def test_run_task_without_session_env_when_no_banner_passes_none(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock, tmp_path: Path
     ) -> None:
         mock_session_instance.files_directory = tmp_path
-        step_script = MagicMock()
-        step_script.embeddedFiles = None
-        step_script.actions.onRun.command = "echo"
-        step_script.actions.onRun.args = None
 
-        adapter._run_task_without_session_env(
-            step_script=step_script,
-            task_parameter_values={},
-            log_task_banner=False,
-        )
+        mock_script = MagicMock()
+        mock_script.embeddedFiles = None
+        mock_script.actions.onRun.command = "echo"
+        mock_script.actions.onRun.args = None
+
+        with patch.object(rust_module, "deserialize_step") as mock_deserialize:
+            mock_deserialize.return_value.script = mock_script
+            adapter._run_task_without_session_env(
+                step_script={"actions": {"onRun": {"command": "echo"}}},
+                task_parameter_values={},
+                log_task_banner=False,
+            )
 
         run_kwargs = mock_session_instance.run_subprocess.call_args.kwargs
         assert run_kwargs["args"] == []
@@ -376,16 +478,22 @@ class TestRustSessionRuntimeDelegation:
         embedded_file = MagicMock()
         embedded_file.name = "Manifest"
         embedded_file.data = "data"
-        step_script = MagicMock()
-        step_script.embeddedFiles = [embedded_file]
-        step_script.actions.onRun.command = "cmd"
-        step_script.actions.onRun.args = None
+
+        mock_script = MagicMock()
+        mock_script.embeddedFiles = [embedded_file]
+        mock_script.actions.onRun.command = "cmd"
+        mock_script.actions.onRun.args = None
 
         with (
+            patch.object(rust_module, "deserialize_step") as mock_deserialize,
             patch.object(rust_module, "chown") as mock_chown,
             patch.object(rust_module.os, "chmod") as mock_chmod,
         ):
-            adapter._run_task_without_session_env(step_script=step_script, task_parameter_values={})
+            mock_deserialize.return_value.script = mock_script
+            adapter._run_task_without_session_env(
+                step_script={"actions": {"onRun": {"command": "cmd"}}},
+                task_parameter_values={},
+            )
 
         mock_chown.assert_called_once()
         assert mock_chown.call_args.kwargs["group"] == "job-group"
@@ -405,18 +513,20 @@ class TestRustSessionRuntimeDelegation:
         real_file.name = "RealFile"
         real_file.data = "real-contents"
 
-        step_script = MagicMock()
-        step_script.embeddedFiles = [none_file, real_file]
-        step_script.actions.onRun.command = "python"
-        step_script.actions.onRun.args = [
+        mock_script = MagicMock()
+        mock_script.embeddedFiles = [none_file, real_file]
+        mock_script.actions.onRun.command = "python"
+        mock_script.actions.onRun.args = [
             "{{ Task.File.EmptyFile }}",
             "{{ Task.File.RealFile }}",
         ]
 
-        adapter._run_task_without_session_env(
-            step_script=step_script,
-            task_parameter_values={},
-        )
+        with patch.object(rust_module, "deserialize_step") as mock_deserialize:
+            mock_deserialize.return_value.script = mock_script
+            adapter._run_task_without_session_env(
+                step_script={"actions": {"onRun": {"command": "python"}}},
+                task_parameter_values={},
+            )
 
         # The None-data embedded file is skipped: only the real-data file is
         # materialized into the session files directory.
@@ -455,16 +565,22 @@ class TestRustSessionRuntimeDelegation:
         embedded_file = MagicMock()
         embedded_file.name = "Manifest"
         embedded_file.data = "data"
-        step_script = MagicMock()
-        step_script.embeddedFiles = [embedded_file]
-        step_script.actions.onRun.command = "cmd"
-        step_script.actions.onRun.args = None
+
+        mock_script = MagicMock()
+        mock_script.embeddedFiles = [embedded_file]
+        mock_script.actions.onRun.command = "cmd"
+        mock_script.actions.onRun.args = None
 
         with (
+            patch.object(rust_module, "deserialize_step") as mock_deserialize,
             patch.object(rust_module, "chown") as mock_chown,
             patch.object(rust_module.os, "chmod") as mock_chmod,
         ):
-            adapter._run_task_without_session_env(step_script=step_script, task_parameter_values={})
+            mock_deserialize.return_value.script = mock_script
+            adapter._run_task_without_session_env(
+                step_script={"actions": {"onRun": {"command": "cmd"}}},
+                task_parameter_values={},
+            )
 
         # No group → no chown, and the chmod mode carries no group-read bit
         # (0o600), leaving the file owner read/write only.
@@ -473,37 +589,44 @@ class TestRustSessionRuntimeDelegation:
         assert mock_chmod.call_args.args[1] == 0o600
         mock_rust_session.return_value.run_subprocess.assert_called_once()
 
-    def test_extend_path_mapping_rules_delegates_without_presorting(
+    def test_run_task_without_session_env_when_decode_fails_raises_session_runtime_decode_error(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock, tmp_path: Path
+    ) -> None:
+        """F3: Decode failure in _run_task_without_session_env is wrapped."""
+        mock_session_instance.files_directory = tmp_path
+        from openjd.model._v1.errors import DecodeValidationError
+
+        with patch.object(rust_module, "deserialize_step") as mock_deserialize:
+            mock_deserialize.side_effect = DecodeValidationError("bad")
+            with pytest.raises(SessionRuntimeDecodeError, match="RustSessionRuntime.run_task"):
+                adapter._run_task_without_session_env(
+                    step_script={"bad": "script"},
+                    task_parameter_values={},
+                )
+
+    def test_extend_path_mapping_rules_delegates_without_conversion(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
         from openjd.expr import PathFormat as ExprPathFormat
         from openjd.expr import PathMappingRule as ExprPathMappingRule
-        from openjd.sessions import PathFormat, PathMappingRule as V0PathMappingRule
 
-        rule_short = V0PathMappingRule(
-            source_path_format=PathFormat.POSIX,
-            source_path=PurePosixPath("/a"),
-            destination_path=PurePosixPath("/b"),
+        rule_short = ExprPathMappingRule(
+            source_path_format=ExprPathFormat.POSIX,
+            source_path="/a",
+            destination_path="/b",
         )
-        rule_long = V0PathMappingRule(
-            source_path_format=PathFormat.POSIX,
-            source_path=PurePosixPath("/longer/path"),
-            destination_path=PurePosixPath("/dest/path"),
+        rule_long = ExprPathMappingRule(
+            source_path_format=ExprPathFormat.POSIX,
+            source_path="/longer/path",
+            destination_path="/dest/path",
         )
-        rules: list[V0PathMappingRule] = [rule_short, rule_long]
+        rules = [rule_short, rule_long]
 
         adapter.extend_path_mapping_rules(rules)
 
         # The public method is called with the rules in their original order —
         # the session sorts internally, so the adapter must not pre-sort.
-        mock_session_instance.extend_path_mapping_rules.assert_called_once()
-        passed = mock_session_instance.extend_path_mapping_rules.call_args.args[0]
-        assert len(passed) == 2
-        assert isinstance(passed[0], ExprPathMappingRule)
-        assert passed[0].source_path_format == ExprPathFormat.POSIX
-        assert passed[0].source_path == "/a"
-        assert passed[0].destination_path == "/b"
-        assert passed[1].source_path == "/longer/path"
+        mock_session_instance.extend_path_mapping_rules.assert_called_once_with(rules)
 
     def test_cancel_action_when_called_delegates_to_wrapped_session(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
@@ -565,28 +688,15 @@ class TestRustSessionRuntimeProperties:
 
         assert adapter.working_directory == Path("/tmp/work")
 
-    def test_action_status_when_accessed_returns_converted_v0_status(
+    def test_action_status_when_accessed_returns_session_value_directly(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        from openjd.sessions import ActionState, ActionStatus
+        """action_status is a pass-through — no conversion needed since both
+        the interface and the Rust session speak the _v1 ActionStatus type."""
+        fake_status = MagicMock()
+        mock_session_instance.action_status = fake_status
 
-        v1_state = MagicMock(**{"__str__.return_value": "running"})
-        v1_status = SimpleNamespace(
-            state=v1_state,
-            progress=42,
-            status_message="working",
-            fail_message=None,
-            exit_code=None,
-        )
-        mock_session_instance.action_status = v1_status
-
-        result = adapter.action_status
-        assert isinstance(result, ActionStatus)
-        assert result.state == ActionState.RUNNING
-        assert result.progress == 42
-        assert result.status_message == "working"
-        assert result.fail_message is None
-        assert result.exit_code is None
+        assert adapter.action_status is fake_status
 
     def test_action_status_when_none_returns_none(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
@@ -594,294 +704,6 @@ class TestRustSessionRuntimeProperties:
         mock_session_instance.action_status = None
 
         assert adapter.action_status is None
-
-
-class TestRustSessionRuntimeTypeConversions:
-    """Tests for v0 ↔ v1 type conversion helpers."""
-
-    @pytest.fixture()
-    def mock_rust_session(self) -> Generator[MagicMock, None, None]:
-        with patch.object(rust_module, "OpenJDRustSession") as mock_cls:
-            yield mock_cls
-
-    def test_job_parameter_values_when_v0_parameter_value_converts_to_native(
-        self, mock_rust_session: MagicMock
-    ) -> None:
-        """A v0 openjd.model ParameterValue is rebuilt as a native _v1 JobParameterValue."""
-        config = SessionRuntimeConfig(
-            session_id="session-conv-1",
-            job_parameter_values={
-                "P": ParameterValue(type=ParameterValueType.STRING, value="hello"),
-            },
-            path_mapping_rules=None,
-            retain_working_dir=False,
-            user=None,
-            action_callback=lambda sid, s: None,
-            os_env_vars=None,
-            session_root_directory=Path("/tmp/sessions/session-conv-1"),
-        )
-
-        RustSessionRuntime(config)
-
-        passed = mock_rust_session.call_args.kwargs["job_parameter_values"]["P"]
-        assert isinstance(passed, rust_module.JobParameterValue)
-        assert passed.value == "hello"
-
-    def test_parameter_values_when_type_unknown_to_binding_raises(self) -> None:
-        """A parameter type the _v1 binding does not define fails loud."""
-        bogus = SimpleNamespace(type=SimpleNamespace(value="HOLOGRAM"), value="x")
-        with pytest.raises(ValueError, match="HOLOGRAM.*JobParameterType does not define"):
-            rust_module._to_rust_job_parameter_values({"P": bogus})
-
-    def test_every_v1_action_state_maps_to_v0(self) -> None:
-        """Every member of the REAL _v1 ActionState enum maps to a v0 member.
-
-        The pyo3 enum is not iterable, so members are collected via dir(). The
-        member-count assertion is the drift tripwire: a state added on the Rust
-        side must be added to _ACTION_STATES deliberately.
-        """
-        from openjd.sessions import ActionState
-        from openjd.sessions._v1 import ActionState as RustActionState
-
-        members = [getattr(RustActionState, n) for n in dir(RustActionState) if n.isupper()]
-        assert len(members) == 5
-        for member in members:
-            assert isinstance(rust_module._to_v0_action_state(member), ActionState)
-
-    def test_unrecognized_v1_action_state_raises(self) -> None:
-        """A _v1 state missing from _ACTION_STATES fails loud instead of drifting."""
-
-        class _FakeState:
-            def __str__(self) -> str:
-                return "warp-speed"
-
-        with pytest.raises(ValueError, match="Unrecognized _v1 ActionState"):
-            rust_module._to_v0_action_state(_FakeState())  # type: ignore[arg-type]
-
-    def test_job_parameter_values_when_dict_passes_through_unchanged(
-        self, mock_rust_session: MagicMock
-    ) -> None:
-        """A dict value is passed through without modification."""
-        config = SessionRuntimeConfig(
-            session_id="session-conv-2",
-            job_parameter_values={
-                "D": {"type": "INT", "value": "42"},
-            },
-            path_mapping_rules=None,
-            retain_working_dir=False,
-            user=None,
-            action_callback=lambda sid, s: None,
-            os_env_vars=None,
-            session_root_directory=Path("/tmp/sessions/session-conv-2"),
-        )
-
-        RustSessionRuntime(config)
-
-        passed = mock_rust_session.call_args.kwargs["job_parameter_values"]
-        assert passed == {"D": {"type": "INT", "value": "42"}}
-
-    def test_path_mapping_rules_when_v0_rules_converts_to_expr_type(
-        self, mock_rust_session: MagicMock
-    ) -> None:
-        """v0 PathMappingRule objects are converted to openjd.expr.PathMappingRule."""
-        from openjd.expr import PathFormat as ExprPathFormat
-        from openjd.expr import PathMappingRule as ExprPathMappingRule
-        from openjd.sessions import PathFormat, PathMappingRule as V0PathMappingRule
-
-        v0_rule = V0PathMappingRule(
-            source_path_format=PathFormat.POSIX,
-            source_path=PurePosixPath("/source"),
-            destination_path=PurePosixPath("/dest"),
-        )
-        config = SessionRuntimeConfig(
-            session_id="session-conv-3",
-            job_parameter_values={},
-            path_mapping_rules=[v0_rule],
-            retain_working_dir=False,
-            user=None,
-            action_callback=lambda sid, s: None,
-            os_env_vars=None,
-            session_root_directory=Path("/tmp/sessions/session-conv-3"),
-        )
-
-        RustSessionRuntime(config)
-
-        passed = mock_rust_session.call_args.kwargs["path_mapping_rules"]
-        assert len(passed) == 1
-        assert isinstance(passed[0], ExprPathMappingRule)
-        assert passed[0].source_path_format == ExprPathFormat.POSIX
-        assert passed[0].source_path == "/source"
-        assert passed[0].destination_path == "/dest"
-
-    def test_path_mapping_rules_when_none_passes_none(self, mock_rust_session: MagicMock) -> None:
-        config = SessionRuntimeConfig(
-            session_id="session-conv-4",
-            job_parameter_values={},
-            path_mapping_rules=None,
-            retain_working_dir=False,
-            user=None,
-            action_callback=lambda sid, s: None,
-            os_env_vars=None,
-            session_root_directory=Path("/tmp/sessions/session-conv-4"),
-        )
-
-        RustSessionRuntime(config)
-
-        assert mock_rust_session.call_args.kwargs["path_mapping_rules"] is None
-
-    def test_callback_when_invoked_converts_v1_status_to_v0(
-        self, mock_rust_session: MagicMock
-    ) -> None:
-        """The callback wrapper converts _v1 ActionStatus to v0 ActionStatus."""
-        from openjd.sessions import ActionState, ActionStatus
-
-        original_callback = MagicMock()
-        config = SessionRuntimeConfig(
-            session_id="session-conv-5",
-            job_parameter_values={},
-            path_mapping_rules=None,
-            retain_working_dir=False,
-            user=None,
-            action_callback=original_callback,
-            os_env_vars=None,
-            session_root_directory=Path("/tmp/sessions/session-conv-5"),
-        )
-
-        RustSessionRuntime(config)
-
-        # Grab the wrapped callback that was passed to the Rust session.
-        wrapped_callback = mock_rust_session.call_args.kwargs["callback"]
-
-        # Simulate a v1 ActionStatus with a state whose str() == "success"
-        v1_state = MagicMock(**{"__str__.return_value": "success"})
-        v1_status = SimpleNamespace(
-            state=v1_state,
-            progress=100,
-            status_message="done",
-            fail_message=None,
-            exit_code=0,
-        )
-
-        wrapped_callback("session-conv-5", v1_status)
-
-        original_callback.assert_called_once()
-        call_args = original_callback.call_args
-        assert call_args[0][0] == "session-conv-5"
-        v0_status = call_args[0][1]
-        assert isinstance(v0_status, ActionStatus)
-        assert v0_status.state == ActionState.SUCCESS
-        assert v0_status.progress == 100
-        assert v0_status.status_message == "done"
-        assert v0_status.fail_message is None
-        assert v0_status.exit_code == 0
-
-    def test_action_status_property_when_v1_status_present_returns_v0(
-        self, mock_rust_session: MagicMock
-    ) -> None:
-        """The action_status property converts _v1 status to v0."""
-        from openjd.sessions import ActionState, ActionStatus
-
-        config = SessionRuntimeConfig(
-            session_id="session-conv-6",
-            job_parameter_values={},
-            path_mapping_rules=None,
-            retain_working_dir=False,
-            user=None,
-            action_callback=lambda sid, s: None,
-            os_env_vars=None,
-            session_root_directory=Path("/tmp/sessions/session-conv-6"),
-        )
-        adapter = RustSessionRuntime(config)
-
-        v1_state = MagicMock(**{"__str__.return_value": "failed"})
-        mock_rust_session.return_value.action_status = SimpleNamespace(
-            state=v1_state,
-            progress=0,
-            status_message=None,
-            fail_message="something broke",
-            exit_code=1,
-        )
-
-        result = adapter.action_status
-        assert isinstance(result, ActionStatus)
-        assert result.state == ActionState.FAILED
-        assert result.fail_message == "something broke"
-        assert result.exit_code == 1
-
-    def test_action_status_property_when_none_returns_none(
-        self, mock_rust_session: MagicMock
-    ) -> None:
-        config = SessionRuntimeConfig(
-            session_id="session-conv-7",
-            job_parameter_values={},
-            path_mapping_rules=None,
-            retain_working_dir=False,
-            user=None,
-            action_callback=lambda sid, s: None,
-            os_env_vars=None,
-            session_root_directory=Path("/tmp/sessions/session-conv-7"),
-        )
-        adapter = RustSessionRuntime(config)
-        mock_rust_session.return_value.action_status = None
-
-        assert adapter.action_status is None
-
-
-class TestToRustTaskParameterValues:
-    """Tests for _to_rust_task_parameter_values conversion helper."""
-
-    def test_converts_parameter_value_objects_to_native(self) -> None:
-        """ParameterValue objects convert to native _v1 TaskParameterValues of the right type."""
-        from openjd.model._v1.types import TaskParameterType
-
-        values: dict[str, Any] = {
-            "StringParam": ParameterValue(type=ParameterValueType.STRING, value="hello"),
-            "IntParam": ParameterValue(type=ParameterValueType.INT, value="42"),
-            "FloatParam": ParameterValue(type=ParameterValueType.FLOAT, value="3.14"),
-            "PathParam": ParameterValue(type=ParameterValueType.PATH, value="/tmp/out"),
-        }
-
-        result = _to_rust_task_parameter_values(values)
-
-        expected: dict[str, tuple[Any, str]] = {
-            "StringParam": (TaskParameterType.STRING, "hello"),
-            "IntParam": (TaskParameterType.INT, "42"),
-            "FloatParam": (TaskParameterType.FLOAT, "3.14"),
-            "PathParam": (TaskParameterType.PATH, "/tmp/out"),
-        }
-        assert result.keys() == expected.keys()
-        for name, (expected_type, expected_value) in expected.items():
-            converted = result[name]
-            assert isinstance(converted, rust_module.TaskParameterValue), name
-            assert str(converted.type) == str(expected_type), name
-            assert converted.value == expected_value, name
-
-    def test_dict_values_pass_through_unchanged(self) -> None:
-        """Values already in dict form are not modified."""
-        values: dict[str, Any] = {
-            "AlreadyDict": {"type": "STRING", "value": "existing"},
-        }
-
-        result = _to_rust_task_parameter_values(values)
-
-        assert result == {"AlreadyDict": {"type": "STRING", "value": "existing"}}
-
-    def test_empty_dict_returns_empty_dict(self) -> None:
-        """An empty input produces an empty output."""
-        assert _to_rust_task_parameter_values({}) == {}
-
-    def test_mixed_parameter_values_and_dicts(self) -> None:
-        """ParameterValue objects convert to native types; plain dicts pass through."""
-        values: dict[str, Any] = {
-            "Obj": ParameterValue(type=ParameterValueType.INT, value="7"),
-            "Dict": {"type": "FLOAT", "value": "2.5"},
-        }
-
-        result = _to_rust_task_parameter_values(values)
-
-        assert isinstance(result["Obj"], rust_module.TaskParameterValue)
-        assert result["Obj"].value == "7"
-        assert result["Dict"] == {"type": "FLOAT", "value": "2.5"}
 
 
 def test_rust_session_runtime_is_session_runtime_subclass() -> None:

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -17,9 +17,6 @@ import pytest
 from openjd.model import ParameterValue
 from openjd.model.v2023_09 import (
     Action,
-    Environment,
-    EnvironmentActions,
-    EnvironmentScript,
     StepActions,
     StepScript,
     StepTemplate,
@@ -29,14 +26,14 @@ from openjd.model.v2023_09 import (
     ExtensionName,
 )
 from openjd.sessions import (
-    ActionState,
-    ActionStatus,
     PathFormat,
     PathMappingRule,
     PosixSessionUser,
     SessionUser,
     WindowsSessionUser,
 )
+from openjd.sessions._v1 import ActionState, ActionStatus
+from openjd.expr import PathFormat as V1PathFormat, PathMappingRule as V1PathMappingRule
 
 from deadline_worker_agent.api_models import (
     EnvironmentAction,
@@ -219,16 +216,10 @@ def enter_env_action(
     """A fixture that provides a EnterEnvironmentAction"""
     return EnterEnvironmentAction(
         details=EnvironmentDetails(
-            environment=Environment(
-                name="EnvName",
-                script=EnvironmentScript(
-                    actions=EnvironmentActions(
-                        onEnter=Action(
-                            command=CommandString("test"),
-                        ),
-                    ),
-                ),
-            ),
+            environment={
+                "name": "EnvName",
+                "script": {"actions": {"onEnter": {"command": "test"}}},
+            },
         ),
         id=action_id,
         job_env_id=job_env_id,
@@ -432,7 +423,21 @@ class TestSessionInit:
         mock_create_runtime.assert_called_once()
         config = mock_create_runtime.call_args[0][1]
         if path_mapping_rules:
-            assert path_mapping_rules == config.path_mapping_rules
+            # The session converts v0 PathMappingRules to v1 (openjd.expr) before
+            # passing them to create_session_runtime.
+            expected_v1_rules = [
+                V1PathMappingRule(
+                    source_path_format=(
+                        V1PathFormat.POSIX
+                        if rule.source_path_format == PathFormat.POSIX
+                        else V1PathFormat.WINDOWS
+                    ),
+                    source_path=str(rule.source_path),
+                    destination_path=str(rule.destination_path),
+                )
+                for rule in path_mapping_rules
+            ]
+            assert expected_v1_rules == config.path_mapping_rules
         else:
             assert not config.path_mapping_rules
 
@@ -1056,16 +1061,10 @@ class TestSessionActionUpdatedImpl:
         current_action = CurrentAction(
             definition=EnterEnvironmentAction(
                 details=EnvironmentDetails(
-                    environment=Environment(
-                        name="EnvName",
-                        script=EnvironmentScript(
-                            actions=EnvironmentActions(
-                                onEnter=Action(
-                                    command=CommandString("test"),
-                                ),
-                            ),
-                        ),
-                    ),
+                    environment={
+                        "name": "EnvName",
+                        "script": {"actions": {"onEnter": {"command": "test"}}},
+                    },
                 ),
                 id=action_id,
                 job_env_id=job_env_id,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Follow-up to #1002. The `RustSessionRuntime` adapter was merged with a v0→v1 type bridge: the worker core speaks OpenJD v0 (Python) types everywhere, and the Rust adapter translates at every boundary crossing. As noted in #1002's review, this points the migration in the wrong direction — when the Python runtime is eventually removed, the v0→v1 translation layer would remain on the Rust path forever, and every new v1 feature would require bridge updates and bridge tests indefinitely.

The type relationship should be reversed: the code should default to v1 types and bridge v1→v0 only where the (legacy) Python runtime needs it, so that finishing the migration means *deleting* code rather than maintaining it.

### What was the solution? (How)

The `SessionRuntime` interface becomes v1-native, with one deliberate adaptation:

- **Scalar types** (`ActionStatus`, `ActionState`, path-mapping rules) cross the runtime interface as **openjd v1 native types**. The worker core — `Session`, the scheduler, session actions, and job entity details — now speaks v1 statuses end to end.
- **Environment and step-script payloads** cross the interface as **wire-format JSON dicts** (the service's own vocabulary from `BatchGetJobEntity`), and each adapter decodes them internally with its own library: the Rust adapter via the native v1 decoders, the Python adapter via the existing pydantic decode.
- **`RustSessionRuntime`** loses its entire v0→v1 conversion layer (~130 lines) and becomes near pass-through.
- **`PythonSessionRuntime`** becomes the v1→v0 bridge, with converters isolated in a new `_v0_compat.py`. Both die together when the Python runtime is retired, leaving the Rust path conversion-free with zero residue.

**Why wire-JSON for the big models instead of passing v1 objects across the interface:** the v1 binding's model objects expose readonly attributes and provide no serializer back to JSON/dict. Passing v1 objects would force the Python adapter to hand-walk the entire template object graph back into pydantic models — a converter that must track every upstream schema addition, i.e. exactly the class of permanent maintenance burden this refactor exists to eliminate. Wire JSON is a neutral boundary both libraries already decode natively; no decoded object ever needs translating into another type system. If v1 serializers ship upstream later, nothing in this design blocks tightening the boundary to v1 objects.

Also included (small follow-ups from #1002 review):

- **Task.File parameter resolution for command strings** in the Rust adapter.
- **`SessionRuntimeDecodeError`**: decode failures at the runtime boundary are wrapped with context identifying which payload failed to decode, in both adapters.
- **Exit-code i32 handling moved to the bridge boundary**: v1 `ActionStatus` stores `exit_code` as a Rust `i32` and raises `OverflowError` at construction for larger values (e.g. Windows exit codes like `0xC0000005`). The signed-32-bit reinterpretation that previously lived in the scheduler now happens in the v0→v1 bridge where the v1 status is constructed; the scheduler workaround is removed since all statuses are i32 by construction.

### What is the impact of this change?

- The Rust session path no longer performs any type conversion; the migration's end state is reached by deleting `python.py` + `_v0_compat.py`.
- No behavior change intended for either runtime. The runtime interface is internal (`_abc.py`); no public API changes.
- Job entity classes (`StepDetails`, `EnvironmentDetails`) carry wire-format dicts instead of pydantic models; validation still occurs at entity ingestion.

### How was this change tested?

- `hatch build` — clean
- `hatch run all:test` — 3032 unit tests pass on Python 3.9 / 3.10 / 3.11
- `hatch run lint` — ruff check, ruff format, and mypy all pass
- `hatch run integ-test` — 73 passed, 4 skipped
- New unit tests cover: the `_v0_compat` converters (including fail-loud behavior on unrecognized enum members), the `SessionRuntimeDecodeError` boundary in both adapters, Task.File command resolution, and exit-code i32 reinterpretation at the bridge (including an integration test proving a v0 status with exit code `0xC0000005` bridges without error).

### Was this change documented?

Internal interface docstrings updated throughout (`_abc.py`, `_v0_compat.py`, both adapters). No user-facing documentation changes required — the runtime interface is not public API.

### Is this a breaking change?

No. Internal refactor only; no public API or configuration changes.
