### PR TITLE
fix: resolve environment job parameter references on the Rust runtime

### DIFF
--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -157,6 +157,33 @@ def _to_rust_task_parameter_values(values: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _to_environment_parameter_definitions(values: dict[str, Any]) -> list[dict[str, str]]:
+    """Synthesize parameterDefinitions entries from job parameter values.
+
+    The environment template is decoded standalone (lifted out of its job
+    context), so the job's parameter declarations must be re-supplied here for
+    ``{{Param.X}}`` references to resolve. Every ``JobParameterType`` member is a
+    valid environment-template parameter type — only task-parameter-space types
+    like ``CHUNK[INT]`` are rejected, and those cannot reach here: ParameterValue
+    objects are constrained by ``JobParameterType`` at session construction, and
+    raw dicts originate from the wire which only carries job parameter types.
+
+    No type filter is applied. All values are declared unconditionally.
+
+    Known limitation: only parameters that have *values* are declared. A job
+    parameter with no value supplied would still fail validation at decode time.
+    In practice everything reaching the worker has a default or submitted value.
+    """
+    definitions: list[dict[str, str]] = []
+    for name, value in values.items():
+        if isinstance(value, dict):
+            type_str = value["type"]
+        else:
+            type_str = value.type.value
+        definitions.append({"name": name, "type": type_str})
+    return definitions
+
+
 def _to_rust_path_mapping_rule(rule: PathMappingRule) -> RustPathMappingRule:
     """Convert one worker (v0) PathMappingRule into the _v1 (openjd.expr) type.
 
@@ -202,6 +229,7 @@ class RustSessionRuntime(SessionRuntime):
 
     _session: OpenJDRustSession
     _user: Optional[SessionUser]
+    _environment_parameter_definitions: list[dict[str, str]]
 
     def __init__(self, config: SessionRuntimeConfig) -> None:
         try:
@@ -236,6 +264,13 @@ class RustSessionRuntime(SessionRuntime):
         # (which runs as that user) can read them.
         self._user = config.user
 
+        # Job parameter values are fixed for the session's lifetime, so the
+        # declarations are synthesized once here. See
+        # _to_environment_parameter_definitions for why they are needed at all.
+        self._environment_parameter_definitions = _to_environment_parameter_definitions(
+            config.job_parameter_values
+        )
+
         # The _v1 session reports status with _v1 ActionStatus/ActionState, but
         # the worker's callback expects the v0 types, so translate on the way out.
         v0_callback = config.action_callback
@@ -268,16 +303,16 @@ class RustSessionRuntime(SessionRuntime):
         # wire shape and rebuild it natively. exclude_none=True is required, not
         # cosmetic: the Rust decoder rejects explicit nulls (OpenJD treats
         # absent and null as equivalent).
-        native_environment = create_environment(
-            decode_environment_template(
-                {
-                    "specificationVersion": "environment-2023-09",
-                    "environment": environment.model_dump(
-                        mode="json", by_alias=True, exclude_none=True
-                    ),
-                }
-            )
-        )
+        template: dict[str, Any] = {
+            "specificationVersion": "environment-2023-09",
+            "environment": environment.model_dump(mode="json", by_alias=True, exclude_none=True),
+        }
+        # The job's parameter declarations must accompany the environment or its
+        # {{Param.X}} references cannot resolve. The key is omitted entirely when
+        # empty, because the schema rejects "parameterDefinitions": [].
+        if self._environment_parameter_definitions:
+            template["parameterDefinitions"] = self._environment_parameter_definitions
+        native_environment = create_environment(decode_environment_template(template))
         return self._session.enter_environment(
             environment=native_environment,
             identifier=identifier,

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -164,9 +164,10 @@ def _to_environment_parameter_definitions(values: dict[str, Any]) -> list[dict[s
     context), so the job's parameter declarations must be re-supplied here for
     ``{{Param.X}}`` references to resolve. Every ``JobParameterType`` member is a
     valid environment-template parameter type — only task-parameter-space types
-    like ``CHUNK[INT]`` are rejected, and those cannot reach here: ParameterValue
-    objects are constrained by ``JobParameterType`` at session construction, and
-    raw dicts originate from the wire which only carries job parameter types.
+    like ``CHUNK[INT]`` are rejected, and those cannot reach here:
+    ``JobDetails._validate_job_parameters`` restricts jobDetails parameters to
+    the job-parameter-type subset (string/path/int/float), and raw dicts
+    originate from the wire which only carries job parameter types.
 
     No type filter is applied. All values are declared unconditionally.
 
@@ -177,7 +178,14 @@ def _to_environment_parameter_definitions(values: dict[str, Any]) -> list[dict[s
     definitions: list[dict[str, str]] = []
     for name, value in values.items():
         if isinstance(value, dict):
-            type_str = value["type"]
+            type_str = value.get("type")
+            if type_str is None:
+                # Skip malformed entries rather than raising — the same raw dict
+                # is passed to _to_rust_job_parameter_values moments later, so a
+                # genuinely invalid value still fails at Rust session construction
+                # with the session's own clear error. This matches the sibling
+                # helper's convention of deferring dict validation to the Rust session.
+                continue
         else:
             type_str = value.type.value
         definitions.append({"name": name, "type": type_str})

--- a/test/integ/sessions/test_differential_runtime.py
+++ b/test/integ/sessions/test_differential_runtime.py
@@ -381,3 +381,74 @@ class TestDifferentialSessionRuntime:
         _cancel_when_registered(runtime)
 
         assert _wait_for_terminal(runtime) == "CANCELED"
+
+    @pytest.mark.timeout(60)
+    @pytest.mark.parametrize("runtime_kind", _RUNTIME_KINDS)
+    def test_enter_environment_when_job_has_typed_params_resolves_param_reference(
+        self, runtime_kind: SessionRuntimeKind, tmp_path: Path
+    ) -> None:
+        """An environment referencing {{Param.X}} succeeds when the runtime is
+        constructed with non-empty job_parameter_values including non-STRING
+        types. This exercises the REAL decoder through the adapter — unit tests
+        mock it and cannot validate payload shape."""
+        from openjd.model._types import ParameterValue, ParameterValueType
+
+        root = tmp_path / f"session-params-{runtime_kind.name.lower()}"
+        root.mkdir(parents=True, exist_ok=True)
+        recorder = _StatusRecorder()
+        config = SessionRuntimeConfig(
+            session_id=f"session-params-{runtime_kind.name.lower()}",
+            job_parameter_values={
+                "Message": ParameterValue(type=ParameterValueType.STRING, value="hello-world"),
+                "Count": ParameterValue(type=ParameterValueType.INT, value="42"),
+            },
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=recorder,
+            os_env_vars=None,
+            session_root_directory=root,
+        )
+        runtime = create_session_runtime(runtime_kind, config)
+        try:
+            # The environment's onEnter script references {{Param.Message}} — the
+            # decoder must resolve it using the parameterDefinitions we supply.
+            env_template = decode_environment_template(
+                template={
+                    "specificationVersion": "environment-2023-09",
+                    "environment": {
+                        "name": "ParamEnv",
+                        "script": {
+                            "actions": {
+                                "onEnter": {
+                                    "command": sys.executable,
+                                    "args": ["-c", "print('{{Param.Message}}')"],
+                                }
+                            }
+                        },
+                    },
+                    "parameterDefinitions": [
+                        {"name": "Message", "type": "STRING"},
+                        {"name": "Count", "type": "INT"},
+                    ],
+                }
+            )
+            environment = env_template.environment
+
+            prev = len(recorder.statuses)
+            identifier = runtime.enter_environment(environment=environment)
+            assert _wait_for_new_action(recorder, prev)
+            terminal = _wait_for_terminal(runtime)
+            assert terminal == "SUCCESS", (
+                f"Expected SUCCESS but got {terminal}; statuses={recorder.state_names}"
+            )
+
+            prev = len(recorder.statuses)
+            runtime.exit_environment(identifier=identifier)
+            assert _wait_for_new_action(recorder, prev)
+            assert _wait_for_terminal(runtime) == "SUCCESS"
+        finally:
+            try:
+                runtime.cleanup()
+            except Exception:
+                pass

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -20,6 +20,7 @@ from deadline_worker_agent.sessions.runtime._abc import SessionRuntimeCrashError
 from deadline_worker_agent.sessions.runtime import rust as rust_module
 from deadline_worker_agent.sessions.runtime.rust import RustSessionRuntime
 from deadline_worker_agent.sessions.runtime.rust import _to_rust_task_parameter_values
+from deadline_worker_agent.sessions.runtime.rust import _to_environment_parameter_definitions
 
 
 @pytest.fixture()
@@ -238,11 +239,14 @@ class TestRustSessionRuntimeDelegation:
             )
 
         # The pydantic environment is serialized and rebuilt natively before
-        # being handed to the session.
+        # being handed to the session. The fixture's job_parameter_values
+        # contains one STRING param in dict form, which must appear as a
+        # parameterDefinitions entry.
         mock_decode.assert_called_once_with(
             {
                 "specificationVersion": "environment-2023-09",
                 "environment": environment.model_dump.return_value,
+                "parameterDefinitions": [{"name": "Param1", "type": "STRING"}],
             }
         )
         environment.model_dump.assert_called_once_with(
@@ -255,6 +259,146 @@ class TestRustSessionRuntimeDelegation:
             os_env_vars=os_env,
         )
         assert result is mock_session_instance.enter_environment.return_value
+
+    def test_enter_environment_includes_all_job_parameter_types(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """All JobParameterType members are declared in parameterDefinitions."""
+        config = SessionRuntimeConfig(
+            session_id="session-env-multi",
+            job_parameter_values={
+                "A": ParameterValue(type=ParameterValueType.STRING, value="hello"),
+                "B": ParameterValue(type=ParameterValueType.INT, value="42"),
+                "C": ParameterValue(type=ParameterValueType.PATH, value="/tmp"),
+                "D": ParameterValue(type=ParameterValueType.FLOAT, value="3.14"),
+                "E": ParameterValue(type=ParameterValueType.BOOL, value="true"),
+            },
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-env-multi"),
+        )
+        adapter = RustSessionRuntime(config)
+
+        environment = MagicMock()
+        with (
+            patch.object(rust_module, "decode_environment_template") as mock_decode,
+            patch.object(rust_module, "create_environment"),
+        ):
+            adapter.enter_environment(environment=environment, identifier="env-1")
+
+        template = mock_decode.call_args.args[0]
+        assert template["parameterDefinitions"] == [
+            {"name": "A", "type": "STRING"},
+            {"name": "B", "type": "INT"},
+            {"name": "C", "type": "PATH"},
+            {"name": "D", "type": "FLOAT"},
+            {"name": "E", "type": "BOOL"},
+        ]
+
+    def test_enter_environment_when_empty_params_omits_parameter_definitions_key(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """Empty job_parameter_values means parameterDefinitions must be absent."""
+        config = SessionRuntimeConfig(
+            session_id="session-env-empty",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-env-empty"),
+        )
+        adapter = RustSessionRuntime(config)
+
+        environment = MagicMock()
+        with (
+            patch.object(rust_module, "decode_environment_template") as mock_decode,
+            patch.object(rust_module, "create_environment"),
+        ):
+            adapter.enter_environment(environment=environment, identifier="env-1")
+
+        template = mock_decode.call_args.args[0]
+        assert template == {
+            "specificationVersion": "environment-2023-09",
+            "environment": environment.model_dump.return_value,
+        }
+        assert "parameterDefinitions" not in template
+
+    def test_enter_environment_when_dict_param_type_invalid_is_still_declared(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """A raw dict with an invalid type (e.g. CHUNK[INT]) is still declared.
+
+        ParameterValue objects cannot carry CHUNK_INT (JobParameterType has no
+        such member), but raw dicts bypass that constraint. No type filter is
+        applied — the decoder itself will reject invalid types at template
+        decode time with a clear error, which is the correct behavior.
+        """
+        config = SessionRuntimeConfig(
+            session_id="session-env-chunk",
+            job_parameter_values={
+                "Good": ParameterValue(type=ParameterValueType.STRING, value="ok"),
+                "Bad": {"type": "CHUNK[INT]", "value": "1-5"},
+            },
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-env-chunk"),
+        )
+        adapter = RustSessionRuntime(config)
+
+        environment = MagicMock()
+        with (
+            patch.object(rust_module, "decode_environment_template") as mock_decode,
+            patch.object(rust_module, "create_environment"),
+        ):
+            adapter.enter_environment(environment=environment, identifier="env-1")
+
+        template = mock_decode.call_args.args[0]
+        # Both params are declared — no type filter. The decoder rejects
+        # CHUNK[INT] at decode time with a clear error.
+        assert template["parameterDefinitions"] == [
+            {"name": "Good", "type": "STRING"},
+            {"name": "Bad", "type": "CHUNK[INT]"},
+        ]
+
+    def test_enter_environment_when_mixed_dict_and_object_params_both_appear(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """Both ParameterValue objects and raw dicts are handled correctly."""
+        config = SessionRuntimeConfig(
+            session_id="session-env-mixed",
+            job_parameter_values={
+                "Obj": ParameterValue(type=ParameterValueType.INT, value="7"),
+                "Dict": {"type": "PATH", "value": "/out"},
+            },
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-env-mixed"),
+        )
+        adapter = RustSessionRuntime(config)
+
+        environment = MagicMock()
+        with (
+            patch.object(rust_module, "decode_environment_template") as mock_decode,
+            patch.object(rust_module, "create_environment"),
+        ):
+            adapter.enter_environment(environment=environment, identifier="env-1")
+
+        template = mock_decode.call_args.args[0]
+        assert template["parameterDefinitions"] == [
+            {"name": "Obj", "type": "INT"},
+            {"name": "Dict", "type": "PATH"},
+        ]
 
     def test_exit_environment_when_called_delegates_to_wrapped_session(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
@@ -950,3 +1094,41 @@ class TestRuntimeCrashConversion:
         with pytest.raises(SessionRuntimeCrashError, match="_FakePanic") as exc_info:
             runtime.extend_path_mapping_rules(rules=[])
         assert isinstance(exc_info.value.__cause__, _FakePanic)
+
+
+class TestToEnvironmentParameterDefinitions:
+    """Direct tests for _to_environment_parameter_definitions helper."""
+
+    def test_extracts_type_from_dict_form(self) -> None:
+        values: dict[str, Any] = {
+            "D": {"type": "STRING", "value": "hello"},
+        }
+        result = _to_environment_parameter_definitions(values)
+        assert result == [{"name": "D", "type": "STRING"}]
+
+    def test_includes_all_parameter_value_types(self) -> None:
+        """No type filter is applied — all ParameterValue types are declared."""
+        values: dict[str, Any] = {
+            "Good": ParameterValue(type=ParameterValueType.STRING, value="ok"),
+            "Also": ParameterValue(type=ParameterValueType.CHUNK_INT, value="1-5"),
+        }
+        result = _to_environment_parameter_definitions(values)
+        assert result == [
+            {"name": "Good", "type": "STRING"},
+            {"name": "Also", "type": "CHUNK[INT]"},
+        ]
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert _to_environment_parameter_definitions({}) == []
+
+    def test_non_primitive_types_are_declared(self) -> None:
+        """Types beyond STRING/PATH/INT/FLOAT (e.g. BOOL) are declared unconditionally."""
+        values: dict[str, Any] = {
+            "Flag": ParameterValue(type=ParameterValueType.BOOL, value="true"),
+            "Expr": {"type": "RANGE_EXPR", "value": "1-10"},
+        }
+        result = _to_environment_parameter_definitions(values)
+        assert result == [
+            {"name": "Flag", "type": "BOOL"},
+            {"name": "Expr", "type": "RANGE_EXPR"},
+        ]

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -400,6 +400,44 @@ class TestRustSessionRuntimeDelegation:
             {"name": "Dict", "type": "PATH"},
         ]
 
+    def test_enter_environment_when_dict_param_missing_type_key_is_skipped(
+        self, mock_rust_session: MagicMock
+    ) -> None:
+        """A dict-shaped value with no "type" key is skipped rather than raising.
+
+        The same raw dict reaches _to_rust_job_parameter_values moments later, so
+        a genuinely malformed value still fails at Rust session construction with
+        the session's own error rather than a KeyError from __init__.
+        """
+        config = SessionRuntimeConfig(
+            session_id="session-env-missing-type",
+            job_parameter_values={
+                "Good": {"type": "PATH", "value": "/tmp"},
+                "Bad": {"value": "oops"},  # no "type" key
+                "AlsoGood": ParameterValue(type=ParameterValueType.FLOAT, value="1.5"),
+            },
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda sid, s: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-env-missing-type"),
+        )
+        adapter = RustSessionRuntime(config)
+
+        environment = MagicMock()
+        with (
+            patch.object(rust_module, "decode_environment_template") as mock_decode,
+            patch.object(rust_module, "create_environment"),
+        ):
+            adapter.enter_environment(environment=environment, identifier="env-1")
+
+        template = mock_decode.call_args.args[0]
+        assert template["parameterDefinitions"] == [
+            {"name": "Good", "type": "PATH"},
+            {"name": "AlsoGood", "type": "FLOAT"},
+        ]
+
     def test_exit_environment_when_called_delegates_to_wrapped_session(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

On the Rust session runtime, any OpenJD environment whose script referenced a job parameter failed to enter:

```
ModelValidationError: 1 validation error for EnvironmentTemplate
environment -> script -> actions -> onEnter -> args[0]:
Failed to parse interpolation expression. Undefined variable: 'Param.Message'
```

`RustSessionRuntime.enter_environment` lifts the environment out of its job and decodes it as a standalone environment template. That template omitted the job's `parameterDefinitions`, so the decoder correctly reported the parameter as undefined. The Python runtime is unaffected — it never decodes the environment itself, and hands the pydantic model to the openjd session which resolves format strings later with the job parameters already in scope.

### What was the solution? (How)

The template now declares the job's parameters, synthesized from the parameter values the adapter already receives and retained at construction. Declaring a parameter does not oblige the caller to supply a value, and `create_environment` strips `parameterDefinitions`, so nothing is exposed downstream. The key is omitted entirely when there is nothing to declare, because an empty `parameterDefinitions` list is rejected by the schema.

No type filter is applied: `decode_environment_template` was empirically verified to accept every `JobParameterType` member. Only task-parameter-space types such as `CHUNK[INT]` are rejected, and those cannot reach this path.

### What is the impact of this change?

Environments referencing `{{Param.X}}` now enter successfully on the Rust runtime. No change to the Python runtime.

Known limitation: only parameters that have values are declared, so a job parameter with no value supplied would still fail validation. In practice everything reaching the worker has a default or a submitted value.

### How was this change tested?

A new differential integration test exercises the real decoder through the adapter — it fails on the Rust runtime without this change and passes on the Python runtime either way. Unit tests cover the multi-parameter, non-primitive type, empty, and mixed-value-shape cases. Build, unit suite, lint, and the integration suite all pass.

**Falsifiability (mutation run).** Disabling the `parameterDefinitions` injection in `enter_environment` makes the integration test fail by name on the Rust runtime only:

```
PASSED  test_enter_environment_when_job_has_typed_params_resolves_param_reference[python]
FAILED  test_enter_environment_when_job_has_typed_params_resolves_param_reference[rust]
  E   Failed to parse interpolation expression at [7, 24]. Undefined variable: 'Param.Message'.
```

Restored, both parametrizations pass. This confirms `env_template.environment` strips the definitions, so the test genuinely depends on the fix.

### Was this change documented?

No user-facing documentation change needed — this fixes a runtime gap in existing OpenJD semantics.

### Is this a breaking change?

No.

