### PR TITLE
docs: add e2e-overnight-run skill for full runtime x OS validation

### DIFF
--- a/skills/e2e-overnight-run/SKILL.md
+++ b/skills/e2e-overnight-run/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: e2e-overnight-run
+description: Run the full worker-agent E2E suite across all four runtime x OS variants (Linux/Windows x Python/Rust session runtimes) unattended against the live Deadline Cloud service. Builds the wheel under test, rebuilds the e2e env, and supervises sequential runs in tmux with automatic retry and a results summary. Use when validating a release candidate, a session-runtime change, or a dependency bump before shipping.
+tags: [deadline-cloud, worker-agent, e2e, session-runtime, rust, python, linux, windows, overnight, release-validation, tmux, hatch, pytest]
+---
+
+# Comprehensive Worker Agent E2E Overnight Run
+
+Run `test/e2e` across all four combinations — **Linux + Python**,
+**Linux + Rust**, **Windows + Python**, **Windows + Rust** — in one unattended,
+tmux-backed, retrying sequence. Built for release validation: kick it off, come
+back later, read one summary table.
+
+The worker agent's `session_runtime` setting selects the OpenJD session backend
+(`python` = v0, `rust` = v1). E2E only pins the runtime on a fresh worker
+config, so validating both backends means running the suite twice per OS. This
+skill automates that matrix. It builds on the E2E setup documented in the
+`worker-agent-testing` skill and `DEVELOPMENT.md`.
+
+## When to use
+
+- Validating a **release candidate** before shipping.
+- A change to the **session runtime** (adapter code, runtime selection, the
+  service `runtimeHint` path) or an **openjd-sessions / openjd-model pin bump**.
+- Any change where "does the agent still run real jobs on both runtimes, on
+  both OSes?" is the question.
+
+For a scoped change (Rust-only), run just the two rust variants — see
+`--variants`.
+
+## Runtime selection reference
+
+| Item | Value |
+|------|-------|
+| Config field | `session_runtime` = `python` \| `rust` \| `service-selected` (config-file / CLI only — no environment variable) |
+| Test-fixtures field | `DeadlineWorkerConfiguration.session_runtime` (recent `deadline-cloud-test-fixtures`) |
+| Hatch scripts | `e2e:test` (agent default = python), `e2e:test-rust` (whole suite pinned to rust) |
+| Runtime selector | `--session-runtime {python,rust,service-selected}` pytest option / `WORKER_AGENT_SESSION_RUNTIME` env var |
+| Canonical runtime proof | worker log line `Selected session runtime: <rt> (hint=...)` |
+
+## Prerequisites
+
+1. **A worker-agent git worktree** with the code under test checked out (or
+   cherry-picked in). The wheel is built from here — test mainline from a
+   mainline checkout, or a PR branch by checking it out first.
+2. **AWS credentials** for your e2e account, valid long enough for the whole
+   run (~6–8h for all four variants). Configure them however you normally do
+   (`AWS_PROFILE` + `AWS_DEFAULT_REGION`, SSO, etc.).
+3. **Testing infrastructure deployed** and the per-OS infra env-var scripts
+   present in the worktree root. See the E2E prerequisites in the
+   `worker-agent-testing` skill / `DEVELOPMENT.md`:
+   ```sh
+   scripts/deploy_e2e_testing_infrastructure.sh
+   ./scripts/get_e2e_test_ids_from_cfn.sh --os Linux   > .e2e_linux_infra.sh
+   ./scripts/get_e2e_test_ids_from_cfn.sh --os Windows > .e2e_windows_infra.sh
+   ```
+4. `tmux`, `hatch`, `git`, `aws` on PATH.
+
+## Run it
+
+```sh
+# All four variants, unattended:
+skills/e2e-overnight-run/scripts/overnight_e2e.sh --repo /path/to/worktree
+
+# Rust-only re-validation after a Rust-path change:
+overnight_e2e.sh --repo /path/to/worktree --variants "linux-rust windows-rust"
+```
+
+The script, in order:
+
+1. Validates every prerequisite (worktree, credentials, infra scripts, tools)
+   and **aborts before provisioning anything** if one is missing.
+2. `hatch build` → exports `WORKER_AGENT_WHL_PATH` to the built wheel.
+3. Rebuilds the `e2e` hatch env so it resolves the pinned test dependencies.
+4. **Verifies `DeadlineWorkerConfiguration` exposes `session_runtime`** — the
+   most common stale-environment failure.
+5. Launches a detached tmux supervisor that runs each variant sequentially,
+   retrying once on failure.
+
+Everything lands in `<repo>/.e2e-overnight/`:
+
+| File | Meaning |
+|------|---------|
+| `<variant>.log` | full pytest output |
+| `<variant>.exit` | exit code (`0` = all passed) |
+| `<variant>-retry.log` | retry attempt, if the first failed |
+| `SUMMARY.md` | one row per attempt with the pytest banner |
+| `SUPERVISOR_DONE` | present once every variant has finished |
+
+## Read the results
+
+```sh
+cat <repo>/.e2e-overnight/SUMMARY.md
+```
+
+- **Exit 0** on a variant = all tests passed on that runtime + OS.
+- **Red on attempt 1, green on retry** = infrastructure flake (EC2 capacity,
+  SSM timeout, bootstrap race), not a code failure.
+- **Red on both** = real failure. Read `<variant>.log`; search for `^FAILED ` /
+  `^ERROR ` lines (not the substring `CREATE_FAILED`, which is benign
+  pre-test-cleanup noise).
+
+Wall time is roughly 6–8h for all four (Linux ~1.5h each, Windows ~2.5h each).
+
+## Verifying a run was genuine (not a silent fallback)
+
+Two traps make a green run meaningless — check both when it matters:
+
+1. **Wrong wheel.** If `WORKER_AGENT_WHL_PATH` is unset, the harness installs
+   the published package instead of your build. `overnight_e2e.sh` always sets
+   it; confirm via the `wheel:` line at the top of each `<variant>.log`.
+2. **Runtime actually used.** The rust variants use `e2e:test-rust` (recorded
+   as the `script:` line in the log). To prove a session used rust, grep the
+   worker's own log line `Selected session runtime: rust`. The
+   `test/e2e/test_session_runtime.py` routing tests assert exactly this, and a
+   negative control (an invalid `session_runtime` value making the worker fail
+   to start) is how the injection path is validated.
+
+## Gotchas
+
+- **Stale e2e env.** A previously built `e2e` env can pin an old
+  `deadline-cloud-test-fixtures` without the `session_runtime` field, so the
+  runtime-routing tests die on a config-injection error. The script rebuilds
+  the env by default; use `--keep-env` only when you know it is current.
+- **Missing binary wheels on older hosts.** If the env build fails compiling a
+  test-only transitive dependency from source, pass a pip constraints file via
+  `--constraints` (see `scripts/e2e-constraints.txt.example`).
+- **Parametrize labels are not the OS.** A test id like
+  `test_...path_mapping[windows]` in the Linux suite is a *parameter label* (a
+  Windows-style storage profile exercised on the Linux worker), not a Windows
+  worker. Real Windows-only tests appear as `SKIPPED` in Linux runs.
+- **Windows `xpassed`/`xfailed`.** Some Windows-only tests are marked
+  `xfail(strict=False)` for known-unreliable environment setup and may xfail or
+  xpass run-to-run without affecting the exit code.
+- **Credential lifetime.** The supervisor cannot refresh credentials; ensure
+  they cover the full run before launching.
+
+## Scripts
+
+| Script | Role |
+|--------|------|
+| `scripts/overnight_e2e.sh` | Entry point — validate, build, prep env, launch supervisor. |
+| `scripts/_supervise.sh` | Internal — sequential runs, retry, `SUMMARY.md`. |
+| `scripts/e2e-constraints.txt.example` | Template for the optional `--constraints` file. |

