### PR TITLE
fix(scheduler): handle start-time mismatch ValidationException gracefully

### DIFF
--- a/src/deadline_worker_agent/scheduler/scheduler.py
+++ b/src/deadline_worker_agent/scheduler/scheduler.py
@@ -61,6 +61,7 @@ from ..aws.deadline import (
     DeadlineRequestUnrecoverableError,
     update_worker_schedule,
 )
+from botocore.exceptions import ClientError as BotocoreClientError
 from ..config import JobsRunAsUserOverride
 from ..utils import MappingWithCallbacks
 from ..file_system_operations import FileSystemPermissionEnum, make_directory, touch_file
@@ -465,8 +466,34 @@ class WorkerScheduler:
 
         # Raises: DeadlineRequestInterrupted, DeadlineRequestWorkerNotFoundError,
         # DeadlineRequestWorkerOfflineError, and DeadlineRequestUnrecoverableError
-        #  - Let these go to the caller
-        response = update_worker_schedule(**request)
+        #  - Let these go to the caller, EXCEPT ValidationException for start-time
+        #    mismatch which is a stale-update issue that should not be fatal.
+        try:
+            response = update_worker_schedule(**request)
+        except DeadlineRequestUnrecoverableError as e:
+            inner = e.inner_exc
+            if (
+                isinstance(inner, BotocoreClientError)
+                and inner.response.get("Error", {}).get("Code") == "ValidationException"
+                and "different from the original start time"
+                # NOTE: This is message-parsing. If the service changes its error wording,
+                # this condition may need updating.
+                in inner.response.get("Error", {}).get("Message", "").lower()
+            ):
+                # The service rejected the batch because an action's startedAt doesn't match
+                # what it already recorded. This happens when fast-completing actions report
+                # their start time after the service already inferred/recorded it from a
+                # previous heartbeat. The actions already completed successfully on the worker;
+                # the service considers them inactive (done). Commit to clear the stale entries
+                # from the map and prevent a death spiral (re-sending the same rejected update).
+                logger.warning(
+                    f"UpdateWorkerSchedule rejected with start-time mismatch "
+                    f"(actions likely completed faster than heartbeat interval): {inner}. "
+                    f"Dropping stale action updates to recover."
+                )
+                commit_completed_actions()
+                return 1  # Re-sync immediately with fresh state
+            raise
 
         commit_completed_actions()
 

--- a/test/unit/scheduler/test_scheduler.py
+++ b/test/unit/scheduler/test_scheduler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Generator, Optional
 from unittest.mock import ANY, MagicMock, Mock, call, patch
@@ -739,6 +739,117 @@ class TestSchedulerSync:
             "outputManifestPath": "s3://bucket/path/to/manifest3",
             "outputManifestHash": "hash3",
         }
