### PR TITLE
feat: add support for EXPR parameter types in API response parsing

### DIFF
--- a/src/deadline_worker_agent/api_models.py
+++ b/src/deadline_worker_agent/api_models.py
@@ -35,6 +35,14 @@ __all__ = [
     "StepDetailsError",
     "StepDetailsIdentifier",
     "StringParameter",
+    "BoolParameter",
+    "BoolListParameter",
+    "FloatListParameter",
+    "IntListParameter",
+    "IntListListParameter",
+    "PathListParameter",
+    "RangeExprParameter",
+    "StringListParameter",
     "TaskRunAction",
     "UpdatedSessionActionInfo",
     "UpdatedSessionActionInfo",
@@ -76,6 +84,38 @@ class ChunkIntParameter(TypedDict):
     chunkInt: str
 
 
+class BoolParameter(TypedDict):
+    bool: bool
+
+
+class RangeExprParameter(TypedDict):
+    rangeExpr: str
+
+
+class StringListParameter(TypedDict):
+    stringList: list[str]
+
+
+class PathListParameter(TypedDict):
+    pathList: list[str]
+
+
+class IntListParameter(TypedDict):
+    intList: list[str]
+
+
+class FloatListParameter(TypedDict):
+    floatList: list[str]
+
+
+class BoolListParameter(TypedDict):
+    boolList: list[bool]
+
+
+class IntListListParameter(TypedDict):
+    intListList: list[list[str]]
+
+
 class TaskRunAction(TypedDict):
     sessionActionId: str
     actionType: StepActionType
@@ -83,7 +123,20 @@ class TaskRunAction(TypedDict):
     stepId: str
     parameters: NotRequired[
         dict[
-            str, StringParameter | PathParameter | IntParameter | FloatParameter | ChunkIntParameter
+            str,
+            StringParameter
+            | PathParameter
+            | IntParameter
+            | FloatParameter
+            | ChunkIntParameter
+            | BoolParameter
+            | RangeExprParameter
+            | StringListParameter
+            | PathListParameter
+            | IntListParameter
+            | FloatListParameter
+            | BoolListParameter
+            | IntListListParameter,
         ]
     ]
 
@@ -305,6 +358,14 @@ class JobDetailsData(JobDetailsIdentifierFields):
             | IntParameter
             | FloatParameter
             | ChunkIntParameter
+            | BoolParameter
+            | RangeExprParameter
+            | StringListParameter
+            | PathListParameter
+            | IntListParameter
+            | FloatListParameter
+            | BoolListParameter
+            | IntListListParameter
             | str,
         ]
     ]

