### PR TITLE
fix!: report total-disk-used-percent on a 0-100 scale

### DIFF
--- a/src/deadline_worker_agent/metrics.py
+++ b/src/deadline_worker_agent/metrics.py
@@ -183,7 +183,10 @@ class HostMetricsLogger:
                 "swap-used-bytes": str(swap.used),
                 "total-disk-bytes": str(disk.total),
                 "total-disk-used-bytes": str(disk.used),
-                "total-disk-used-percent": str(round(disk.used / disk.total, ndigits=1)),
+                # Computed from the root-based total/used values reported above rather than
+                # using psutil's disk.percent, which is measured against user-available
+                # space and so would not agree with the other total-disk-* metrics.
+                "total-disk-used-percent": str(round(disk.used / disk.total * 100, ndigits=1)),
                 "user-disk-available-bytes": str(disk.free),
                 "network-sent-bytes-per-second": network_sent,
                 "network-recv-bytes-per-second": network_recv,

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -229,7 +229,10 @@ class TestHostMetricsLogger:
         @pytest.fixture
         def disk_usage(self) -> tuple:
             du = namedtuple("du", ["total", "used", "free", "percent"])
-            return du(100, 25, 75, 25)
+            # psutil's own "percent" is measured against user-available space, so it does
+            # not equal used/total. It is deliberately different here so that the
+            # total-disk-used-percent assertion pins down which formula is used.
+            return du(100, 25, 75, 40)
 
         @pytest.fixture
         def cpu_percent(self) -> int:
@@ -311,7 +314,9 @@ class TestHostMetricsLogger:
             assert isinstance(log_line, MetricsLogEvent)
             assert log_line.metrics.get("total-disk-bytes", "") == "100"
             assert log_line.metrics.get("total-disk-used-bytes", "") == "25"
-            assert log_line.metrics.get("total-disk-used-percent", "") == "0.2"
+            # 25/100 bytes used, expressed on a 0-100 scale. Note this is derived from the
+            # total/used byte values above, not from psutil's user-space disk.percent (40).
+            assert log_line.metrics.get("total-disk-used-percent", "") == "25.0"
             assert log_line.metrics.get("user-disk-available-bytes", "") == "75"
 
         def test_logs_disk_rate(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `total-disk-used-percent` host metric emitted `disk.used / disk.total` — a
0.0–1.0 fraction — despite the metric name promising a percentage. A disk 25% full
was reported as `0.2`.

Every other `*-percent` metric the worker emits (`cpu-usage-percent`,
`memory-used-percent`, `gpu-utilization-percent`, `gpu-memory-used-percent`) is on
a 0–100 scale, so this one was the odd one out.

Split out of #1036, where it was riding along with an unrelated host metrics
thread-scheduling fix. It is separated here because, unlike that fix, it is
customer visible and needs its own `BREAKING CHANGE` release note.

### What was the solution? (How)

Multiply by 100 so the value matches its name.

Computed from the root-based `total`/`used` values rather than switching to
psutil's `disk_usage(...).percent`: psutil measures `percent` against
user-available space (`used / (used + free)`) to mimic `df`, which excludes
root-reserved blocks. Using it would produce a number that disagrees with the
sibling `total-disk-bytes` and `total-disk-used-bytes` values in the same log
line. The unit test fixture now sets psutil's `percent` to a deliberately
different value (40) from `used/total` (25) so the assertion pins down which
formula is in use.

### What is the impact of this change?

`total-disk-used-percent` is reported on the expected 0–100 scale.

This is a 100x change to a value a public product emits. Any CloudWatch alarm,
dashboard, or log-based metric keyed on `total-disk-used-percent` must be
re-tuned: a threshold of `> 0.8` will now fire almost always, and a threshold of
`> 80` that previously never fired will begin working as intended.

### How was this change tested?

- `hatch run test`: 3,076 passed, 47 skipped.
- `hatch run lint`: Ruff lint and formatting passed; Mypy passed for 198 source
  files.

### Was this change documented?

Carried in the release notes via the `BREAKING CHANGE` footer on the commit, so
operators are told to re-tune anything built on the previous fractional values.
Metric names and the log schema are unchanged.

### Is this a breaking change?

**Yes** — the emitted value changes by 100x, as described above. The metric name
and log schema are unchanged.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
