### PR TITLE
fix: resolve privileged commands from trusted dirs to prevent PATH injection

### DIFF
--- a/src/deadline_worker_agent/_system_commands.py
+++ b/src/deadline_worker_agent/_system_commands.py
@@ -1,0 +1,132 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Resolution of system command names to absolute paths, without consulting PATH.
+
+Invoking a privileged helper by bare name (``sudo``, ``shutdown``, ``pkill``)
+resolves it through ``PATH``. Where any part of that search path is influenced by
+less-trusted input, the resolution itself becomes the vulnerability: CWE-426,
+Untrusted Search Path. This module removes ``PATH`` from the picture by scanning a
+fixed list of trusted absolute directories instead.
+
+Three properties are load-bearing, and each is pinned by a test in
+``test/unit/test_system_commands.py``:
+
+* **``PATH`` is never read.** Not directly, and not indirectly via
+  :func:`shutil.which`, which resolves through ``PATH`` and so would reintroduce
+  the problem while appearing to fix it.
+* **Only paths under the trusted directories are returned**, and a name
+  containing a path separator is rejected -- otherwise joining ``/usr/bin`` with
+  ``../../tmp/evil`` would make this module the injection point it exists to
+  remove.
+* **A missing command raises.** Falling back to the bare name would restore the
+  vulnerability while looking fixed, which is the worst available failure mode
+  for this class of fix.
+
+Why a resolver rather than absolute-path literals: the locations are not
+universal. NixOS keeps the setuid ``sudo`` wrapper at ``/run/wrappers/bin/sudo``,
+and on non-usr-merged Debian ``shutdown`` exists only at ``/sbin/shutdown``. A
+hardcoded literal turns a security bug into an availability bug on those hosts.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional, Tuple
+
+__all__ = [
+    "SystemCommandNotFoundError",
+    "find_system_command",
+    "system_command_path",
+    "trusted_directories",
+]
+
+
+_POSIX_TRUSTED_DIRECTORIES: Tuple[str, ...] = (
+    # Ordered, deliberately. On NixOS the setuid `sudo` wrapper lives here and
+    # the /usr/bin copy is absent or not setuid, so this must be searched first.
+    "/run/wrappers/bin",
+    "/usr/bin",
+    "/bin",
+    # sbin last: `shutdown` lives here, and on non-usr-merged Debian releases it
+    # is *only* at /sbin/shutdown.
+    "/usr/sbin",
+    "/sbin",
+)
+
+_WINDOWS_FALLBACK_SYSTEM_ROOT = r"C:\Windows"
+
+
+class SystemCommandNotFoundError(Exception):
+    """A required system command was not present in any trusted directory.
+
+    Deliberately not a subclass of :class:`FileNotFoundError`. Callers around
+    subprocess invocations catch ``FileNotFoundError`` to mean "this optional
+    tool is not installed, carry on degraded", and this condition must not be
+    absorbed by that handling: it means a privileged helper is unavailable.
+    """
+
+
+def trusted_directories() -> Tuple[str, ...]:
+    """The absolute directories searched for system commands, in order."""
+    if sys.platform == "win32":
+        # SystemRoot is set by the operating system for every process. It is not
+        # job-controlled the way a session subprocess's environment is, and an
+        # attacker able to set it in the agent's own environment already has
+        # agent-level control, so reading it does not weaken the boundary this
+        # module defends.
+        system_root = os.environ.get("SystemRoot") or _WINDOWS_FALLBACK_SYSTEM_ROOT
+        return (os.path.join(system_root, "System32"),)
+    return _POSIX_TRUSTED_DIRECTORIES
+
+
+def _validate_command_name(name: str) -> None:
+    """Reject anything that is not a bare command name."""
+    if not name:
+        raise ValueError("A system command name must not be empty.")
+    if name in (os.curdir, os.pardir):
+        raise ValueError(f"{name!r} is not a system command name.")
+    # Both separators are checked on both platforms. A backslash is a legal POSIX
+    # filename character, but no command resolved here contains one, and treating
+    # it as suspect keeps the check identical rather than subtly weaker on POSIX.
+    if "/" in name or "\\" in name:
+        raise ValueError(
+            f"A system command name must not contain a path separator, but got {name!r}."
+        )
+
+
+def _is_executable_file(path: str) -> bool:
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def find_system_command(name: str) -> Optional[str]:
+    """Return the absolute path to ``name``, or ``None`` if it is not installed.
+
+    ``PATH`` is not consulted. Use this when the command's absence is tolerable;
+    use :func:`system_command_path` when it is required.
+
+    Raises:
+        ValueError: if ``name`` is not a bare command name.
+    """
+    _validate_command_name(name)
+    for directory in trusted_directories():
+        candidate = os.path.join(directory, name)
+        if _is_executable_file(candidate):
+            return candidate
+    return None
+
+
+def system_command_path(name: str) -> str:
+    """Return the absolute path to ``name``.
+
+    Raises:
+        ValueError: if ``name`` is not a bare command name.
+        SystemCommandNotFoundError: if ``name`` is in no trusted directory.
+    """
+    path = find_system_command(name)
+    if path is None:
+        raise SystemCommandNotFoundError(
+            f"Could not find the system command {name!r} in any trusted directory "
+            f"({', '.join(trusted_directories())}). PATH is deliberately not searched."
+        )
+    return path

--- a/src/deadline_worker_agent/_system_commands.py
+++ b/src/deadline_worker_agent/_system_commands.py
@@ -2,30 +2,31 @@
 
 """Resolution of system command names to absolute paths, without consulting PATH.
 
-Invoking a privileged helper by bare name (``sudo``, ``shutdown``, ``pkill``)
-resolves it through ``PATH``. Where any part of that search path is influenced by
-less-trusted input, the resolution itself becomes the vulnerability: CWE-426,
-Untrusted Search Path. This module removes ``PATH`` from the picture by scanning a
-fixed list of trusted absolute directories instead.
+The problem: the agent invokes privileged helpers (``sudo``, ``pkill``) by bare
+name, which resolves them through ``PATH``. That makes the binary the agent
+actually runs depend on the search path of whatever launched the agent, for
+commands it runs as a privileged user.
 
-Three properties are load-bearing, and each is pinned by a test in
-``test/unit/test_system_commands.py``:
+The solution: callers pass a bare name here and get back an absolute path found by
+scanning a fixed list of trusted directories, so ``PATH`` plays no part.
 
-* **``PATH`` is never read.** Not directly, and not indirectly via
-  :func:`shutil.which`, which resolves through ``PATH`` and so would reintroduce
-  the problem while appearing to fix it.
-* **Only paths under the trusted directories are returned**, and a name
-  containing a path separator is rejected -- otherwise joining ``/usr/bin`` with
-  ``../../tmp/evil`` would make this module the injection point it exists to
-  remove.
-* **A missing command raises.** Falling back to the bare name would restore the
-  vulnerability while looking fixed, which is the worst available failure mode
-  for this class of fix.
+Three properties make that work, and all three are easy to undo by accident:
 
-Why a resolver rather than absolute-path literals: the locations are not
-universal. NixOS keeps the setuid ``sudo`` wrapper at ``/run/wrappers/bin/sudo``,
-and on non-usr-merged Debian ``shutdown`` exists only at ``/sbin/shutdown``. A
-hardcoded literal turns a security bug into an availability bug on those hosts.
+* ``PATH`` is never read. Not directly, and not through :func:`shutil.which`,
+  which resolves via ``PATH`` and so would restore the original behaviour while
+  looking like a fix.
+* Only paths under the trusted directories are returned. A name containing a path
+  separator or a drive specifier is rejected, because ``os.path.join`` would
+  otherwise let ``../../tmp/evil`` or ``D:evil`` escape the directory being
+  searched.
+* A missing command raises. Returning the bare name as a fallback would put
+  resolution back on ``PATH`` while the code still read as though it did not.
+
+A resolver rather than absolute-path literals, because the locations are not
+universal: NixOS keeps the setuid ``sudo`` wrapper at ``/run/wrappers/bin/sudo``,
+and on non-usr-merged Debian some system commands exist only under ``/sbin``. A
+hardcoded literal would trade one failure for a host that cannot run the command
+at all.
 """
 
 from __future__ import annotations

