### PR TITLE
feat: deliver step-scope let to Python session

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline-job-attachments == 0.1.3",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.11.0",
+    # 0.11.1 is the floor: it adds run_task(extra_let_bindings=...), which this
+    # package now passes to deliver step-template-scope `let` to the Python
+    # session. Against 0.11.0 that call raises TypeError.
+    "openjd-sessions == 0.11.1",
     "openjd-model >= 0.11.4, < 0.12",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -80,10 +80,17 @@ class RunStepTaskAction(OpenjdAction):
             env_vars["DEADLINE_TASK_ID"] = self.task_id
 
         # The service resolves step template syntax sugar, so script is always present.
+        #
+        # extra_let_bindings: the step template arrives un-instantiated, with
+        # step-scope `let` (StepTemplate.let) and script-scope `let`
+        # (StepTemplate.script.let) as separate fields. Nothing folds the former
+        # into the latter on this path, so pass it explicitly or step-scope names
+        # are missing from the Python session's symbol table.
         session.run_task(
             step_script=cast("StepScript", self._details.step_template.script),
             task_parameter_values=self._task_parameter_values,
             os_env_vars=env_vars,
             step_name=self._details.step_template.name,
             resolved_symbol_table_json=self._details.resolved_symbol_table_json,
+            extra_let_bindings=self._details.step_template.let,
         )

--- a/src/deadline_worker_agent/sessions/runtime/_abc.py
+++ b/src/deadline_worker_agent/sessions/runtime/_abc.py
@@ -86,8 +86,18 @@ class SessionRuntime(ABC):
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
-        """Run a task within the session's active environment(s)."""
+        """Run a task within the session's active environment(s).
+
+        ``extra_let_bindings`` carries the step's step-template-scope EXPR
+        ``let`` bindings (``StepTemplate.let``, RFC 0005 §3.6). The Python
+        runtime needs them: that scope resolves at job instantiation, and the
+        service serves an un-instantiated ``StepTemplate`` whose ``let`` and
+        ``script.let`` are separate fields, so without them a step-scope name
+        is absent from the session's symbol table. The Rust runtime gets the
+        same values inside ``resolved_symbol_table_json`` and ignores this.
+        """
         ...
 
     @abstractmethod

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -118,15 +118,18 @@ class PythonSessionRuntime(SessionRuntime):
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
         # resolved_symbol_table_json: not forwarded — the v0 Python session does
