### PR TITLE
fix: accept EXPR parameter types in job details entity validation

### DIFF
--- a/src/deadline_worker_agent/sessions/job_entities/job_details.py
+++ b/src/deadline_worker_agent/sessions/job_entities/job_details.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import PurePath, PurePosixPath, PureWindowsPath
-from typing import Any, cast
+from typing import Any, Callable, cast
 import os
 
 from openjd.model import (
@@ -486,6 +486,27 @@ class JobDetails:
 
     @classmethod
     def _validate_job_parameters(cls, job_parameters: dict[str, Any]) -> None:
+        # Maps each accepted wire-format type key to a predicate that checks the
+        # value has the shape the service sends for that type.
+        def _is_str_list(value: Any) -> bool:
+            return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+        value_shape_checks: dict[str, Callable[[Any], bool]] = {
+            "string": lambda v: isinstance(v, str),
+            "path": lambda v: isinstance(v, str),
+            "int": lambda v: isinstance(v, str),
+            "float": lambda v: isinstance(v, str),
+            "chunkInt": lambda v: isinstance(v, str),
+            "bool": lambda v: isinstance(v, bool),
+            "rangeExpr": lambda v: isinstance(v, str),
+            "stringList": _is_str_list,
+            "pathList": _is_str_list,
+            "intList": _is_str_list,
+            "floatList": _is_str_list,
+            "boolList": lambda v: isinstance(v, list) and all(isinstance(item, bool) for item in v),
+            "intListList": lambda v: isinstance(v, list) and all(_is_str_list(item) for item in v),
+        }
+
         for key, value in job_parameters.items():
             if not isinstance(value, dict):
                 raise ValueError(f'Expected parameters["{key}"] to be a dict but got {type(value)}')
@@ -497,12 +518,13 @@ class JobDetails:
                     f'Expected parameters["{key}"] to have a single key, but got {keys_str}'
                 )
             type_key = list(value.keys())[0]
-            if type_key not in ("string", "path", "int", "float"):
+            if type_key not in value_shape_checks:
+                expected_keys = ", ".join(f'"{k}"' for k in value_shape_checks)
                 raise ValueError(
-                    f'Expected parameters["{key}"] to have a single key with one of "string", "path", "int", "float" but got "{type_key}"'
+                    f'Expected parameters["{key}"] to have a single key with one of {expected_keys} but got "{type_key}"'
                 )
             param_value = list(value.values())[0]
-            if not isinstance(param_value, str):
+            if not value_shape_checks[type_key](param_value):
                 raise ValueError(
-                    f'Expected parameters["{key}"] to have a single a single key whose value is a string but the value was {type(param_value)}'
+                    f'Value of parameters["{key}"] does not match the expected shape for its type "{type_key}"'
                 )

--- a/test/unit/sessions/job_entities/test_job_details.py
+++ b/test/unit/sessions/job_entities/test_job_details.py
@@ -90,6 +90,24 @@ def job_details_only_run_as_worker_agent_user() -> JobDetails:
                 "jobId": "job-0000",
                 "logGroupName": "/aws/deadline/queue-0000",
                 "schemaVersion": "jobtemplate-0000-00",
+                "parameters": {
+                    "boolParam": {"bool": True},
+                    "rangeExprParam": {"rangeExpr": "1-10:2"},
+                    "stringListParam": {"stringList": ["a", "b"]},
+                    "pathListParam": {"pathList": ["/path/a", "/path/b"]},
+                    "intListParam": {"intList": ["1", "2"]},
+                    "floatListParam": {"floatList": ["1.1", "2.2"]},
+                    "boolListParam": {"boolList": [True, False]},
+                    "intListListParam": {"intListList": [["1", "2"], ["3"]]},
+                },
+            },
+            id="valid expr parameters",
+        ),
+        pytest.param(
+            {
+                "jobId": "job-0000",
+                "logGroupName": "/aws/deadline/queue-0000",
+                "schemaVersion": "jobtemplate-0000-00",
                 "pathMappingRules": [],
             },
             id="valid pathMappingRules - empty list",
@@ -390,6 +408,96 @@ def test_convert_job_user_from_boto(data: JobDetailsData, expected: JobDetails, 
                 },
             },
             id="nonvalid parameters - a type key is unknown type.",
