### PR TITLE
fix: give step-scoped environments their step's name and let bindings

### DIFF
--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -61,6 +61,25 @@ else:
 
 logger = getLogger(__name__)
 
+_STEP_ENVIRONMENT_ID_PREFIX = "STEP:"
+
+
+def _step_id_from_environment_id(environment_id: str) -> str | None:
+    """Extract the step id from a step-scoped environment id.
+
+    Environment ids are scope-prefixed and carry their scope's id, as in
+    ``STEP:step-<uuid>:<environment name>`` or ``JOB:job-<uuid>:<name>``.
+    Returns None for anything that is not step-scoped, so job-scoped
+    environments are never given a step's context.
+    """
+    if not environment_id.startswith(_STEP_ENVIRONMENT_ID_PREFIX):
+        return None
+    remainder = environment_id[len(_STEP_ENVIRONMENT_ID_PREFIX) :]
+    step_id, separator, _ = remainder.partition(":")
+    if not separator or not step_id:
+        return None
+    return step_id
+
 
 @dataclass(frozen=True)
 class SessionActionQueueEntry(Generic[D]):
@@ -443,10 +462,31 @@ class SessionActionQueue:
                             action_id, SessionActionLogKind.ENV_EXIT, str(e)
                         ) from e
                 if action_type == "ENV_ENTER":
+                    # Step-scoped environments need the step's name and `let`
+                    # bindings so their scripts can resolve Step.Name and
+                    # step-level let values. The step id is carried in the
+                    # environment id itself, so this does not depend on where
+                    # the action sits in the queue.
+                    step_name: str | None = None
+                    extra_let_bindings: list[str] | None = None
+                    if (env_step_id := _step_id_from_environment_id(environment_id)) is not None:
+                        try:
+                            env_step_details = self._job_entities.step_details(step_id=env_step_id)
+                        except (ValueError, RuntimeError, UnsupportedSchema):
+                            # The task run for this step will surface the real
+                            # entity error; entering without step context here
+                            # matches the pre-existing behavior.
+                            pass
+                        else:
+                            step_name = env_step_details.step_template.name
+                            extra_let_bindings = env_step_details.step_template.let
+
                     next_action = EnterEnvironmentAction(
                         id=action_id,
                         job_env_id=environment_id,
                         details=environment_details,
+                        step_name=step_name,
+                        extra_let_bindings=extra_let_bindings,
                     )
                 elif action_type == "ENV_EXIT":
                     next_action = ExitEnvironmentAction(

--- a/src/deadline_worker_agent/sessions/actions/enter_env.py
+++ b/src/deadline_worker_agent/sessions/actions/enter_env.py
@@ -32,6 +32,8 @@ class EnterEnvironmentAction(OpenjdAction):
     _job_env_id: str
     _details: EnvironmentDetails
     _session_env_id: EnvironmentIdentifier | None = None
+    _step_name: str | None
+    _extra_let_bindings: list[str] | None
 
     def __init__(
         self,
@@ -39,12 +41,16 @@ class EnterEnvironmentAction(OpenjdAction):
         id: str,
         job_env_id: str,
         details: EnvironmentDetails,
+        step_name: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
         super(EnterEnvironmentAction, self).__init__(
             id=id, action_log_kind=SessionActionLogKind.ENV_ENTER
         )
         self._job_env_id = job_env_id
         self._details = details
+        self._step_name = step_name
+        self._extra_let_bindings = extra_let_bindings
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -53,6 +59,8 @@ class EnterEnvironmentAction(OpenjdAction):
             and self._job_env_id == other._job_env_id
             and self._session_env_id == other._session_env_id
             and self._details == other._details
+            and self._step_name == other._step_name
+            and self._extra_let_bindings == other._extra_let_bindings
         )
 
     @classmethod
@@ -110,4 +118,6 @@ class EnterEnvironmentAction(OpenjdAction):
             environment=self._details.environment,
             os_env_vars={"DEADLINE_SESSIONACTION_ID": self._id},
             resolved_symbol_table_json=self._details.resolved_symbol_table_json,
+            step_name=self._step_name,
+            extra_let_bindings=self._extra_let_bindings,
         )

