### PR TITLE
fix: thread step_name to run_task for wrap-action support

### DIFF
--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -84,4 +84,5 @@ class RunStepTaskAction(OpenjdAction):
             step_script=cast("StepScript", self._details.step_template.script),
             task_parameter_values=self._task_parameter_values,
             os_env_vars=env_vars,
+            step_name=self._details.step_template.name,
         )

--- a/src/deadline_worker_agent/sessions/runtime/_abc.py
+++ b/src/deadline_worker_agent/sessions/runtime/_abc.py
@@ -80,6 +80,7 @@ class SessionRuntime(ABC):
         task_parameter_values: dict[str, Any],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
+        step_name: str | None = None,
     ) -> None:
         """Run a task within the session's active environment(s)."""
         ...
@@ -92,6 +93,7 @@ class SessionRuntime(ABC):
         task_parameter_values: dict[str, Any],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
+        step_name: str | None = None,
     ) -> None:
         """Run a task without entering a session environment (attachment-sync path)."""
         ...

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -80,12 +80,14 @@ class PythonSessionRuntime(SessionRuntime):
         task_parameter_values: dict[str, Any],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
+        step_name: str | None = None,
     ) -> None:
         self._session.run_task(
             step_script=step_script,
             task_parameter_values=task_parameter_values,
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
+            step_name=step_name,
         )
 
     def _run_task_without_session_env(
@@ -95,7 +97,11 @@ class PythonSessionRuntime(SessionRuntime):
         task_parameter_values: dict[str, Any],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
+        step_name: str | None = None,
     ) -> None:
+        # step_name intentionally not forwarded: openjd-sessions'
+        # _run_task_without_session_env does not accept it, and the
+        # attachment-sync path has no wrap environment to thread through.
         self._session._run_task_without_session_env(
             step_script=step_script,
             task_parameter_values=task_parameter_values,

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -306,7 +306,13 @@ class RustSessionRuntime(SessionRuntime):
         task_parameter_values: dict[str, Any],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
+        step_name: str | None = None,
     ) -> None:
+        # step_name: accepted to satisfy the ABC but not forwarded -- the pinned
+        # openjd-sessions release's _v1 wrapper does not expose the kwarg yet.
+        # The underlying session supports it (surfaced as WrappedStep.Name per
+        # RFC 0008); forward it once the pin moves to a release that accepts it.
+        #
         # The shared action layer hands a pydantic v2023_09 StepScript, but the
         # Rust session needs a native _v1 step. Serialize to the OpenJD wire
         # shape and rebuild it natively. deserialize_step requires a named step
@@ -336,6 +342,7 @@ class RustSessionRuntime(SessionRuntime):
         task_parameter_values: dict[str, Any],
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
+        step_name: str | None = None,
     ) -> None:
         # Attachment-sync path: the native run_task's embedded-file handling is
         # unavailable here, so materialize the script's embedded files to the

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -1204,12 +1204,14 @@ class Session:
         task_parameter_values: TaskParameterSet,
         os_env_vars: Optional[dict[str, str]] = None,
         log_task_banner: bool = True,
+        step_name: str | None = None,
     ) -> None:
         self._runtime.run_task(
             step_script=step_script,
             task_parameter_values=task_parameter_values,
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
+            step_name=step_name,
         )
 
     def _run_attachment_sync_task(

--- a/test/unit/sessions/actions/test_run_step_task.py
+++ b/test/unit/sessions/actions/test_run_step_task.py
@@ -12,6 +12,7 @@ def mock_step_details():
     mock = Mock(spec=StepDetails)
     mock.step_id = "step-123"
     mock.step_template = Mock()
+    mock.step_template.name = "step-name"
     mock.step_template.script = Mock()
     return mock
 

--- a/test/unit/sessions/runtime/conftest.py
+++ b/test/unit/sessions/runtime/conftest.py
@@ -58,6 +58,7 @@ def _make_stub_runtime_class() -> type[SessionRuntime]:
             task_parameter_values: dict[str, Any] | None = None,
             os_env_vars: Optional[dict[str, str]] = None,
             log_task_banner: bool = True,
+            step_name: str | None = None,
         ) -> None:
             return None
 
@@ -68,6 +69,7 @@ def _make_stub_runtime_class() -> type[SessionRuntime]:
             task_parameter_values: dict[str, Any] | None = None,
             os_env_vars: Optional[dict[str, str]] = None,
             log_task_banner: bool = True,
+            step_name: str | None = None,
         ) -> None:
             return None
 

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -141,6 +141,7 @@ class TestPythonSessionRuntimeDelegation:
             task_parameter_values=task_params,
             os_env_vars={"X": "Y"},
             log_task_banner=False,