--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -22,13 +22,21 @@ from openjd.sessions import (
 from openjd.sessions import PathMappingRule as OPENJDPathMappingRule
 
 from ...api_models import (
+    BoolListParameter,
+    BoolParameter,
+    FloatListParameter,
     FloatParameter,
+    IntListListParameter,
+    IntListParameter,
     IntParameter,
     JobDetailsData,
     JobAttachmentQueueSettings as JobAttachmentSettingsBoto,
     JobRunAsUser as JobRunAsUserModel,
+    PathListParameter,
     PathMappingRule,
     PathParameter,
+    RangeExprParameter,
+    StringListParameter,
     StringParameter,
     ChunkIntParameter,
 )
@@ -40,7 +48,20 @@ from .validation import Field, validate_object
 def parameters_from_api_response(
     params: dict[
         str,
-        StringParameter | PathParameter | IntParameter | FloatParameter | ChunkIntParameter | str,
+        StringParameter
+        | PathParameter
+        | IntParameter
+        | FloatParameter
+        | ChunkIntParameter
+        | BoolParameter
+        | RangeExprParameter
+        | StringListParameter
+        | PathListParameter
+        | IntListParameter
+        | FloatListParameter
+        | BoolListParameter
+        | IntListListParameter
+        | str,
     ],
 ) -> dict[str, ParameterValue]:
     result = dict[str, ParameterValue]()
@@ -60,6 +81,38 @@ def parameters_from_api_response(
         elif "chunkInt" in value:
             value = cast(ChunkIntParameter, value)
             param_value = ParameterValue(type=ParameterValueType.CHUNK_INT, value=value["chunkInt"])
+        elif "bool" in value:
+            value = cast(BoolParameter, value)
+            param_value = ParameterValue(type=ParameterValueType.BOOL, value=value["bool"])
+        elif "rangeExpr" in value:
+            value = cast(RangeExprParameter, value)
+            param_value = ParameterValue(
+                type=ParameterValueType.RANGE_EXPR, value=value["rangeExpr"]
+            )
+        elif "stringList" in value:
+            value = cast(StringListParameter, value)
+            param_value = ParameterValue(
+                type=ParameterValueType.LIST_STRING, value=value["stringList"]
+            )
+        elif "pathList" in value:
+            value = cast(PathListParameter, value)
+            param_value = ParameterValue(type=ParameterValueType.LIST_PATH, value=value["pathList"])
+        elif "intList" in value:
+            value = cast(IntListParameter, value)
+            param_value = ParameterValue(type=ParameterValueType.LIST_INT, value=value["intList"])
+        elif "floatList" in value:
+            value = cast(FloatListParameter, value)
+            param_value = ParameterValue(
+                type=ParameterValueType.LIST_FLOAT, value=value["floatList"]
+            )
+        elif "boolList" in value:
+            value = cast(BoolListParameter, value)
+            param_value = ParameterValue(type=ParameterValueType.LIST_BOOL, value=value["boolList"])
+        elif "intListList" in value:
+            value = cast(IntListListParameter, value)
+            param_value = ParameterValue(
+                type=ParameterValueType.LIST_LIST_INT, value=value["intListList"]
+            )
         else:
             raise ValueError(f"Parameter {name} -- unknown form in API response: {str(value)}")
         result[name] = param_value

--- a/test/unit/sessions/job_entities/test_parameters_from_api_response.py
+++ b/test/unit/sessions/job_entities/test_parameters_from_api_response.py
@@ -16,6 +16,44 @@ class TestParametersFromApiResponse:
             ("intParam", {"int": "42"}, ParameterValueType.INT, "42"),
             ("floatParam", {"float": "3.14"}, ParameterValueType.FLOAT, "3.14"),
             ("chunkIntParam", {"chunkInt": "1-5"}, ParameterValueType.CHUNK_INT, "1-5"),
+            ("boolParam", {"bool": True}, ParameterValueType.BOOL, True),
+            ("rangeExprParam", {"rangeExpr": "1-10:2"}, ParameterValueType.RANGE_EXPR, "1-10:2"),
+            (
+                "stringListParam",
+                {"stringList": ["a", "b", "c"]},
+                ParameterValueType.LIST_STRING,
+                ["a", "b", "c"],
+            ),
+            (
+                "pathListParam",
+                {"pathList": ["/path/a", "/path/b"]},
+                ParameterValueType.LIST_PATH,
+                ["/path/a", "/path/b"],
+            ),
+            (
+                "intListParam",
+                {"intList": ["1", "2", "3"]},
+                ParameterValueType.LIST_INT,
+                ["1", "2", "3"],
+            ),
+            (
+                "floatListParam",
+                {"floatList": ["1.1", "2.2"]},
+                ParameterValueType.LIST_FLOAT,
+                ["1.1", "2.2"],
+            ),
+            (
+                "boolListParam",
+                {"boolList": [True, False, True]},
+                ParameterValueType.LIST_BOOL,
+                [True, False, True],
+            ),
+            (
+                "intListListParam",
+                {"intListList": [["1", "2"], ["3", "4"]]},
+                ParameterValueType.LIST_LIST_INT,
+                [["1", "2"], ["3", "4"]],
+            ),
         ],
     )
     def test_parameters_from_api_response(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The service now supports 8 new EXPR parameter types (`bool`, `rangeExpr`, `stringList`, `pathList`, `intList`, `floatList`, `boolList`, `intListList`) via CreateJob. When these parameters reach the worker agent through GetJob/UpdateWorkerSchedule, `parameters_from_api_response()` raises `ValueError` on the unrecognized wire keys, crashing the session.

### What was the solution? (How)

Added TypedDict definitions, union type updates, and elif parsing branches for all 8 new parameter types. The wire keys map to their corresponding `ParameterValueType` enum values already present in openjd-model 0.11.2+.

### What is the impact of this change?

Workers can now parse jobs that use EXPR parameter types without crashing. No behavioral change for existing parameter types.

### How was this change tested?

- 8 new parametrized unit test cases (all pass)
- `hatch run lint` clean (ruff + format + mypy)
- Full unit suite: 3078 passed, 39 skipped

### Was this change documented?

No documentation changes needed — internal parsing logic only.

### Is this a breaking change?

No.