### PR TITLE
test(e2e): add session_runtime routing and failure recovery tests

### DIFF
--- a/.kiro/steering/no-internal-references.md
+++ b/.kiro/steering/no-internal-references.md
@@ -1,15 +1,15 @@
 # No Internal References
 
-This is a public repository. Never include internal Amazon references in
-code, comments, docstrings, commit messages, PR titles or descriptions, or
-issue text. This includes:
+This is a public repository. Never include references to internal (non-public)
+systems in code, comments, docstrings, commit messages, PR titles or
+descriptions, or issue text. This includes:
 
-- Internal ticket or issue IDs (SIM/Taskei IDs such as `Bea-*`, `t.corp`
-  or `issues.amazon.com` links)
+- Internal ticket or issue tracker IDs and links
 - Internal package, pipeline, or service codenames
-- Internal URLs (`code.amazon.com`, internal wikis)
-- AWS account IDs and internal team or user aliases
+- URLs that only resolve on an internal network (code hosting, wikis,
+  dashboards)
+- Cloud account IDs and internal team or personal aliases
 
-Describe internal context in generic terms instead (for example, "tracked
-internally" rather than naming a ticket). Scan for these patterns before
-pushing or posting anything public.
+Describe such context in generic terms instead (for example, "tracked
+internally" rather than naming a ticket). Scan your changes for anything in
+this list before pushing or posting.

--- a/.kiro/steering/no-internal-references.md
+++ b/.kiro/steering/no-internal-references.md
@@ -1,0 +1,15 @@
+# No Internal References
+
+This is a public repository. Never include internal Amazon references in
+code, comments, docstrings, commit messages, PR titles or descriptions, or
+issue text. This includes:
+
+- Internal ticket or issue IDs (SIM/Taskei IDs such as `Bea-*`, `t.corp`
+  or `issues.amazon.com` links)
+- Internal package, pipeline, or service codenames
+- Internal URLs (`code.amazon.com`, internal wikis)
+- AWS account IDs and internal team or user aliases
+
+Describe internal context in generic terms instead (for example, "tracked
+internally" rather than naming a ticket). Scan for these patterns before
+pushing or posting anything public.

--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -2,7 +2,7 @@ backoff == 2.2.*
 boto3 >= 1.34.75
 deadline >= 0.60.2, < 0.61
 deadline-job-attachments >= 0.1.1, < 0.1.4
-deadline-cloud-test-fixtures >= 0.18.17, < 0.19
+deadline-cloud-test-fixtures >= 0.18.18, < 0.19
 flaky == 3.8.*
 mypy >= 2.3.0, < 2.4; python_version >= "3.10"
 mypy >= 1.19.1, < 1.20; python_version < "3.10"

--- a/test/e2e/test_session_runtime.py
+++ b/test/e2e/test_session_runtime.py
@@ -1,0 +1,579 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+End-to-end tests for the session_runtime worker configuration (Bea-56390).
+
+These tests validate that the worker agent correctly routes session execution
+to the configured runtime (python, rust, or service-selected) and that
+missing-runtime failures surface visibly rather than silently falling back.
+
+TestRustUnavailableAndRecovery is adaptive: it explicitly removes the Rust
+extension files before testing failure, then switches to python and verifies
+recovery, all within a single test function to guarantee phase ordering.
+Shell commands branch per OS: Linux workers use bash, Windows workers use
+PowerShell via SSM AWS-RunPowerShellScript.
+
+Hint-dependent scenarios:
+    Two classes below cannot run until the service stamps a runtimeHint on
+    session specs for the test account, which requires that account to be
+    allowlisted for the service-side runtime-hint feature gates. The tests
+    themselves cannot create or observe that state, so they carry an
+    unconditional skip mark with the unlock condition in the reason. Remove
+    the mark when the account reaches the corresponding state:
+
+      TestServiceSelectedWithRustHint       account allowlisted for the
+                                            per-OS runtime gate (hint=rust)
+      TestServiceSelectedWithPythonexprHint outer gate open, per-OS gate
+                                            closed (hint=pythonexpr)
+
+    Note that TestServiceSelectedDefaultsToPython asserts the absence of a
+    hint. Its premise inverts in either of those worlds, so it will start
+    failing and must be retired at the same time.
+
+The Rust adapter needs no env var: openjd-model ships the Rust extension
+(openjd._openjd_rs) in its platform wheels from 0.10.0 onward, and this
+package pins openjd-model >= 0.11.1, so a worker installed from this wheel
+always has it. The rust scenarios therefore run unconditionally.
+
+Log assertion anchor: the scheduler logs
+    "Selected session runtime: <kind> (hint=...)"
+per session start (PR #1016).
+
+Worker agent log paths:
+    Linux:   /var/log/amazon/deadline/worker-agent.log
+    Windows: C:\\ProgramData\\Amazon\\Deadline\\Logs\\worker-agent.log
+
+Worker venv / site-packages paths (for making the Rust adapter unloadable):
+    Linux:   /opt/deadline/worker/lib/python3.*/site-packages/openjd/
+    Windows: resolved from the system python at test time (see the\n    fault-injection step in TestRustUnavailableAndRecovery)
+"""
+
+from typing import Generator, Type
+
+import backoff
+import dataclasses
+import logging
+import os
+import pytest
+
+from deadline_test_fixtures import (
+    DeadlineClient,
+    DeadlineWorker,
+    DeadlineWorkerConfiguration,
+    EC2InstanceWorker,
+    TaskStatus,
+)
+
+from e2e.conftest import DeadlineResources, create_worker, stop_worker
+from e2e.utils import (
+    is_worker_started,
+    job_failure_message,
+    submit_sleep_job,
+)
+
+LOG = logging.getLogger(__name__)
+
+# Agent log paths per OS
+_LINUX_AGENT_LOG = "/var/log/amazon/deadline/worker-agent.log"
+_WINDOWS_AGENT_LOG = r"C:\ProgramData\Amazon\Deadline\Logs\worker-agent.log"
+
+# Worker config paths per OS
+_LINUX_WORKER_TOML = "/etc/amazon/deadline/worker.toml"
+_WINDOWS_WORKER_TOML = r"C:\ProgramData\Amazon\Deadline\Config\worker.toml"
+
+# Worker venv site-packages path (for making the Rust adapter unloadable).
+# Linux: the worker agent runs inside a venv at this path. This is not a
+# guess: it is the same literal deadline_test_fixtures uses to create the
+# venv in its userdata ("python3 -m venv /opt/deadline/worker"). The openjd
+# package location inside it is resolved by asking that venv's python at
+# test time, so no Python minor version appears here. On Windows the
+# installer puts python on the machine PATH (PrependPath=1 in the fixtures
+# userdata), so the interpreter is asked directly.
+_LINUX_WORKER_VENV = "/opt/deadline/worker"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _running_on_windows() -> bool:
+    """Return True when the suite is running against Windows workers.
+
+    Reads OPERATING_SYSTEM, the variable every other e2e module in this
+    package branches on. Duck-typing the worker object instead (checking for
+    a Windows-only class attribute) would silently fall through to the Linux
+    branch if the fixture library ever renamed that attribute, sending bash
+    to a Windows host.
+    """
+    return os.environ["OPERATING_SYSTEM"].lower() == "windows"
+
+
+def _agent_log_path(worker: EC2InstanceWorker) -> str:
+    """Return the agent log path appropriate for the worker's OS."""
+    return _WINDOWS_AGENT_LOG if _running_on_windows() else _LINUX_AGENT_LOG
+
+
+def _assert_log_contains(
+    worker: EC2InstanceWorker,
+    pattern: str,
+    description: str,
+) -> None:
+    """Assert that the agent log on the remote worker contains *pattern*.
+
+    Uses grep on Linux, Select-String on Windows.
+    """
+    log_path = _agent_log_path(worker)
+
+    if _running_on_windows():
+        # PowerShell: Select-String with -Quiet returns $true/$false.
+        # Single quotes inside the pattern are doubled for PS literal strings.
+        ps_pattern = pattern.replace("'", "''")
+        cmd = (
+            f"if (Select-String -Path '{log_path}' -Pattern '{ps_pattern}' -SimpleMatch -Quiet) "
+            f"{{ exit 0 }} else {{ exit 1 }}"
+        )
+    else:
+        cmd = f"grep -q '{pattern}' {log_path}"
+
+    cmd_result = worker.send_command(cmd)
+    assert cmd_result.exit_code == 0, (
+        f"Expected agent log to contain '{pattern}' ({description}). "
+        f"exit_code={cmd_result.exit_code}, stdout={cmd_result.stdout!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test classes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        pytest.param("python", id="python"),
+        pytest.param("rust", id="rust"),
+    ],
+)
+def explicit_runtime_worker(
+    request: pytest.FixtureRequest,
+    worker_config: DeadlineWorkerConfiguration,
+    ec2_worker_type: Type[EC2InstanceWorker],
+) -> Generator[tuple[EC2InstanceWorker, str], None, None]:
+    """Create a worker with session_runtime set to the parametrized value.
+
+    Two values: python and rust. Both run unconditionally; the Rust
+    extension ships in openjd-model's platform wheels.
+
+    Yields (worker, runtime) so tests can access the runtime string alongside
+    the worker instance.
+    """
+    runtime: str = request.param
+    with create_worker(
+        dataclasses.replace(worker_config, session_runtime=runtime),
+        ec2_worker_type,
+        request,
+    ) as worker:
+        assert isinstance(worker, EC2InstanceWorker)
+        yield worker, runtime
+    stop_worker(request, worker)
+
+
+class TestExplicitModeRouting:
+    """Worker with a given session_runtime routes sessions to the expected adapter.
+
+    Parametrized over python and rust. Each parameter gets its own worker
+    with the corresponding session_runtime in worker.toml.
+
+    We assert the exact "Selected session runtime: <kind>" log line since
+    the selected runtime is deterministic for explicit python/rust modes.
+    """
+
+    def test_job_succeeds_and_log_shows_runtime_selected(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        explicit_runtime_worker: tuple[EC2InstanceWorker, str],
+    ) -> None:
+        worker, runtime = explicit_runtime_worker
+        job = submit_sleep_job(
+            f"session_runtime={runtime} routing test",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+        )
+        job.wait_until_complete(client=deadline_client)
+        assert job.task_run_status == TaskStatus.SUCCEEDED, job_failure_message(
+            job, deadline_client, deadline_resources.queue_a, deadline_resources
+        )
+
+        _assert_log_contains(
+            worker,
+            f"Selected session runtime: {runtime}",
+            f"session_runtime={runtime} should log {runtime} selection",
+        )
+
+
+@pytest.fixture(scope="class")
+def service_selected_worker(
+    request: pytest.FixtureRequest,
+    worker_config: DeadlineWorkerConfiguration,
+    ec2_worker_type: Type[EC2InstanceWorker],
+) -> Generator[DeadlineWorker, None, None]:
+    with create_worker(
+        dataclasses.replace(worker_config, session_runtime="service-selected"),
+        ec2_worker_type,
+        request,
+    ) as worker:
+        yield worker
+    stop_worker(request, worker)
+
+
+class TestServiceSelectedDefaultsToPython:
+    """Worker with session_runtime=service-selected defaults to python when no hint is stamped.
+
+    The service does not stamp runtimeHint today (the service-side feature
+    gates are closed). This validates the no-hint default branch on real
+    infrastructure: when session_runtime=service-selected and no runtimeHint
+    is present in the session spec, the worker falls back to the python
+    adapter. NOTE: this premise inverts once the runtime-hint feature gates
+    open for the test account. This class will then start failing and must be
+    retired, at the same time as the hint-following classes below are enabled.
+    """
+
+    def test_job_succeeds_and_log_shows_python_selected(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        service_selected_worker: EC2InstanceWorker,
+    ) -> None:
+        job = submit_sleep_job(
+            "session_runtime=service-selected (no hint) routing test",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+        )
+        job.wait_until_complete(client=deadline_client)
+        assert job.task_run_status == TaskStatus.SUCCEEDED, job_failure_message(
+            job, deadline_client, deadline_resources.queue_a, deadline_resources
+        )
+
+        _assert_log_contains(
+            service_selected_worker,
+            "Selected session runtime: python (hint=None)",
+            "service-selected with no hint should default to python",
+        )
+
+
+@pytest.fixture(scope="class")
+def service_selected_hint_worker(
+    request: pytest.FixtureRequest,
+    worker_config: DeadlineWorkerConfiguration,
+    ec2_worker_type: Type[EC2InstanceWorker],
+) -> Generator[DeadlineWorker, None, None]:
+    with create_worker(
+        dataclasses.replace(worker_config, session_runtime="service-selected"),
+        ec2_worker_type,
+        request,
+    ) as worker:
+        yield worker
+    stop_worker(request, worker)
+
+
+@pytest.mark.skip(
+    reason="Requires the test account to be allowlisted for the service-side "
+    "runtime-hint gates so the service stamps runtimeHint=rust. Remove this "
+    "mark once that is true; see the module docstring."
+)
+class TestServiceSelectedWithRustHint:
+    """Worker with session_runtime=service-selected routes to rust when DP stamps hint=rust.
+
+    Skipped unconditionally: the account must be allowlisted for the
+    service-side runtime-hint feature gates before the hint appears in session
+    specs. The Rust extension itself always ships, so no other precondition is
+    outstanding.
+    """
+
+    def test_job_succeeds_and_log_shows_rust_selected(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        service_selected_hint_worker: EC2InstanceWorker,
+    ) -> None:
+        job = submit_sleep_job(
+            "session_runtime=service-selected (hint=rust) routing test",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+        )
+        job.wait_until_complete(client=deadline_client)
+        assert job.task_run_status == TaskStatus.SUCCEEDED, job_failure_message(
+            job, deadline_client, deadline_resources.queue_a, deadline_resources
+        )
+
+        _assert_log_contains(
+            service_selected_hint_worker,
+            "Selected session runtime: rust (hint='rust')",
+            "service-selected with hint=rust should route to rust",
+        )
+
+
+@pytest.fixture(scope="class")
+def service_selected_pythonexpr_hint_worker(
+    request: pytest.FixtureRequest,
+    worker_config: DeadlineWorkerConfiguration,
+    ec2_worker_type: Type[EC2InstanceWorker],
+) -> Generator[DeadlineWorker, None, None]:
+    with create_worker(
+        dataclasses.replace(worker_config, session_runtime="service-selected"),
+        ec2_worker_type,
+        request,
+    ) as worker:
+        yield worker
+    stop_worker(request, worker)
+
+
+@pytest.mark.skip(
+    reason="Requires the test account to be in the intermediate allowlist state "
+    "(outer runtime-hint gate open, per-OS gate closed) so the service stamps "
+    "runtimeHint=pythonexpr. Remove this mark once that is true; see the "
+    "module docstring."
+)
+class TestServiceSelectedWithPythonexprHint:
+    """Worker with session_runtime=service-selected routes to python when DP stamps hint=pythonexpr.
+
+    Unlock condition: the staged-rollout intermediate state where the test
+    account is allowlisted for the outer runtime-hint feature gate but NOT
+    the per-OS runtime gate, so the service stamps hint=pythonexpr. This
+    class validates the hint-following path routes to python (distinct code
+    path from the no-hint default).
+
+    RETIREMENT: delete this class when the feature gates are fully
+    open/removed (the intermediate state no longer exists).
+    """
+
+    def test_job_succeeds_and_log_shows_python_selected_with_pythonexpr_hint(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        service_selected_pythonexpr_hint_worker: EC2InstanceWorker,
+    ) -> None:
+        job = submit_sleep_job(
+            "session_runtime=service-selected (hint=pythonexpr) routing test",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+        )
+        job.wait_until_complete(client=deadline_client)
+        assert job.task_run_status == TaskStatus.SUCCEEDED, job_failure_message(
+            job, deadline_client, deadline_resources.queue_a, deadline_resources
+        )
+
+        _assert_log_contains(
+            service_selected_pythonexpr_hint_worker,
+            "Selected session runtime: python (hint='pythonexpr')",
+            "service-selected with hint=pythonexpr should route to python via hint path",
+        )
+
+
+@pytest.fixture(scope="class")
+def rust_unavailable_worker(
+    request: pytest.FixtureRequest,
+    worker_config: DeadlineWorkerConfiguration,
+    ec2_worker_type: Type[EC2InstanceWorker],
+) -> Generator[DeadlineWorker, None, None]:
+    with create_worker(
+        dataclasses.replace(worker_config, session_runtime="rust"),
+        ec2_worker_type,
+        request,
+    ) as worker:
+        yield worker
+    stop_worker(request, worker)
+
+
+class TestRustUnavailableAndRecovery:
+    """Worker with session_runtime=rust fails visibly when the Rust adapter cannot load,
+    then recovers after switching to python via config edit + service restart.
+
+    This is a single sequential test function rather than separate methods because
+    the phases share one worker and are order-dependent: extension removal is
+    irreversible on this instance. A single function makes the ordering immune to
+    test reordering/parallelization plugins (pytest-xdist, pytest-randomly).
+    """
+
+    def test_rust_unavailable_fails_visibly_then_recovers_after_switch_to_python(
+        self,
+        deadline_resources: DeadlineResources,
+        deadline_client: DeadlineClient,
+        rust_unavailable_worker: EC2InstanceWorker,
+    ) -> None:
+        """Rust mode fails visibly when the adapter cannot load, then recovers after
+        switching to python via worker.toml edit + service restart."""
+
+        worker = rust_unavailable_worker
+        is_win = _running_on_windows()
+
+        # -- Phase 1: Make the Rust adapter unloadable ---------------------------
+        # Fault injection: remove openjd/model/_v1, the one import the Rust
+        # adapter needs that nothing else does. rust.py imports
+        # openjd.model._v1 (plus openjd._openjd_rs and openjd.expr), so
+        # deleting it makes the adapter fail to import while leaving the agent
+        # itself intact.
+        #
+        # Do NOT delete openjd/_openjd_rs.* or openjd/expr: openjd.sessions'
+        # pure-Python runner (_runner_base.py) imports openjd.expr, which is a
+        # facade over the native extension. Removing those stops the agent from
+        # starting at all -- which is a broken install, not an unavailable
+        # adapter, and defeats the point of this test.
+        #
+        # The openjd location is resolved by asking the worker's own python,
+        # and the removal is asserted before (target exists) and after (target
+        # gone), so a change in install layout fails loudly right here instead
+        # of surfacing later as a confusing job-outcome mismatch.
+        if is_win:
+            rm_cmd = (
+                "$model = python -c "
+                # openjd is a namespace package (no __init__), so its __file__ is
+                # None; resolve the concrete openjd.model subpackage instead.
+                '"import openjd.model, os; print(os.path.dirname(openjd.model.__file__))"; '
+                "if (-not $model) { Write-Error 'could not resolve the openjd.model package location'; exit 1 }; "
+                "$v1 = Join-Path $model '_v1'; "
+                'if (-not (Test-Path $v1)) { Write-Error "expected $v1 to exist before removal"; exit 1 }; '
+                "Remove-Item -Recurse -Force $v1; "
+                'if (Test-Path $v1) { Write-Error "failed to remove $v1"; exit 1 }; '
+                "exit 0"
+            )
+        else:
+            rm_cmd = (
+                "set -e; "
+                # openjd is a namespace package (no __init__), so its __file__ is
+                # None; resolve the concrete openjd.model subpackage instead.
+                f"MODEL=$({_LINUX_WORKER_VENV}/bin/python -c "
+                "'import openjd.model, os; print(os.path.dirname(openjd.model.__file__))'); "
+                'V1="$MODEL/_v1"; '
+                'if [ ! -d "$V1" ]; then echo "expected $V1 to exist before removal" >&2; exit 1; fi; '
+                'rm -rf "$V1"; '
+                'if [ -d "$V1" ]; then echo "failed to remove $V1" >&2; exit 1; fi'
+            )
+
+        rm_result = worker.send_command(rm_cmd)
+        assert rm_result.exit_code == 0, f"Failed to remove openjd.model._v1: {rm_result}"
+
+        # -- Phase 2: Submit job as rust mode -> expect failure --------------------
+        job = submit_sleep_job(
+            "session_runtime=rust (unavailable) failure test",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+        )
+
+        job.wait_until_complete(client=deadline_client)
+
+        # The job should fail because the Rust runtime is unavailable
+        assert job.task_run_status == TaskStatus.FAILED, (
+            f"Expected job to FAIL when Rust runtime is unavailable, but got {job.task_run_status}"
+        )
+
+        # Verify the error message mentions the adapter being unavailable
+        _assert_log_contains(
+            worker,
+            "RustSessionRuntime adapter is not available",
+            "rust mode with missing extension should log adapter-not-available error",
+        )
+
+        # -- Phase 3: Switch to python + restart service --------------------------
+        toml_path = _WINDOWS_WORKER_TOML if is_win else _LINUX_WORKER_TOML
+
+        if is_win:
+            # PowerShell: line-by-line -replace (no -Raw: '^' must anchor each
+            # line, matching the fixture's injection mode; with -Raw it only
+            # matches the start of the whole file and silently no-ops).
+            # Select-String makes a silent no-op loud; '.' wildcards the quotes
+            # to avoid another quote-escaping layer.
+            switch_cmd = (
+                f"$content = Get-Content -Path '{toml_path}'; "
+                f"$content = $content -replace '^session_runtime = .*', "
+                f"'session_runtime = \"python\"'; "
+                f"Set-Content -Path '{toml_path}' -Value $content; "
+                f"if (-not (Select-String -Path '{toml_path}' "
+                f"-Pattern '^session_runtime = .python.$' -Quiet)) {{ exit 1 }}"
+            )
+        else:
+            switch_cmd = (
+                f"sed -i 's/^session_runtime = .*/session_runtime = \"python\"/' {toml_path}"
+                f" && grep -q '^session_runtime = .python.$' {toml_path}"
+            )
+
+        sed_result = worker.send_command(switch_cmd)
+        assert sed_result.exit_code == 0, (
+            f"Failed to update worker.toml session_runtime: {sed_result}"
+        )
+
+        # Restart the worker service to pick up the new config
+        worker.stop_worker_service()
+
+        if is_win:
+
+            @backoff.on_exception(
+                backoff.constant,
+                Exception,
+                max_time=45,
+                interval=5,
+            )
+            def check_worker_service_stopped_win() -> None:
+                status_result = worker.send_command("(Get-Service DeadlineWorker).Status")
+                assert status_result.stdout.strip() != "Running"
+
+            check_worker_service_stopped_win()
+        else:
+
+            @backoff.on_exception(
+                backoff.constant,
+                Exception,
+                max_time=45,
+                interval=5,
+            )
+            def check_worker_service_stopped() -> None:
+                status_result = worker.send_command("systemctl is-active deadline-worker")
+                assert status_result.exit_code != 0
+                assert status_result.stdout.strip() != "active"
+
+            check_worker_service_stopped()
+
+        worker.start_worker_service()
+
+        # Wait for the worker to come back online
+        assert worker.worker_id is not None
+
+        @backoff.on_exception(
+            backoff.constant,
+            Exception,
+            max_time=120,
+            interval=10,
+        )
+        def wait_worker_started() -> None:
+            assert is_worker_started(
+                deadline_client=deadline_client,
+                farm_id=deadline_resources.farm.id,
+                fleet_id=deadline_resources.fleet.id,
+                worker_id=worker.worker_id,
+            )
+
+        wait_worker_started()
+
+        # -- Phase 4: Submit job -> expect success with python --------------------
+        job = submit_sleep_job(
+            "session_runtime switch rust->python test",
+            deadline_client,
+            deadline_resources.farm,
+            deadline_resources.queue_a,
+        )
+        job.wait_until_complete(client=deadline_client)
+        assert job.task_run_status == TaskStatus.SUCCEEDED, job_failure_message(
+            job, deadline_client, deadline_resources.queue_a, deadline_resources
+        )
+
+        _assert_log_contains(
+            worker,
+            "Selected session runtime: python",
+            "after switching to python, log should show python selection",
+        )

--- a/test/e2e/test_session_runtime.py
+++ b/test/e2e/test_session_runtime.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 """
-End-to-end tests for the session_runtime worker configuration (Bea-56390).
+End-to-end tests for the session_runtime worker configuration.
 
 These tests validate that the worker agent correctly routes session execution
 to the configured runtime (python, rust, or service-selected) and that
@@ -120,7 +120,11 @@ def _assert_log_contains(
 ) -> None:
     """Assert that the agent log on the remote worker contains *pattern*.
 
-    Uses grep on Linux, Select-String on Windows.
+    Uses grep on Linux, Select-String on Windows. Retries briefly: every
+    caller greps only after awaiting the job's terminal status, and the
+    asserted line is written at session start, so the line is normally on
+    disk minutes before the first attempt -- the retry is defence against
+    slow log flushes or a transient SSM hiccup, not an expected wait.
     """
     log_path = _agent_log_path(worker)
 
@@ -135,11 +139,15 @@ def _assert_log_contains(
     else:
         cmd = f"grep -q '{pattern}' {log_path}"
 
-    cmd_result = worker.send_command(cmd)
-    assert cmd_result.exit_code == 0, (
-        f"Expected agent log to contain '{pattern}' ({description}). "
-        f"exit_code={cmd_result.exit_code}, stdout={cmd_result.stdout!r}"
-    )
+    @backoff.on_exception(backoff.constant, AssertionError, max_time=30, interval=5)
+    def _check() -> None:
+        cmd_result = worker.send_command(cmd)
+        assert cmd_result.exit_code == 0, (
+            f"Expected agent log to contain '{pattern}' ({description}). "
+            f"exit_code={cmd_result.exit_code}, stdout={cmd_result.stdout!r}"
+        )
+
+    _check()
 
 
 # ---------------------------------------------------------------------------

--- a/test/e2e/test_session_runtime.py
+++ b/test/e2e/test_session_runtime.py
@@ -42,9 +42,10 @@ Worker agent log paths:
     Linux:   /var/log/amazon/deadline/worker-agent.log
     Windows: C:\\ProgramData\\Amazon\\Deadline\\Logs\\worker-agent.log
 
-Worker venv / site-packages paths (for making the Rust adapter unloadable):
-    Linux:   /opt/deadline/worker/lib/python3.*/site-packages/openjd/
-    Windows: resolved from the system python at test time (see the\n    fault-injection step in TestRustUnavailableAndRecovery)
+Worker openjd package location (for making the Rust adapter unloadable):
+    Resolved from the worker's own python at test time on both platforms
+    (Linux: the venv at /opt/deadline/worker; Windows: the system python; see the
+    fault-injection step in TestRustUnavailableAndRecovery)
 """
 
 from typing import Generator, Type
@@ -237,6 +238,7 @@ def service_selected_worker(
         ec2_worker_type,
         request,
     ) as worker:
+        assert isinstance(worker, EC2InstanceWorker)
         yield worker
     stop_worker(request, worker)
 
@@ -277,21 +279,6 @@ class TestServiceSelectedDefaultsToPython:
         )
 
 
-@pytest.fixture(scope="class")
-def service_selected_hint_worker(
-    request: pytest.FixtureRequest,
-    worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
-) -> Generator[DeadlineWorker, None, None]:
-    with create_worker(
-        dataclasses.replace(worker_config, session_runtime="service-selected"),
-        ec2_worker_type,
-        request,
-    ) as worker:
-        yield worker
-    stop_worker(request, worker)
-
-
 @pytest.mark.skip(
     reason="Requires the test account to be allowlisted for the service-side "
     "runtime-hint gates so the service stamps runtimeHint=rust. Remove this "
@@ -310,7 +297,7 @@ class TestServiceSelectedWithRustHint:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        service_selected_hint_worker: EC2InstanceWorker,
+        service_selected_worker: EC2InstanceWorker,
     ) -> None:
         job = submit_sleep_job(
             "session_runtime=service-selected (hint=rust) routing test",
@@ -324,25 +311,10 @@ class TestServiceSelectedWithRustHint:
         )
 
         _assert_log_contains(
-            service_selected_hint_worker,
+            service_selected_worker,
             "Selected session runtime: rust (hint='rust')",
             "service-selected with hint=rust should route to rust",
         )
-
-
-@pytest.fixture(scope="class")
-def service_selected_pythonexpr_hint_worker(
-    request: pytest.FixtureRequest,
-    worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
-) -> Generator[DeadlineWorker, None, None]:
-    with create_worker(
-        dataclasses.replace(worker_config, session_runtime="service-selected"),
-        ec2_worker_type,
-        request,
-    ) as worker:
-        yield worker
-    stop_worker(request, worker)
 
 
 @pytest.mark.skip(
@@ -368,7 +340,7 @@ class TestServiceSelectedWithPythonexprHint:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        service_selected_pythonexpr_hint_worker: EC2InstanceWorker,
+        service_selected_worker: EC2InstanceWorker,
     ) -> None:
         job = submit_sleep_job(
             "session_runtime=service-selected (hint=pythonexpr) routing test",
@@ -382,7 +354,7 @@ class TestServiceSelectedWithPythonexprHint:
         )
 
         _assert_log_contains(
-            service_selected_pythonexpr_hint_worker,
+            service_selected_worker,
             "Selected session runtime: python (hint='pythonexpr')",
             "service-selected with hint=pythonexpr should route to python via hint path",
         )
@@ -399,6 +371,7 @@ def rust_unavailable_worker(
         ec2_worker_type,
         request,
     ) as worker:
+        assert isinstance(worker, EC2InstanceWorker)
         yield worker
     stop_worker(request, worker)
 

--- a/test/e2e/test_session_runtime.py
+++ b/test/e2e/test_session_runtime.py
@@ -53,6 +53,8 @@ import backoff
 import dataclasses
 import logging
 import os
+import shlex
+
 import pytest
 
 from deadline_test_fixtures import (
@@ -120,7 +122,10 @@ def _assert_log_contains(
 ) -> None:
     """Assert that the agent log on the remote worker contains *pattern*.
 
-    Uses grep on Linux, Select-String on Windows. Retries briefly: every
+    Matches *pattern* as a literal string on both platforms (grep -F on
+    Linux, Select-String -SimpleMatch on Windows), so regex metacharacters
+    and embedded quotes in patterns like (hint='rust') need no escaping by
+    callers. Retries briefly: every
     caller greps only after awaiting the job's terminal status, and the
     asserted line is written at session start, so the line is normally on
     disk minutes before the first attempt -- the retry is defence against
@@ -137,7 +142,7 @@ def _assert_log_contains(
             f"{{ exit 0 }} else {{ exit 1 }}"
         )
     else:
-        cmd = f"grep -q '{pattern}' {log_path}"
+        cmd = f"grep -qF {shlex.quote(pattern)} {log_path}"
 
     @backoff.on_exception(backoff.constant, AssertionError, max_time=30, interval=5)
     def _check() -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent selects its OpenJD session runtime via the `session_runtime` setting (`worker.toml` `[worker]` section; `python`, `rust`, or `service-selected`). In `service-selected` mode the service's per-session `runtimeHint` decides, and absent a hint the worker defaults to python. None of that routing had end-to-end coverage.

Unit tests cover `select_runtime()` exhaustively, and the differential integ tests added in #1015 compare the two adapters' behavior, but neither exercises the path that only exists on a real host: the setting travels from the installer's `worker.toml`, through the service start, into the agent's selection logic — and the hint only exists in a real `UpdateWorkerSchedule` response.

### What was the solution? (How)

New `test/e2e/test_session_runtime.py`, on real EC2 workers:

| Test class | Worker config | Service hint | Asserted | Runs today |
|---|---|---|---|---|
| `TestExplicitModeRouting[python]` | `python` | any (never consulted) | job succeeds; log shows `Selected session runtime: python` | yes |
| `TestExplicitModeRouting[rust]` | `rust` | any (never consulted) | job succeeds; log shows `Selected session runtime: rust` | yes |
| `TestServiceSelectedDefaultsToPython` | `service-selected` | none (today's state: account not allowlisted) | job succeeds; log pins the full `Selected session runtime: python (hint=None)`, so it cannot pass for the wrong reason once a hint starts arriving | yes |
| `TestServiceSelectedWithRustHint` | `service-selected` | `rust` | job succeeds; log pins `Selected session runtime: rust (hint='rust')`, proving the hint caused the routing rather than a pinned config | skipped until the account is allowlisted for the rust hint |
| `TestServiceSelectedWithPythonexprHint` | `service-selected` | `pythonexpr` | job succeeds; log pins `Selected session runtime: python (hint='pythonexpr')`, distinguishing "followed the hint to python" from "defaulted because no hint" | skipped until the account is in the pythonexpr-hint state |
| `TestRustUnavailableAndRecovery` | `rust`, adapter made unloadable | any | job FAILS with the adapter-not-available log line (no silent fallback); after switching `worker.toml` to python and restarting the service, a new job succeeds on python | yes |

Every scenario asserts both job outcome and the `Selected session runtime: <kind> (hint=...)` log line. Job success alone is not evidence: a broken config injection would leave the worker on its default runtime and a sleep job would still succeed.


#### What to change in this module as the rollout progresses

Each step is a small code change in this file, guarded so that forgetting it produces a loud failure rather than a silent one:

1. **When the service starts stamping `hint='pythonexpr'` for the test account:** remove the `@pytest.mark.skip` from `TestServiceSelectedWithPythonexprHint`, and retire `TestServiceSelectedDefaultsToPython` — its `(hint=None)` assertion no longer matches reality.
   *If this step is missed:* the defaults test goes permanently red on every e2e run from the moment the hint starts arriving — post-merge CI and the canary stay failing until someone acts. That is deliberate: the red run is the reminder. The cost of missing it is alarm noise and a masked signal (a real regression elsewhere in the suite is easier to overlook while a known-red test is normalized), not silently lost coverage.

2. **When the service starts stamping `hint='rust'`:** remove the `@pytest.mark.skip` from `TestServiceSelectedWithRustHint`; retire `TestServiceSelectedWithPythonexprHint` the same way if the pythonexpr state no longer applies. Also tighten `TestExplicitModeRouting`'s assertion from `Selected session runtime: <kind>` to the full `(hint=...)` form, converting the "explicit mode ignores the hint" known gap into a real proof.
   *If this step is missed:* the rollout's core scenario — service-selected workers actually routing to rust — completes without ever being proven end to end, and the two known gaps stay open permanently. Nothing turns red to force this one (the skip mark keeps the test silent), so it must be tracked in the rollout checklist rather than left to the suite to surface.

3. **When the rollout completes and a permanent runtime lane (or none) is decided:** delete the retired classes, their fixtures, and the module docstring's "Hint-dependent scenarios" section.
   *If this step is missed:* no coverage impact — only dead skip-marked code and stale docs misleading the next reader about what is actually tested.

Note: the service evaluates the hint gates per OS family, but the skip marks are per-class (both platforms). Remove a mark only once both platforms receive that hint, or the not-yet-allowlisted platform's run will fail on the hint assertion.


Three details worth calling out:

- **Fault injection removes `openjd/model/_v1`**, the one import the Rust adapter needs that nothing else does. It deliberately does *not* remove `openjd/_openjd_rs.*` or `openjd/expr`: `openjd.sessions`' own runner imports `openjd.expr`, which is a facade over the native extension, so removing those stops the agent from starting at all — a broken install rather than an unavailable adapter. The test comments record this so the narrower target is not "simplified" back later.
- **The injection resolves the package location by asking the worker's own interpreter** (`openjd.model.__file__` — `openjd` itself is a namespace package whose `__file__` is `None`) rather than hardcoding a site-packages glob, and asserts the target directory exists before removal and is gone after. A change in install layout fails loudly at the injection step with a message naming the problem, instead of surfacing later as a confusing job-outcome mismatch. The only path literal left is the Linux venv root, which is the same literal the fixtures' userdata uses to create that venv.
- **The rust scenarios submit plain sleep jobs, not WRAP_ACTIONS container sessions.** The ticket's container-session criterion is blocked on more than allowlisting: `openjd-model`'s PyO3 bindings currently mis-map `ModelExtension.from_str("WRAP_ACTIONS")` to `EXPR` (the binding enum is missing the `WRAP_ACTIONS` member and a catch-all silently substitutes `EXPR`), so a WRAP_ACTIONS job template cannot be faithfully exercised end to end. The binding bug needs to be fixed upstream first; the WRAP_ACTIONS job template is then an additive change to the rust-hint test.

### What is the impact of this change?

Test-only. The module is 4 passed / 2 skipped per platform, and the rest of the suite is untouched — `test/e2e/conftest.py` has no diff against mainline.

### How was this change tested?

Full e2e suite on real infrastructure, both platforms, at this commit:

- **Windows: 51 passed, 19 skipped, 0 failed** (2:33:10; the 8 xfailed are the pre-existing `test_domain_user.py` AD DS markers, whose setup exceeded 28 minutes on this run)
- **Linux: 52 passed, 25 skipped, 1 failed** (1:33:23). The single failure was `test_job_attachments.py::test_worker_job_attachments_output_only`, unrelated to this change — `conftest.py` is unchanged against mainline and this commit touches only the new module and the requirements floor. Re-run in isolation: **1 passed** (4:00), confirming a flake.
- After the full-suite runs, the fault-injection command was reworked (site-packages glob → interpreter-resolved path with pre/post assertions); the affected test, `TestRustUnavailableAndRecovery`, was then re-run in isolation on both platforms: **1 passed each** (Linux 6:02, Windows 8:13).

Collected item counts on both platforms account exactly for the new module, so nothing was silently dropped from collection.

This is also the first full e2e pass since the openjd pin bump landed on mainline (`openjd-model` 0.9 → 0.11.1, `openjd-sessions` → 0.10.11); none of that release's validation tightenings affected the suite.

Five real defects were caught during development and fixed:

1. A Windows worker deployed into a Linux-declared fleet never receives sessions — customer-managed fleets filter on the fleet's declared OS, not on what the worker reports.
2. A PowerShell `-replace` with a `^` anchor silently no-ops when the content is read with `-Raw`, since the anchor then matches only the start of the whole file.
3. The original fault injection deleted the native extension, which stopped the agent from starting rather than making the adapter unavailable (see above). The previous Windows pass on that test was a false green — its `-Include` pattern never matched.
4. The rust scenarios were gated on a variable declaring "the rust extension is published". It has in fact shipped in `openjd-model`'s platform wheels since 0.10.0, and mainline now pins `>= 0.11.1`, so the gate was removed and both rust scenarios run unconditionally.
5. The first interpreter-resolved injection read `openjd.__file__`, which is `None` because `openjd` is a namespace package. The new pre-removal assertion caught this on its first run in three minutes with an error naming the exact line — the same defect under the old silent-no-op style would have surfaced as an unexplained job success two phases later.

### Was this change documented?

The module docstring documents the runtime selection matrix, the two hint-dependent scenarios with their unlock conditions and the retirement coupling with the no-hint default test, and the log-line anchor the assertions depend on.

### Known gaps

Two of the ticket's acceptance criteria are not met here:

- **Container WRAP_ACTIONS session under a rust hint.** Blocked on two things in sequence: the upstream `openjd-model` PyO3 binding bug that silently maps `WRAP_ACTIONS` to `EXPR` (must be fixed first), and the account allowlisting. Once both hold, the WRAP_ACTIONS job template is an additive change to the rust-hint test.
- **"Explicit mode ignores the hint."** The explicit tests assert the selected runtime but not the hint that was offered, so in today's no-hint environment they prove "the configured runtime is honored" rather than "the hint is ignored". The scheduler logs both on one line, so this becomes a one-line assertion tightening once a hint arrives (step 2 of the rollout playbook).

Both are covered exhaustively at the unit level; what is missing is end-to-end proof over the real wire.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*