--- a/skills/e2e-overnight-run/scripts/_supervise.sh
+++ b/skills/e2e-overnight-run/scripts/_supervise.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# _supervise.sh — internal helper for overnight_e2e.sh. Runs each requested
+# variant to completion, one at a time (never two farms' workers concurrently),
+# retrying once on failure, and records a results table in SUMMARY.md.
+#
+# Expects these from the caller's environment:
+#   REPO                   worker-agent worktree
+#   REGION                 AWS region
+#   VARIANTS               space-separated variant list
+#   WORKER_AGENT_WHL_PATH  wheel under test
+#   PIP_CONSTRAINT         (optional) pip constraints file
+#
+# Not meant to be invoked directly — run overnight_e2e.sh instead.
+set -uo pipefail
+
+OUTDIR="$REPO/.e2e-overnight"
+SUMMARY="$OUTDIR/SUMMARY.md"
+
+export AWS_DEFAULT_REGION="$REGION"
+export WORKER_AGENT_WHL_PATH
+[[ -n "${PIP_CONSTRAINT:-}" ]] && export PIP_CONSTRAINT
+
+cd "$REPO"
+
+variant_infra()  { case "$1" in linux-*) echo ".e2e_linux_infra.sh";; windows-*) echo ".e2e_windows_infra.sh";; esac; }
+variant_script() { case "$1" in *-python) echo "test";; *-rust) echo "test-rust";; esac; }
+
+pytest_banner() {
+    grep -aoE '=+ [0-9]+ (passed|failed)[^=]*=+' "$1" 2>/dev/null | tail -1 \
+        || echo "(no pytest summary — run did not reach a verdict)"
+}
+
+{
+    echo "# Worker Agent E2E — overnight run summary"
+    echo
+    echo "- started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "- repo: $REPO"
+    echo "- commit: $(git log --oneline -1)"
+    echo "- wheel: $WORKER_AGENT_WHL_PATH"
+    echo "- region: $REGION"
+    echo
+    echo "| variant | attempt | exit | pytest summary |"
+    echo "|---------|---------|------|----------------|"
+} > "$SUMMARY"
+
+run_one() {
+    local tag="$1" infra="$2" script="$3" log="$OUTDIR/${1}.log"
+    {
+        echo "=== $tag ==="
+        echo "started:  $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "infra:    $infra"
+        echo "script:   hatch run e2e:$script"
+        echo "wheel:    $WORKER_AGENT_WHL_PATH"
+        echo "identity: $(aws sts get-caller-identity --query Arn --output text 2>&1)"
+        echo "==============================="
+    } > "$log"
+    # shellcheck disable=SC1090
+    ( source "$REPO/$infra"; echo "OPERATING_SYSTEM=${OPERATING_SYSTEM:-?} FARM_ID=${FARM_ID:-?}" >> "$log"; \
+      hatch run "e2e:$script" >> "$log" 2>&1 )
+    local rc=$?
+    { echo "==============================="; echo "finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)"; echo "EXIT=$rc"; } >> "$log"
+    return $rc
+}
+
+for tag in $VARIANTS; do
+    infra="$(variant_infra "$tag")"
+    script="$(variant_script "$tag")"
+
+    echo "[supervisor] starting $tag ($(date -u +%H:%MZ))"
+    run_one "$tag" "$infra" "$script"; rc=$?
+    echo "$rc" > "$OUTDIR/${tag}.exit"
+    echo "| $tag | 1 | $rc | $(pytest_banner "$OUTDIR/${tag}.log") |" >> "$SUMMARY"
+
+    # One automatic retry. Most non-zero exits here are transient infra flakes
+    # (EC2 capacity, SSM timeouts, bootstrap races); pre_test_cleanup runs at
+    # the start of every attempt. Keep both logs so a real failure (both red)
+    # is distinguishable from a flake (retry green).
+    if [[ "$rc" != "0" ]]; then
+        echo "[supervisor] $tag failed (exit=$rc); retrying once"
+        run_one "${tag}-retry" "$infra" "$script"; rrc=$?
+        echo "$rrc" > "$OUTDIR/${tag}-retry.exit"
+        echo "| $tag | 2 (retry) | $rrc | $(pytest_banner "$OUTDIR/${tag}-retry.log") |" >> "$SUMMARY"
+    fi
+done
+
+{
+    echo
+    echo "- finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo
+    echo "Exit 0 = all tests passed. Non-zero = pytest reported failures or the"
+    echo "run could not start; read the matching .log. A variant that is red on"
+    echo "attempt 1 but green on retry was an infrastructure flake, not a"
+    echo "code failure."
+} >> "$SUMMARY"
+
+touch "$OUTDIR/SUPERVISOR_DONE"
+echo "[supervisor] ALL RUNS COMPLETE — see $SUMMARY"

