### PR TITLE
fix: forward step_name on the Rust runtime and add e2e test-rust script

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -129,6 +129,14 @@ source .e2e_windows_infra.sh
 hatch run e2e:test
 ```
 
+To run the entire e2e suite pinned to the Rust session runtime:
+```
+hatch run e2e:test-rust
+```
+
+The `--session-runtime` pytest option (and `WORKER_AGENT_SESSION_RUNTIME` env var) also accept
+`python` and `service-selected` for other runtime configurations.
+
 You can also override the `openjd-sessions` and/or `deadline-cloud` packages installed on the worker
 by pointing to local wheel files. This is useful when testing against unreleased or locally-built versions.
 Both variables accept a path (glob patterns are supported, but must resolve to exactly one file).

--- a/hatch.toml
+++ b/hatch.toml
@@ -51,6 +51,12 @@ test = [
   "pytest --no-cov -rfExX test/e2e {args:}",
   "echo pytest done",
 ]
+test-rust = [
+  "sync",
+  "python test/e2e/pre_test_cleanup.py",
+  "pytest --no-cov -rfExX test/e2e --session-runtime=rust {args:}",
+  "echo pytest done",
+]
 typing = "mypy --config-file test/e2e/mypy.ini {args:test/e2e}"
 style = [
   "ruff check {args:test/e2e}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline-job-attachments == 0.1.3",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.10.11",
+    "openjd-sessions == 0.10.13",
     "openjd-model >= 0.11.1, < 0.12",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -308,10 +308,8 @@ class RustSessionRuntime(SessionRuntime):
         log_task_banner: bool = True,
         step_name: str | None = None,
     ) -> None:
-        # step_name: accepted to satisfy the ABC but not forwarded -- the pinned
-        # openjd-sessions release's _v1 wrapper does not expose the kwarg yet.
-        # The underlying session supports it (surfaced as WrappedStep.Name per
-        # RFC 0008); forward it once the pin moves to a release that accepts it.
+        # step_name: forwarded to the _v1 session so RFC 0008's WrappedStep.Name
+        # resolves correctly inside onWrapTaskRun hooks.
         #
         # The shared action layer hands a pydantic v2023_09 StepScript, but the
         # Rust session needs a native _v1 step. Serialize to the OpenJD wire
@@ -323,7 +321,7 @@ class RustSessionRuntime(SessionRuntime):
         # explicit nulls (OpenJD treats absent and null as equivalent).
         native_step_script = deserialize_step(
             {
-                "name": "Placeholder",
+                "name": step_name or "Placeholder",
                 "script": step_script.model_dump(mode="json", by_alias=True, exclude_none=True),
             }
         ).script
@@ -332,6 +330,7 @@ class RustSessionRuntime(SessionRuntime):
             task_parameter_values=_to_rust_task_parameter_values(task_parameter_values),
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
+            step_name=step_name,
         )
 
     @convert_runtime_crashes

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -10,7 +10,7 @@ from collections.abc import Generator
 from configparser import ConfigParser
 from contextlib import contextmanager
 from dataclasses import InitVar, dataclass, field
-from typing import Callable, Type
+from typing import Callable, Optional, Type
 
 import backoff
 import boto3
@@ -40,6 +40,39 @@ from deadline_test_fixtures import (
 LOG = logging.getLogger(__name__)
 
 pytest_plugins = ["deadline_test_fixtures.pytest_hooks"]
+
+_VALID_SESSION_RUNTIMES = ("python", "rust", "service-selected")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--session-runtime",
+        choices=_VALID_SESSION_RUNTIMES,
+        default=None,
+        help=(
+            "Pin the session_runtime worker config setting for every worker in the run. "
+            "Accepts: python, rust, service-selected. "
+            "Falls back to the WORKER_AGENT_SESSION_RUNTIME env var when not given."
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
+def session_runtime_option(request: pytest.FixtureRequest) -> Optional[str]:
+    """Resolve the session runtime from the CLI option or environment variable.
+
+    CLI option takes precedence over the environment variable.
+    Returns None when neither is set (agent default behaviour).
+    """
+    value: Optional[str] = request.config.getoption("--session-runtime")
+    if value is None:
+        value = os.environ.get("WORKER_AGENT_SESSION_RUNTIME")
+        if value is not None and value not in _VALID_SESSION_RUNTIMES:
+            raise pytest.UsageError(
+                f"WORKER_AGENT_SESSION_RUNTIME={value!r} is invalid. "
+                f"Valid choices: {', '.join(_VALID_SESSION_RUNTIMES)}"
+            )
+    return value
 
 
 @dataclass(frozen=True)
@@ -251,6 +284,7 @@ def worker_config(
     posix_config_override_job_user: PosixSessionUser,
     worker_config: DeadlineWorkerConfiguration,
     windows_job_users: list[str],
+    session_runtime_option: Optional[str],
 ) -> DeadlineWorkerConfiguration:
     """
     Builds the configuration for a DeadlineWorker.
@@ -265,6 +299,8 @@ def worker_config(
             If WORKER_AGENT_WHL_PATH is provided, this option is ignored.
         LOCAL_MODEL_PATH: Path to a local Deadline model file to use for API calls.
             If DEADLINE_SERVICE_MODEL_S3_URI was provided, this option is ignored.
+        WORKER_AGENT_SESSION_RUNTIME: Pin the session_runtime worker config setting.
+            Accepts: python, rust, service-selected. Overridden by --session-runtime CLI option.
 
     Returns:
         DeadlineWorkerConfiguration: Configuration for use by DeadlineWorker.
@@ -280,6 +316,7 @@ def worker_config(
         windows_job_users=windows_job_users,
         # TODO: Temporary workaround due to AWS CLI v2 upgrade causing canary failures when copying over AWS models for deadline
         service_model_path=None,
+        session_runtime=session_runtime_option,
     )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Rust runtime accepted `step_name` but did not forward it to the `_v1` session wrapper (the pinned openjd-sessions release lacked the kwarg). Additionally, `{{ Task.File.* }}` references in `command` were not resolved in the attachment-sync stopgap path, and there was no way to run the full e2e suite pinned to the Rust runtime.

### What was the solution? (How)

1. Bump `openjd-sessions` pin from `== 0.10.11` to `== 0.10.13` (carries OpenJobDescription/openjd-sessions-for-python#345).
2. Forward `step_name` to `self._session.run_task(...)` in `rust.py` and use the real step name in `deserialize_step` instead of `"Placeholder"`.
3. Apply `{{ Task.File.* }}` regex substitution to `command` (same regex already used for `args`).
4. Add `hatch run e2e:test-rust` script and a `--session-runtime` pytest option (`WORKER_AGENT_SESSION_RUNTIME` env var fallback) so the full suite can run pinned to any runtime.

### What is the impact of this change?

The Rust session runtime now resolves `WrappedStep.Name` correctly for RFC 0008. The `Task.File` command fix closes a latent gap in the attachment-sync stopgap. The e2e script gives developers a one-command way to validate the Rust runtime.

### How was this change tested?


#### E2E run summary

- started: 2026-08-05T23:59:10Z
- commit: 5190130 fix: thread step_name to run_task for wrap-action support
- wheel: dist/deadline_cloud_worker_agent-0.30.2.post1.dev22-py3-none-any.whl

| run | attempt | exit | pytest summary |
|-----|---------|------|----------------|
| linux-python | 1 | 0 | ================= 53 passed, 25 skipped in 5393.90s (1:29:53) ================== |
| linux-rust | 1 | 0 | ================= 53 passed, 25 skipped in 5468.02s (1:31:08) ================== |
| windows-python | 1 | 0 | ====== 51 passed, 19 skipped, 8 xfailed, 3 warnings in 9228.77s (2:33:48) ====== |
| windows-rust | 1 | 0 | = 51 passed, 19 skipped, 3 xfailed, 5 xpassed, 4 warnings in 9871.06s (2:44:31) = |

- finished: 2026-08-06T08:12:33Z


- Unit tests: 98 passed against a local openjd-sessions wheel carrying #345
- Ruff check + format clean
- E2E (overnight 2026-08-05): full matrix (linux-python, linux-rust, windows-python, windows-rust) all green — 53/53 Linux, 51/51 Windows per run
- CI will fail on the pin until openjd-sessions 0.10.13 publishes to PyPI

### Was this change documented?

Yes — DEVELOPMENT.md updated with the new e2e invocations.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*