### PR TITLE
fix(test): relax session root dir assertion for openjd-sessions 0.11.0

### DIFF
--- a/test/e2e/test_worker_config.py
+++ b/test/e2e/test_worker_config.py
@@ -221,15 +221,15 @@ class TestWorkerConfiguration:
             run_script = f"""#!/usr/bin/bash
 set -euo pipefail
 echo "=== Session Root Dir Test ==="
-echo "Expected prefix: {session_root_dir}/session-"
+echo "Expected: working dir under {session_root_dir}/"
 echo ""
 echo "--- Step 1: Getting current working directory ---"
 cwd=$(pwd)
 echo "Current directory: $cwd"
 echo ""
 echo "--- Step 2: Validating session root ---"
-if [[ "$cwd" != {session_root_dir}/session-* ]]; then
-    echo "FAIL: pwd '$cwd' does not start with {session_root_dir}/session-"
+if [[ "$cwd" != {session_root_dir}/* ]]; then
+    echo "FAIL: pwd '$cwd' is not under {session_root_dir}/"
     exit 1
 fi
 echo "PASS: Working directory is under configured session root"
@@ -239,15 +239,15 @@ echo "=== All checks passed ==="
             session_root_dir = "C:\\Sessions"
             run_script = f"""$ErrorActionPreference = 'Stop'
 Write-Output "=== Session Root Dir Test ==="
-Write-Output "Expected prefix: {session_root_dir}\\session-"
+Write-Output "Expected: working dir under {session_root_dir}\\"
 Write-Output ""
 Write-Output "--- Step 1: Getting current working directory ---"
 $cwd = (Get-Item .).FullName
 Write-Output "Current directory: $cwd"
 Write-Output ""
 Write-Output "--- Step 2: Validating session root ---"
-if (-not ($cwd -like '{session_root_dir}\\session-*')) {{
-    Write-Output "FAIL: pwd '$cwd' does not start with {session_root_dir}\\session-"
+if (-not ($cwd -like '{session_root_dir}\\*')) {{
+    Write-Output "FAIL: pwd '$cwd' is not under {session_root_dir}\\"
     exit 1
 }}
 Write-Output "PASS: Working directory is under configured session root"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `test_session_root_dir` e2e test asserts that the session working directory
matches `<session_root>/session-*`. `openjd-sessions` 0.11.0
(OpenJobDescription/openjd-sessions-for-python#348) removed the session ID
prefix from directory names for Windows MAX_PATH savings. This broke the
mainline canary on both Linux and Windows.

### What was the solution? (How)

Relaxed the assertion to verify the working directory is under the configured
session root (`<session_root>/*`) without coupling to the internal naming
scheme.

### What is the impact of this change?

Fixes the mainline canary. No behavioral change to the worker agent itself.

### How was this change tested?

Ran `test_session_root_dir` against a live Deadline Cloud farm with
`openjd-sessions` 0.11.0 installed — passed on Linux (3m48s).

### Was this change documented?

N/A — test-only change.

### Is this a breaking change?

No.