### PR TITLE
fix: set explicit Windows ACL on materialized embedded files

### DIFF
--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -39,6 +39,11 @@ from openjd.sessions._v1 import (
     WindowsSessionUser as RustWindowsSessionUser,
 )
 
+from deadline_worker_agent.file_system_operations import (
+    FileSystemPermissionEnum,
+    set_permissions,
+)
+
 from . import SessionRuntime, SessionRuntimeConfig
 from ._abc import convert_runtime_crashes
 
@@ -422,15 +427,26 @@ class RustSessionRuntime(SessionRuntime):
                 # manifest JSON, which the reader script decodes as UTF-8.
                 with os.fdopen(fd, "w", encoding="utf-8") as f:
                     f.write(str(embedded_file.data))
-                # Owner read/write. On POSIX, also grant the session user's group
-                # read access so the job user can read the materialized file.
+                # Owner read/write. On POSIX, grant the session user's group read
+                # access so the job user can read the materialized file. On Windows,
+                # set an explicit ACL (agent=full control, job user=read) rather than
+                # relying on NTFS inheritance which may be absent or misconfigured.
                 mode = stat.S_IRUSR | stat.S_IWUSR
                 if self._user is not None and os.name == "posix":
                     group = getattr(self._user, "group", None)
                     if group is not None:
                         chown(path, group=group)
                         mode |= stat.S_IRGRP
-                os.chmod(path, mode)
+                    os.chmod(path, mode)
+                elif self._user is not None and os.name == "nt":
+                    set_permissions(
+                        file_path=Path(path),
+                        agent_user_permission=FileSystemPermissionEnum.READ_WRITE,
+                        user_permission=FileSystemPermissionEnum.READ,
+                        permitted_user=self._user,
+                    )
+                else:
+                    os.chmod(path, mode)
                 file_paths[embedded_file.name] = path
 
         command = str(step_script.actions.onRun.command)

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import stat
 from dataclasses import replace
 from datetime import timedelta
 from pathlib import Path, PurePosixPath
@@ -15,6 +16,7 @@ import pytest
 from openjd.model._types import ParameterValue, ParameterValueType
 from openjd.model._v1.types import ModelProfile, SpecificationRevision
 
+from deadline_worker_agent.file_system_operations import FileSystemPermissionEnum
 from deadline_worker_agent.sessions.runtime import SessionRuntime, SessionRuntimeConfig
 from deadline_worker_agent.sessions.runtime._abc import SessionRuntimeCrashError
 from deadline_worker_agent.sessions.runtime import rust as rust_module
@@ -657,6 +659,81 @@ class TestRustSessionRuntimeDelegation:
         mock_chmod.assert_called_once()
         assert mock_chmod.call_args.args[1] == 0o600
         mock_rust_session.return_value.run_subprocess.assert_called_once()