+        ),
+        pytest.param(
+            {
+                "jobId": "job-0000",
+                "logGroupName": "/aws/deadline/queue-0000",
+                "schemaVersion": "jobtemplate-0000-00",
+                "parameters": {
+                    "param1": {"bool": "true"},
+                },
+                "jobRunAsUser": {
+                    "posix": {
+                        "user": "abc",
+                        "group": "abc",
+                    },
+                    "runAs": "QUEUE_CONFIGURED_USER",
+                },
+            },
+            id="nonvalid parameters - bool value is a string, not a boolean.",
+        ),
+        pytest.param(
+            {
+                "jobId": "job-0000",
+                "logGroupName": "/aws/deadline/queue-0000",
+                "schemaVersion": "jobtemplate-0000-00",
+                "parameters": {
+                    "param1": {"stringList": "not-a-list"},
+                },
+                "jobRunAsUser": {
+                    "posix": {
+                        "user": "abc",
+                        "group": "abc",
+                    },
+                    "runAs": "QUEUE_CONFIGURED_USER",
+                },
+            },
+            id="nonvalid parameters - stringList value is not a list.",
+        ),
+        pytest.param(
+            {
+                "jobId": "job-0000",
+                "logGroupName": "/aws/deadline/queue-0000",
+                "schemaVersion": "jobtemplate-0000-00",
+                "parameters": {
+                    "param1": {"intList": [1, 2]},
+                },
+                "jobRunAsUser": {
+                    "posix": {
+                        "user": "abc",
+                        "group": "abc",
+                    },
+                    "runAs": "QUEUE_CONFIGURED_USER",
+                },
+            },
+            id="nonvalid parameters - intList elements are ints, not strings.",
+        ),
+        pytest.param(
+            {
+                "jobId": "job-0000",
+                "logGroupName": "/aws/deadline/queue-0000",
+                "schemaVersion": "jobtemplate-0000-00",
+                "parameters": {
+                    "param1": {"boolList": ["true", "false"]},
+                },
+                "jobRunAsUser": {
+                    "posix": {
+                        "user": "abc",
+                        "group": "abc",
+                    },
+                    "runAs": "QUEUE_CONFIGURED_USER",
+                },
+            },
+            id="nonvalid parameters - boolList elements are strings, not booleans.",
+        ),
+        pytest.param(
+            {
+                "jobId": "job-0000",
+                "logGroupName": "/aws/deadline/queue-0000",
+                "schemaVersion": "jobtemplate-0000-00",
+                "parameters": {
+                    "param1": {"intListList": [["1"], "2"]},
+                },
+                "jobRunAsUser": {
+                    "posix": {
+                        "user": "abc",
+                        "group": "abc",
+                    },
+                    "runAs": "QUEUE_CONFIGURED_USER",
+                },
+            },
+            id="nonvalid parameters - intListList element is not a nested list.",
         ),
         pytest.param(
             {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Follow-up to #1064. That PR added EXPR parameter parsing to `parameters_from_api_response()`, but `JobDetails.validate_entity_data` runs `_validate_job_parameters()` **before** `from_boto()` reaches the parser. The validator hard-coded the type-key allowlist to `("string", "path", "int", "float")` and required all values to be strings, so job parameters using any EXPR type were rejected at entity validation time — the #1064 branches were unreachable on the BatchGetJobEntity path. Only the UpdateWorkerSchedule task-parameter path was actually fixed.

### What was the solution? (How)

- Widened `_validate_job_parameters()` with a per-type value-shape check table covering all 12 wire-format types (original 4 scalars + 8 EXPR forms with their native shapes: boolean, list of strings, list of booleans, list of lists of strings).
- Also trimmed the unknown-form `ValueError` in `parameters_from_api_response()` to report key names only, so customer parameter values do not leak into logs (review feedback on #1064).

### What is the impact of this change?

Job-level EXPR parameters returned by BatchGetJobEntity now pass entity validation and parse end to end. Malformed shapes are still rejected with per-type errors.

### How was this change tested?

- New entity-validation test cases: 1 success case covering all 8 EXPR forms + 5 failure cases for mismatched value shapes. The success case fails against the previous validator (verified by running the same inputs against the prior mainline commit).
- Full unit suite: 3082 passed, 39 skipped. `hatch run lint` clean (ruff + format + mypy).

### Was this change documented?

No documentation changes needed — internal validation logic only.

### Is this a breaking change?

No.