### PR TITLE
chore: bump openjd-sessions to 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline-job-attachments == 0.1.3",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.10.14",
+    "openjd-sessions == 0.11.0",
     "openjd-model >= 0.11.4, < 0.12",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

PR #1063 (merged) passes `resolved_symtab=` to `_v1.Session.enter_environment`, `exit_environment`, and `run_task`. This kwarg was introduced in openjd-sessions 0.11.0 and does not exist in 0.10.14. Without this bump, a released worker would TypeError on the first Rust-runtime environment enter.

### What was the solution? (How)

Bump the exact pin from `== 0.10.14` to `== 0.11.0`.

### What is the impact of this change?

openjd-sessions 0.11.0 includes a breaking change: session working directory name shortened for Windows MAX_PATH — session working dir is no longer prefixed with session ID; `embedded_files<random>` renamed to `ef<random>`. This affects the on-disk layout of session working directories. Existing sessions are not migrated.

### How was this change tested?

Unit tests pass. The editable install used by CI has been running at 0.10.14.post11 (11 commits past 0.10.14, superset of 0.11.0) for weeks with no issues.

### Was this change documented?

No documentation change needed.

### Is this a breaking change?

The worker agent itself does not break API/CLI, but the underlying openjd-sessions 0.11.0 changes on-disk session directory naming on Windows.