+
+    def test_run_task_without_session_env_when_windows_user_sets_acl(
+        self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock, tmp_path: Path
+    ) -> None:
+        """On Windows with a session user, set_permissions grants the agent full
+        control and the job user read access on materialized embedded files."""
+        from openjd.sessions import WindowsSessionUser
+
+        user = MagicMock(spec=WindowsSessionUser)
+        user.user = "job-user"
+        user.password = "fake"
+        user.logon_token = None
+        config = replace(runtime_config, session_id="session-win-acl", user=user)
+
+        with patch.object(rust_module, "_to_rust_session_user", return_value=MagicMock()):
+            adapter = RustSessionRuntime(config)
+        mock_rust_session.return_value.files_directory = tmp_path
+
+        embedded_file = MagicMock()
+        embedded_file.name = "Manifest"
+        embedded_file.data = '{"files": []}'
+        step_script = MagicMock()
+        step_script.embeddedFiles = [embedded_file]
+        step_script.actions.onRun.command = "cmd"
+        step_script.actions.onRun.args = None
+
+        with (
+            patch.object(rust_module.os, "name", "nt"),
+            patch.object(rust_module, "set_permissions") as mock_set_perms,
+            patch.object(rust_module, "Path", side_effect=lambda p: PurePosixPath(p)),
+        ):
+            adapter._run_task_without_session_env(step_script=step_script, task_parameter_values={})
+
+        mock_set_perms.assert_called_once()
+        call_kwargs = mock_set_perms.call_args.kwargs
+        assert call_kwargs["agent_user_permission"] == FileSystemPermissionEnum.READ_WRITE
+        assert call_kwargs["user_permission"] == FileSystemPermissionEnum.READ
+        assert call_kwargs["permitted_user"] is user
+
+    def test_run_task_without_session_env_when_no_user_falls_back_to_chmod(
+        self, mock_rust_session: MagicMock, tmp_path: Path
+    ) -> None:
+        """Without a session user, falls back to owner-only chmod on any platform."""
+        config = SessionRuntimeConfig(
+            session_id="session-no-user",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda session_id, status: None,
+            os_env_vars=None,
+            session_root_directory=Path("/tmp/sessions/session-no-user"),
+        )
+        adapter = RustSessionRuntime(config)
+        mock_rust_session.return_value.files_directory = tmp_path
+
+        embedded_file = MagicMock()
+        embedded_file.name = "Manifest"
+        embedded_file.data = "data"
+        step_script = MagicMock()
+        step_script.embeddedFiles = [embedded_file]
+        step_script.actions.onRun.command = "cmd"
+        step_script.actions.onRun.args = None
+
+        with (
+            patch.object(rust_module.os, "name", "nt"),
+            patch.object(rust_module, "set_permissions") as mock_set_perms,
+            patch.object(rust_module.os, "chmod") as mock_chmod,
+        ):
+            adapter._run_task_without_session_env(step_script=step_script, task_parameter_values={})
+
+        # No user → no set_permissions call, just chmod with owner-only mode
+        mock_set_perms.assert_not_called()
+        mock_chmod.assert_called_once()
+        assert mock_chmod.call_args.args[1] == (stat.S_IRUSR | stat.S_IWUSR)
 
     def test_extend_path_mapping_rules_delegates_without_presorting(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Rust runtime adapter's stopgap file materialization for attachment-sync manifests relied on NTFS inheritance for job-user read access on Windows. If inheritance is absent or misconfigured, files are either unreadable (breaking attachment sync) or over-exposed to other session users.

### What was the solution? (How)

Added an explicit `set_permissions` call on Windows granting the agent user full control and the job user read access. This matches the pattern already used by `run_attachment_download.py`. Restructured the permission block to if/elif/else so each platform has a single clear code path.

### What is the impact of this change?

On Windows with a session user: materialized embedded files now get an explicit ACL regardless of parent directory inheritance. On POSIX: behavior unchanged. Without a session user: owner-only chmod (unchanged).

### How was this change tested?

- 2 new unit tests (Windows ACL branch via mocked `os.name`, no-user fallback)
- Full unit suite: 3070 passed / 39 skipped
- Lint: ruff check + ruff format + mypy all clean
- rust.py coverage: 98%

E2E test log
```
===End Flaky Test Report===
============================= slowest 5 durations ==============================
678.01s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
671.73s setup    test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_local_queue_user[ddl]
328.71s setup    test/e2e/test_session_runtime.py::TestExplicitModeRouting::test_job_succeeds_and_log_shows_runtime_selected[python]
324.66s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_session_root_dir
323.99s setup    test/e2e/test_session_runtime.py::TestServiceSelectedDefaultsToPython::test_job_succeeds_and_log_shows_python_selected
=========================== short test summary info ============================
XFAIL test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_queue_user[ddl] - AD DS install on EC2 is unreliable
XFAIL test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_queue_user[upn] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_local_queue_user[ddl] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_service_identity[ddl] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_config_override_user[ddl] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_local_queue_user[upn] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_service_identity[upn] - AD DS install on EC2 is unreliable
XPASS test/e2e/test_domain_user.py::TestDomainUser::test_job_runs_as_domain_config_override_user[upn] - AD DS install on EC2 is unreliable
= 51 passed, 20 skipped, 2 xfailed, 6 xpassed, 4 warnings in 8083.31s (2:14:43) =
cmd [4] | echo pytest done
pytest done
===============================
```

### Was this change documented?

No doc changes needed — internal implementation detail.

### Is this a breaking change?

No