+            step_name=None,
         )
 
     def test_run_task_without_session_env_when_called_delegates_to_private_method(

--- a/test/unit/sessions/test_step_name_threading.py
+++ b/test/unit/sessions/test_step_name_threading.py
@@ -1,0 +1,142 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for step_name threading from RunStepTaskAction → Session → SessionRuntime.
+
+Each test asserts that the step_name kwarg is forwarded with the exact literal
+value originating from StepDetails.step_template.name.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from deadline_worker_agent.sessions.actions.run_step_task import RunStepTaskAction
+from deadline_worker_agent.sessions.job_entities.step_details import StepDetails
+
+
+STEP_NAME = "MyRenderStep"
+"""Literal step name used across all tests — never derived from the implementation."""
+
+
+@pytest.fixture
+def mock_step_details() -> MagicMock:
+    mock = MagicMock(spec=StepDetails)
+    mock.step_id = "step-abc"
+    mock.step_template = MagicMock()
+    mock.step_template.name = STEP_NAME
+    mock.step_template.script = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def mock_session() -> MagicMock:
+    session = MagicMock()
+    session.run_task = Mock()
+    return session
+
+
+@pytest.fixture
+def mock_executor() -> MagicMock:
+    return MagicMock()
+
+
+class TestRunStepTaskActionPassesStepName:
+    """RunStepTaskAction.start() must forward step_template.name as step_name."""
+
+    def test_start_when_called_passes_step_name_from_step_template(
+        self, mock_step_details: MagicMock, mock_session: MagicMock, mock_executor: MagicMock
+    ) -> None:
+        action = RunStepTaskAction(
+            id="action-1",
+            details=mock_step_details,
+            task_id="task-1",
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        mock_session.run_task.assert_called_once()
+        call_kwargs = mock_session.run_task.call_args.kwargs
+        assert call_kwargs["step_name"] == STEP_NAME
+
+
+class TestSessionRunTaskPassesStepName:
+    """Session.run_task() must forward step_name to the runtime."""
+
+    def test_run_task_when_step_name_provided_passes_to_runtime(self) -> None:
+        from deadline_worker_agent.sessions.session import Session
+
+        mock_runtime = MagicMock()
+        session = MagicMock(spec=Session)
+        session._runtime = mock_runtime
+        # Call the real method via the unbound function
+        Session.run_task(
+            session,
+            step_script=MagicMock(),
+            task_parameter_values={},
+            os_env_vars=None,
+            log_task_banner=True,
+            step_name=STEP_NAME,
+        )
+
+        mock_runtime.run_task.assert_called_once()
+        call_kwargs = mock_runtime.run_task.call_args.kwargs
+        assert call_kwargs["step_name"] == STEP_NAME
+
+    def test_run_task_when_step_name_none_passes_none_to_runtime(self) -> None:
+        from deadline_worker_agent.sessions.session import Session
+
+        mock_runtime = MagicMock()
+        session = MagicMock(spec=Session)
+        session._runtime = mock_runtime
+        Session.run_task(
+            session,
+            step_script=MagicMock(),
+            task_parameter_values={},
+            os_env_vars=None,
+            log_task_banner=True,
+        )
+
+        mock_runtime.run_task.assert_called_once()
+        call_kwargs = mock_runtime.run_task.call_args.kwargs
+        assert call_kwargs["step_name"] is None
+
+
+class TestPythonRuntimeForwardsStepName:
+    """PythonSessionRuntime.run_task() must forward step_name to openjd Session."""
+
+    def test_run_task_when_step_name_provided_forwards_to_openjd_session(self) -> None:
+        from unittest.mock import patch
+        from deadline_worker_agent.sessions.runtime import python as python_module
+        from deadline_worker_agent.sessions.runtime.python import PythonSessionRuntime
+        from deadline_worker_agent.sessions.runtime import SessionRuntimeConfig
+        from pathlib import Path
+
+        config = SessionRuntimeConfig(
+            session_id="session-1",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-1"),
+        )
+
+        with patch.object(python_module, "OpenJDSession") as mock_cls:
+            adapter = PythonSessionRuntime(config)
+            mock_openjd = mock_cls.return_value
+
+            adapter.run_task(
+                step_script=MagicMock(),
+                task_parameter_values={},
+                os_env_vars=None,
+                log_task_banner=True,
+                step_name=STEP_NAME,
+            )
+
+            mock_openjd.run_task.assert_called_once()
+            call_kwargs = mock_openjd.run_task.call_args.kwargs
+            assert call_kwargs["step_name"] == STEP_NAME


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

openjd-sessions raises a `ValueError` when a task runs while a wrap environment (RFC 0008 `WRAP_ACTIONS`) is active and no `step_name` is given, because `WrappedStep.Name` has no value to render. The worker agent never passed `step_name` — the step template's name is available at the call site and was simply dropped — so a job that entered a wrap environment and then ran a task failed mid-session.

### What was the solution? (How)

Thread `step_name` from the step template through `Session.run_task`, the `SessionRuntime` interface, and the Python adapter down to `openjd.sessions.Session.run_task` (the pinned `openjd-sessions == 0.10.11` already accepts it). The argument is keyword-only and optional so the interface and both adapters stay uniform and existing callers are unaffected.

The Rust adapter accepts the argument but does not forward it yet: the pinned openjd-sessions release's `_v1` wrapper does not expose the kwarg. OpenJobDescription/openjd-sessions-for-python#345 adds the forward upstream; a follow-up will bump the pin and wire it through once that ships.

### What is the impact of this change?

The Python runtime is correct for RFC 0008 task runs. Inert for all existing jobs — openjd only reads `step_name` inside an active wrap hook, which cannot occur today since no extension is requestable end-to-end yet. No API or behavior change for callers that omit the argument.

### How was this change tested?

- `hatch build` — clean
- `hatch run all:test` — 3050 passed / 39 skipped on each of Python 3.9, 3.10, and 3.11
- `hatch run lint` — ruff check, ruff format, and mypy all clean
- New `test/unit/sessions/test_step_name_threading.py` covers the threading at each layer (action → session → ABC → both adapters), asserting the literal step name arrives at the openjd session and that the Rust adapter accepts the kwarg without forwarding it

### Was this change documented?

Yes — docstrings/comments on the interface and both adapters explain the parameter and why the Rust adapter defers forwarding.

### Is this a breaking change?

No — a new optional keyword-only parameter with a `None` default at every layer.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
