### PR TITLE
fix: raise openjd-model floor to >= 0.11.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "deadline-job-attachments == 0.1.3",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
     "openjd-sessions == 0.10.14",
-    "openjd-model >= 0.11.2, < 0.12",
+    "openjd-model >= 0.11.3, < 0.12",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "tomlkit >= 0.13,< 0.16",


### PR DESCRIPTION
Bump the openjd-model dependency floor from >= 0.11.2 to >= 0.11.3.

openjd-model 0.11.3 ships updated Rust bindings (openjd-rs expr 0.3.0, model 0.5.1, sessions 0.5.1) which carry:
- Env.File.* references now resolve inside wrap action hooks
- repr_sh(flatten([])) no longer errors on empty lists
- IntRangeExpr expansion is no longer capped at 1024 elements

The floor raise ensures the AMI resolves the fixed wheel rather than relying on pip's resolution order.

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*