### PR TITLE
feat: drive session extension enablement from the job's declaration

### DIFF
--- a/src/deadline_worker_agent/sessions/_extensions.py
+++ b/src/deadline_worker_agent/sessions/_extensions.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping
 
 from openjd.model.v2023_09 import ExtensionName
 
-__all__ = ["RUNTIME_CAPABILITY_EXTENSIONS", "resolve_supported_extensions"]
+__all__ = ["RUNTIME_CAPABILITY_EXTENSIONS", "resolve_supported_extensions", "session_extensions"]
 
 # The full set of known extension names, passed to the session runtime at
 # construction time. This is NOT a parse-site fallback — it is a runtime
@@ -14,8 +14,35 @@ __all__ = ["RUNTIME_CAPABILITY_EXTENSIONS", "resolve_supported_extensions"]
 # behavior: for example, openjd/sessions/_action_filter.py gates env-var
 # propagation via REDACTED_ENV_VARS on whether the extension name appears in the
 # session's RevisionExtensions. Omitting an extension from the session-level
-# list disables the runtime feature, so all known extensions must be declared.
+# list disables the runtime feature, so this tuple represents the ceiling of
+# extensions the worker runtime implements. Per-entity template validation is
+# governed separately by resolve_supported_extensions.
 RUNTIME_CAPABILITY_EXTENSIONS: tuple[str, ...] = tuple(v.value for v in ExtensionName)
+
+# REDACTED_ENV_VARS controls env-var redaction in session logs. It must always
+# be enabled regardless of the job's extension declaration — disabling it would
+# silently leak sensitive environment variables into session output.
+_ALWAYS_ON_EXTENSIONS: frozenset[str] = frozenset({"REDACTED_ENV_VARS"})
+
+
+def session_extensions(job_extensions: list[str] | None) -> tuple[str, ...]:
+    """Derive the session-level supported extensions from the job's declaration.
+
+    Rules:
+    - None (field absent): the service has not yet shipped the field, or this is
+      a legacy job. Fall back to advertising all known extensions to preserve
+      today's behavior.
+    - [] (empty list): the job declared no extensions. Enable only the always-on
+      set (REDACTED_ENV_VARS).
+    - Non-empty list: enable exactly those extensions plus the always-on set.
+
+    REDACTED_ENV_VARS is unconditionally included because it gates env-var
+    redaction in session logs — turning it off would be a security regression
+    for jobs that did not explicitly declare it.
+    """
+    if job_extensions is None:
+        return RUNTIME_CAPABILITY_EXTENSIONS
+    return tuple(set(job_extensions) | _ALWAYS_ON_EXTENSIONS)
 
 
 def resolve_supported_extensions(entity_data: Mapping[str, Any]) -> tuple[str, ...]:

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -279,6 +279,13 @@ class JobDetails:
     queue_role_arn: str | None = None
     """The ARN of the Job's Queue Role, if it has one."""
 