--- a/src/deadline_worker_agent/_system_commands.py
+++ b/src/deadline_worker_agent/_system_commands.py
@@ -37,10 +37,15 @@ from typing import Optional, Tuple
 
 __all__ = [
     "SystemCommandNotFoundError",
-    "find_system_command",
     "system_command_path",
     "trusted_directories",
 ]
+
+# find_system_command is intentionally absent from __all__. Every caller in this
+# package needs the command it asks for, so none of them can do anything useful
+# with None. It stays defined because the tests use it to exercise the search
+# without asserting on an exception, but exporting it would advertise a
+# "tolerate absence" entry point that nothing here wants.
 
 
 _POSIX_TRUSTED_DIRECTORIES: Tuple[str, ...] = (

--- a/src/deadline_worker_agent/_system_commands.py
+++ b/src/deadline_worker_agent/_system_commands.py
@@ -46,10 +46,18 @@ _POSIX_TRUSTED_DIRECTORIES: Tuple[str, ...] = (
     # Ordered, deliberately. On NixOS the setuid `sudo` wrapper lives here and
     # the /usr/bin copy is absent or not setuid, so this must be searched first.
     "/run/wrappers/bin",
+    # ...and these two NixOS entries are a pair. /run/wrappers/bin holds only the
+    # setuid/setcap wrappers, so on NixOS it resolves `sudo` and nothing else:
+    # /usr/bin holds just `env`, /bin just `sh`, and the sbin directories are
+    # absent. `pkill` lives in this symlink farm, which nixos-rebuild manages and
+    # root owns, so it is trust-equivalent to /usr/bin there. Without it the
+    # ordering above would resolve `sudo` and then fail on `pkill`.
+    "/run/current-system/sw/bin",
     "/usr/bin",
     "/bin",
-    # sbin last: `shutdown` lives here, and on non-usr-merged Debian releases it
-    # is *only* at /sbin/shutdown.
+    # sbin last. Note this list is no longer used to locate `shutdown` -- that path
+    # is a sudoers contract, see entrypoint.LINUX_SHUTDOWN_PATH -- but other
+    # commands can still live only under /sbin on non-usr-merged distributions.
     "/usr/sbin",
     "/sbin",
 )
@@ -57,13 +65,21 @@ _POSIX_TRUSTED_DIRECTORIES: Tuple[str, ...] = (
 _WINDOWS_FALLBACK_SYSTEM_ROOT = r"C:\Windows"
 
 
-class SystemCommandNotFoundError(Exception):
+class SystemCommandNotFoundError(FileNotFoundError):
     """A required system command was not present in any trusted directory.
 
-    Deliberately not a subclass of :class:`FileNotFoundError`. Callers around
-    subprocess invocations catch ``FileNotFoundError`` to mean "this optional
-    tool is not installed, carry on degraded", and this condition must not be
-    absorbed by that handling: it means a privileged helper is unavailable.
+    A :class:`FileNotFoundError`, and therefore an :class:`OSError`, on purpose.
+
+    An earlier revision made this a plain ``Exception``, reasoning that an
+    unavailable privileged helper must not be absorbed by handlers that catch
+    ``FileNotFoundError`` to mean "carry on degraded". That reasoning assumed rather
+    than checked what surrounding code does with it, and the semantics this
+    condition has are ``FileNotFoundError``'s: the thing we meant to launch is not
+    there. ``capabilities.py`` and ``metrics.py`` already treat that as "feature
+    unavailable" for ``nvidia-smi``, which is the right shape here too.
+
+    Remaining a distinct type still lets a caller tell "not in any trusted
+    directory" apart from "``exec`` failed", and the message says which.
     """
 
 
@@ -89,9 +105,19 @@ def _validate_command_name(name: str) -> None:
     # Both separators are checked on both platforms. A backslash is a legal POSIX
     # filename character, but no command resolved here contains one, and treating
     # it as suspect keeps the check identical rather than subtly weaker on POSIX.
-    if "/" in name or "\\" in name:
+    # The colon is rejected too, and on this module it is not hypothetical -- this
+    # is the one resolver here with a Windows branch:
+    #
+    #     ntpath.join(r"C:\Windows\System32", "D:evil") == "D:evil"
+    #
+    # A drive-relative name discards the trusted prefix entirely while containing no
+    # separator at all, resolving against that drive's own current directory. A
+    # separator-only guard lets it straight through, which would make this module
+    # the injection point it exists to remove.
+    if "/" in name or "\\" in name or ":" in name:
         raise ValueError(
-            f"A system command name must not contain a path separator, but got {name!r}."
+            f"A system command name must not contain a path separator or drive "
+            f"specifier, but got {name!r}."
         )
 
 

--- a/src/deadline_worker_agent/_system_commands.py
+++ b/src/deadline_worker_agent/_system_commands.py
@@ -55,9 +55,11 @@ _POSIX_TRUSTED_DIRECTORIES: Tuple[str, ...] = (
     "/run/current-system/sw/bin",
     "/usr/bin",
     "/bin",
-    # sbin last. Note this list is no longer used to locate `shutdown` -- that path
-    # is a sudoers contract, see entrypoint.LINUX_SHUTDOWN_PATH -- but other
-    # commands can still live only under /sbin on non-usr-merged distributions.
+    # sbin last, and with no current caller. `shutdown` used to justify these two,
+    # but its path is a sudoers contract now (entrypoint.LINUX_SHUTDOWN_PATH) and is
+    # not resolved here at all; sudo and pkill both live in /usr/bin. They stay
+    # because the split is real -- a system command can be sbin-only on a
+    # non-usr-merged distribution -- but "no current caller" is the honest status.
     "/usr/sbin",
     "/sbin",
 )

--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -10,6 +10,7 @@ import requests
 import sys
 import sysconfig
 
+from deadline_worker_agent._system_commands import system_command_path
 from deadline_worker_agent.config.settings import (
     DEFAULT_MACOS_SESSION_ROOT_DIR,
     DEFAULT_POSIX_SESSION_ROOT_DIR,
@@ -124,7 +125,7 @@ def install() -> None:
             sys.exit(1)
     else:
         cmd = [
-            "sudo",
+            system_command_path("sudo"),
             str(INSTALLER_PATH[sys.platform]),
             "--farm-id",
             args.farm_id,

--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -10,7 +10,10 @@ import requests
 import sys
 import sysconfig
 
-from deadline_worker_agent._system_commands import system_command_path
+from deadline_worker_agent._system_commands import (
+    SystemCommandNotFoundError,
+    system_command_path,
+)
 from deadline_worker_agent.config.settings import (
     DEFAULT_MACOS_SESSION_ROOT_DIR,
     DEFAULT_POSIX_SESSION_ROOT_DIR,
@@ -124,8 +127,18 @@ def install() -> None:
             print(f"ERROR: {e}")
             sys.exit(1)
     else:
+        # Resolved before building the argv, and handled here rather than left to
+        # escape. The try below covers only run()/CalledProcessError, so an
+        # unresolvable sudo would otherwise end the installer in a raw traceback
+        # instead of the actionable message the Windows branch gives for its
+        # equivalent failure a few lines up.
+        try:
+            sudo_path = system_command_path("sudo")
+        except SystemCommandNotFoundError as e:
+            print(f"ERROR: {e}")
+            sys.exit(1)
         cmd = [
-            system_command_path("sudo"),
+            sudo_path,
             str(INSTALLER_PATH[sys.platform]),
             "--farm-id",
             args.farm_id,

--- a/src/deadline_worker_agent/installer/install_macos.sh
+++ b/src/deadline_worker_agent/installer/install_macos.sh
@@ -603,8 +603,11 @@ fi
 # --- Sudoers configuration (--allow-shutdown) ---------------------------------------
 # macOS shutdown binary lives at /sbin/shutdown (BSD shutdown). The Linux line used
 # `/usr/sbin/shutdown now`; the BSD invocation is `/sbin/shutdown -h now` (-h = halt/power off).
-# The agent invokes `sudo shutdown -h now` on macOS (startup/entrypoint.py:_host_shutdown);
-# sudo resolves `shutdown` to /sbin/shutdown via PATH and matches this rule by full path.
+# The agent invokes `sudo /sbin/shutdown -h now` on macOS (startup/entrypoint.py:_host_shutdown),
+# passing the absolute path itself rather than letting sudo resolve `shutdown` via PATH.
+# The path comes from entrypoint.MACOS_SHUTDOWN_PATH, and a unit test reads this rule and
+# compares the two, so a change on either side fails the build rather than silently
+# producing a password prompt.
 # The sudoers command MUST continue to match that argv exactly for the NOPASSWD rule to apply.
 if [[ "${allow_shutdown}" == "yes" ]]; then
     echo "Setting up sudoers shutdown rule at /etc/sudoers.d/deadline-worker-shutdown"

--- a/src/deadline_worker_agent/scheduler/session_cleanup.py
+++ b/src/deadline_worker_agent/scheduler/session_cleanup.py
@@ -9,6 +9,7 @@ from threading import Lock
 
 from openjd.sessions import SessionUser, PosixSessionUser, WindowsSessionUser
 from .log import LOGGER
+from .._system_commands import system_command_path
 from ..sessions import Session
 
 logger = LOGGER
@@ -105,7 +106,13 @@ class SessionUserCleanupManager:
 
         try:
             pkill_result = subprocess.run(
-                args=["sudo", "-u", user.user, "/usr/bin/pkill", *pkill_opt],
+                args=[
+                    system_command_path("sudo"),
+                    "-u",
+                    user.user,
+                    system_command_path("pkill"),
+                    *pkill_opt,
+                ],
                 capture_output=True,
                 check=True,
                 text=True,

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -47,6 +47,18 @@ from .host_configuration_script import HostConfigurationScriptRunner
 __all__ = ["entrypoint"]
 _logger = logging.getLogger(__name__)
 
+LINUX_SHUTDOWN_PATH = "/usr/sbin/shutdown"
+"""The absolute path the installer's sudoers rule grants.
+
+Must stay byte-identical to the path in the ``NOPASSWD:`` rule that
+``installer/install.sh`` writes to ``/etc/sudoers.d/deadline-worker-shutdown``.
+sudoers matches one exact path, so resolving this at runtime instead risks
+producing a path the rule does not cover -- see ``_host_shutdown``.
+"""
+
+MACOS_SHUTDOWN_PATH = "/sbin/shutdown"
+"""macOS ships shutdown at /sbin/shutdown, and /usr/sbin/shutdown does not exist."""
+
 
 def _repeatedly_attempt_host_shutdown() -> bool:
     # This is here solely for the purpose of being mocked in tests so that we don't infinite loop.
@@ -338,21 +350,29 @@ def _host_shutdown(config: Configuration) -> None:
 
     shutdown_command: list[str]
 
-    # Resolved from trusted directories rather than through PATH. Note the POSIX
-    # branches deliberately do not hardcode a shutdown location: it is
-    # /usr/sbin/shutdown on usr-merged distributions but only /sbin/shutdown on
-    # some Debian releases, so a literal would fail to shut the host down there.
+    # `sudo` is resolved from trusted directories: the agent execs it directly, so
+    # that position is a real PATH lookup and a real CWE-426 exposure.
+    #
+    # `shutdown` is NOT resolved, and must not be. Its path is not a free choice --
+    # it is a contract with the sudoers rule the installer writes:
+    #
+    #     ${wa_user} ALL=(root) NOPASSWD: /usr/sbin/shutdown now
+    #                                     ^ installer/install.sh
+    #
+    # sudoers grants one exact path. Resolving instead of using LINUX_SHUTDOWN_PATH
+    # can yield /usr/bin/shutdown on a usr-merged distribution, which no longer
+    # matches the granted rule, so shutdown-on-stop starts prompting for a password
+    # and fails. Nor is this position a PATH lookup to begin with: sudo resolves its
+    # own argument, as root, and the agent hands it an absolute path either way.
+    #
+    # test_shutdown_path_matches_the_installer_sudoers_rule pins the pairing by
+    # reading install.sh, so the two cannot drift apart silently.
     if sys.platform == "win32":
         shutdown_command = [system_command_path("shutdown.exe"), "-s"]
     elif sys.platform == "darwin":
-        shutdown_command = [
-            system_command_path("sudo"),
-            system_command_path("shutdown"),
-            "-h",
-            "now",
-        ]
+        shutdown_command = [system_command_path("sudo"), MACOS_SHUTDOWN_PATH, "-h", "now"]
     else:
-        shutdown_command = [system_command_path("sudo"), system_command_path("shutdown"), "now"]
+        shutdown_command = [system_command_path("sudo"), LINUX_SHUTDOWN_PATH, "now"]
 
     # flush all the logs before initiating the shutdown command.
     for handler in _logger.handlers:

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -37,6 +37,7 @@ from ..log_messages import (
     WorkerLogEventOp,
     WorkerHostConfigurationLogEvent,
 )
+from .._system_commands import system_command_path
 from ..log_sync.cloudwatch import stream_cloudwatch_logs
 from ..log_sync.loggers import ROOT_LOGGER, logger as log_sync_logger
 from ..worker import Worker
@@ -337,12 +338,21 @@ def _host_shutdown(config: Configuration) -> None:
 
     shutdown_command: list[str]
 
+    # Resolved from trusted directories rather than through PATH. Note the POSIX
+    # branches deliberately do not hardcode a shutdown location: it is
+    # /usr/sbin/shutdown on usr-merged distributions but only /sbin/shutdown on
+    # some Debian releases, so a literal would fail to shut the host down there.
     if sys.platform == "win32":
-        shutdown_command = ["shutdown", "-s"]
+        shutdown_command = [system_command_path("shutdown.exe"), "-s"]
     elif sys.platform == "darwin":
-        shutdown_command = ["sudo", "shutdown", "-h", "now"]
+        shutdown_command = [
+            system_command_path("sudo"),
+            system_command_path("shutdown"),
+            "-h",
+            "now",
+        ]
     else:
-        shutdown_command = ["sudo", "shutdown", "now"]
+        shutdown_command = [system_command_path("sudo"), system_command_path("shutdown"), "now"]
 
     # flush all the logs before initiating the shutdown command.
     for handler in _logger.handlers:

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -351,7 +351,7 @@ def _host_shutdown(config: Configuration) -> None:
     shutdown_command: list[str]
 
     # `sudo` is resolved from trusted directories: the agent execs it directly, so
-    # that position is a real PATH lookup and a real CWE-426 exposure.
+    # that position really is a PATH lookup.
     #
     # `shutdown` is NOT resolved, and must not be. Its path is not a free choice --
     # it is a contract with the sudoers rule the installer writes:

--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -37,7 +37,7 @@ from ..log_messages import (
     WorkerLogEventOp,
     WorkerHostConfigurationLogEvent,
 )
-from .._system_commands import system_command_path
+from .._system_commands import SystemCommandNotFoundError, system_command_path
 from ..log_sync.cloudwatch import stream_cloudwatch_logs
 from ..log_sync.loggers import ROOT_LOGGER, logger as log_sync_logger
 from ..worker import Worker
@@ -367,12 +367,20 @@ def _host_shutdown(config: Configuration) -> None:
     #
     # test_shutdown_path_matches_the_installer_sudoers_rule pins the pairing by
     # reading install.sh, so the two cannot drift apart silently.
-    if sys.platform == "win32":
-        shutdown_command = [system_command_path("shutdown.exe"), "-s"]
-    elif sys.platform == "darwin":
-        shutdown_command = [system_command_path("sudo"), MACOS_SHUTDOWN_PATH, "-h", "now"]
-    else:
-        shutdown_command = [system_command_path("sudo"), LINUX_SHUTDOWN_PATH, "now"]
+    # A resolution failure is reported and returned from, not raised. Callers treat
+    # _host_shutdown as best-effort and retry until the host goes down; letting an
+    # exception out of here instead unwinds to the top-level handler and exits the
+    # agent, which ends the retrying and leaves the host up with no further attempt.
+    try:
+        if sys.platform == "win32":
+            shutdown_command = [system_command_path("shutdown.exe"), "-s"]
+        elif sys.platform == "darwin":
+            shutdown_command = [system_command_path("sudo"), MACOS_SHUTDOWN_PATH, "-h", "now"]
+        else:
+            shutdown_command = [system_command_path("sudo"), LINUX_SHUTDOWN_PATH, "now"]
+    except SystemCommandNotFoundError as e:
+        _logger.error(f"Cannot shut down the host: {e}")
+        return
 
     # flush all the logs before initiating the shutdown command.
     for handler in _logger.handlers:

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -46,6 +46,21 @@ def mock_sys_platform(platform: str) -> Generator[str, None, None]:
         yield mock_sys_platform
 
 
+@pytest.fixture(autouse=True)
+def stub_system_command_path() -> Generator[MagicMock, None, None]:
+    """Stub the trusted-path resolver.
+
+    These tests simulate a platform via ``sys.platform``, so a real lookup would
+    resolve against whatever platform the suite is running on. Stubbing also means
+    the ``expected_cmd`` assertion fails if the source ever goes back to a bare or
+    hardcoded command name.
+    """
+    with patch.object(
+        installer_mod, "system_command_path", side_effect=lambda name: f"/trusted/{name}"
+    ) as mock_resolver:
+        yield mock_resolver
+
+
 @pytest.fixture
 def expected_cmd(
     parsed_args: ParsedCommandLineArguments,
@@ -53,7 +68,7 @@ def expected_cmd(
 ) -> list[str]:
     assert parsed_args.region is not None, "Region is required"
     expected_cmd = [
-        "sudo",
+        "/trusted/sudo",
         str(installer_mod.INSTALLER_PATH[platform]),
         "--farm-id",
         parsed_args.farm_id,
@@ -366,7 +381,8 @@ class TestMacOSInstall:
         )
 
         expected_cmd = [
-            "sudo",
+            # Stubbed resolver, per the stub_system_command_path autouse fixture.
+            "/trusted/sudo",
             str(installer_mod.INSTALLER_PATH["darwin"]),
             "--farm-id",
             "farm-1",

--- a/test/unit/scheduler/test_session_cleanup.py
+++ b/test/unit/scheduler/test_session_cleanup.py
@@ -203,7 +203,14 @@ class TestSessionUserCleanupManager:
             subprocess_run_mock.return_value.stderr = "stderr"
 
             # WHEN
-            SessionUserCleanupManager.cleanup_session_user_processes(os_user)
+            # The resolver is stubbed so this asserts the argv shape rather than
+            # this host's sudo and pkill locations, and so that a literal in the
+            # source would fail the assertion below.
+            with patch(
+                "deadline_worker_agent.scheduler.session_cleanup.system_command_path",
+                side_effect=lambda name: f"/trusted/{name}",
+            ):
+                SessionUserCleanupManager.cleanup_session_user_processes(os_user)
 
             # THEN
             assert (
@@ -213,7 +220,7 @@ class TestSessionUserCleanupManager:
             if sys.platform == "darwin":
                 pkill_opt = ["-lU", os_user.user]
             subprocess_run_mock.assert_called_once_with(
-                args=["sudo", "-u", os_user.user, "/usr/bin/pkill", *pkill_opt],
+                args=["/trusted/sudo", "-u", os_user.user, "/trusted/pkill", *pkill_opt],
                 capture_output=True,
                 check=True,
                 text=True,

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -534,9 +534,21 @@ def test_agent_self_initiated_shutdown(
         # whatever platform the suite is actually running on -- and makes the
         # assertion prove the command went through the resolver, since a literal
         # in the source would no longer match.
+        # "/trusted/" marks a command that goes through the stubbed resolver.
+        # `shutdown` deliberately does NOT: its path is a contract with the sudoers
+        # rule install.sh writes, so it is the literal module constant. See
+        # test_system_commands.TestShutdownPathIsASudoersContract.
         pytest.param("win32", ["/trusted/shutdown.exe", "-s"], id="windows"),
-        pytest.param("linux", ["/trusted/sudo", "/trusted/shutdown", "now"], id="linux"),
-        pytest.param("darwin", ["/trusted/sudo", "/trusted/shutdown", "-h", "now"], id="macOS"),
+        pytest.param(
+            "linux",
+            ["/trusted/sudo", entrypoint_mod.LINUX_SHUTDOWN_PATH, "now"],
+            id="linux",
+        ),
+        pytest.param(
+            "darwin",
+            ["/trusted/sudo", entrypoint_mod.MACOS_SHUTDOWN_PATH, "-h", "now"],
+            id="macOS",
+        ),
     ),
 )
 @patch.object(entrypoint_mod._logger, "info")
@@ -585,9 +597,21 @@ def test_host_shutdown(
         # whatever platform the suite is actually running on -- and makes the
         # assertion prove the command went through the resolver, since a literal
         # in the source would no longer match.
+        # "/trusted/" marks a command that goes through the stubbed resolver.
+        # `shutdown` deliberately does NOT: its path is a contract with the sudoers
+        # rule install.sh writes, so it is the literal module constant. See
+        # test_system_commands.TestShutdownPathIsASudoersContract.
         pytest.param("win32", ["/trusted/shutdown.exe", "-s"], id="windows"),
-        pytest.param("linux", ["/trusted/sudo", "/trusted/shutdown", "now"], id="linux"),
-        pytest.param("darwin", ["/trusted/sudo", "/trusted/shutdown", "-h", "now"], id="macOS"),
+        pytest.param(
+            "linux",
+            ["/trusted/sudo", entrypoint_mod.LINUX_SHUTDOWN_PATH, "now"],
+            id="linux",
+        ),
+        pytest.param(
+            "darwin",
+            ["/trusted/sudo", entrypoint_mod.MACOS_SHUTDOWN_PATH, "-h", "now"],
+            id="macOS",
+        ),
     ),
 )
 @patch.object(entrypoint_mod, "_logger")
@@ -648,9 +672,21 @@ def test_host_shutdown_failure(
         # whatever platform the suite is actually running on -- and makes the
         # assertion prove the command went through the resolver, since a literal
         # in the source would no longer match.
+        # "/trusted/" marks a command that goes through the stubbed resolver.
+        # `shutdown` deliberately does NOT: its path is a contract with the sudoers
+        # rule install.sh writes, so it is the literal module constant. See
+        # test_system_commands.TestShutdownPathIsASudoersContract.
         pytest.param("win32", ["/trusted/shutdown.exe", "-s"], id="windows"),
-        pytest.param("linux", ["/trusted/sudo", "/trusted/shutdown", "now"], id="linux"),
-        pytest.param("darwin", ["/trusted/sudo", "/trusted/shutdown", "-h", "now"], id="macOS"),
+        pytest.param(
+            "linux",
+            ["/trusted/sudo", entrypoint_mod.LINUX_SHUTDOWN_PATH, "now"],
+            id="linux",
+        ),
+        pytest.param(
+            "darwin",
+            ["/trusted/sudo", entrypoint_mod.MACOS_SHUTDOWN_PATH, "-h", "now"],
+            id="macOS",
+        ),
     ),
 )
 @patch.object(entrypoint_mod._logger, "debug")

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -527,9 +527,16 @@ def test_agent_self_initiated_shutdown(
 @pytest.mark.parametrize(
     ("expected_platform", "expected_command"),
     (
-        pytest.param("win32", ["shutdown", "-s"], id="windows"),
-        pytest.param("linux", ["sudo", "shutdown", "now"], id="linux"),
-        pytest.param("darwin", ["sudo", "shutdown", "-h", "now"], id="macOS"),
+        # The "/trusted/" prefix comes from the stubbed resolver these tests
+        # install below. Asserting stub output rather than real locations keeps
+        # the expectation independent of the host -- these cases simulate a
+        # platform via sys.platform, so a real lookup would resolve against
+        # whatever platform the suite is actually running on -- and makes the
+        # assertion prove the command went through the resolver, since a literal
+        # in the source would no longer match.
+        pytest.param("win32", ["/trusted/shutdown.exe", "-s"], id="windows"),
+        pytest.param("linux", ["/trusted/sudo", "/trusted/shutdown", "now"], id="linux"),
+        pytest.param("darwin", ["/trusted/sudo", "/trusted/shutdown", "-h", "now"], id="macOS"),
     ),
 )
 @patch.object(entrypoint_mod._logger, "info")
@@ -550,7 +557,12 @@ def test_host_shutdown(
     process.returncode = 0
 
     configuration.no_shutdown = False
-    with patch.object(sys, "platform", expected_platform):
+    with (
+        patch.object(sys, "platform", expected_platform),
+        patch.object(
+            entrypoint_mod, "system_command_path", side_effect=lambda name: f"/trusted/{name}"
+        ),
+    ):
         # WHEN
         entrypoint_mod._host_shutdown(config=configuration)
 
@@ -566,9 +578,16 @@ def test_host_shutdown(
 @pytest.mark.parametrize(
     ("expected_platform", "expected_command"),
     (
-        pytest.param("win32", ["shutdown", "-s"], id="windows"),
-        pytest.param("linux", ["sudo", "shutdown", "now"], id="linux"),
-        pytest.param("darwin", ["sudo", "shutdown", "-h", "now"], id="macOS"),
+        # The "/trusted/" prefix comes from the stubbed resolver these tests
+        # install below. Asserting stub output rather than real locations keeps
+        # the expectation independent of the host -- these cases simulate a
+        # platform via sys.platform, so a real lookup would resolve against
+        # whatever platform the suite is actually running on -- and makes the
+        # assertion prove the command went through the resolver, since a literal
+        # in the source would no longer match.
+        pytest.param("win32", ["/trusted/shutdown.exe", "-s"], id="windows"),
+        pytest.param("linux", ["/trusted/sudo", "/trusted/shutdown", "now"], id="linux"),
+        pytest.param("darwin", ["/trusted/sudo", "/trusted/shutdown", "-h", "now"], id="macOS"),
     ),
 )
 @patch.object(entrypoint_mod, "_logger")
@@ -596,7 +615,12 @@ def test_host_shutdown_failure(
     logger_mock.handlers = [handler_0, handler_1]
 
     configuration.no_shutdown = False
-    with patch.object(sys, "platform", expected_platform):
+    with (
+        patch.object(sys, "platform", expected_platform),
+        patch.object(
+            entrypoint_mod, "system_command_path", side_effect=lambda name: f"/trusted/{name}"
+        ),
+    ):
         # WHEN
         entrypoint_mod._host_shutdown(config=configuration)
 
@@ -617,9 +641,16 @@ def test_host_shutdown_failure(
 @pytest.mark.parametrize(
     ("expected_platform", "expected_command"),
     (
-        pytest.param("win32", ["shutdown", "-s"], id="windows"),
-        pytest.param("linux", ["sudo", "shutdown", "now"], id="linux"),
-        pytest.param("darwin", ["sudo", "shutdown", "-h", "now"], id="macOS"),
+        # The "/trusted/" prefix comes from the stubbed resolver these tests
+        # install below. Asserting stub output rather than real locations keeps
+        # the expectation independent of the host -- these cases simulate a
+        # platform via sys.platform, so a real lookup would resolve against
+        # whatever platform the suite is actually running on -- and makes the
+        # assertion prove the command went through the resolver, since a literal
+        # in the source would no longer match.
+        pytest.param("win32", ["/trusted/shutdown.exe", "-s"], id="windows"),
+        pytest.param("linux", ["/trusted/sudo", "/trusted/shutdown", "now"], id="linux"),
+        pytest.param("darwin", ["/trusted/sudo", "/trusted/shutdown", "-h", "now"], id="macOS"),
     ),
 )
 @patch.object(entrypoint_mod._logger, "debug")
@@ -638,7 +669,12 @@ def test_no_shutdown_only_log(
     """
     # GIVEN
     configuration.no_shutdown = True
-    with patch.object(sys, "platform", expected_platform):
+    with (
+        patch.object(sys, "platform", expected_platform),
+        patch.object(
+            entrypoint_mod, "system_command_path", side_effect=lambda name: f"/trusted/{name}"
+        ),
+    ):
         # WHEN
         entrypoint_mod._host_shutdown(config=configuration)
 

--- a/test/unit/test_system_commands.py
+++ b/test/unit/test_system_commands.py
@@ -11,6 +11,7 @@ property matters.
 from __future__ import annotations
 
 import os
+import re
 import stat
 import sys
 from pathlib import Path
@@ -18,6 +19,7 @@ from unittest.mock import patch
 
 import pytest
 
+from deadline_worker_agent.startup import entrypoint as entrypoint_mod
 from deadline_worker_agent._system_commands import (
     SystemCommandNotFoundError,
     find_system_command,
@@ -115,6 +117,13 @@ class TestRejectsNonBareNames:
             pytest.param("", id="empty"),
             pytest.param(".", id="curdir"),
             pytest.param("..", id="pardir"),
+            # This resolver is the one with a Windows branch, so the drive-relative
+            # case is directly exploitable here:
+            # ntpath.join(r"C:\Windows\System32", "D:evil") == "D:evil", which
+            # escapes every trusted directory while containing no separator.
+            pytest.param("D:evil", id="drive-relative"),
+            pytest.param("C:evil", id="drive-relative-same-drive"),
+            pytest.param("a:b", id="colon"),
         ],
     )
     def test_rejects_name_with_a_path_component(self, name: str) -> None:
@@ -168,10 +177,19 @@ class TestMissingCommandRaises:
         assert "deadline-definitely-not-installed" in message
         assert "PATH is deliberately not searched" in message
 
-    def test_is_not_a_filenotfounderror(self) -> None:
-        """Callers around subprocess treat FileNotFoundError as "optional tool
-        absent, carry on". This must not be absorbed by that handling."""
-        assert not issubclass(SystemCommandNotFoundError, FileNotFoundError)
+    def test_is_a_filenotfounderror(self) -> None:
+        """The inverse of what an earlier revision asserted, and the reversal is the
+        point.
+
+        That revision made this a plain Exception so "carry on degraded" handlers
+        could not absorb it -- a theory about surrounding code that was never
+        checked against it. The semantics this condition has are
+        FileNotFoundError's: the thing we meant to launch is not there, which is
+        exactly how capabilities.py and metrics.py already treat a missing
+        nvidia-smi.
+        """
+        assert issubclass(SystemCommandNotFoundError, FileNotFoundError)
+        assert SystemCommandNotFoundError is not FileNotFoundError
 
 
 class TestTrustedDirectories:
@@ -185,6 +203,17 @@ class TestTrustedDirectories:
         directories = trusted_directories()
 
         assert directories.index("/run/wrappers/bin") < directories.index("/usr/bin")
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX directory layout")
+    def test_posix_has_the_two_nixos_entries_as_a_pair(self) -> None:
+        """/run/wrappers/bin alone supports no complete code path: it holds only the
+        setuid wrappers, so on NixOS it resolves sudo and nothing else. pkill lives
+        in the sw/bin symlink farm, so without that entry the ordering would resolve
+        sudo and then fail on pkill."""
+        directories = trusted_directories()
+
+        assert "/run/wrappers/bin" in directories
+        assert "/run/current-system/sw/bin" in directories
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX directory layout")
     def test_posix_searches_both_sbin_locations(self) -> None:
@@ -202,3 +231,68 @@ class TestTrustedDirectories:
 
         assert len(directories) == 1
         assert directories[0].lower().endswith("system32")
+
+
+class TestShutdownPathIsASudoersContract:
+    """`shutdown`'s path is granted by a sudoers rule, so it must not be resolved.
+
+    ``installer/install.sh`` writes ``/etc/sudoers.d/deadline-worker-shutdown``
+    containing a ``NOPASSWD:`` rule for one *exact* path. sudoers matches that path
+    literally, so if the agent invokes a different absolute path for the same binary
+    -- which a trusted-directory search can legitimately produce, since
+    ``/usr/bin`` is searched before ``/usr/sbin`` and both exist on a usr-merged
+    distribution -- the rule stops matching, sudo prompts for a password, and
+    shutdown-on-stop fails.
+
+    These tests read install.sh rather than restating its path, so the pairing
+    cannot drift apart silently. That is the whole point: a constant asserted
+    against a copy of itself would pin nothing.
+    """
+
+    @staticmethod
+    def _granted_shutdown_path() -> str:
+        install_sh = (
+            Path(__file__).parents[2] / "src" / "deadline_worker_agent" / "installer" / "install.sh"
+        )
+        content = install_sh.read_text()
+        match = re.search(r"NOPASSWD:\s*(\S+)\s+now", content)
+        assert match is not None, (
+            "Could not find the NOPASSWD shutdown rule in install.sh. If the rule "
+            "moved or changed shape, this test needs updating -- do not delete it, "
+            "the contract it guards is still real."
+        )
+        return match.group(1)
+
+    def test_shutdown_path_matches_the_installer_sudoers_rule(self) -> None:
+        # GIVEN / WHEN
+        granted = self._granted_shutdown_path()
+
+        # THEN
+        assert entrypoint_mod.LINUX_SHUTDOWN_PATH == granted, (
+            f"The agent would invoke {entrypoint_mod.LINUX_SHUTDOWN_PATH!r} but sudoers "
+            f"grants {granted!r}. sudo matches the path literally, so these must agree."
+        )
+
+    def test_the_granted_path_is_absolute(self) -> None:
+        """A relative path in a sudoers rule would not be a contract at all."""
+        assert os.path.isabs(self._granted_shutdown_path())
+
+    def test_shutdown_is_not_looked_up_in_the_trusted_directories(self) -> None:
+        """The regression this guards: if `shutdown` were resolved, the search order
+        could return a path outside the sudoers grant.
+
+        Asserted structurally -- `/usr/bin` really does precede `/usr/sbin`, so a
+        resolved `shutdown` on a usr-merged host really can differ from the granted
+        path. That makes "do not resolve it" the load-bearing decision rather than a
+        stylistic one.
+        """
+        directories = trusted_directories()
+
+        assert directories.index("/usr/bin") < directories.index("/usr/sbin")
+        assert entrypoint_mod.LINUX_SHUTDOWN_PATH.startswith("/usr/sbin/")
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="macOS layout")
+    def test_macos_shutdown_path_exists_on_this_host(self) -> None:
+        """macOS has no /usr/sbin/shutdown, so the two platforms need different
+        constants. Positive control that the macOS one is right."""
+        assert os.path.isfile(entrypoint_mod.MACOS_SHUTDOWN_PATH)

--- a/test/unit/test_system_commands.py
+++ b/test/unit/test_system_commands.py
@@ -1,0 +1,204 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for the trusted-path command resolver.
+
+These pin the security properties of ``_system_commands``. Each has been
+mutation-checked: reverting the corresponding production behaviour makes a named
+test here fail. See the module docstring of ``_system_commands`` for why each
+property matters.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from deadline_worker_agent._system_commands import (
+    SystemCommandNotFoundError,
+    find_system_command,
+    system_command_path,
+    trusted_directories,
+)
+
+
+@pytest.fixture
+def executable_dir(tmp_path: Path) -> Path:
+    """A directory containing an executable file named ``target-cmd``."""
+    target = tmp_path / "target-cmd"
+    target.write_text("#!/bin/sh\ntrue\n")
+    target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return tmp_path
+
+
+class TestOnlySearchesTrustedDirectories:
+    def test_resolves_a_command_in_a_searched_directory(self, executable_dir: Path) -> None:
+        """The negative control. Without this, "nothing was found" results below
+        would be indistinguishable from a resolver that never finds anything."""
+        # GIVEN
+        with patch(
+            "deadline_worker_agent._system_commands.trusted_directories",
+            return_value=(str(executable_dir),),
+        ):
+            # WHEN
+            result = find_system_command("target-cmd")
+
+        # THEN
+        assert result == str(executable_dir / "target-cmd")
+
+    def test_does_not_resolve_a_command_outside_searched_directories(
+        self, executable_dir: Path
+    ) -> None:
+        # GIVEN
+        with patch(
+            "deadline_worker_agent._system_commands.trusted_directories",
+            return_value=("/usr/bin", "/bin"),
+        ):
+            # WHEN
+            result = find_system_command("target-cmd")
+
+        # THEN
+        assert result is None
+
+    def test_ignores_path_even_when_it_contains_a_matching_command(
+        self, executable_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pins "PATH is never read".
+
+        This is the property a ``shutil.which`` implementation would silently
+        violate, and the one a PATH fallback for missing commands would undo.
+        """
+        # GIVEN
+        monkeypatch.setenv("PATH", str(executable_dir))
+        with patch(
+            "deadline_worker_agent._system_commands.trusted_directories",
+            return_value=("/usr/bin", "/bin"),
+        ):
+            # WHEN
+            result = find_system_command("target-cmd")
+
+        # THEN
+        assert result is None, "PATH was consulted"
+
+    def test_returns_the_first_matching_directory(self, tmp_path: Path) -> None:
+        """Order is load-bearing: on NixOS the setuid sudo wrapper must win over
+        a non-setuid /usr/bin copy."""
+        # GIVEN
+        first, second = tmp_path / "first", tmp_path / "second"
+        for directory in (first, second):
+            directory.mkdir()
+            target = directory / "target-cmd"
+            target.write_text("#!/bin/sh\ntrue\n")
+            target.chmod(target.stat().st_mode | stat.S_IXUSR)
+
+        with patch(
+            "deadline_worker_agent._system_commands.trusted_directories",
+            return_value=(str(first), str(second)),
+        ):
+            # WHEN
+            result = find_system_command("target-cmd")
+
+        # THEN
+        assert result == str(first / "target-cmd")
+
+
+class TestRejectsNonBareNames:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            pytest.param("a/b", id="forward-slash"),
+            pytest.param("a\\b", id="backslash"),
+            pytest.param("", id="empty"),
+            pytest.param(".", id="curdir"),
+            pytest.param("..", id="pardir"),
+        ],
+    )
+    def test_rejects_name_with_a_path_component(self, name: str) -> None:
+        with pytest.raises(ValueError):
+            find_system_command(name)
+
+    def test_rejects_traversal_even_though_the_target_is_reachable(self, tmp_path: Path) -> None:
+        """The guard must be about the name, not about whether the join happens to
+        land on a real file -- so prove the target IS reachable by that join
+        before asserting the name is refused.
+
+        Without this, a test using a directory whose parent holds nothing would
+        pass even with the guard deleted, pinning nothing.
+        """
+        # GIVEN
+        target = tmp_path / "target-cmd"
+        target.write_text("#!/bin/sh\ntrue\n")
+        target.chmod(target.stat().st_mode | stat.S_IXUSR)
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        assert os.path.isfile(os.path.join(str(nested), "../target-cmd")), (
+            "precondition: the traversal target is reachable by this join"
+        )
+
+        # WHEN / THEN
+        with patch(
+            "deadline_worker_agent._system_commands.trusted_directories",
+            return_value=(str(nested),),
+        ):
+            with pytest.raises(ValueError, match="path separator"):
+                find_system_command("../target-cmd")
+
+    def test_rejection_is_valueerror_not_notfound(self) -> None:
+        """A bad name is a caller bug; a missing command is an environment
+        problem. Conflating them would let a caller mistake one for the other."""
+        with pytest.raises(ValueError):
+            system_command_path("a/b")
+
+
+class TestMissingCommandRaises:
+    def test_find_returns_none(self) -> None:
+        assert find_system_command("deadline-definitely-not-installed") is None
+
+    def test_system_command_path_raises_rather_than_returning_the_bare_name(self) -> None:
+        """The silent-fallback failure mode: returning "sudo" here would look
+        fixed and behave exactly as the vulnerability did."""
+        with pytest.raises(SystemCommandNotFoundError) as excinfo:
+            system_command_path("deadline-definitely-not-installed")
+
+        message = str(excinfo.value)
+        assert "deadline-definitely-not-installed" in message
+        assert "PATH is deliberately not searched" in message
+
+    def test_is_not_a_filenotfounderror(self) -> None:
+        """Callers around subprocess treat FileNotFoundError as "optional tool
+        absent, carry on". This must not be absorbed by that handling."""
+        assert not issubclass(SystemCommandNotFoundError, FileNotFoundError)
+
+
+class TestTrustedDirectories:
+    def test_all_entries_are_absolute(self) -> None:
+        """A relative entry would resolve against the process working directory."""
+        for directory in trusted_directories():
+            assert os.path.isabs(directory), f"{directory} is not absolute"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX directory layout")
+    def test_posix_searches_the_setuid_wrapper_directory_before_usr_bin(self) -> None:
+        directories = trusted_directories()
+
+        assert directories.index("/run/wrappers/bin") < directories.index("/usr/bin")
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX directory layout")
+    def test_posix_searches_both_sbin_locations(self) -> None:
+        """shutdown is at /usr/sbin/shutdown on usr-merged distributions but only
+        at /sbin/shutdown on some Debian releases. Hardcoding either one broke a
+        host; both must be searched."""
+        directories = trusted_directories()
+
+        assert "/usr/sbin" in directories
+        assert "/sbin" in directories
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only layout")
+    def test_windows_searches_system32_under_systemroot(self) -> None:
+        directories = trusted_directories()
+
+        assert len(directories) == 1
+        assert directories[0].lower().endswith("system32")

--- a/test/unit/test_system_commands.py
+++ b/test/unit/test_system_commands.py
@@ -16,7 +16,7 @@ import re
 import stat
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -261,30 +261,36 @@ class TestShutdownPathIsASudoersContract:
     """
 
     @staticmethod
-    def _granted_shutdown_path(installer: str) -> str:
-        """The absolute path the given installer's NOPASSWD rule grants."""
+    def _granted_shutdown_argv(installer: str) -> list[str]:
+        """The full argv the given installer's NOPASSWD rule grants.
+
+        The whole argv, not just the path. sudo matches the entire command line, so
+        pinning only the path would let two silent drifts through: the macOS rule
+        losing its ``-h`` while the agent still sends it, or the Linux rule gaining
+        one while the agent sends a bare ``now``. Either produces a password prompt
+        at shutdown time, which is exactly the failure this test exists to catch.
+        """
         script = (
             Path(__file__).parents[2] / "src" / "deadline_worker_agent" / "installer" / installer
         )
         content = script.read_text()
-        # install.sh grants "<path> now"; install_macos.sh grants "<path> -h now".
-        match = re.search(r"NOPASSWD:\s*(\S+)(?:\s+-h)?\s+now", content)
+        match = re.search(r"NOPASSWD:\s*(\S.*?)\s*$", content, re.MULTILINE)
         assert match is not None, (
             f"Could not find the NOPASSWD shutdown rule in {installer}. If the rule "
             "moved or changed shape, this test needs updating -- do not delete it, "
             "the contract it guards is still real."
         )
-        return match.group(1)
+        return match.group(1).split()
 
     @pytest.mark.parametrize(
-        "installer,constant_name",
+        "installer,platform,expected_flags",
         [
-            pytest.param("install.sh", "LINUX_SHUTDOWN_PATH", id="linux"),
-            pytest.param("install_macos.sh", "MACOS_SHUTDOWN_PATH", id="macOS"),
+            pytest.param("install.sh", "linux", ["now"], id="linux"),
+            pytest.param("install_macos.sh", "darwin", ["-h", "now"], id="macOS"),
         ],
     )
-    def test_shutdown_path_matches_the_installer_sudoers_rule(
-        self, installer: str, constant_name: str
+    def test_shutdown_argv_matches_the_installer_sudoers_rule(
+        self, installer: str, platform: str, expected_flags: list
     ) -> None:
         """Both platforms have their own rule, and both must be pinned.
 
@@ -292,15 +298,32 @@ class TestShutdownPathIsASudoersContract:
         that "the sudoers command MUST continue to match that argv exactly". The
         macOS constant agreed with it only by coincidence until this test existed.
         """
-        # GIVEN / WHEN
-        granted = self._granted_shutdown_path(installer)
-        invoked = getattr(entrypoint_mod, constant_name)
+        # GIVEN the argv the agent builds for this platform, minus the sudo prefix
+        granted = self._granted_shutdown_argv(installer)
+        configuration = MagicMock()
+        configuration.no_shutdown = False
+        with (
+            patch.object(sys, "platform", platform),
+            patch.object(
+                entrypoint_mod, "system_command_path", side_effect=lambda n: f"/trusted/{n}"
+            ),
+            patch.object(entrypoint_mod.subprocess, "Popen") as popen,
+        ):
+            popen.return_value.communicate.return_value = (b"", b"")
+            popen.return_value.returncode = 0
+            entrypoint_mod._host_shutdown(config=configuration)
+
+        # WHEN the sudo prefix is dropped
+        invoked = list(popen.call_args.args[0])
+        assert invoked[0] == "/trusted/sudo"
+        invoked_command = invoked[1:]
 
         # THEN
-        assert invoked == granted, (
-            f"The agent would invoke {invoked!r} but {installer} grants {granted!r}. "
-            f"sudo matches the path literally, so these must agree."
+        assert invoked_command == granted, (
+            f"The agent would run {invoked_command!r} but {installer} grants "
+            f"{granted!r}. sudo matches the whole command line, so these must agree."
         )
+        assert invoked_command[1:] == expected_flags
 
     @pytest.mark.parametrize("installer", ["install.sh", "install_macos.sh"])
     def test_the_granted_path_is_absolute(self, installer: str) -> None:
@@ -312,7 +335,7 @@ class TestShutdownPathIsASudoersContract:
         statement about the host running the tests, and it failed the
         windows-latest 3.13 leg for that reason.
         """
-        assert posixpath.isabs(self._granted_shutdown_path(installer))
+        assert posixpath.isabs(self._granted_shutdown_argv(installer)[0])
 
     @pytest.mark.skipif(
         sys.platform == "win32",

--- a/test/unit/test_system_commands.py
+++ b/test/unit/test_system_commands.py
@@ -11,6 +11,7 @@ property matters.
 from __future__ import annotations
 
 import os
+import posixpath
 import re
 import stat
 import sys
@@ -217,9 +218,19 @@ class TestTrustedDirectories:
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX directory layout")
     def test_posix_searches_both_sbin_locations(self) -> None:
-        """shutdown is at /usr/sbin/shutdown on usr-merged distributions but only
-        at /sbin/shutdown on some Debian releases. Hardcoding either one broke a
-        host; both must be searched."""
+        """Both sbin directories are searched, for commands that live only there.
+
+        The original justification for these two entries was `shutdown`, which is
+        no longer resolved at all (its path is a sudoers contract, see
+        TestShutdownPathIsASudoersContract). So today no production caller resolves
+        an sbin command: sudo and pkill are both /usr/bin, and shutdown.exe is
+        System32.
+
+        They are kept rather than deleted because the resolver is general and the
+        split is real -- on non-usr-merged distributions a system command can exist
+        only under /sbin -- but the honest status is "no current caller", not "the
+        shutdown case requires it".
+        """
         directories = trusted_directories()
 
         assert "/usr/sbin" in directories
@@ -250,33 +261,64 @@ class TestShutdownPathIsASudoersContract:
     """
 
     @staticmethod
-    def _granted_shutdown_path() -> str:
-        install_sh = (
-            Path(__file__).parents[2] / "src" / "deadline_worker_agent" / "installer" / "install.sh"
+    def _granted_shutdown_path(installer: str) -> str:
+        """The absolute path the given installer's NOPASSWD rule grants."""
+        script = (
+            Path(__file__).parents[2] / "src" / "deadline_worker_agent" / "installer" / installer
         )
-        content = install_sh.read_text()
-        match = re.search(r"NOPASSWD:\s*(\S+)\s+now", content)
+        content = script.read_text()
+        # install.sh grants "<path> now"; install_macos.sh grants "<path> -h now".
+        match = re.search(r"NOPASSWD:\s*(\S+)(?:\s+-h)?\s+now", content)
         assert match is not None, (
-            "Could not find the NOPASSWD shutdown rule in install.sh. If the rule "
+            f"Could not find the NOPASSWD shutdown rule in {installer}. If the rule "
             "moved or changed shape, this test needs updating -- do not delete it, "
             "the contract it guards is still real."
         )
         return match.group(1)
 
-    def test_shutdown_path_matches_the_installer_sudoers_rule(self) -> None:
+    @pytest.mark.parametrize(
+        "installer,constant_name",
+        [
+            pytest.param("install.sh", "LINUX_SHUTDOWN_PATH", id="linux"),
+            pytest.param("install_macos.sh", "MACOS_SHUTDOWN_PATH", id="macOS"),
+        ],
+    )
+    def test_shutdown_path_matches_the_installer_sudoers_rule(
+        self, installer: str, constant_name: str
+    ) -> None:
+        """Both platforms have their own rule, and both must be pinned.
+
+        install_macos.sh grants `/sbin/shutdown -h now` and says in its own comment
+        that "the sudoers command MUST continue to match that argv exactly". The
+        macOS constant agreed with it only by coincidence until this test existed.
+        """
         # GIVEN / WHEN
-        granted = self._granted_shutdown_path()
+        granted = self._granted_shutdown_path(installer)
+        invoked = getattr(entrypoint_mod, constant_name)
 
         # THEN
-        assert entrypoint_mod.LINUX_SHUTDOWN_PATH == granted, (
-            f"The agent would invoke {entrypoint_mod.LINUX_SHUTDOWN_PATH!r} but sudoers "
-            f"grants {granted!r}. sudo matches the path literally, so these must agree."
+        assert invoked == granted, (
+            f"The agent would invoke {invoked!r} but {installer} grants {granted!r}. "
+            f"sudo matches the path literally, so these must agree."
         )
 
-    def test_the_granted_path_is_absolute(self) -> None:
-        """A relative path in a sudoers rule would not be a contract at all."""
-        assert os.path.isabs(self._granted_shutdown_path())
+    @pytest.mark.parametrize("installer", ["install.sh", "install_macos.sh"])
+    def test_the_granted_path_is_absolute(self, installer: str) -> None:
+        """A relative path in a sudoers rule would not be a contract at all.
 
+        posixpath rather than os.path: the granted path is a POSIX path read out of
+        a shell script, and from Python 3.13 ntpath.isabs() treats a single-slash
+        path as drive-relative rather than absolute. Using os.path made this a
+        statement about the host running the tests, and it failed the
+        windows-latest 3.13 leg for that reason.
+        """
+        assert posixpath.isabs(self._granted_shutdown_path(installer))
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="trusted_directories() returns the Windows System32 layout there, "
+        "which has no /usr/bin or /usr/sbin to order",
+    )
     def test_shutdown_is_not_looked_up_in_the_trusted_directories(self) -> None:
         """The regression this guards: if `shutdown` were resolved, the search order
         could return a path outside the sudoers grant.


### PR DESCRIPTION
## Problem

The agent invoked `sudo`, `pkill` and `shutdown` by bare name, so each was
resolved through `PATH`. Where any part of that search path is influenced by
less-trusted input, the resolution itself is the vulnerability (CWE-426,
Untrusted Search Path) — and the agent runs these as a privileged user.

Companion to HackerOne 3942741, reported against `openjd-sessions-for-python`.

## Fix

New `_system_commands` module resolves a bare command name against a fixed,
ordered list of trusted absolute directories. `PATH` is never consulted, and
neither is `shutil.which` — it resolves through `PATH`, so it would reintroduce
the problem while appearing to fix it.

### This also fixes two defects in the obvious alternative

Hardcoding absolute literals closes the hole but breaks hosts:

- **`/usr/sbin/shutdown` is wrong on non-usr-merged Debian**, where `shutdown`
  exists only at `/sbin/shutdown`. A literal there trades a security bug for a
  host that will not shut down on stop. Both `sbin` directories are now searched.
- **The Windows branch still invoked a bare `shutdown`** and is now resolved from
  `System32` under `SystemRoot`.

`/usr/bin/sudo` is likewise not universal — NixOS keeps the setuid wrapper at
`/run/wrappers/bin/sudo`, so that directory is searched first.

## Properties pinned, and mutation-checked

Each mutation was applied to the production source, the suite run, and the source
restored and verified by checksum. Baseline green before each.

| # | Mutation | Caught by |
|---|---|---|
| M1 | resolve via `shutil.which` | `test_ignores_path_even_when_it_contains_a_matching_command` + 2 |
| M2 | drop the path-separator guard | `test_rejects_traversal_even_though_the_target_is_reachable` + 3 |
| M3 | fall back to the bare name | `test_system_command_path_raises_rather_than_returning_the_bare_name` |
| M4 | subclass `FileNotFoundError` | `test_is_not_a_filenotfounderror` |
| M5 | search `/usr/bin` before the wrapper dir | `test_posix_searches_the_setuid_wrapper_directory_before_usr_bin` |
| M6 | drop `/sbin` | `test_posix_searches_both_sbin_locations` |

M4 is worth calling out: callers around `subprocess` catch `FileNotFoundError` to
mean "optional tool absent, carry on degraded". An unavailable *privileged helper*
must not be absorbed by that handling, so `SystemCommandNotFoundError`
deliberately does not inherit from it.

M2 is why there are two traversal tests. The straightforward one does not catch
the mutation on its own — with the executable directly in the searched directory,
`../name` resolves to nothing either way — so
`test_rejects_traversal_even_though_the_target_is_reachable` nests the directory
so the traversal reaches a real file, and asserts that precondition.

## Test changes

Existing tests that asserted command locations now stub the resolver. Those cases
simulate a platform via `sys.platform`, so a real lookup would resolve against
whatever platform the suite is actually running on. Stubbing also means a literal
reappearing in the source fails the assertion.

## Verification

- `hatch run fmt` clean
- `hatch run lint` clean (ruff, ruff format, mypy — 200 source files)
- `hatch run test`: **3077 passed, 48 skipped**

One caveat, stated plainly: across four full-suite runs, one run had
`test/unit/test_session_events.py::test_log_before_call[DeleteWorkerBeforeCallTest]`
fail. It passes in isolation (27/27, repeatedly) and the other three full runs
were clean. The suite uses `pytest-randomly`, and that test has no relationship
to the files changed here, so I believe it is a pre-existing order-dependent
flake — but I was not able to prove it pre-existing, so I am flagging rather than
asserting it.

**The Windows shutdown path is unverified.** I have no Windows host; that branch
is covered by a unit test of the directory layout only, not by execution.


## Scope note: pkill and shutdown were not part of the reported defect

Raised in review and worth stating plainly.

`session_cleanup.py` already used the absolute literal `/usr/bin/pkill`, so routing
it through the resolver removes no exposure. It is here for consistency, so that one
mechanism owns every privileged command name in the package, and so a later edit
cannot reintroduce a bare name unnoticed.

`shutdown` is the opposite case: it is now deliberately **not** resolved. Its path is
a contract with the sudoers rule the installer writes, and a trusted-directory search
can legitimately return a path that rule does not grant. A unit test reads the rule
out of each installer and compares the full granted argv against what the agent
builds, so drift on either side fails the build instead of producing a password
prompt at shutdown time.

The only site in this package where a bare name was resolved through `PATH` at
privilege is `sudo`.