-        # not support pre-resolved symbol tables.
+        # not support pre-resolved symbol tables. extra_let_bindings is how this
+        # runtime gets the step-scope `let` values that table would have carried.
         self._session.run_task(
             step_script=step_script,
             task_parameter_values=task_parameter_values,
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
             step_name=step_name,
+            extra_let_bindings=extra_let_bindings,
         )
 
     def _run_task_without_session_env(

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -430,7 +430,14 @@ class RustSessionRuntime(SessionRuntime):
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
+        # extra_let_bindings: accepted and not forwarded. The step-scope `let`
+        # values it carries are already inside resolved_symbol_table_json, which
+        # create_job pre-resolved and which the _v1 session takes as the base of
+        # its per-action table. Applying them a second time here would duplicate
+        # the definitions. Mirrors how enter_environment drops it.
+        #
         # step_name: forwarded to the _v1 session so RFC 0008's WrappedStep.Name
         # resolves correctly inside onWrapTaskRun hooks.
         #

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -1232,6 +1232,7 @@ class Session:
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
         self._runtime.run_task(
             step_script=step_script,
@@ -1240,6 +1241,7 @@ class Session:
             log_task_banner=log_task_banner,
             step_name=step_name,
             resolved_symbol_table_json=resolved_symbol_table_json,
+            extra_let_bindings=extra_let_bindings,
         )
 
     def _run_attachment_sync_task(

--- a/test/unit/sessions/actions/test_run_step_task.py
+++ b/test/unit/sessions/actions/test_run_step_task.py
@@ -93,3 +93,47 @@ class TestRunStepTaskAction:
         assert env_vars["DEADLINE_STEP_ID"] == "step-123"
         assert env_vars["DEADLINE_SESSIONACTION_ID"] == "action-123"
         assert "DEADLINE_TASK_ID" not in env_vars
+
+
+class TestRunStepTaskActionStepScopeLetBindings:
+    """The action must hand the step's step-template-scope `let` to the session.
+
+    The service serves an un-instantiated StepTemplate: step-scope `let` lives
+    in StepTemplate.let and script-scope `let` in StepTemplate.script.let, as
+    separate fields. Nothing folds the former into the latter on the worker's
+    path, so if the action drops StepTemplate.let then a step-scope name is
+    simply absent from the Python session's symbol table and every reference to
+    it fails to resolve.
+    """
+
+    def test_start_passes_step_scope_let_bindings(
+        self, mock_step_details, mock_session, mock_executor
+    ):
+        mock_step_details.step_template.let = ["region = 'us-west-2'"]
+        action = RunStepTaskAction(
+            id="action-123",
+            details=mock_step_details,
+            task_id="task-456",
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        call_kwargs = mock_session.run_task.call_args.kwargs
+        assert call_kwargs["extra_let_bindings"] == ["region = 'us-west-2'"]
+
+    def test_start_passes_none_when_step_has_no_let_bindings(
+        self, mock_step_details, mock_session, mock_executor
+    ):
+        """A step without `let` must send None, not an empty list or a Mock."""
+        mock_step_details.step_template.let = None
+        action = RunStepTaskAction(
+            id="action-123",
+            details=mock_step_details,
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        call_kwargs = mock_session.run_task.call_args.kwargs
+        assert call_kwargs["extra_let_bindings"] is None

--- a/test/unit/sessions/runtime/conftest.py
+++ b/test/unit/sessions/runtime/conftest.py
@@ -64,6 +64,7 @@ def _make_stub_runtime_class() -> type[SessionRuntime]:
             log_task_banner: bool = True,
             step_name: str | None = None,
             resolved_symbol_table_json: str | None = None,
+            extra_let_bindings: list[str] | None = None,
         ) -> None:
             return None
 

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -188,6 +188,34 @@ class TestPythonSessionRuntimeDelegation:
             os_env_vars={"X": "Y"},
             log_task_banner=False,
             step_name=None,
+            extra_let_bindings=None,
+        )
+
+    def test_run_task_forwards_step_scope_let_bindings_to_wrapped_session(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """Step-template-scope `let` bindings reach the Python session.
+
+        The service serves an un-instantiated StepTemplate, so StepTemplate.let
+        is never folded into script.let on this path. This kwarg is the only way
+        those bindings reach the v0 session's task symbol table.
+        """
+        step_script = MagicMock()
+
+        adapter.run_task(
+            step_script=step_script,
+            task_parameter_values={},
+            step_name="MyStep",
+            extra_let_bindings=["region = 'us-west-2'"],
+        )
+
+        mock_session_instance.run_task.assert_called_once_with(
+            step_script=step_script,
+            task_parameter_values={},
+            os_env_vars=None,
+            log_task_banner=True,
+            step_name="MyStep",
+            extra_let_bindings=["region = 'us-west-2'"],
         )
 
     def test_run_task_without_session_env_when_called_delegates_to_private_method(

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -1415,6 +1415,25 @@ class TestResolvedSymbolTableForwarding:
         call_kwargs = mock_session_instance.run_task.call_args.kwargs
         assert call_kwargs["resolved_symtab"] is fake_symtab
 
+    def test_run_task_omits_extra_let_bindings_from_rust_session(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """extra_let_bindings is accepted and not forwarded to the _v1 session.
+
+        The step-scope `let` values it carries are already inside
+        resolved_symtab, which create_job pre-resolved. Forwarding them too
+        would define the same names twice.
+        """
+        with patch.object(rust_module, "deserialize_step"):
+            adapter.run_task(
+                step_script=MagicMock(),
+                task_parameter_values={},
+                extra_let_bindings=["region = 'us-west-2'"],
+            )
+
+        call_kwargs = mock_session_instance.run_task.call_args.kwargs
+        assert "extra_let_bindings" not in call_kwargs
+
     def test_enter_environment_graceful_degradation_on_malformed_json(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -2572,6 +2572,39 @@ class TestRunAttachmentSyncTask:
             log_task_banner=log_task_banner,
         )
 
+
+class TestRunTaskStepScopeLetBindings:
+    """Session.run_task must pass step-scope `let` bindings to the runtime.
+
+    Session.run_task is a pass-through to the configured runtime; this pins the
+    step-scope `let` channel so the Python runtime can seed those names into the
+    task's symbol table.
+    """
+
+    @pytest.mark.parametrize(
+        "extra_let_bindings",
+        [None, ["region = 'us-west-2'"], ["a = 1", "b = a + 1"]],
+        ids=["none", "single", "multiple_dependent"],
+    )
+    def test_forwards_extra_let_bindings_to_runtime(
+        self,
+        session: Session,
+        mock_runtime: MagicMock,
+        extra_let_bindings: list[str] | None,
+    ) -> None:
+        # GIVEN
+        step_script_model = MagicMock()
+
+        # WHEN
+        session.run_task(
+            step_script=step_script_model,
+            task_parameter_values=dict[str, ParameterValue](),
+            extra_let_bindings=extra_let_bindings,
+        )
+
+        # THEN
+        assert mock_runtime.run_task.call_args.kwargs["extra_let_bindings"] is extra_let_bindings
+
     def test_propagates_exception_from_openjd_session(
         self,
         session: Session,

--- a/test/unit/sessions/test_step_scope_let_end_to_end.py
+++ b/test/unit/sessions/test_step_scope_let_end_to_end.py
@@ -1,0 +1,262 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""End-to-end coverage for step-template-scope ``let`` delivery (RFC 0005 §3.6).
+
+This drives the worker's real chain for a task run --
+
+    BatchGetJobEntity payload
+      -> StepDetails.from_boto        (real parse, real extension gating)
+      -> RunStepTaskAction.start      (real action)
+      -> Session.run_task             (stood in for; see _RunTaskOnlySession)
+      -> PythonSessionRuntime.run_task(real adapter)
+      -> openjd.sessions.Session      (real v0 session, real subprocess)
+
+-- and asserts on the *actual* text the task's command emitted, not on mock
+call arguments. The plumbing-level assertions live in test_python.py,
+test_rust.py, test_session.py and actions/test_run_step_task.py; this file
+exists to prove the whole path resolves a real step-scope name.
+
+Why the defect is invisible to most callers: step-scope ``let`` resolves at job
+instantiation, and ``create_job`` folds ``StepTemplate.let`` into
+``script.let``. Anyone instantiating a job locally (openjd-cli) therefore never
+sees a problem. The worker is handed a service-resolved, *un-instantiated*
+``StepTemplate`` whose ``let`` and ``script.let`` are separate fields, and it
+never calls ``resolve_syntax_sugar``. Without an explicit channel the step-scope
+names are simply absent from the task's symbol table.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from openjd.sessions import ActionState
+
+from deadline_worker_agent.sessions.actions.run_step_task import RunStepTaskAction
+from deadline_worker_agent.sessions.job_entities.step_details import StepDetails
+from deadline_worker_agent.sessions.runtime import SessionRuntimeConfig
+from deadline_worker_agent.sessions.runtime.python import PythonSessionRuntime
+
+# Bound on how long a single `echo` task may take before the test gives up.
+# Generous: this waits on a real subprocess, and a hang is a test bug worth
+# failing loudly rather than blocking the suite forever.
+_ACTION_TIMEOUT = 30.0
+
+
+class _RunTaskOnlySession:
+    """Stands in for ``deadline_worker_agent.sessions.Session``.
+
+    The real class is a scheduler-facing orchestrator (queue, asset sync,
+    telemetry, action reporting) whose construction pulls in far more than this
+    test needs. Its ``run_task`` is a verbatim pass-through to the runtime, and
+    that pass-through -- including ``extra_let_bindings`` -- is pinned
+    independently by ``TestRunTaskStepScopeLetBindings`` in test_session.py. So
+    this reproduces just that one hop and lets the real runtime and the real
+    openjd session do the work.
+    """
+
+    def __init__(self, runtime: PythonSessionRuntime) -> None:
+        self._runtime = runtime
+
+    def run_task(self, **kwargs: Any) -> None:
+        self._runtime.run_task(**kwargs)
+
+
+def _step_details(
+    *,
+    step_let: list[str] | None,
+    script_let: list[str] | None,
+    args: list[str],
+) -> StepDetails:
+    """Build a StepDetails from the shape the service actually serves.
+
+    Note ``let`` and ``script.let`` are siblings here, never folded together --
+    that is the served shape, and the reason this defect exists.
+    """
+    template: dict[str, Any] = {
+        "name": "MyStep",
+        "script": {"actions": {"onRun": {"command": "echo", "args": args}}},
+    }
+    if step_let is not None:
+        template["let"] = step_let
+    if script_let is not None:
+        template["script"]["let"] = script_let
+
+    return StepDetails.from_boto(
+        {
+            "jobId": "job-123",
+            "stepId": "step-123",
+            "schemaVersion": "jobtemplate-2023-09",
+            "dependencies": [],
+            "extensions": ["EXPR"],
+            "template": template,
+        }
+    )
+
+
+def _run_action_to_completion(
+    details: StepDetails, session_root: Path
+) -> tuple[ActionState, PythonSessionRuntime]:
+    """Run the step's task through the real chain and return its final state."""
+    runtime = PythonSessionRuntime(
+        SessionRuntimeConfig(
+            session_id=f"session-{uuid.uuid4().hex}",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda session_id, status: None,
+            os_env_vars=None,
+            session_root_directory=session_root,
+            supported_extensions=("EXPR",),
+        )
+    )
+    try:
+        action = RunStepTaskAction(
+            id="sessionaction-123",
+            details=details,
+            task_id="task-456",
+            task_parameter_values={},
+        )
+
+        action.start(session=_RunTaskOnlySession(runtime), executor=Mock())  # type: ignore[arg-type]
+
+        # run_task is asynchronous -- it spawns the subprocess on its own
+        # thread. Poll the real status rather than sleeping a fixed amount.
+        deadline = time.monotonic() + _ACTION_TIMEOUT
+        while True:
+            status = runtime.action_status
+            if status is not None and status.state != ActionState.RUNNING:
+                return status.state, runtime
+            if time.monotonic() > deadline:
+                pytest.fail(
+                    f"task action did not finish within {_ACTION_TIMEOUT}s (last status: {status})"
+                )
+            time.sleep(0.05)
+    finally:
+        runtime.cleanup()
+
+
+class TestStepScopeLetEndToEnd:
+    def test_step_scope_let_resolves_in_the_task_command(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A step-scope ``let`` name resolves in the command the task runs.
+
+        This is the regression. Before the fix the action dropped
+        ``StepTemplate.let``, so ``{{ from_step }}`` had no definition and the
+        action failed to resolve it.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=["from_step = 'step value'"],
+            script_let=None,
+            args=["STEP:{{ from_step }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("STEP:step value" in m for m in caplog.messages)
+
+    def test_both_scopes_resolve_and_script_scope_shadows_step_scope(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Both scopes reach the task, and script scope wins on a name clash.
+
+        RFC 0005 orders step-scope bindings before script-scope ones, so a
+        script-scope binding of the same name shadows the step's, and a
+        script-scope binding may reference a step-scope one.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=["shared = 'from step'", "base = 'step base'"],
+            script_let=["shared = 'from script'", "derived = base + ' + script'"],
+            args=["SHARED:{{ shared }} DERIVED:{{ derived }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("SHARED:from script" in m for m in caplog.messages)
+        assert any("DERIVED:step base + script" in m for m in caplog.messages)
+
+    def test_step_scope_let_can_reference_step_name(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Step-scope bindings evaluate after ``Step.Name`` is seeded.
+
+        Pins the seeding order through the whole worker chain: the action passes
+        ``step_name`` and ``extra_let_bindings`` together, and the session must
+        place ``Step.Name`` in the table before evaluating the bindings.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=["msg = 'step is ' + Step.Name"],
+            script_let=None,
+            args=["NAME:{{ msg }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("NAME:step is MyStep" in m for m in caplog.messages)
+
+    def test_a_step_without_let_bindings_still_runs(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Negative control: the common no-``let`` step is unaffected.
+
+        Guards against over-correction -- a fix that only works when bindings
+        are present, or that breaks when ``StepTemplate.let`` is None.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(step_let=None, script_let=None, args=["PLAIN:ok"])
+        assert details.step_template.let is None
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("PLAIN:ok" in m for m in caplog.messages)
+
+    def test_script_scope_let_alone_still_resolves(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Negative control: script-scope ``let`` was never broken.
+
+        It travels inside the StepScript the action already forwards. If a
+        change to the step-scope channel were to disturb it, this fails.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=None,
+            script_let=["from_script = 'script value'"],
+            args=["SCRIPT:{{ from_script }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("SCRIPT:script value" in m for m in caplog.messages)
+
+    def test_a_broken_step_scope_binding_fails_the_action_cleanly(self, tmp_path: Path) -> None:
+        """An unresolvable step-scope binding fails the action, not the worker.
+
+        The binding references an undefined symbol. The session must fail the
+        action before starting the subprocess rather than raising out through
+        the worker's action layer.
+        """
+        details = _step_details(
+            step_let=["msg = NoSuchSymbol"],
+            script_let=None,
+            args=["NEVER:{{ msg }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.FAILED


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked on a dependency release.** This needs
> OpenJobDescription/openjd-sessions-for-python#356 merged and released as
> `openjd-sessions` 0.11.1. The pin in this PR points at 0.11.1, so CI cannot
> install until that release exists. Please do not merge before then.

## What changed

`RunStepTaskAction` now passes the step's step-template-scope `let` bindings
(`StepTemplate.let`) through to the session runtime, and the Python runtime
forwards them to `openjd.sessions.Session.run_task(extra_let_bindings=...)`.

Plumbing, five files:

| File | Change |
|---|---|
| `sessions/actions/run_step_task.py` | passes `extra_let_bindings=self._details.step_template.let` |
| `sessions/session.py` | pass-through to the runtime |
| `sessions/runtime/_abc.py` | new parameter on the abstract `run_task` |
| `sessions/runtime/python.py` | forwards to the openjd session |
| `sessions/runtime/rust.py` | accepts and ignores (see below) |

## Why

A step's step-template-scope `let` bindings (RFC 0005 §3.6) never reached the
task when running under the Python session runtime, so any reference to a
step-scope name failed to resolve with `Undefined variable`.

Those bindings normally resolve at job instantiation — `create_job` folds
`StepTemplate.let` into `StepTemplate.script.let` via `resolve_syntax_sugar`.
This agent is handed a service-resolved but **un-instantiated** `StepTemplate`,
where `let` and `script.let` arrive as separate fields, and it never calls
`resolve_syntax_sugar`. So the fold never happened for what this agent sees, and
the step-scope names were absent from the task's symbol table.

Environments already had this channel: `enter_environment` takes
`extra_let_bindings`, and `scheduler/session_queue.py` extracts
`step_template.let` for `ENV_ENTER` actions. Task runs were left out.

## Why the Rust runtime ignores it

The `_v1` session receives the same values inside `resolved_symbol_table_json`,
which `create_job` pre-resolved and which that session uses as the base of its
per-action symbol table. Forwarding the bindings as well would define the same
names twice. This matches how `enter_environment` already drops the parameter on
that path. The behaviour is pinned by a test, so a future change to forward them
trips it rather than passing silently.

## Alternative considered

Fold `StepTemplate.let` into `script.let` in this package by calling
`resolve_syntax_sugar`. Rejected: that transform is not idempotent — a second
call duplicates the bindings — so it puts a double-apply hazard in this code
path, and it duplicates model logic outside the model.

## Tests

13 new tests.

`test/unit/sessions/test_step_scope_let_end_to_end.py` (6) drives the real chain
and asserts on the text the task actually emitted, not on mock call arguments:

```
StepDetails.from_boto  ->  RunStepTaskAction.start  ->  Session.run_task
  ->  PythonSessionRuntime.run_task  ->  openjd.sessions.Session  ->  subprocess
```

Only the scheduler-facing `Session` orchestrator is stood in for; its `run_task`
is a one-line pass-through, pinned separately in `test_session.py`. The entity is
built from the real served `BatchGetJobEntity` payload shape, so the test
exercises the actual condition — `let` and `script.let` as separate unfolded
fields.

Covered: a step-scope binding resolving in the command; both scopes resolving
with script scope shadowing step scope; a binding referencing `Step.Name`; an
unresolvable binding failing the action cleanly; and two negative controls — a
step with no `let`, and script-scope `let` alone — so an over-correction fails
something.

The remaining 7 pin the plumbing in `test_python.py`, `test_rust.py`,
`test_session.py` and `actions/test_run_step_task.py`.

Verification performed:

- **Mutation-checked, 5/5 caught.** Reverting the action to its pre-fix state,
  making it send `None`, dropping the Python adapter's forwarding, dropping the
  `enter_environment` forwarding, and making the Rust adapter forward — each
  fails at least one new test, and the negative controls survive every one.
- **Full unit suite: 3162 passed / 47 skipped**, measured against a
  3149-passed / 47-skipped baseline. The +13 is exactly the tests added; no
  pre-existing test changed behaviour.
- `ruff format`, `ruff check` and `mypy` clean across 217 files.