+    extensions: list[str] | None = None
+    """The OpenJD extensions the job declared, as served by BatchGetJobEntity.
+
+    None means the response omitted the field; see session_extensions() for how
+    that differs from an empty list.
+    """
+
     @classmethod
     def from_boto(cls, job_details_data: JobDetailsData) -> JobDetails:
         """Parses the data returned in the BatchGetJobEntity response
@@ -330,6 +337,7 @@ class JobDetails:
             path_mapping_rules=path_mapping_rules,
             job_attachment_settings=job_attachment_settings,
             queue_role_arn=queue_role_arn,
+            extensions=job_details_data.get("extensions", None),
         )
 
     @classmethod

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -45,6 +45,7 @@ from deadline_worker_agent.file_system_operations import (
 )
 
 from . import SessionRuntime, SessionRuntimeConfig
+from .._extensions import RUNTIME_CAPABILITY_EXTENSIONS
 from ._abc import convert_runtime_crashes
 
 if TYPE_CHECKING:
@@ -240,6 +241,34 @@ def _to_v0_action_status(status: RustActionStatus) -> ActionStatus:
     )
 
 
+def _to_rust_model_extensions(
+    names: tuple[str, ...] | list[str],
+    *,
+    warn_on_unsupported: bool = False,
+) -> tuple[list[ModelExtension], list[str]]:
+    """Convert extension name strings to Rust ModelExtension enums.
+
+    Returns a pair: (converted enums, the names that converted successfully).
+    Names that the Rust crate does not recognize are skipped. When
+    *warn_on_unsupported* is True, a warning is logged for each skipped name
+    so the operator knows their configured extension will not take effect.
+    """
+    extensions: list[ModelExtension] = []
+    converted_names: list[str] = []
+    for name in names:
+        extension = ModelExtension.from_str(name)
+        if extension is None:
+            if warn_on_unsupported:
+                logger.warning(
+                    "OpenJD model extension %r is not supported by the Rust session runtime; ignoring it.",
+                    name,
+                )
+            continue
+        extensions.append(extension)
+        converted_names.append(name)
+    return extensions, converted_names
+
+
 class RustSessionRuntime(SessionRuntime):
     """SessionRuntime backed by openjd.sessions._v1 (Rust implementation)."""
 
@@ -247,6 +276,7 @@ class RustSessionRuntime(SessionRuntime):
     _user: Optional[SessionUser]
     _environment_parameter_definitions: list[dict[str, str]]
     _supported_extensions: tuple[str, ...]
+    _decode_extensions: tuple[str, ...]
 
     def __init__(self, config: SessionRuntimeConfig) -> None:
         try:
@@ -265,21 +295,17 @@ class RustSessionRuntime(SessionRuntime):
         # template that actually requires a skipped extension is rejected at
         # decode time with a clear error, matching how the v0 session
         # tolerates extension names it doesn't recognize.
-        extensions: list[ModelExtension] = []
-        # Kept in sync with `extensions` — only names that convert successfully
-        # are retained, so both lists always describe the same set.
-        supported_extension_names: list[str] = []
-        for name in config.supported_extensions:
-            extension = ModelExtension.from_str(name)
-            if extension is None:
-                logger.warning(
-                    "OpenJD model extension %r is not supported by the Rust session runtime; ignoring it.",
-                    name,
-                )
-                continue
-            extensions.append(extension)
-            supported_extension_names.append(name)
+        extensions, supported_extension_names = _to_rust_model_extensions(
+            config.supported_extensions, warn_on_unsupported=True
+        )
         self._supported_extensions: tuple[str, ...] = tuple(supported_extension_names)
+
+        # The decode-scoped extensions are the Rust-convertible subset of the
+        # full runtime capability ceiling. These drive template re-decode only;
+        # job-level narrowing applies to ModelProfile (above), not decode
+        # acceptance.
+        _, decode_names = _to_rust_model_extensions(list(RUNTIME_CAPABILITY_EXTENSIONS))
+        self._decode_extensions: tuple[str, ...] = tuple(decode_names)
 
         # Kept for the attachment-sync path: on POSIX it grants the files it
         # writes group-read access for the session user's group, so the job
@@ -334,12 +360,16 @@ class RustSessionRuntime(SessionRuntime):
         # empty, because the schema rejects "parameterDefinitions": [].
         if self._environment_parameter_definitions:
             template["parameterDefinitions"] = self._environment_parameter_definitions
-        if self._supported_extensions:
-            template["extensions"] = list(self._supported_extensions)
+        if self._decode_extensions:
+            template["extensions"] = list(self._decode_extensions)
+        # The environment was already validated against its own entity-level
+        # extension declaration; this decode only reconstructs the native
+        # representation. Job-level narrowing applies to runtime capability
+        # (ModelProfile), not to decode acceptance.
         native_environment = create_environment(
             decode_environment_template(
                 template,
-                supported_extensions=list(self._supported_extensions) or None,
+                supported_extensions=list(self._decode_extensions) or None,
             )
         )
         return self._session.enter_environment(

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -59,7 +59,7 @@ from deadline.job_attachments.progress_tracker import ProgressReportMetadata
 from ..scheduler.session_action_status import SessionActionStatus
 from ..sessions.errors import SessionActionError
 from ..aws.deadline import record_runtime_failure_telemetry_event
-from ._extensions import RUNTIME_CAPABILITY_EXTENSIONS
+from ._extensions import session_extensions
 from .runtime._abc import SessionRuntimeCrashError
 from .runtime import (
     SessionRuntimeKind,
@@ -220,7 +220,7 @@ class Session:
                 os_env_vars=self._env,
                 session_root_directory=session_root_dir,
                 spec_revision="2023-09",
-                supported_extensions=RUNTIME_CAPABILITY_EXTENSIONS,
+                supported_extensions=session_extensions(self._job_details.extensions),
             ),
         )
 

--- a/test/unit/sessions/job_entities/test_job_details.py
+++ b/test/unit/sessions/job_entities/test_job_details.py
@@ -774,3 +774,37 @@ def test_input_validation_failure(data: dict[str, Any]) -> None:
     """Test that validate_entity_data() raises a ValueError when nonvalid input data is provided."""
     with pytest.raises(ValueError):
         JobDetails.validate_entity_data(entity_data=data, job_user_override=None)
+
+
+class TestJobDetailsFromBotoExtensions:
+    """Tests for extensions field extraction from BatchGetJobEntity."""
+
+    @pytest.fixture
+    def valid_job_details_data(self) -> JobDetailsData:
+        return cast(
+            JobDetailsData,
+            {
+                "jobId": "job-0000",
+                "logGroupName": "/aws/deadline/queue-0000",
+                "schemaVersion": "jobtemplate-2023-09",
+            },
+        )
+
+    def test_extensions_absent_defaults_to_none(
+        self, valid_job_details_data: JobDetailsData
+    ) -> None:
+        # extensions not in the response -> None
+        result = JobDetails.from_boto(valid_job_details_data)
+        assert result.extensions is None
+
+    def test_extensions_empty_list(self, valid_job_details_data: JobDetailsData) -> None:
+        data = cast(JobDetailsData, {**valid_job_details_data, "extensions": []})
+        result = JobDetails.from_boto(data)
+        assert result.extensions == []
+
+    def test_extensions_populated(self, valid_job_details_data: JobDetailsData) -> None:
+        data = cast(
+            JobDetailsData, {**valid_job_details_data, "extensions": ["EXPR", "WRAP_ACTIONS"]}
+        )
+        result = JobDetails.from_boto(data)
+        assert result.extensions == ["EXPR", "WRAP_ACTIONS"]

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from pathlib import Path, PurePosixPath
 from typing import Any, Generator
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -23,6 +23,17 @@ from deadline_worker_agent.sessions.runtime import rust as rust_module
 from deadline_worker_agent.sessions.runtime.rust import RustSessionRuntime
 from deadline_worker_agent.sessions.runtime.rust import _to_rust_task_parameter_values
 from deadline_worker_agent.sessions.runtime.rust import _to_environment_parameter_definitions
+
+# Literal expected value: the Rust-convertible subset of RUNTIME_CAPABILITY_EXTENSIONS
+# in ExtensionName declaration order.  Determined by printing ExtensionName members and
+# verifying each converts via ModelExtension.from_str (all 5 do today).
+_EXPECTED_DECODE_EXTENSIONS: list[str] = [
+    "TASK_CHUNKING",
+    "REDACTED_ENV_VARS",
+    "FEATURE_BUNDLE_1",
+    "EXPR",
+    "WRAP_ACTIONS",
+]
 
 
 @pytest.fixture()
@@ -71,14 +82,17 @@ class TestRustSessionRuntimeConstruction:
         self, runtime_config: SessionRuntimeConfig, mock_rust_session: MagicMock
     ) -> None:
         # Proves the extensions are NOT hardcoded: an empty config yields an
-        # empty extensions list rather than a fixed set.
+        # empty ModelProfile extensions list rather than a fixed set.  The
+        # decode path still converts RUNTIME_CAPABILITY_EXTENSIONS, so
+        # from_str IS called — but no warning is emitted because
+        # warn_on_unsupported=False for the decode conversion.
         with (
             patch.object(rust_module, "ModelProfile") as mock_profile,
-            patch.object(rust_module, "ModelExtension") as mock_extension,
+            patch.object(rust_module, "logger") as mock_logger,
         ):
             RustSessionRuntime(runtime_config)
 
-        mock_extension.from_str.assert_not_called()
+        mock_logger.warning.assert_not_called()
         profile_kwargs = mock_profile.call_args.kwargs
         assert profile_kwargs["extensions"] == []
         assert profile_kwargs["revision"] == SpecificationRevision.v2023_09
@@ -105,8 +119,7 @@ class TestRustSessionRuntimeConstruction:
             mock_extension.from_str.side_effect = lambda name: f"EXT::{name}"
             RustSessionRuntime(config)
 
-        # Each configured extension identifier is coerced via from_str, in order.
-        assert mock_extension.from_str.call_args_list == [call("EXPR"), call("TASK_CHUNKING")]
+        # ModelProfile receives exactly the job-narrowed converted list.
         profile_kwargs = mock_profile.call_args.kwargs
         assert profile_kwargs["extensions"] == ["EXT::EXPR", "EXT::TASK_CHUNKING"]
 
@@ -243,15 +256,16 @@ class TestRustSessionRuntimeDelegation:
         # The pydantic environment is serialized and rebuilt natively before
         # being handed to the session. The fixture's job_parameter_values
         # contains one STRING param in dict form, which must appear as a
-        # parameterDefinitions entry. The fixture declares no extensions, so the
-        # extensions key is omitted and the decode kwarg is None.
+        # parameterDefinitions entry. Decode uses the runtime capability ceiling
+        # (all Rust-convertible extensions), regardless of the per-job narrowing.
         mock_decode.assert_called_once_with(
             {
                 "specificationVersion": "environment-2023-09",
                 "environment": environment.model_dump.return_value,
                 "parameterDefinitions": [{"name": "Param1", "type": "STRING"}],
+                "extensions": _EXPECTED_DECODE_EXTENSIONS,
             },
-            supported_extensions=None,
+            supported_extensions=_EXPECTED_DECODE_EXTENSIONS,
         )
         environment.model_dump.assert_called_once_with(
             mode="json", by_alias=True, exclude_none=True
@@ -329,6 +343,7 @@ class TestRustSessionRuntimeDelegation:
         assert template == {
             "specificationVersion": "environment-2023-09",
             "environment": environment.model_dump.return_value,
+            "extensions": _EXPECTED_DECODE_EXTENSIONS,
         }
         assert "parameterDefinitions" not in template
 

--- a/test/unit/sessions/test_extensions.py
+++ b/test/unit/sessions/test_extensions.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+from openjd.model.v2023_09 import ExtensionName
+
 from deadline_worker_agent.sessions._extensions import (
+    RUNTIME_CAPABILITY_EXTENSIONS,
     resolve_supported_extensions,
+    session_extensions,
 )
 
 
@@ -41,3 +46,48 @@ class TestResolveSupportedExtensions:
         entity_data: dict[str, Any] = {"template": {}, "extensions": ["EXPR", "FUTURE_UNKNOWN_EXT"]}
         result = resolve_supported_extensions(entity_data)
         assert result == ("EXPR", "FUTURE_UNKNOWN_EXT")
+
+
+class TestSessionExtensions:
+    """Tests for session_extensions — derives session-level enablement from the job declaration."""
+
+    def test_none_returns_all_known_extensions(self) -> None:
+        """When extensions is None (field absent / legacy), all known extensions are enabled."""
+        result = session_extensions(None)
+        assert result == RUNTIME_CAPABILITY_EXTENSIONS
+        for ext in ExtensionName:
+            assert ext.value in result
+
+    def test_empty_list_returns_only_redacted_env_vars(self) -> None:
+        """When job declared no extensions, only the always-on set is enabled."""
+        result = session_extensions([])
+        assert "REDACTED_ENV_VARS" in result
+        assert len(result) == 1
+
+    def test_list_includes_declared_plus_redacted_env_vars(self) -> None:
+        """When job declared specific extensions, those plus REDACTED_ENV_VARS are returned."""
+        result = session_extensions(["EXPR", "WRAP_ACTIONS"])
+        assert "EXPR" in result
+        assert "WRAP_ACTIONS" in result
+        assert "REDACTED_ENV_VARS" in result
+        assert len(result) == 3
+
+    def test_redacted_env_vars_not_duplicated(self) -> None:
+        """When job explicitly declares REDACTED_ENV_VARS, it appears only once."""
+        result = session_extensions(["EXPR", "REDACTED_ENV_VARS"])
+        assert result.count("REDACTED_ENV_VARS") == 1
+        assert "EXPR" in result
+        assert len(result) == 2
+
+    @pytest.mark.parametrize(
+        "job_extensions",
+        [
+            pytest.param([], id="empty-list"),
+            pytest.param(["EXPR"], id="single-extension"),
+            pytest.param(["EXPR", "WRAP_ACTIONS", "FEATURE_BUNDLE_1"], id="multiple-extensions"),
+        ],
+    )
+    def test_redacted_env_vars_always_present(self, job_extensions: list[str]) -> None:
+        """REDACTED_ENV_VARS is unconditionally present regardless of the job's declaration."""
+        result = session_extensions(job_extensions)
+        assert "REDACTED_ENV_VARS" in result