+
+    def test_validation_exception_start_time_mismatch_recovers(
+        self,
+        scheduler: WorkerScheduler,
+        mock_update_worker_schedule: MagicMock,
+    ) -> None:
+        """Tests that when the service rejects UpdateWorkerSchedule with a
+        ValidationException about a start-time mismatch (common with fast-completing
+        actions), the scheduler does NOT crash. Instead, it logs a warning, clears the
+        stale action updates from the map, and returns a short re-sync interval.
+
+        This prevents the death spiral where the same rejected startedAt gets re-sent
+        on every heartbeat until the agent terminates.
+        """
+        # GIVEN - an action update with start_time in the map
+        action_id = "sessionaction-3f833c25c12240fbbaeafea88c71b87a-2"
+        start_time = datetime(2026, 6, 26, 15, 22, 54, 733000, tzinfo=timezone.utc)
+        scheduler._action_updates_map = {
+            action_id: SessionActionStatus(
+                id=action_id,
+                start_time=start_time,
+                end_time=datetime(2026, 6, 26, 15, 22, 55, 0, tzinfo=timezone.utc),
+                completed_status="SUCCEEDED",
+                status=ActionStatus(state=ActionState.SUCCESS),
+            ),
+        }
+
+        # Service rejects with ValidationException about start-time mismatch
+        client_error = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ValidationException",
+                    "Message": (
+                        f"Cannot update inactive {action_id} because the provided start time "
+                        "2026-06-26 15:22:54.733 +0000 UTC is different from the original "
+                        "start time 2026-06-26 15:22:53.225 +0000 UTC"
+                    ),
+                }
+            },
+            operation_name="UpdateWorkerSchedule",
+        )
+        mock_update_worker_schedule.side_effect = DeadlineRequestUnrecoverableError(client_error)
+
+        # WHEN - the scheduler handles the error gracefully
+        interval = scheduler._sync()
+
+        # THEN - scheduler survives and returns a short re-sync interval
+        assert interval == 1
+        # AND - the stale entry is cleared from the map (death spiral broken)
+        assert action_id not in scheduler._action_updates_map
+
+    def test_non_start_time_validation_exception_still_fatal(
+        self,
+        scheduler: WorkerScheduler,
+        mock_update_worker_schedule: MagicMock,
+    ) -> None:
+        """Tests that a ValidationException NOT about start-time mismatch is still
+        treated as unrecoverable (the fix only catches the specific start-time case).
+        """
+        # GIVEN
+        action_id = "sessionaction-abc-1"
+        scheduler._action_updates_map = {
+            action_id: SessionActionStatus(
+                id=action_id,
+                start_time=datetime(2026, 6, 26, 15, 22, 54, 0, tzinfo=timezone.utc),
+                completed_status="SUCCEEDED",
+                status=ActionStatus(state=ActionState.SUCCESS),
+            ),
+        }
+
+        # A ValidationException about something OTHER than start time
+        client_error = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ValidationException",
+                    "Message": "Some other validation error unrelated to timestamps",
+                }
+            },
+            operation_name="UpdateWorkerSchedule",
+        )
+        mock_update_worker_schedule.side_effect = DeadlineRequestUnrecoverableError(client_error)
+
+        # WHEN / THEN - still raises (we only catch start-time mismatch)
+        with pytest.raises(DeadlineRequestUnrecoverableError):
+            scheduler._sync()
+
+    def test_non_client_error_unrecoverable_still_fatal(
+        self,
+        scheduler: WorkerScheduler,
+        mock_update_worker_schedule: MagicMock,
+    ) -> None:
+        """Tests that a DeadlineRequestUnrecoverableError wrapping a non-ClientError
+        (e.g. from the generic catch-all) is NOT accidentally swallowed by the
+        start-time mismatch handler.
+        """
+        # GIVEN
+        scheduler._action_updates_map = {
+            "sessionaction-xyz-1": SessionActionStatus(
+                id="sessionaction-xyz-1",
+                start_time=datetime(2026, 6, 26, 15, 0, 0, 0, tzinfo=timezone.utc),
+                completed_status="SUCCEEDED",
+                status=ActionStatus(state=ActionState.SUCCESS),
+            ),
+        }
+        mock_update_worker_schedule.side_effect = DeadlineRequestUnrecoverableError(
+            Exception("unexpected generic error")
+        )
+
+        # WHEN / THEN - still raises (isinstance guard rejects non-ClientError)
+        with pytest.raises(DeadlineRequestUnrecoverableError):
+            scheduler._sync()
 
 
 class TestCreateNewSessions:


### PR DESCRIPTION
## Problem

When multiple environment-enter actions complete faster than the heartbeat interval (e.g. fast environment-enter scripts in Perforce/UE workflows), the agent re-reports a `startedAt` timestamp that the service already recorded differently from an earlier heartbeat. The service rejects with `ValidationException: Cannot update inactive sessionaction-... because the provided start time X is different from the original start time Y`.

Previously this was treated as unrecoverable, causing a death spiral: the stale entry stays in `_action_updates_map` (commit never called on failure), gets re-sent every heartbeat, and the agent terminates the session.

## Fix

In `_sync()`, catch `DeadlineRequestUnrecoverableError` when the inner exception is a `ValidationException` containing the specific service message about start-time mismatch. On match: log WARNING, call `commit_completed_actions()` to clear the stale entries, return interval=1 for immediate re-sync. Other ValidationExceptions and unrecoverable errors still propagate as before.

## Tradeoff: batch-level commit

`commit_completed_actions()` drops all pending updates in the rejected batch, not just the offending action. This is correct assuming the service rejects the entire batch atomically (the error is a single ValidationException, no partial-success). The service already considers the affected actions inactive/done, and fresh updates will be re-reported on the next heartbeat (~1s later).

## Testing

- Recovery test: scheduler survives, stale entry cleared, returns interval=1.
- Non-matching ValidationException still fatal (not accidentally swallowed).
- Non-ClientError inner_exc still fatal (isinstance guard works).

## Impact

Any customer with multiple fast-completing environment-enter actions (common in Perforce/UE workflows) can hit this. The session is terminated and the job fails despite all actions executing successfully.