### PR TITLE
fix(test): resolve worker agent PID via systemd in cap_kill e2e test

### DIFF
--- a/test/e2e/test_cap_kill.py
+++ b/test/e2e/test_cap_kill.py
@@ -258,17 +258,19 @@ def test_worker_only_has_cap_kill(
                                 "name": "CheckCaps",
                                 "type": "TEXT",
                                 "runnable": True,
-                                # The worker process is the parent of the parent of the current process.
-                                # We get its PID and verify it only has cap_kill=ep (effective+permitted, not inheritable).
+                                # Resolve the worker agent PID via systemd rather than walking the
+                                # process tree. This is runtime-agnostic: the Rust session runtime's
+                                # persistent helper binary adds an extra process layer that changes
+                                # the tree depth, making grandparent-based resolution unreliable.
                                 "data": "\n".join(
                                     [
                                         "#!/bin/bash",
                                         "set -euo pipefail",
                                         'echo "=== Testing: verifying worker process only has cap_kill=ep ==="',
-                                        "export CURRENT_PPID=$PPID",
-                                        "export PPPID=$(ps -o ppid= $CURRENT_PPID)",
-                                        'echo "Worker PID: $PPPID"',
-                                        "OUTPUT=$(getpcaps $PPPID)",
+                                        "WORKER_PID=$(systemctl show --property=MainPID --value deadline-worker)",
+                                        '[ -n "$WORKER_PID" ] && [ "$WORKER_PID" -gt 0 ] || { echo "FAIL: could not resolve worker agent PID from systemd"; exit 1; }',
+                                        'echo "Worker PID: $WORKER_PID"',
+                                        "OUTPUT=$(getpcaps $WORKER_PID)",
                                         'echo "Capabilities output: $OUTPUT"',
                                         'echo "$OUTPUT" | grep -Pq "\\d+: cap_kill=ep$" || { echo "FAIL: expected only cap_kill=ep, got: $OUTPUT"; exit 1; }',
                                         'echo "PASS: worker only has cap_kill=ep"',


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`test_worker_only_has_cap_kill` needs the worker agent's PID, and got it by walking two process levels up from the job script. That only lands on the agent when `sudo`, `bash -l` and `setsid` collapse into a single PID — a property of the Python session runtime, not a guarantee. Under `session_runtime = "rust"` the runtime's persistent helper binary adds a process layer, so the walk lands on `sudo` running as root and `getpcaps` reports `=ep` (all capabilities) instead of `cap_kill=ep`. The agent's capabilities were correct; only the test's PID lookup was runtime-coupled.

### What was the solution? (How)

Ask systemd for the PID instead of inferring it from the process tree:

```bash
WORKER_PID=$(systemctl show --property=MainPID --value deadline-worker)
```

plus a guard that fails loudly if it can't be resolved. The assertion is unchanged. The other two tests in this file don't resolve the agent PID, so they needed no change.

### What is the impact of this change?

Test-only. The test now passes on both the Python and Rust session runtimes.

### How was this change tested?

Full e2e buckets on Linux and Windows against the live AWS Deadline Cloud service with the worker deployed using `session_runtime = "rust"`, on mainline's released openjd pins (no local wheels).

```
============================= slowest 5 durations ==============================
581.99s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
258.71s setup    test/e2e/test_job_attachments.py::TestJobAttachments::test_worker_job_attachment_storage_profile_path_mapping[linux]
251.93s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
233.78s setup    test/e2e/test_cap_kill.py::test_cap_kill_not_inherited_by_running_jobs
213.43s setup    test/e2e/test_override_job_user.py::TestLinuxJobUserOverride::test_no_user_override
================= 49 passed, 23 skipped in 4232.14s (1:10:32) ==================
```

```
============================= slowest 5 durations ==============================
951.52s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
766.40s setup    test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_local_queue_user[ddl]
641.69s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_local_session_logs_can_be_turned_off
394.13s setup    test/e2e/test_worker_status.py::TestWorkerStatus::test_windows_worker_restarts_process
386.08s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
= 47 passed, 17 skipped, 2 xfailed, 6 xpassed, 4 warnings in 7893.44s (2:11:33) =
```

The worker agent confirms the runtime it selected in its own log:

```
[INFO] 🔷 Session.Starting 🔷 [session-...] Selected session runtime: rust (hint=None) [queue-.../job-...]
```

The Windows xfail/xpass are pre-existing — the `TestDomainUser` "AD DS install on EC2 is unreliable" marker from #955.

### Was this change documented?

No — a comment at the call site records why the PID is resolved out-of-band.

### Is this a breaking change?

No.
