### PR TITLE
test(e2e): fix mypy Optional narrowing in test_session_runtime

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -54,3 +54,25 @@ jobs:
 
     - name: Run Integration Tests
       run: hatch run integ-test
+
+  E2ELint:
+    name: E2E Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ inputs.tag || inputs.branch || github.ref }}
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: '3.11'
+
+    - name: Install Hatch
+      run: |
+        pip install --upgrade hatch
+
+    - name: Run E2E Lint
+      run: hatch run e2e:lint

--- a/test/e2e/test_session_runtime.py
+++ b/test/e2e/test_session_runtime.py
@@ -537,6 +537,7 @@ class TestRustUnavailableAndRecovery:
             interval=10,
         )
         def wait_worker_started() -> None:
+            assert worker.worker_id is not None  # narrow Optional inside the closure for mypy
             assert is_worker_started(
                 deadline_client=deadline_client,
                 farm_id=deadline_resources.farm.id,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`hatch run e2e:lint` (the `e2e` hatch env's ruff + mypy over `test/e2e`) is a separate lint gate that CI never ran, so a mypy error in the e2e tests reached mainline and broke the release publish step. The standard `hatch run lint` in CI covers `src`/`test/unit`, not `test/e2e`.

### What was the solution? (How)

Two changes:

1. **Fix the mypy error.** `test/e2e/test_session_runtime.py` passed `worker.worker_id` (`str | None`) to `is_worker_started(worker_id: str)`. It is narrowed with an `assert ... is not None` in the enclosing scope, but the call sits inside the `wait_worker_started()` backoff closure, where mypy re-widens the Optional. Added the assert inside the closure, matching the existing idiom in `test_worker_status.py`.
2. **Run `e2e:lint` in CI.** Added an `E2E Lint` job to the Code Quality workflow that runs `hatch run e2e:lint` on every PR and mainline push, so this class of error is caught going forward. The job only lints/type-checks (no AWS credentials, no live e2e run).

### What is the impact of this change?

Test/CI-only. No runtime or shipped-code change. PRs now run ruff + mypy over `test/e2e`.

### How was this change tested?

`hatch run e2e:lint` locally: `ruff check` "All checks passed", `ruff format --check` "15 files already formatted", `mypy` "Success: no issues found in 15 source files". Workflow YAML validated (parses; jobs: UnitTest, IntegrationTests, E2ELint). The new job also runs on this PR.

### Was this change documented?

No; test/CI-only.

### Is this a breaking change?

No.
