### PR TITLE
fix: resolve Rust parameter type enum members by name, not value

### DIFF
--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -135,7 +135,10 @@ def _to_rust_parameter_values(
         if isinstance(value, dict):
             converted[name] = value
             continue
-        native_type = getattr(type_cls, value.type.value, None)
+        # Resolve by enum member name, not value: bracketed type values like
+        # "LIST[STRING]" and "CHUNK[INT]" are not valid attribute names, but
+        # their members are spelled LIST_STRING / CHUNK_INT in the binding.
+        native_type = getattr(type_cls, value.type.name, None)
         if native_type is None:
             raise ValueError(
                 f"Parameter {name!r} has type {value.type.value!r}, which the "

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -814,9 +814,47 @@ class TestRustSessionRuntimeTypeConversions:
 
     def test_parameter_values_when_type_unknown_to_binding_raises(self) -> None:
         """A parameter type the _v1 binding does not define fails loud."""
-        bogus = SimpleNamespace(type=SimpleNamespace(value="HOLOGRAM"), value="x")
+        bogus = SimpleNamespace(type=SimpleNamespace(name="HOLOGRAM", value="HOLOGRAM"), value="x")
         with pytest.raises(ValueError, match="HOLOGRAM.*JobParameterType does not define"):
             rust_module._to_rust_job_parameter_values({"P": bogus})
+
+    @pytest.mark.parametrize(
+        "param_type, value",
+        [
+            pytest.param(ParameterValueType.BOOL, True, id="bool"),
+            pytest.param(ParameterValueType.RANGE_EXPR, "1-10:2", id="rangeExpr"),
+            pytest.param(ParameterValueType.LIST_STRING, ["a", "b"], id="list-string"),
+            pytest.param(ParameterValueType.LIST_PATH, ["/tmp/a", "/tmp/b"], id="list-path"),
+            pytest.param(ParameterValueType.LIST_INT, ["1", "2"], id="list-int"),
+            pytest.param(ParameterValueType.LIST_FLOAT, ["1.5", "2.5"], id="list-float"),
+            pytest.param(ParameterValueType.LIST_BOOL, [True, False], id="list-bool"),
+            pytest.param(ParameterValueType.LIST_LIST_INT, [["1"], ["2", "3"]], id="list-list-int"),
+        ],
+    )
+    def test_expr_job_parameter_values_convert_to_native(
+        self, param_type: ParameterValueType, value: Any
+    ) -> None:
+        """EXPR-typed job parameters resolve their _v1 enum member by name.
+
+        The bracketed enum values ("LIST[STRING]") are not attribute names, so
+        a lookup by value misses members the binding does define.
+        """
+        from openjd.model._v1.types import JobParameterType
+
+        result = rust_module._to_rust_job_parameter_values(
+            {"P": ParameterValue(type=param_type, value=value)}
+        )
+
+        converted = result["P"]
+        assert isinstance(converted, rust_module.JobParameterValue)
+        assert str(converted.type) == str(getattr(JobParameterType, param_type.name))
+
+    def test_expr_type_on_task_parameters_still_fails_loud(self) -> None:
+        """EXPR types are job-parameter-only; the task binding rejects them."""
+        with pytest.raises(ValueError, match="LIST\\[STRING\\].*TaskParameterType does not define"):
+            rust_module._to_rust_task_parameter_values(
+                {"P": ParameterValue(type=ParameterValueType.LIST_STRING, value=["a"])}
+            )
 
     def test_every_v1_action_state_maps_to_v0(self) -> None:
         """Every member of the REAL _v1 ActionState enum maps to a v0 member.
@@ -1054,6 +1092,23 @@ class TestToRustTaskParameterValues:
     def test_empty_dict_returns_empty_dict(self) -> None:
         """An empty input produces an empty output."""
         assert _to_rust_task_parameter_values({}) == {}
+
+    def test_chunk_int_parameter_converts_to_native(self) -> None:
+        """CHUNK[INT] task parameters resolve their _v1 enum member by name.
+
+        The enum value "CHUNK[INT]" is not an attribute name, so a lookup by
+        value misses the CHUNK_INT member the binding defines.
+        """
+        from openjd.model._v1.types import TaskParameterType
+
+        result = _to_rust_task_parameter_values(
+            {"Frames": ParameterValue(type=ParameterValueType.CHUNK_INT, value="1-10")}
+        )
+
+        converted = result["Frames"]
+        assert isinstance(converted, rust_module.TaskParameterValue)
+        assert str(converted.type) == str(TaskParameterType.CHUNK_INT)
+        assert converted.value == "1-10"
 
     def test_mixed_parameter_values_and_dicts(self) -> None:
         """ParameterValue objects convert to native types; plain dicts pass through."""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`_to_rust_parameter_values()` resolved the `_v1` binding's enum member via `getattr(type_cls, value.type.value)`. That only works when the enum value equals the member name. Bracketed values are not attribute names: `ParameterValueType.LIST_STRING.value` is `"LIST[STRING]"` while the binding's member is spelled `LIST_STRING`, so the lookup returned `None` and raised "type not defined" for types the binding does define. All six `LIST[*]` job parameter types and `CHUNK[INT]` task parameters were affected under the Rust session runtime. The Python runtime is unaffected.

### What was the solution? (How)

Resolve by enum member name (`value.type.name`), keeping the human-readable value in the error message. Types genuinely absent from a binding (e.g. EXPR types on `TaskParameterType`, which are job-parameter-only per the Open Job Description specification) still fail loud.

### What is the impact of this change?

EXPR list-typed job parameters and chunked task parameters now convert correctly on the Rust session runtime.

### How was this change tested?

Parametrized conversion tests for all 8 EXPR job parameter types, a `CHUNK[INT]` task parameter case, and a case asserting EXPR types on the task binding still raise. All new cases were run against the previous lookup: the 7 affected ones fail as expected (`bool`/`rangeExpr` pass under both since their value equals their name). Full unit suite: 3086 passed, 39 skipped. Lint clean.

### Was this change documented?

No — internal conversion logic only.

### Is this a breaking change?

No.