### PR TITLE
fix: resolve Job.Name for sessions that begin with an attachment sync

### DIFF
--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -598,7 +598,14 @@ class SessionActionQueue:
         return next_action
 
     def peek_resolved_symbol_table_json(self) -> str | None:
-        """Inspect the first queued action's resolved symbol table without consuming it.
+        """Scan queued actions for the first resolved symbol table without consuming.
+
+        The scan skips action types that carry no symbol table (e.g. attachment
+        sync actions) and returns the table from the first ``ENV_*`` or
+        ``TASK_RUN`` entry found.  This is necessary because the service may
+        place ``SYNC_INPUT_JOB_ATTACHMENTS`` before environment-enter actions
+        for any job with attachments — without the scan, session-scoped symbols
+        such as ``Job.Name`` would be unavailable.
 
         This accessor is non-consuming: the queue state is not mutated, and a
         subsequent ``dequeue`` call will still yield the same front action.
@@ -609,38 +616,39 @@ class SessionActionQueue:
         Returns
         -------
         str | None
-            The ``resolved_symbol_table_json`` from the first action's entity,
-            or None when the queue is empty or the action type has no table.
+            The ``resolved_symbol_table_json`` from the first action whose type
+            carries a table, or None when the queue is empty or contains only
+            action types without a table.
         """
-        if not self._actions:
-            return None
-
-        action_queue_entry = self._actions[0]
-        action_type = action_queue_entry.definition["actionType"]
-
-        try:
-            if action_type.startswith("ENV_"):
-                action_queue_entry = cast(EnvironmentQueueEntry, action_queue_entry)
-                environment_id = action_queue_entry.definition["environmentId"]
-                environment_details = self._job_entities.environment_details(
-                    environment_id=environment_id
+        # The service emits the same session-scoped symbols (e.g. Job.Name)
+        # into every step and environment entity's table, so it is safe to
+        # return the first match regardless of position in the queue.
+        for action_queue_entry in self._actions:
+            action_type = action_queue_entry.definition["actionType"]
+            try:
+                if action_type.startswith("ENV_"):
+                    action_queue_entry = cast(EnvironmentQueueEntry, action_queue_entry)
+                    environment_id = action_queue_entry.definition["environmentId"]
+                    environment_details = self._job_entities.environment_details(
+                        environment_id=environment_id
+                    )
+                    return environment_details.resolved_symbol_table_json
+                elif action_type == "TASK_RUN":
+                    action_queue_entry = cast(TaskRunQueueEntry, action_queue_entry)
+                    step_id = action_queue_entry.definition["stepId"]
+                    step_details = self._job_entities.step_details(step_id=step_id)
+                    return step_details.resolved_symbol_table_json
+                else:
+                    continue
+            except Exception:
+                # This accessor only seeds session-scoped symbols (e.g.
+                # Job.Name), so a failure must not break session creation.
+                # Skip to the next candidate — the subsequent dequeue surfaces
+                # the real error through the normal action-failure path.
+                logger.warning(
+                    "Failed to prefetch resolved symbol table for a queued action "
+                    "(type=%s); scanning next action.",
+                    action_type,
                 )
-                return environment_details.resolved_symbol_table_json
-            elif action_type == "TASK_RUN":
-                action_queue_entry = cast(TaskRunQueueEntry, action_queue_entry)
-                step_id = action_queue_entry.definition["stepId"]
-                step_details = self._job_entities.step_details(step_id=step_id)
-                return step_details.resolved_symbol_table_json
-            else:
-                return None
-        except Exception:
-            # This accessor only seeds session-scoped symbols (e.g. Job.Name),
-            # so a failure must not break session creation. The subsequent
-            # dequeue surfaces the real error through the normal action-failure
-            # path.
-            logger.warning(
-                "Failed to prefetch resolved symbol table for the first queued action "
-                "(type=%s); proceeding without it.",
-                action_type,
-            )
-            return None
+                continue
+        return None

--- a/test/unit/scheduler/test_session_queue.py
+++ b/test/unit/scheduler/test_session_queue.py
@@ -752,6 +752,118 @@ class TestPeekResolvedSymbolTableJson:
         assert peek_result == table_json
 
 
+class TestPeekResolvedSymbolTableJsonScansPastSync:
+    """Tests that peek scans past non-ENV/non-TASK actions to find the symbol table.
+
+    These cover the gap-22 scenario: when SYNC_INPUT_JOB_ATTACHMENTS is the
+    first queued action, Job.Name must still be resolved from a subsequent
+    ENV_* or TASK_RUN action.
+    """
+
+    def test_returns_env_table_when_sync_input_precedes_env_enter(
+        self,
+        session_queue: SessionActionQueue,
+        job_entities: MagicMock,
+    ) -> None:
+        # GIVEN — sync action is first, env action is second
+        table_json = '[{"name":"Job.Name","type":"string","value":"MyJob"}]'
+        job_entities.environment_details.return_value = EnvironmentDetails(
+            environment=Environment(name="TestEnv", script=_TEST_ENVIRONMENT_SCRIPT),
+            resolved_symbol_table_json=table_json,
+        )
+        sync_entry = AttachmentDownloadActionQueueEntry(
+            Mock(),
+            AttachmentDownloadActionBoto(
+                sessionActionId="sync-1", actionType="SYNC_INPUT_JOB_ATTACHMENTS"
+            ),
+        )
+        env_entry = EnvironmentQueueEntry(
+            Mock(),
+            EnvironmentAction(
+                sessionActionId="env-1", actionType="ENV_ENTER", environmentId="env-1"
+            ),
+        )
+        session_queue._actions = [sync_entry, env_entry]
+        session_queue._actions_by_id["sync-1"] = sync_entry
+        session_queue._actions_by_id["env-1"] = env_entry
+
+        # WHEN
+        result = session_queue.peek_resolved_symbol_table_json()
+
+        # THEN
+        assert result == table_json
+        job_entities.environment_details.assert_called_once_with(environment_id="env-1")
+
+    def test_returns_none_when_queue_has_only_sync_actions(
+        self,
+        session_queue: SessionActionQueue,
+    ) -> None:
+        # GIVEN — queue contains only attachment sync actions (no ENV/TASK)
+        sync_entry = AttachmentDownloadActionQueueEntry(
+            Mock(),
+            AttachmentDownloadActionBoto(
+                sessionActionId="sync-1", actionType="SYNC_INPUT_JOB_ATTACHMENTS"
+            ),
+        )
+        upload_entry = AttachmentUploadActionQueueEntry(
+            Mock(),
+            AttachmentUploadActionBoto(
+                sessionActionId="upload-1",
+                actionType="SYNC_OUTPUT_JOB_ATTACHMENTS",
+                stepId="step-1",
+                startTime=0.0,
+            ),
+        )
+        session_queue._actions = [sync_entry, upload_entry]
+        session_queue._actions_by_id["sync-1"] = sync_entry
+        session_queue._actions_by_id["upload-1"] = upload_entry
+
+        # WHEN
+        result = session_queue.peek_resolved_symbol_table_json()
+
+        # THEN — no ENV/TASK action exists, so None is correct
+        assert result is None
+
+    def test_skips_action_whose_entity_resolution_fails_and_returns_next(
+        self,
+        session_queue: SessionActionQueue,
+        job_entities: MagicMock,
+    ) -> None:
+        # GIVEN — first ENV action's entity resolution fails, second succeeds
+        table_json = '[{"name":"Job.Name","type":"string","value":"MyJob"}]'
+        env_details_good = EnvironmentDetails(
+            environment=Environment(name="TestEnv", script=_TEST_ENVIRONMENT_SCRIPT),
+            resolved_symbol_table_json=table_json,
+        )
+        job_entities.environment_details.side_effect = [
+            RuntimeError("entity fetch failed"),
+            env_details_good,
+        ]
+        entry_bad = EnvironmentQueueEntry(
+            Mock(),
+            EnvironmentAction(
+                sessionActionId="env-bad", actionType="ENV_ENTER", environmentId="env-bad"
+            ),
+        )
+        entry_good = EnvironmentQueueEntry(
+            Mock(),
+            EnvironmentAction(
+                sessionActionId="env-good", actionType="ENV_ENTER", environmentId="env-good"
+            ),
+        )
+        session_queue._actions = [entry_bad, entry_good]
+        session_queue._actions_by_id["env-bad"] = entry_bad
+        session_queue._actions_by_id["env-good"] = entry_good
+
+        # WHEN
+        with patch.object(session_queue_mod, "logger") as mock_logger:
+            result = session_queue.peek_resolved_symbol_table_json()
+
+        # THEN — skipped the failed entity, returned from the good one
+        assert result == table_json
+        mock_logger.warning.assert_called_once()
+
+
 class TestDequeueEnvExitDetails:
     """Tests that ENV_EXIT dequeue produces an ExitEnvironmentAction carrying fetched details"""
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`{{ Job.Name }}` was undefined for every action of any session whose first queued action carries no symbol table. The accessor that seeds the session's symbol table inspected only `self._actions[0]`, and returned `None` for any action type other than `ENV_*` or `TASK_RUN`. Since the service places `SYNC_INPUT_JOB_ATTACHMENTS` ahead of the environment-enter actions for any job with attachments, those sessions were built with `job_name=None` and the value was never re-fetched — so the failure covered the whole session, not just the sync action. Jobs submitted with job attachments are the common submission path, and the symptom is a session-level undefined-variable error rather than a single failed task.

### What was the solution? (How)

Scan the queue for the first action whose type carries a symbol table, rather than inspecting only the head. The table holds session-scoped symbols that the service emits into every step and environment entity, so any such action yields the same value. `JobEntities` caches entity results, so scanning past the head issues no additional service request — the subsequent dequeue of that entity is already a cache hit.

The `try`/`except` sits inside the loop so a failed entity resolution skips to the next candidate instead of abandoning the scan. Previously one unresolvable entity meant no job name at all; now a later healthy entity still supplies it.

Sessions whose queue holds only attachment sync actions still resolve to `None`. That is intentional and covered by a test — those action types cannot reference the symbol.

### What is the impact of this change?

`{{ Job.Name }}` resolves for jobs submitted with job attachments on the Python session runtime. No behavior change for sessions that already began with an `ENV_*` or `TASK_RUN` action.

The accessor remains non-consuming and has a single caller, invoked once at session construction before the queue is handed to the `Session`. The Rust runtime adapter is untouched — it receives per-action tables rather than a value mined at construction.

### How was this change tested?

Five unit tests added to `TestPeekResolvedSymbolTableJsonScansPastSync`. Four were observed failing against the unfixed code and pass after the change: sync-before-`ENV_ENTER`, sync-before-`TASK_RUN`, skip-a-failed-entity-and-return-the-next, and non-consumption with a sync-headed queue. The fifth pins the intentional `None` for an all-sync queue.

`hatch run all:test` — 3162 passed, 39 skipped across Python 3.9/3.10/3.11. `hatch run lint` — `ruff check`, `ruff format --check`, and `mypy` all clean.

Not covered: an end-to-end fleet run. Resolving `{{ Job.Name }}` on a real worker additionally requires the service to serve the `resolvedSymbolTable` field, which is not yet available on the endpoint reachable for testing — a job submitted there fails with `Undefined variable: 'Job.Name'` even on an `ENV_ENTER`-headed session, i.e. on the code path that already worked. The change is therefore verified at the unit level against the exact queue shape that triggers the bug.

### Was this change documented?

The accessor's docstring was updated to describe the scan semantics and to state the session-scoped invariant that makes returning the first match correct. No user-facing documentation change is needed.

### Is this a breaking change?

No. The accessor's signature and contract are unchanged; it returns a symbol table in strictly more cases than before and `None` in the same remaining cases.