--- a/skills/e2e-overnight-run/scripts/e2e-constraints.txt.example
+++ b/skills/e2e-overnight-run/scripts/e2e-constraints.txt.example
@@ -1,0 +1,13 @@
+# Optional pip constraints for the e2e env, passed via
+#   overnight_e2e.sh --constraints scripts/e2e-constraints.txt.example
+#
+# Only needed on hosts where a test-only transitive dependency (pulled in by
+# deadline-cloud-test-fixtures) has no compatible pre-built wheel and fails to
+# build from source — for example an older Linux whose glibc predates the
+# manylinux target of a recent pillow/numpy release. On such a host, pin those
+# dependencies below their first incompatible version. CI runners on current
+# base images do not need this file.
+#
+# Example (adjust versions to the packages that fail on your host):
+# pillow < 12.3
+# numpy < 2.3

--- a/skills/e2e-overnight-run/scripts/overnight_e2e.sh
+++ b/skills/e2e-overnight-run/scripts/overnight_e2e.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# overnight_e2e.sh — one-command, unattended worker-agent E2E across all four
+# runtime x OS variants (linux-python, linux-rust, windows-python,
+# windows-rust).
+#
+# It validates every prerequisite up front (fail loud, never silently test the
+# wrong thing), builds the wheel under test, rebuilds the e2e hatch env, then
+# launches a detached tmux supervisor that runs each variant to completion with
+# a single automatic retry on failure.
+#
+# USAGE
+#   overnight_e2e.sh --repo /path/to/worktree [options]
+#
+# OPTIONS
+#   --repo DIR         Worker-agent git worktree to test (REQUIRED). The wheel
+#                      is built from HERE, so check out / cherry-pick the code
+#                      under test into it first.
+#   --variants "..."   Space-separated subset of:
+#                        linux-python linux-rust windows-python windows-rust
+#                      Default: all four.
+#   --region REGION    AWS region (default: from AWS_DEFAULT_REGION, else
+#                      us-west-2).
+#   --constraints FILE Optional pip constraints file (exported as PIP_CONSTRAINT
+#                      for the env build). Use on hosts where a test-only
+#                      transitive dependency has no compatible binary wheel.
+#   --keep-env         Do not remove/rebuild the e2e hatch env. Faster, but
+#                      risks a stale deadline-cloud-test-fixtures without the
+#                      session_runtime field.
+#   --session TMUX     tmux session name (default: e2e).
+#   -h | --help        Show this help.
+#
+# PREREQUISITES (checked; the script aborts if any are missing)
+#   * Run from inside a git worktree of deadline-cloud-worker-agent.
+#   * Valid AWS credentials for your e2e account (aws sts get-caller-identity).
+#   * .e2e_linux_infra.sh and/or .e2e_windows_infra.sh present in --repo.
+#     Generate them once per account (see the E2E prerequisites in the skill
+#     README / DEVELOPMENT.md):
+#       ./scripts/get_e2e_test_ids_from_cfn.sh --os Linux   > .e2e_linux_infra.sh
+#       ./scripts/get_e2e_test_ids_from_cfn.sh --os Windows > .e2e_windows_infra.sh
+#   * tmux, hatch, git, aws on PATH.
+#
+# OUTPUT (under <repo>/.e2e-overnight/)
+#   <variant>.log         full pytest output for the first attempt
+#   <variant>.exit        exit code sentinel (0 = all passed)
+#   <variant>-retry.log   retry attempt, if the first failed
+#   SUMMARY.md            one table row per attempt with the pytest banner
+#   SUPERVISOR_DONE       created when every variant has finished
+#
+# MONITOR
+#   tmux attach -t e2e
+#   tail -f <repo>/.e2e-overnight/<variant>.log
+#   cat <repo>/.e2e-overnight/SUMMARY.md
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REPO=""
+VARIANTS="linux-python linux-rust windows-python windows-rust"
+REGION="${AWS_DEFAULT_REGION:-us-west-2}"
+CONSTRAINTS_SRC=""
+KEEP_ENV=0
+TMUX_SESSION="e2e"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)        REPO="$2"; shift 2;;
+        --variants)    VARIANTS="$2"; shift 2;;
+        --region)      REGION="$2"; shift 2;;
+        --constraints) CONSTRAINTS_SRC="$2"; shift 2;;
+        --keep-env)    KEEP_ENV=1; shift;;
+        --session)     TMUX_SESSION="$2"; shift 2;;
+        -h|--help)     grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+        *) die "unknown argument: $1";;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validate prerequisites — fail loud before spending hours on EC2.
+# ---------------------------------------------------------------------------
+[[ -n "$REPO" ]] || die "--repo is required"
+REPO="$(cd "$REPO" 2>/dev/null && pwd)" || die "--repo path does not exist"
+cd "$REPO"
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || die "$REPO is not a git worktree"
+
+for tool in tmux hatch git aws; do
+    command -v "$tool" >/dev/null 2>&1 || die "$tool not found on PATH"
+done
+
+export AWS_DEFAULT_REGION="$REGION"
+aws sts get-caller-identity >/dev/null 2>&1 \
+    || die "no valid AWS credentials for region $REGION (configure them first)"
+
+needs_linux=0; needs_windows=0
+for v in $VARIANTS; do
+    case "$v" in
+        linux-*)   needs_linux=1;;
+        windows-*) needs_windows=1;;
+        *) die "unknown variant '$v' (want: linux-python linux-rust windows-python windows-rust)";;
+    esac
+done
+[[ $needs_linux -eq 1   && ! -f "$REPO/.e2e_linux_infra.sh"   ]] && die "missing $REPO/.e2e_linux_infra.sh"
+[[ $needs_windows -eq 1 && ! -f "$REPO/.e2e_windows_infra.sh" ]] && die "missing $REPO/.e2e_windows_infra.sh"
+
+OUTDIR="$REPO/.e2e-overnight"
+mkdir -p "$OUTDIR"
+
+CONSTRAINTS=""
+if [[ -n "$CONSTRAINTS_SRC" ]]; then
+    [[ -f "$CONSTRAINTS_SRC" ]] || die "--constraints file not found: $CONSTRAINTS_SRC"
+    CONSTRAINTS="$OUTDIR/constraints.txt"
+    cp "$CONSTRAINTS_SRC" "$CONSTRAINTS"
+    export PIP_CONSTRAINT="$CONSTRAINTS"
+fi
+
+echo "==> Building the wheel under test from $REPO"
+rm -f dist/*
+hatch build >/dev/null
+WHL="$(ls "$REPO"/dist/*.whl | head -1)"
+[[ -f "$WHL" ]] || die "wheel build produced no .whl"
+export WORKER_AGENT_WHL_PATH="$WHL"
+echo "    wheel: $WHL"
+echo "    commit: $(git log --oneline -1)"
+
+if [[ $KEEP_ENV -eq 0 ]]; then
+    echo "==> Rebuilding the e2e hatch env (avoids a stale test-fixtures pin)"
+    hatch env remove e2e >/dev/null 2>&1 || true
+    hatch run e2e:sync >/dev/null 2>&1 \
+        || die "e2e env sync failed (see requirements-e2e.txt; a --constraints file may be needed on this host)"
+fi
+
+# The single most valuable guard: the fixtures library MUST expose the
+# session_runtime field or the runtime-routing tests fail on a config-injection
+# error rather than a real signal.
+echo "==> Verifying deadline-cloud-test-fixtures exposes session_runtime"
+hatch run e2e:python - <<'PY' || die "test-fixtures lacks session_runtime; recreate the env or bump requirements-e2e.txt"
+import dataclasses, sys
+from deadline_test_fixtures import DeadlineWorkerConfiguration as C
+sys.exit(0 if "session_runtime" in {f.name for f in dataclasses.fields(C)} else 1)
+PY
+
+# ---------------------------------------------------------------------------
+# Launch the supervisor in a detached tmux session.
+# ---------------------------------------------------------------------------
+rm -f "$OUTDIR/SUPERVISOR_DONE"
+# env -u TMUX so this works whether or not you are already inside tmux.
+env -u TMUX tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+env -u TMUX tmux new-session -d -s "$TMUX_SESSION" -x 220 -y 50
+env -u TMUX tmux send-keys -t "$TMUX_SESSION" \
+    "REPO='$REPO' REGION='$REGION' VARIANTS='$VARIANTS' PIP_CONSTRAINT='${CONSTRAINTS}' WORKER_AGENT_WHL_PATH='$WHL' bash '$SCRIPT_DIR/_supervise.sh' 2>&1 | tee '$OUTDIR/supervisor.log'" \
+    C-m
+
+echo
+echo "==> Launched. All requested variants will run unattended in tmux session '$TMUX_SESSION'."
+echo "    Monitor : tmux attach -t $TMUX_SESSION"
+echo "    Results : cat $OUTDIR/SUMMARY.md"
+echo "    Done when: $OUTDIR/SUPERVISOR_DONE exists"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Validating a worker-agent release candidate means running the E2E suite across all four runtime x OS combinations (Linux/Windows x Python/Rust session runtimes). Done by hand this is four long, error-prone runs with several easy-to-miss traps (wrong wheel silently tested, stale test-fixtures env, distinguishing infra flakes from real failures).

### What was the solution? (How)

Add an `e2e-overnight-run` skill under `skills/`:
- `overnight_e2e.sh` — single entry point. Validates prerequisites (worktree, credentials, infra scripts, tools) and aborts before provisioning if any are missing; builds the wheel under test and exports `WORKER_AGENT_WHL_PATH`; rebuilds the e2e env; verifies the test-fixtures expose `session_runtime`; launches a detached tmux supervisor.
- `_supervise.sh` — runs each variant sequentially (never two farms concurrently), retries once on failure, writes a `SUMMARY.md` results table with per-attempt pytest banners.
- `e2e-constraints.txt.example` — template for the optional `--constraints` file on hosts lacking a pre-built wheel for a test dependency.

Complements the existing `worker-agent-testing` skill (which documents the one-off E2E setup) by automating the full validation matrix.

### What is the impact of this change?

Docs/tooling only. No product code touched. Gives a repeatable, one-command way to validate both session runtimes on both OSes.

### How was this change tested?

- `bash -n` on both scripts; `--help` and fail-loud prerequisite validation exercised manually.
- The workflow it encodes was used to run the full four-variant matrix during session-runtime release validation.

### Was this change documented?

Yes — the skill's `SKILL.md` is the runbook.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*