--- a/src/deadline_worker_agent/sessions/runtime/_abc.py
+++ b/src/deadline_worker_agent/sessions/runtime/_abc.py
@@ -58,6 +58,8 @@ class SessionRuntime(ABC):
         identifier: Optional[EnvironmentIdentifier] = None,
         os_env_vars: Optional[dict[str, str]] = None,
         resolved_symbol_table_json: str | None = None,
+        step_name: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> EnvironmentIdentifier:
         """Enter an environment; returns its identifier."""
         ...

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -80,6 +80,8 @@ class PythonSessionRuntime(SessionRuntime):
         identifier: Optional[EnvironmentIdentifier] = None,
         os_env_vars: Optional[dict[str, str]] = None,
         resolved_symbol_table_json: str | None = None,
+        step_name: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> EnvironmentIdentifier:
         # resolved_symbol_table_json: not forwarded — the v0 Python session does
         # not support pre-resolved symbol tables.
@@ -87,6 +89,8 @@ class PythonSessionRuntime(SessionRuntime):
             environment=environment,
             identifier=identifier,
             os_env_vars=os_env_vars,
+            step_name=step_name,
+            extra_let_bindings=extra_let_bindings,
         )
 
     def exit_environment(

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -361,6 +361,8 @@ class RustSessionRuntime(SessionRuntime):
         identifier: Optional[EnvironmentIdentifier] = None,
         os_env_vars: Optional[dict[str, str]] = None,
         resolved_symbol_table_json: str | None = None,
+        step_name: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> EnvironmentIdentifier:
         # The shared action layer hands a pydantic v2023_09 environment, but the
         # Rust session needs a native _v1 environment. Serialize to the OpenJD
@@ -392,6 +394,8 @@ class RustSessionRuntime(SessionRuntime):
         # Parse the pre-resolved symbol table if the service provided one.
         resolved_symtab = _parse_resolved_symtab(resolved_symbol_table_json)
 
+        # step_name and extra_let_bindings are Python-session inputs; the Rust
+        # session receives equivalent step context via resolved_symtab.
         return self._session.enter_environment(
             environment=native_environment,
             identifier=identifier,

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -879,12 +879,16 @@ class Session:
         environment: EnvironmentModel,
         os_env_vars: Optional[dict[str, str]] = None,
         resolved_symbol_table_json: str | None = None,
+        step_name: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
         session_env_id = self._runtime.enter_environment(
             environment=environment,
             identifier=job_env_id,
             os_env_vars=os_env_vars,
             resolved_symbol_table_json=resolved_symbol_table_json,
+            step_name=step_name,
+            extra_let_bindings=extra_let_bindings,
         )
         self._active_envs.append(
             ActiveEnvironment(

--- a/test/unit/scheduler/test_step_env_context.py
+++ b/test/unit/scheduler/test_step_env_context.py
@@ -1,0 +1,183 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from deadline_worker_agent.scheduler.session_queue import (
+    EnvironmentQueueEntry,
+    SessionActionQueue,
+    _step_id_from_environment_id,
+)
+from deadline_worker_agent.sessions.actions import EnterEnvironmentAction
+from deadline_worker_agent.api_models import EnvironmentAction
+
+
+class TestStepIdFromEnvironmentId:
+    """Unit tests for the _step_id_from_environment_id helper."""
+
+    @pytest.mark.parametrize(
+        "environment_id, expected",
+        [
+            pytest.param(
+                "STEP:step-0771968389a54c26adf4afd80bac1b82:Identifier",
+                "step-0771968389a54c26adf4afd80bac1b82",
+                id="step-scoped",
+            ),
+            pytest.param(
+                "JOB:job-ac95524e7128498b9082375f8e3d7665:TestEnvironment",
+                None,
+                id="job-scoped",
+            ),
+            pytest.param(
+                "STEP:step-abc:name:with:colons",
+                "step-abc",
+                id="colons-in-name",
+            ),
+            pytest.param(
+                "STEP:step-abc",
+                None,
+                id="no-second-colon",
+            ),
+            pytest.param(
+                "STEP::envname",
+                None,
+                id="empty-step-id",
+            ),
+            pytest.param(
+                "",
+                None,
+                id="empty-string",
+            ),
+            pytest.param(
+                "step-abc:name",
+                None,
+                id="no-STEP-prefix",
+            ),
+        ],
+    )
+    def test(self, environment_id: str, expected: str | None) -> None:
+        assert _step_id_from_environment_id(environment_id) == expected
+
+
+class TestDequeueStepContext:
+    """Integration tests: dequeue() provides step context via environment id parsing."""
+
+    @pytest.fixture
+    def job_entities(self) -> MagicMock:
+        mock = MagicMock()
+        step_template = MagicMock()
+        step_template.name = "MyStep"
+        step_template.let = ["VAR=value"]
+        mock.step_details.return_value.step_template = step_template
+        return mock
+
+    @pytest.fixture
+    def session_queue(self, job_entities: MagicMock) -> SessionActionQueue:
+        return SessionActionQueue(
+            queue_id="queue-1",
+            job_id="job-aaa",
+            session_id="session-bbb",
+            job_entities=job_entities,
+            action_update_callback=Mock(),
+        )
+
+    def test_step_scoped_env_gets_step_context(
+        self, session_queue: SessionActionQueue, job_entities: MagicMock
+    ) -> None:
+        """A STEP:-prefixed env-enter receives step name and let bindings."""
+        entry = EnvironmentQueueEntry(
+            cancel=Mock(),
+            definition=EnvironmentAction(
+                sessionActionId="sa-1",
+                actionType="ENV_ENTER",
+                environmentId="STEP:step-abc123:MyEnv",
+            ),
+        )
+        session_queue._actions = [entry]
+        session_queue._actions_by_id["sa-1"] = entry
+
+        result = session_queue.dequeue()
+
+        assert isinstance(result, EnterEnvironmentAction)
+        assert result._step_name == "MyStep"
+        assert result._extra_let_bindings == ["VAR=value"]
+        job_entities.step_details.assert_called_once_with(step_id="step-abc123")
+
+    def test_job_scoped_env_gets_no_step_context(
+        self, session_queue: SessionActionQueue, job_entities: MagicMock
+    ) -> None:
+        """A JOB:-prefixed env-enter gets no step context and step_details is NOT called."""
+        entry = EnvironmentQueueEntry(
+            cancel=Mock(),
+            definition=EnvironmentAction(
+                sessionActionId="sa-2",
+                actionType="ENV_ENTER",
+                environmentId="JOB:job-def456:SharedEnv",
+            ),
+        )
+        session_queue._actions = [entry]
+        session_queue._actions_by_id["sa-2"] = entry
+
+        result = session_queue.dequeue()
+
+        assert isinstance(result, EnterEnvironmentAction)
+        assert result._step_name is None
+        assert result._extra_let_bindings is None
+        job_entities.step_details.assert_not_called()
+
+    def test_two_consecutive_step_envs_both_get_context(
+        self, session_queue: SessionActionQueue, job_entities: MagicMock
+    ) -> None:
+        """Multiple step-scoped env-enters for the same step all receive context."""
+        entry1 = EnvironmentQueueEntry(
+            cancel=Mock(),
+            definition=EnvironmentAction(
+                sessionActionId="sa-3",
+                actionType="ENV_ENTER",
+                environmentId="STEP:step-same:Env1",
+            ),
+        )
+        entry2 = EnvironmentQueueEntry(
+            cancel=Mock(),
+            definition=EnvironmentAction(
+                sessionActionId="sa-4",
+                actionType="ENV_ENTER",
+                environmentId="STEP:step-same:Env2",
+            ),
+        )
+        session_queue._actions = [entry1, entry2]
+        session_queue._actions_by_id["sa-3"] = entry1
+        session_queue._actions_by_id["sa-4"] = entry2
+
+        result1 = session_queue.dequeue()
+        result2 = session_queue.dequeue()
+
+        assert isinstance(result1, EnterEnvironmentAction)
+        assert isinstance(result2, EnterEnvironmentAction)
+        assert result1._step_name == "MyStep"
+        assert result2._step_name == "MyStep"
+
+    def test_step_details_raises_graceful_degradation(
+        self, session_queue: SessionActionQueue, job_entities: MagicMock
+    ) -> None:
+        """When step_details raises ValueError, the action is produced with no step context."""
+        job_entities.step_details.side_effect = ValueError("not found")
+        entry = EnvironmentQueueEntry(
+            cancel=Mock(),
+            definition=EnvironmentAction(
+                sessionActionId="sa-5",
+                actionType="ENV_ENTER",
+                environmentId="STEP:step-bad:Broken",
+            ),
+        )
+        session_queue._actions = [entry]
+        session_queue._actions_by_id["sa-5"] = entry
+
+        result = session_queue.dequeue()
+
+        assert isinstance(result, EnterEnvironmentAction)
+        assert result._step_name is None
+        assert result._extra_let_bindings is None

--- a/test/unit/sessions/runtime/conftest.py
+++ b/test/unit/sessions/runtime/conftest.py
@@ -40,6 +40,8 @@ def _make_stub_runtime_class() -> type[SessionRuntime]:
             identifier: Any = None,
             os_env_vars: Optional[dict[str, str]] = None,
             resolved_symbol_table_json: str | None = None,
+            step_name: str | None = None,
+            extra_let_bindings: list[str] | None = None,
         ) -> str:
             return "env-id"
 

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -105,10 +105,40 @@ class TestPythonSessionRuntimeDelegation:
         )
 
         mock_session_instance.enter_environment.assert_called_once_with(
-            environment=env, identifier=identifier, os_env_vars=os_env
+            environment=env,
+            identifier=identifier,
+            os_env_vars=os_env,
+            step_name=None,
+            extra_let_bindings=None,
         )
         # enter_environment is the only non-void method — verify the return value
         # (EnvironmentIdentifier) flows through the adapter.
+        assert result is mock_session_instance.enter_environment.return_value
+
+    def test_enter_environment_forwards_step_context_to_wrapped_session(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """Non-None step_name and extra_let_bindings are forwarded to the
+        Python session, which uses them for wrap-action symbol resolution."""
+        env = MagicMock()
+        identifier = "env-123"
+        os_env = {"K": "V"}
+
+        result = adapter.enter_environment(
+            environment=env,
+            identifier=identifier,
+            os_env_vars=os_env,
+            step_name="MyStep",
+            extra_let_bindings=["VAR=value"],
+        )
+
+        mock_session_instance.enter_environment.assert_called_once_with(
+            environment=env,
+            identifier=identifier,
+            os_env_vars=os_env,
+            step_name="MyStep",
+            extra_let_bindings=["VAR=value"],
+        )
         assert result is mock_session_instance.enter_environment.return_value
 
     def test_exit_environment_when_called_delegates_to_wrapped_session(

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -279,6 +279,34 @@ class TestRustSessionRuntimeDelegation:
         )
         assert result is mock_session_instance.enter_environment.return_value
 
+    def test_enter_environment_omits_step_context_from_rust_session(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """step_name and extra_let_bindings are not forwarded to the _v1
+        session — it receives equivalent context via resolved_symtab."""
+        environment = MagicMock()
+        identifier = "env-456"
+        os_env = {"K": "V"}
+
+        with (
+            patch.object(rust_module, "decode_environment_template"),
+            patch.object(rust_module, "create_environment") as mock_create,
+        ):
+            adapter.enter_environment(
+                environment=environment,
+                identifier=identifier,
+                os_env_vars=os_env,
+                step_name="MyStep",
+                extra_let_bindings=["X=1"],
+            )
+
+        mock_session_instance.enter_environment.assert_called_once_with(
+            environment=mock_create.return_value,
+            identifier=identifier,
+            os_env_vars=os_env,
+            resolved_symtab=None,
+        )
+
     def test_enter_environment_includes_all_job_parameter_types(
         self, mock_rust_session: MagicMock
     ) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

A step-scoped environment's scripts can reference `{{ Step.Name }}` and the step's `let` values, but the worker entered every environment without that context, so those references failed to resolve. `openjd.sessions.Session.enter_environment` already accepts `step_name` and `extra_let_bindings` — the worker simply never passed them.

### What was the solution? (How)

Resolve the step from the environment id. Environment ids are scope-prefixed and carry their scope's id (`STEP:step-<uuid>:<name>` vs `JOB:job-<uuid>:<name>`), so `_step_id_from_environment_id()` parses the prefix and the step entity is fetched from that. The context then flows `EnterEnvironmentAction` → `Session` → `SessionRuntime` → both adapters.

Two properties fall out of using the id rather than the action's position in the queue, and a position-based discriminator gets both wrong:

- A step may declare **several** step environments, so they arrive as consecutive `ENV_ENTER`s before the `TASK_RUN`. Each resolves its own step context independently of ordering.
- A **job**-scoped environment is never handed a step's context. It is entered once and shared across steps, so binding it to any single step would be a silent wrong answer rather than a failure.

`exit_environment` needs no change — openjd-sessions replays the values recorded at entry.

### What is the impact of this change?

Step-scoped environment scripts can resolve `Step.Name` and step-level `let` bindings. Job-scoped environments are unaffected. Both runtime adapters gained the two keyword arguments; they default to `None`, so callers that do not supply them behave as before.

If the step entity cannot be resolved, the environment still enters without step context (previous behaviour) and the step's task run reports the underlying entity error.

The Rust adapter no longer forwards `step_name` or `extra_let_bindings` to `_v1.Session.enter_environment`, which does not accept those keywords. The Python adapter continues to forward both. Equivalent Rust context flows through `resolved_symtab` in a separate change. This prevents the unsupported-keyword crash but does not provide end-to-end Rust step-environment support (upstream `decode_environment_template` rejects step expressions before any symbol table is read).

### How was this change tested?

`hatch run lint` clean; full unit suite 3079 passed / 39 skipped.

New `test/unit/scheduler/test_step_env_context.py` covers the parser (step-scoped, job-scoped, colons in the environment name, missing separator, empty step id, unprefixed) and the dequeue path: a `STEP:` environment receives the template's real name and `let` list, a `JOB:` environment receives neither and does not trigger a step-entity lookup, two consecutive `STEP:` enters for one step **both** receive context, and an entity-resolution failure degrades to no context.

Sensitivity checked by mutation: forcing `_step_id_from_environment_id` to always return `None` fails 4 of the new tests, including the two-consecutive-environments case; reverting restores green.

Not verified: no end-to-end run. Submitting a job whose step environment references `Step.Name` currently depends on service-side support for requesting the relevant OpenJD extensions, so this is covered at the unit tier only.

### Was this change documented?

No — no public API or configuration surface changes. The non-obvious part (why the discriminator is the environment id rather than queue position) is documented in the helper's docstring and at the call site.

### Is this a breaking change?

No. The new parameters are keyword-only with `None` defaults, and behaviour for job-scoped environments is unchanged.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