### PR DESCRIPTION
# gated on backend change

### What was the problem/requirement? (What/Why)

The worker agent hardcodes `supported_extensions` to all known OpenJD extensions
at session construction time (`RUNTIME_CAPABILITY_EXTENSIONS`). This is
over-permissive — the session should only enable extensions the job actually
declared. The original code had a TODO comment acknowledging this shortcut:
"should be changed at a later date to the list of requested extensions once
those are returned by BatchGetJobEntity."

### What was the solution? (How)

1. Store the `extensions` field from BatchGetJobEntity's JobDetails response
   on the `JobDetails` dataclass (the field was already whitelisted in the
   entity validator but never persisted).

2. Add `session_extensions()` helper that derives the session-level extension
   list from the job's declaration:
   - `None` (field absent): fall back to all known extensions (backward compat
     with services that don't yet populate the field).
   - `[]` (empty list): enable only REDACTED_ENV_VARS.
   - Non-empty list: enable exactly those extensions plus REDACTED_ENV_VARS.

3. Replace the hardcoded `RUNTIME_CAPABILITY_EXTENSIONS` in session construction
   with `session_extensions(job_details.extensions)`.

REDACTED_ENV_VARS is unconditionally included because it gates env-var redaction
in session logs — it is a runtime security feature, not a template syntax
extension, and should not depend on the job's extension declaration.

### What is the impact of this change?

No behavioral change until the service populates `extensions` on JobDetails.
When the field is absent (`None`), the fallback returns all known extensions —
identical to today's hardcode. Once the service ships the field, session
enablement narrows to what the job declared plus REDACTED_ENV_VARS.

### How was this change tested?

- Unit tests for `session_extensions()` covering all three states (None, empty
  list, non-empty list) plus REDACTED_ENV_VARS always-present invariant.
- Unit tests for `JobDetails.from_boto` extensions field storage.
- Pre-existing `test_session_includes_redacted_env_vars_extension` continues
  to pass (exercises the None fallback path).
- Full unit suite: 3078 passed, 39 skipped.
- Lint: ruff check + ruff format + mypy all clean.

### Was this change documented?

Inline docstrings on `session_extensions()` and the `JobDetails.extensions`
field document the semantics.

### Is this a breaking change?

No. The change is inert until the service populates the field.