### PR TITLE
feat: forward the resolved symbol table to the v0 session

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,14 @@ dependencies = [
     #     this package no longer passes. Code still passing it would raise
     #     TypeError against 0.12.0.
     "openjd-sessions == 0.12.0",
+    # This package also depends on two openjd-model APIs directly:
+    # StepTemplate.resolve_syntax_sugar() (run_step_task.py, for FEATURE_BUNDLE_1
+    # simple-action steps) and openjd.expr.SerializedSymbolTable (the runtime
+    # adapters). resolve_syntax_sugar() first shipped in openjd-model 0.9.0, well
+    # below the floor here, so no floor change is needed for it to exist. It is
+    # recorded because the fold order it produces,
+    # [*step lets, *simple-action lets], is model behaviour this package's tests
+    # assert rather than behaviour this package controls.
     "openjd-model >= 0.11.4, < 0.12",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline-job-attachments == 0.1.3",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    "openjd-sessions == 0.11.0",
+    # 0.11.1 is the floor: it adds run_task(extra_let_bindings=...), which this
+    # package now passes to deliver step-template-scope `let` to the Python
+    # session. Against 0.11.0 that call raises TypeError.
+    "openjd-sessions == 0.11.1",
     "openjd-model >= 0.11.4, < 0.12",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,16 @@ dependencies = [
     "boto3 >= 1.34.75",
     "deadline-job-attachments == 0.1.3",
     # Pinned to patch version due to Host Config Script runner usage of private OpenJD Sessions API.
-    # 0.11.1 is the floor: it adds run_task(extra_let_bindings=...), which this
-    # package now passes to deliver step-template-scope `let` to the Python
-    # session. Against 0.11.0 that call raises TypeError.
-    "openjd-sessions == 0.11.1",
+    # 0.12.0 is required in both directions, so this pin and the code change in
+    # this PR must ship together:
+    #   - it adds `resolved_symtab` to the v0 Session's enter_environment,
+    #     exit_environment and run_task, which this package now passes to
+    #     deliver step-scope `let` and the rest of the service-resolved table;
+    #     against 0.11.0 those calls raise TypeError.
+    #   - it removes `extra_let_bindings` from the same three methods, which
+    #     this package no longer passes. Code still passing it would raise
+    #     TypeError against 0.12.0.
+    "openjd-sessions == 0.12.0",
     "openjd-model >= 0.11.4, < 0.12",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",

--- a/src/deadline_worker_agent/scheduler/session_queue.py
+++ b/src/deadline_worker_agent/scheduler/session_queue.py
@@ -462,13 +462,13 @@ class SessionActionQueue:
                             action_id, SessionActionLogKind.ENV_EXIT, str(e)
                         ) from e
                 if action_type == "ENV_ENTER":
-                    # Step-scoped environments need the step's name and `let`
-                    # bindings so their scripts can resolve Step.Name and
-                    # step-level let values. The step id is carried in the
-                    # environment id itself, so this does not depend on where
-                    # the action sits in the queue.
+                    # Step-scoped environments need the step's name so their
+                    # scripts can resolve Step.Name. The step id is carried in
+                    # the environment id itself, so this does not depend on
+                    # where the action sits in the queue. Step-scope `let`
+                    # values arrive separately, in the environment's own
+                    # resolved symbol table.
                     step_name: str | None = None
-                    extra_let_bindings: list[str] | None = None
                     if (env_step_id := _step_id_from_environment_id(environment_id)) is not None:
                         try:
                             env_step_details = self._job_entities.step_details(step_id=env_step_id)
@@ -479,14 +479,12 @@ class SessionActionQueue:
                             pass
                         else:
                             step_name = env_step_details.step_template.name
-                            extra_let_bindings = env_step_details.step_template.let
 
                     next_action = EnterEnvironmentAction(
                         id=action_id,
                         job_env_id=environment_id,
                         details=environment_details,
                         step_name=step_name,
-                        extra_let_bindings=extra_let_bindings,
                     )
                 elif action_type == "ENV_EXIT":
                     next_action = ExitEnvironmentAction(

--- a/src/deadline_worker_agent/sessions/actions/enter_env.py
+++ b/src/deadline_worker_agent/sessions/actions/enter_env.py
@@ -33,7 +33,6 @@ class EnterEnvironmentAction(OpenjdAction):
     _details: EnvironmentDetails
     _session_env_id: EnvironmentIdentifier | None = None
     _step_name: str | None
-    _extra_let_bindings: list[str] | None
 
     def __init__(
         self,
@@ -42,7 +41,6 @@ class EnterEnvironmentAction(OpenjdAction):
         job_env_id: str,
         details: EnvironmentDetails,
         step_name: str | None = None,
-        extra_let_bindings: list[str] | None = None,
     ) -> None:
         super(EnterEnvironmentAction, self).__init__(
             id=id, action_log_kind=SessionActionLogKind.ENV_ENTER
@@ -50,7 +48,6 @@ class EnterEnvironmentAction(OpenjdAction):
         self._job_env_id = job_env_id
         self._details = details
         self._step_name = step_name
-        self._extra_let_bindings = extra_let_bindings
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -60,7 +57,6 @@ class EnterEnvironmentAction(OpenjdAction):
             and self._session_env_id == other._session_env_id
             and self._details == other._details
             and self._step_name == other._step_name
-            and self._extra_let_bindings == other._extra_let_bindings
         )
 
     @classmethod
@@ -119,5 +115,4 @@ class EnterEnvironmentAction(OpenjdAction):
             os_env_vars={"DEADLINE_SESSIONACTION_ID": self._id},
             resolved_symbol_table_json=self._details.resolved_symbol_table_json,
             step_name=self._step_name,
-            extra_let_bindings=self._extra_let_bindings,
         )

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -29,16 +29,16 @@ def _resolve_step_script(
     `extra_let_bindings` or step-scope names are missing from the session's
     symbol table.
 
-    A FEATURE_BUNDLE_1 simple-action template (`bash:`, `powershell:`, `cmd:`,
-    `python:`, `node:`) has no `script` at all -- the service serves the sugar
-    as authored, and the worker never instantiates a job, so nothing de-sugars
-    it. `resolve_syntax_sugar()` does that here, returning a new template whose
-    script carries `[*step lets, *simple-action lets]`.
+    A FEATURE_BUNDLE_1 simple-action template (`bash:`, `cmd:`, `node:`,
+    `powershell:`, `python:`) has no `script` at all. The service serves the
+    sugar as authored and the worker never instantiates a job, so nothing
+    de-sugars it. `resolve_syntax_sugar()` does that here, returning a new
+    template whose script carries `[*step lets, *simple-action lets]`.
 
     That fold is why the de-sugared path sends `extra_let_bindings=None`: the
-    step-scope bindings are already inside `script.let`, and applying them a
-    second time is not harmless. A literal binding is idempotent, but a
-    self-referential one is not -- `n = n + 1` applied twice yields 3.
+    step-scope bindings are already inside `script.let`, and applying them
+    twice is not harmless. A literal binding is idempotent, but a
+    self-referential one is not, and `n = n + 1` applied twice yields 3.
     """
     script = step_template.script
     if script is not None:

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -10,10 +10,45 @@ from ...log_messages import SessionActionLogKind
 from .openjd_action import OpenjdAction
 
 if TYPE_CHECKING:
-    from openjd.model.v2023_09 import StepScript
+    from openjd.model.v2023_09 import StepScript, StepTemplate
 
     from ..job_entities import StepDetails
     from ..session import Session
+
+
+def _resolve_step_script(
+    step_template: StepTemplate,
+) -> tuple[StepScript, Optional[list[str]]]:
+    """Pick the StepScript to run, and the step-scope `let` to send with it.
+
+    The step template arrives un-instantiated, in either of two shapes.
+
+    A `script:` template has step-scope `let` (StepTemplate.let) and
+    script-scope `let` (StepTemplate.script.let) as separate fields. Nothing
+    folds the former into the latter on this path, so it goes out as
+    `extra_let_bindings` or step-scope names are missing from the session's
+    symbol table.
+
+    A FEATURE_BUNDLE_1 simple-action template (`bash:`, `powershell:`, `cmd:`,
+    `python:`, `node:`) has no `script` at all -- the service serves the sugar
+    as authored, and the worker never instantiates a job, so nothing de-sugars
+    it. `resolve_syntax_sugar()` does that here, returning a new template whose
+    script carries `[*step lets, *simple-action lets]`.
+
+    That fold is why the de-sugared path sends `extra_let_bindings=None`: the
+    step-scope bindings are already inside `script.let`, and applying them a
+    second time is not harmless. A literal binding is idempotent, but a
+    self-referential one is not -- `n = n + 1` applied twice yields 3.
+    """
+    script = step_template.script
+    if script is not None:
+        return script, step_template.let
+
+    # The model rejects a StepTemplate carrying neither `script` nor a simple
+    # action, so the fold always produces a script. The cast records that
+    # invariant for the type checker; it is not a runtime conversion.
+    folded = step_template.resolve_syntax_sugar()
+    return cast("StepScript", folded.script), None
 
 
 class RunStepTaskAction(OpenjdAction):
@@ -79,18 +114,14 @@ class RunStepTaskAction(OpenjdAction):
         if self.task_id is not None:
             env_vars["DEADLINE_TASK_ID"] = self.task_id
 
-        # The service resolves step template syntax sugar, so script is always present.
-        #
-        # extra_let_bindings: the step template arrives un-instantiated, with
-        # step-scope `let` (StepTemplate.let) and script-scope `let`
-        # (StepTemplate.script.let) as separate fields. Nothing folds the former
-        # into the latter on this path, so pass it explicitly or step-scope names
-        # are missing from the Python session's symbol table.
+        step_template = self._details.step_template
+        step_script, extra_let_bindings = _resolve_step_script(step_template)
+
         session.run_task(
-            step_script=cast("StepScript", self._details.step_template.script),
+            step_script=step_script,
             task_parameter_values=self._task_parameter_values,
             os_env_vars=env_vars,
-            step_name=self._details.step_template.name,
+            step_name=step_template.name,
             resolved_symbol_table_json=self._details.resolved_symbol_table_json,
-            extra_let_bindings=self._details.step_template.let,
+            extra_let_bindings=extra_let_bindings,
         )

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -80,10 +80,17 @@ class RunStepTaskAction(OpenjdAction):
             env_vars["DEADLINE_TASK_ID"] = self.task_id
 
         # The service resolves step template syntax sugar, so script is always present.
+        #
+        # extra_let_bindings: the step template arrives un-instantiated, with
+        # step-scope `let` (StepTemplate.let) and script-scope `let`
+        # (StepTemplate.script.let) as separate fields. Nothing folds the former
+        # into the latter on this path, so pass it explicitly or step-scope names
+        # are missing from the Python session's symbol table.
         session.run_task(
             step_script=cast("StepScript", self._details.step_template.script),
             task_parameter_values=self._task_parameter_values,
             os_env_vars=env_vars,
             step_name=self._details.step_template.name,
             resolved_symbol_table_json=self._details.resolved_symbol_table_json,
+            extra_let_bindings=self._details.step_template.let,
         )

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -16,18 +16,13 @@ if TYPE_CHECKING:
     from ..session import Session
 
 
-def _resolve_step_script(
-    step_template: StepTemplate,
-) -> tuple[StepScript, Optional[list[str]]]:
-    """Pick the StepScript to run, and the step-scope `let` to send with it.
+def _resolve_step_script(step_template: StepTemplate) -> StepScript:
+    """Pick the StepScript to run.
 
     The step template arrives un-instantiated, in either of two shapes.
 
-    A `script:` template has step-scope `let` (StepTemplate.let) and
-    script-scope `let` (StepTemplate.script.let) as separate fields. Nothing
-    folds the former into the latter on this path, so it goes out as
-    `extra_let_bindings` or step-scope names are missing from the session's
-    symbol table.
+    A `script:` template already carries the script to run, in
+    `StepTemplate.script`.
 
     A FEATURE_BUNDLE_1 simple-action template (`bash:`, `cmd:`, `node:`,
     `powershell:`, `python:`) has no `script` at all. The service serves the
@@ -35,20 +30,18 @@ def _resolve_step_script(
     de-sugars it. `resolve_syntax_sugar()` does that here, returning a new
     template whose script carries `[*step lets, *simple-action lets]`.
 
-    That fold is why the de-sugared path sends `extra_let_bindings=None`: the
-    step-scope bindings are already inside `script.let`, and applying them
-    twice is not harmless. A literal binding is idempotent, but a
-    self-referential one is not, and `n = n + 1` applied twice yields 3.
+    Step-scope `let` values reach the session through the resolved symbol
+    table the service serves, not through this function.
     """
     script = step_template.script
     if script is not None:
-        return script, step_template.let
+        return script
 
     # The model rejects a StepTemplate carrying neither `script` nor a simple
     # action, so the fold always produces a script. The cast records that
     # invariant for the type checker; it is not a runtime conversion.
     folded = step_template.resolve_syntax_sugar()
-    return cast("StepScript", folded.script), None
+    return cast("StepScript", folded.script)
 
 
 class RunStepTaskAction(OpenjdAction):
@@ -115,7 +108,7 @@ class RunStepTaskAction(OpenjdAction):
             env_vars["DEADLINE_TASK_ID"] = self.task_id
 
         step_template = self._details.step_template
-        step_script, extra_let_bindings = _resolve_step_script(step_template)
+        step_script = _resolve_step_script(step_template)
 
         session.run_task(
             step_script=step_script,
@@ -123,5 +116,4 @@ class RunStepTaskAction(OpenjdAction):
             os_env_vars=env_vars,
             step_name=step_template.name,
             resolved_symbol_table_json=self._details.resolved_symbol_table_json,
-            extra_let_bindings=extra_let_bindings,
         )

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -30,8 +30,18 @@ def _resolve_step_script(step_template: StepTemplate) -> StepScript:
     de-sugars it. `resolve_syntax_sugar()` does that here, returning a new
     template whose script carries `[*step lets, *simple-action lets]`.
 
-    Step-scope `let` values reach the session through the resolved symbol
-    table the service serves, not through this function.
+    Step-scope `let` values reach the session through the resolved symbol table
+    the service serves. For a `script:` template that is the only channel, and
+    the source expressions are never re-evaluated here.
+
+    That is not true of the sugar path: the fold above re-declares every
+    step-scope binding in the produced `script.let`, so on a sugar template
+    those names arrive twice -- once resolved by the service in the table, and
+    once as a source expression the session re-evaluates on top of it. No test
+    covers a sugar template together with a populated resolvedSymbolTable, so
+    whether the two channels can disagree (a binding that re-evaluates to a
+    different value, or fails to re-evaluate against the per-action table) is
+    currently unverified rather than known-safe.
     """
     script = step_template.script
     if script is not None:

--- a/src/deadline_worker_agent/sessions/runtime/__init__.py
+++ b/src/deadline_worker_agent/sessions/runtime/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from ._abc import SessionRuntime
+from ._abc import ResolvedSymbolTableError, SessionRuntime
 from ._config import ActionCallback, SessionRuntimeConfig
 from ._factory import create_session_runtime
 from ._select import select_runtime
@@ -8,6 +8,7 @@ from ..._session_runtime_kind import SessionRuntimeKind
 
 __all__ = [
     "ActionCallback",
+    "ResolvedSymbolTableError",
     "SessionRuntimeKind",
     "SessionRuntime",
     "SessionRuntimeConfig",

--- a/src/deadline_worker_agent/sessions/runtime/_abc.py
+++ b/src/deadline_worker_agent/sessions/runtime/_abc.py
@@ -86,8 +86,18 @@ class SessionRuntime(ABC):
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
-        """Run a task within the session's active environment(s)."""
+        """Run a task within the session's active environment(s).
+
+        ``extra_let_bindings`` carries the step's step-template-scope EXPR
+        ``let`` bindings (``StepTemplate.let``, RFC 0005 §3.6). The Python
+        runtime needs them: that scope resolves at job instantiation, and the
+        service serves an un-instantiated ``StepTemplate`` whose ``let`` and
+        ``script.let`` are separate fields, so without them a step-scope name
+        is absent from the session's symbol table. The Rust runtime gets the
+        same values inside ``resolved_symbol_table_json`` and ignores this.
+        """
         ...
 
     @abstractmethod

--- a/src/deadline_worker_agent/sessions/runtime/_abc.py
+++ b/src/deadline_worker_agent/sessions/runtime/_abc.py
@@ -59,7 +59,6 @@ class SessionRuntime(ABC):
         os_env_vars: Optional[dict[str, str]] = None,
         resolved_symbol_table_json: str | None = None,
         step_name: str | None = None,
-        extra_let_bindings: list[str] | None = None,
     ) -> EnvironmentIdentifier:
         """Enter an environment; returns its identifier."""
         ...
@@ -86,17 +85,13 @@ class SessionRuntime(ABC):
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
-        extra_let_bindings: list[str] | None = None,
     ) -> None:
         """Run a task within the session's active environment(s).
 
-        ``extra_let_bindings`` carries the step's step-template-scope EXPR
-        ``let`` bindings (``StepTemplate.let``, RFC 0005 §3.6). The Python
-        runtime needs them: that scope resolves at job instantiation, and the
-        service serves an un-instantiated ``StepTemplate`` whose ``let`` and
-        ``script.let`` are separate fields, so without them a step-scope name
-        is absent from the session's symbol table. The Rust runtime gets the
-        same values inside ``resolved_symbol_table_json`` and ignores this.
+        ``resolved_symbol_table_json`` is the authoritative source of
+        step-scope EXPR ``let`` values (``StepTemplate.let``, RFC 0005 §3.6):
+        the service resolves that scope and serves it in the table, which both
+        runtimes seed as the base of their per-action symbol table.
         """
         ...
 

--- a/src/deadline_worker_agent/sessions/runtime/_abc.py
+++ b/src/deadline_worker_agent/sessions/runtime/_abc.py
@@ -27,6 +27,25 @@ class SessionRuntimeCrashError(Exception):
     instead of the session thread dying silently."""
 
 
+class ResolvedSymbolTableError(Exception):
+    """The service served a resolvedSymbolTable this worker cannot parse.
+
+    Raised rather than degrading to None because the resolved table is the only
+    channel for step-scope EXPR `let` values: proceeding without it runs the
+    action with those symbols simply undefined, and the operator sees a
+    downstream "undefined symbol" failure that names the symbol rather than the
+    malformed table. Raising fails the action at start with the real cause,
+    through the same path as any other start-time exception.
+
+    Deliberately not a SessionRuntimeCrashError: that class is reserved for
+    BaseException escapes (e.g. a Rust panic) and emits a runtime-crash
+    telemetry event, which would misattribute a bad service payload.
+
+    The message must stay free of payload contents -- it is reported to the
+    service as the action's fail message. Full detail goes to the agent log.
+    """
+
+
 def convert_runtime_crashes(method: _F) -> _F:
     """Converts BaseException escapes from a runtime adapter method into
     SessionRuntimeCrashError. Regular Exceptions and interpreter control-flow

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -7,13 +7,13 @@ from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
-from openjd.expr import SerializedSymbolTable
 from openjd.model import RevisionExtensions, SpecificationRevision
 from openjd.sessions import Session as OpenJDSession
 
 from . import SessionRuntime, SessionRuntimeConfig
 
 if TYPE_CHECKING:
+    from openjd.expr import SerializedSymbolTable
     from openjd.sessions import (
         ActionStatus,
         EnvironmentIdentifier,
@@ -36,6 +36,11 @@ def _extract_job_name(json_str: str | None) -> str | None:
     """
     if json_str is None:
         return None
+    # Imported lazily, behind the None guard above: SerializedSymbolTable lives
+    # in openjd.expr, a facade over the native extension. A session that never
+    # receives a resolved table must not load the extension.
+    from openjd.expr import SerializedSymbolTable
+
     try:
         symtab = SerializedSymbolTable.from_json_str(json_str).to_symtab()
         entry = symtab.get("Job.Name")
@@ -45,6 +50,25 @@ def _extract_job_name(json_str: str | None) -> str | None:
         return value if isinstance(value, str) else None
     except Exception as e:
         logger.warning("Failed to extract Job.Name from resolvedSymbolTable: %s", e)
+        return None
+
+
+def _parse_resolved_symtab(json_str: str | None) -> Optional["SerializedSymbolTable"]:
+    """Parse a resolved symbol table JSON string into a SerializedSymbolTable.
+
+    Returns None when the input is None or when parsing fails (graceful
+    degradation — the session proceeds without the pre-resolved table).
+    Mirrors _parse_resolved_symtab in the Rust adapter.
+    """
+    if json_str is None:
+        return None
+    # Imported lazily, behind the None guard above: see _extract_job_name.
+    from openjd.expr import SerializedSymbolTable
+
+    try:
+        return SerializedSymbolTable.from_json_str(json_str)
+    except Exception as e:
+        logger.warning("Failed to parse resolvedSymbolTable; proceeding without it: %s", e)
         return None
 
 
@@ -83,14 +107,16 @@ class PythonSessionRuntime(SessionRuntime):
         step_name: str | None = None,
         extra_let_bindings: list[str] | None = None,
     ) -> EnvironmentIdentifier:
-        # resolved_symbol_table_json: not forwarded — the v0 Python session does
-        # not support pre-resolved symbol tables.
+        # Parse the pre-resolved symbol table if the service provided one. The
+        # v0 session seeds it as the base of its per-action symbol table, the
+        # same layering the _v1 (Rust) session applies.
         return self._session.enter_environment(
             environment=environment,
             identifier=identifier,
             os_env_vars=os_env_vars,
             step_name=step_name,
             extra_let_bindings=extra_let_bindings,
+            resolved_symtab=_parse_resolved_symtab(resolved_symbol_table_json),
         )
 
     def exit_environment(
@@ -101,12 +127,12 @@ class PythonSessionRuntime(SessionRuntime):
         keep_session_running: bool = False,
         resolved_symbol_table_json: str | None = None,
     ) -> None:
-        # resolved_symbol_table_json: not forwarded — the v0 Python session does
-        # not support pre-resolved symbol tables.
+        # Parse the pre-resolved symbol table if the service provided one.
         self._session.exit_environment(
             identifier=identifier,
             os_env_vars=os_env_vars,
             keep_session_running=keep_session_running,
+            resolved_symtab=_parse_resolved_symtab(resolved_symbol_table_json),
         )
 
     def run_task(
@@ -120,9 +146,11 @@ class PythonSessionRuntime(SessionRuntime):
         resolved_symbol_table_json: str | None = None,
         extra_let_bindings: list[str] | None = None,
     ) -> None:
-        # resolved_symbol_table_json: not forwarded — the v0 Python session does
-        # not support pre-resolved symbol tables. extra_let_bindings is how this
-        # runtime gets the step-scope `let` values that table would have carried.
+        # Parse the pre-resolved symbol table if the service provided one. The
+        # v0 session seeds it first and layers Session.*/Task.* values on top,
+        # matching the _v1 (Rust) session. extra_let_bindings is still forwarded
+        # as the fallback channel for step-scope `let` values when no table is
+        # served; when both are present the values agree.
         self._session.run_task(
             step_script=step_script,
             task_parameter_values=task_parameter_values,
@@ -130,6 +158,7 @@ class PythonSessionRuntime(SessionRuntime):
             log_task_banner=log_task_banner,
             step_name=step_name,
             extra_let_bindings=extra_let_bindings,
+            resolved_symtab=_parse_resolved_symtab(resolved_symbol_table_json),
         )
 
     def _run_task_without_session_env(

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -65,8 +65,12 @@ def _parse_resolved_symtab(json_str: str | None) -> Optional["SerializedSymbolTa
     would also make a partially-serviceable table (schema skew, truncation)
     indistinguishable from "no table served".
 
+    Callers on the enter and run paths let that propagate. exit_environment
+    deliberately catches it and degrades to None so teardown is unconditional --
+    see the comment there.
+
     Mirrors _parse_resolved_symtab in the Rust adapter. Note the deliberate
-    asymmetry with _extract_job_name above, which still degrades: it runs during
+    asymmetry with _extract_job_name above, which also degrades: it runs during
     session construction rather than action start, and the job name it recovers
     only labels log output.
     """
@@ -141,11 +145,34 @@ class PythonSessionRuntime(SessionRuntime):
         resolved_symbol_table_json: str | None = None,
     ) -> None:
         # Parse the pre-resolved symbol table if the service provided one.
+        #
+        # Unlike enter_environment and run_task, an unparseable table must NOT
+        # fail this call. Session.exit_environment pops the environment off
+        # _active_envs only after this returns, so raising would leave it active
+        # and Session._cleanup would retry the exit with the same stored table
+        # inside a `except Exception: warning` -- same payload, same failure,
+        # swallowed. onExit would never run: no license released, no daemon
+        # stopped, no teardown of whatever the environment set up, and only a
+        # warning line to show for it.
+        #
+        # The trade differs from the enter/run paths. There, degrading means an
+        # action runs with step-scope symbols undefined and reports a confusing
+        # downstream error instead of the real cause. Here it means onExit runs
+        # with some symbols possibly undefined -- recoverable, and visible in the
+        # session log -- rather than not running at all and leaking state the
+        # worker cannot reclaim later. Teardown stays unconditional.
+        #
+        # _parse_resolved_symtab has already logged the cause at error level.
+        try:
+            resolved_symtab = _parse_resolved_symtab(resolved_symbol_table_json)
+        except ResolvedSymbolTableError:
+            resolved_symtab = None
+
         self._session.exit_environment(
             identifier=identifier,
             os_env_vars=os_env_vars,
             keep_session_running=keep_session_running,
-            resolved_symtab=_parse_resolved_symtab(resolved_symbol_table_json),
+            resolved_symtab=resolved_symtab,
         )
 
     def run_task(

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from openjd.model import RevisionExtensions, SpecificationRevision
 from openjd.sessions import Session as OpenJDSession
 
-from . import SessionRuntime, SessionRuntimeConfig
+from . import ResolvedSymbolTableError, SessionRuntime, SessionRuntimeConfig
 
 if TYPE_CHECKING:
     from openjd.expr import SerializedSymbolTable
@@ -56,9 +56,19 @@ def _extract_job_name(json_str: str | None) -> str | None:
 def _parse_resolved_symtab(json_str: str | None) -> Optional["SerializedSymbolTable"]:
     """Parse a resolved symbol table JSON string into a SerializedSymbolTable.
 
-    Returns None when the input is None or when parsing fails (graceful
-    degradation — the session proceeds without the pre-resolved table).
-    Mirrors _parse_resolved_symtab in the Rust adapter.
+    Returns None only when the input is None -- the common, benign case of the
+    service serving no table. A table that is present but unparseable raises
+    ResolvedSymbolTableError instead of degrading to None, because the table is
+    the only channel for step-scope `let` values: proceeding without it would
+    run the action with those symbols undefined and report a downstream
+    "undefined symbol" error naming the symbol rather than the real cause. It
+    would also make a partially-serviceable table (schema skew, truncation)
+    indistinguishable from "no table served".
+
+    Mirrors _parse_resolved_symtab in the Rust adapter. Note the deliberate
+    asymmetry with _extract_job_name above, which still degrades: it runs during
+    session construction rather than action start, and the job name it recovers
+    only labels log output.
     """
     if json_str is None:
         return None
@@ -68,8 +78,13 @@ def _parse_resolved_symtab(json_str: str | None) -> Optional["SerializedSymbolTa
     try:
         return SerializedSymbolTable.from_json_str(json_str)
     except Exception as e:
-        logger.warning("Failed to parse resolvedSymbolTable; proceeding without it: %s", e)
-        return None
+        # Full detail to the agent log; the raised message reaches the service
+        # as the action's fail message, so it must not echo payload contents.
+        logger.error("Failed to parse resolvedSymbolTable: %s", e)
+        raise ResolvedSymbolTableError(
+            "The service served a resolvedSymbolTable this worker could not parse "
+            f"({type(e).__name__}); step-scope `let` values cannot be resolved"
+        ) from e
 
 
 class PythonSessionRuntime(SessionRuntime):

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -118,15 +118,18 @@ class PythonSessionRuntime(SessionRuntime):
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
         # resolved_symbol_table_json: not forwarded — the v0 Python session does
-        # not support pre-resolved symbol tables.
+        # not support pre-resolved symbol tables. extra_let_bindings is how this
+        # runtime gets the step-scope `let` values that table would have carried.
         self._session.run_task(
             step_script=step_script,
             task_parameter_values=task_parameter_values,
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
             step_name=step_name,
+            extra_let_bindings=extra_let_bindings,
         )
 
     def _run_task_without_session_env(

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -36,12 +36,14 @@ def _extract_job_name(json_str: str | None) -> str | None:
     """
     if json_str is None:
         return None
-    # Imported lazily, behind the None guard above: SerializedSymbolTable lives
-    # in openjd.expr, a facade over the native extension. A session that never
-    # receives a resolved table must not load the extension.
-    from openjd.expr import SerializedSymbolTable
-
     try:
+        # Imported lazily, behind the None guard above: SerializedSymbolTable
+        # lives in openjd.expr, a facade over the native extension. A session
+        # that never receives a resolved table must not load the extension.
+        # Inside the try so an extension-load ImportError is handled here rather
+        # than escaping raw from a lazy import.
+        from openjd.expr import SerializedSymbolTable
+
         symtab = SerializedSymbolTable.from_json_str(json_str).to_symtab()
         entry = symtab.get("Job.Name")
         if entry is None:
@@ -76,11 +78,25 @@ def _parse_resolved_symtab(json_str: str | None) -> Optional["SerializedSymbolTa
     """
     if json_str is None:
         return None
-    # Imported lazily, behind the None guard above: see _extract_job_name.
-    from openjd.expr import SerializedSymbolTable
-
     try:
+        # Imported lazily, behind the None guard above: see _extract_job_name.
+        # Deliberately inside the try. Moving this import from module scope to
+        # function scope moved where an unloadable native extension is
+        # discovered: it used to fail at adapter construction, which
+        # _factory.create_session_runtime turns into a clean NotImplementedError
+        # ("adapter is not available"). Left outside the try it would instead
+        # surface mid-session as a raw ImportError reported as the task's fail
+        # message. Catching it here gives it the same handling as any other
+        # reason the table cannot be turned into a symbol table.
+        from openjd.expr import SerializedSymbolTable
+
         return SerializedSymbolTable.from_json_str(json_str)
+    # Broad on purpose. Empirically the decoder only raises ValueError, and only
+    # for malformed JSON: openjd-model 0.11.6 accepts a well-formed table with an
+    # unknown symbol type, an unknown extra field, or a missing required field,
+    # so an additive service-side change does not land here. The breadth is to
+    # cover the ImportError above and anything the native extension surprises us
+    # with, not to paper over version skew.
     except Exception as e:
         # Full detail to the agent log; the raised message reaches the service
         # as the action's fail message, so it must not echo payload contents.

--- a/src/deadline_worker_agent/sessions/runtime/python.py
+++ b/src/deadline_worker_agent/sessions/runtime/python.py
@@ -105,7 +105,6 @@ class PythonSessionRuntime(SessionRuntime):
         os_env_vars: Optional[dict[str, str]] = None,
         resolved_symbol_table_json: str | None = None,
         step_name: str | None = None,
-        extra_let_bindings: list[str] | None = None,
     ) -> EnvironmentIdentifier:
         # Parse the pre-resolved symbol table if the service provided one. The
         # v0 session seeds it as the base of its per-action symbol table, the
@@ -115,7 +114,6 @@ class PythonSessionRuntime(SessionRuntime):
             identifier=identifier,
             os_env_vars=os_env_vars,
             step_name=step_name,
-            extra_let_bindings=extra_let_bindings,
             resolved_symtab=_parse_resolved_symtab(resolved_symbol_table_json),
         )
 
@@ -144,20 +142,17 @@ class PythonSessionRuntime(SessionRuntime):
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
-        extra_let_bindings: list[str] | None = None,
     ) -> None:
         # Parse the pre-resolved symbol table if the service provided one. The
         # v0 session seeds it first and layers Session.*/Task.* values on top,
-        # matching the _v1 (Rust) session. extra_let_bindings is still forwarded
-        # as the fallback channel for step-scope `let` values when no table is
-        # served; when both are present the values agree.
+        # matching the _v1 (Rust) session. It is the only channel for
+        # step-scope `let` values.
         self._session.run_task(
             step_script=step_script,
             task_parameter_values=task_parameter_values,
             os_env_vars=os_env_vars,
             log_task_banner=log_task_banner,
             step_name=step_name,
-            extra_let_bindings=extra_let_bindings,
             resolved_symtab=_parse_resolved_symtab(resolved_symbol_table_json),
         )
 

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -419,7 +419,16 @@ class RustSessionRuntime(SessionRuntime):
         keep_session_running: bool = False,
         resolved_symbol_table_json: str | None = None,
     ) -> None:
-        resolved_symtab = _parse_resolved_symtab(resolved_symbol_table_json)
+        # An unparseable table must not fail the exit: raising would leave the
+        # environment on Session._active_envs and Session._cleanup would retry
+        # with the same stored table and swallow the same failure, so onExit
+        # would never run. See the Python adapter's copy for the full reasoning;
+        # the two are kept in lockstep on purpose.
+        try:
+            resolved_symtab = _parse_resolved_symtab(resolved_symbol_table_json)
+        except ResolvedSymbolTableError:
+            resolved_symtab = None
+
         self._session.exit_environment(
             identifier=identifier,
             os_env_vars=os_env_vars,

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -430,7 +430,14 @@ class RustSessionRuntime(SessionRuntime):
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
+        # extra_let_bindings: accepted and not forwarded. The step-scope `let`
+        # values it carries are already inside resolved_symbol_table_json, which
+        # create_job pre-resolved and which the _v1 session takes as the base of
+        # its per-action table. Applying them a second time here would duplicate
+        # the definitions. Mirrors how enter_environment drops it.
+        #
         # step_name: forwarded to the _v1 session so RFC 0008's WrappedStep.Name
         # resolves correctly inside onWrapTaskRun hooks.
         #

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -362,7 +362,6 @@ class RustSessionRuntime(SessionRuntime):
         os_env_vars: Optional[dict[str, str]] = None,
         resolved_symbol_table_json: str | None = None,
         step_name: str | None = None,
-        extra_let_bindings: list[str] | None = None,
     ) -> EnvironmentIdentifier:
         # The shared action layer hands a pydantic v2023_09 environment, but the
         # Rust session needs a native _v1 environment. Serialize to the OpenJD
@@ -394,8 +393,8 @@ class RustSessionRuntime(SessionRuntime):
         # Parse the pre-resolved symbol table if the service provided one.
         resolved_symtab = _parse_resolved_symtab(resolved_symbol_table_json)
 
-        # step_name and extra_let_bindings are Python-session inputs; the Rust
-        # session receives equivalent step context via resolved_symtab.
+        # step_name is a Python-session input; the Rust session receives
+        # equivalent step context via resolved_symtab.
         return self._session.enter_environment(
             environment=native_environment,
             identifier=identifier,
@@ -430,14 +429,7 @@ class RustSessionRuntime(SessionRuntime):
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
-        extra_let_bindings: list[str] | None = None,
     ) -> None:
-        # extra_let_bindings: accepted and not forwarded. The step-scope `let`
-        # values it carries are already inside resolved_symbol_table_json, which
-        # create_job pre-resolved and which the _v1 session takes as the base of
-        # its per-action table. Applying them a second time here would duplicate
-        # the definitions. Mirrors how enter_environment drops it.
-        #
         # step_name: forwarded to the _v1 session so RFC 0008's WrappedStep.Name
         # resolves correctly inside onWrapTaskRun hooks.
         #

--- a/src/deadline_worker_agent/sessions/runtime/rust.py
+++ b/src/deadline_worker_agent/sessions/runtime/rust.py
@@ -46,7 +46,7 @@ from deadline_worker_agent.file_system_operations import (
 
 from . import SessionRuntime, SessionRuntimeConfig
 from .._extensions import RUNTIME_CAPABILITY_EXTENSIONS
-from ._abc import convert_runtime_crashes
+from ._abc import ResolvedSymbolTableError, convert_runtime_crashes
 
 if TYPE_CHECKING:
     from openjd.sessions import (
@@ -272,16 +272,24 @@ def _to_rust_model_extensions(
 def _parse_resolved_symtab(json_str: str | None) -> Any:
     """Parse a resolved symbol table JSON string into a SerializedSymbolTable.
 
-    Returns None when the input is None or when parsing fails (graceful
-    degradation — the session proceeds without the pre-resolved table).
+    Returns None only when the input is None -- the common, benign case of the
+    service serving no table. A table that is present but unparseable raises
+    ResolvedSymbolTableError rather than degrading to None; see the Python
+    adapter's copy for the reasoning. Kept in lockstep with it deliberately: the
+    same malformed payload must fail the same way whichever runtime is selected.
     """
     if json_str is None:
         return None
     try:
         return SerializedSymbolTable.from_json_str(json_str)
     except Exception as e:
-        logger.warning("Failed to parse resolvedSymbolTable; proceeding without it: %s", e)
-        return None
+        # Full detail to the agent log; the raised message reaches the service
+        # as the action's fail message, so it must not echo payload contents.
+        logger.error("Failed to parse resolvedSymbolTable: %s", e)
+        raise ResolvedSymbolTableError(
+            "The service served a resolvedSymbolTable this worker could not parse "
+            f"({type(e).__name__}); step-scope `let` values cannot be resolved"
+        ) from e
 
 
 class RustSessionRuntime(SessionRuntime):

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -880,7 +880,6 @@ class Session:
         os_env_vars: Optional[dict[str, str]] = None,
         resolved_symbol_table_json: str | None = None,
         step_name: str | None = None,
-        extra_let_bindings: list[str] | None = None,
     ) -> None:
         session_env_id = self._runtime.enter_environment(
             environment=environment,
@@ -888,7 +887,6 @@ class Session:
             os_env_vars=os_env_vars,
             resolved_symbol_table_json=resolved_symbol_table_json,
             step_name=step_name,
-            extra_let_bindings=extra_let_bindings,
         )
         self._active_envs.append(
             ActiveEnvironment(
@@ -1232,7 +1230,6 @@ class Session:
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
-        extra_let_bindings: list[str] | None = None,
     ) -> None:
         self._runtime.run_task(
             step_script=step_script,
@@ -1241,7 +1238,6 @@ class Session:
             log_task_banner=log_task_banner,
             step_name=step_name,
             resolved_symbol_table_json=resolved_symbol_table_json,
-            extra_let_bindings=extra_let_bindings,
         )
 
     def _run_attachment_sync_task(

--- a/src/deadline_worker_agent/sessions/session.py
+++ b/src/deadline_worker_agent/sessions/session.py
@@ -1232,6 +1232,7 @@ class Session:
         log_task_banner: bool = True,
         step_name: str | None = None,
         resolved_symbol_table_json: str | None = None,
+        extra_let_bindings: list[str] | None = None,
     ) -> None:
         self._runtime.run_task(
             step_script=step_script,
@@ -1240,6 +1241,7 @@ class Session:
             log_task_banner=log_task_banner,
             step_name=step_name,
             resolved_symbol_table_json=resolved_symbol_table_json,
+            extra_let_bindings=extra_let_bindings,
         )
 
     def _run_attachment_sync_task(

--- a/test/unit/scheduler/test_step_env_context.py
+++ b/test/unit/scheduler/test_step_env_context.py
@@ -70,7 +70,6 @@ class TestDequeueStepContext:
         mock = MagicMock()
         step_template = MagicMock()
         step_template.name = "MyStep"
-        step_template.let = ["VAR=value"]
         mock.step_details.return_value.step_template = step_template
         return mock
 
@@ -87,7 +86,7 @@ class TestDequeueStepContext:
     def test_step_scoped_env_gets_step_context(
         self, session_queue: SessionActionQueue, job_entities: MagicMock
     ) -> None:
-        """A STEP:-prefixed env-enter receives step name and let bindings."""
+        """A STEP:-prefixed env-enter receives the step name."""
         entry = EnvironmentQueueEntry(
             cancel=Mock(),
             definition=EnvironmentAction(
@@ -103,7 +102,6 @@ class TestDequeueStepContext:
 
         assert isinstance(result, EnterEnvironmentAction)
         assert result._step_name == "MyStep"
-        assert result._extra_let_bindings == ["VAR=value"]
         job_entities.step_details.assert_called_once_with(step_id="step-abc123")
 
     def test_job_scoped_env_gets_no_step_context(
@@ -125,7 +123,6 @@ class TestDequeueStepContext:
 
         assert isinstance(result, EnterEnvironmentAction)
         assert result._step_name is None
-        assert result._extra_let_bindings is None
         job_entities.step_details.assert_not_called()
 
     def test_two_consecutive_step_envs_both_get_context(
@@ -180,4 +177,3 @@ class TestDequeueStepContext:
 
         assert isinstance(result, EnterEnvironmentAction)
         assert result._step_name is None
-        assert result._extra_let_bindings is None

--- a/test/unit/sessions/actions/test_run_step_task.py
+++ b/test/unit/sessions/actions/test_run_step_task.py
@@ -96,50 +96,6 @@ class TestRunStepTaskAction:
         assert "DEADLINE_TASK_ID" not in env_vars
 
 
-class TestRunStepTaskActionStepScopeLetBindings:
-    """The action must hand the step's step-template-scope `let` to the session.
-
-    The service serves an un-instantiated StepTemplate: step-scope `let` lives
-    in StepTemplate.let and script-scope `let` in StepTemplate.script.let, as
-    separate fields. Nothing folds the former into the latter on the worker's
-    path, so if the action drops StepTemplate.let then a step-scope name is
-    simply absent from the Python session's symbol table and every reference to
-    it fails to resolve.
-    """
-
-    def test_start_passes_step_scope_let_bindings(
-        self, mock_step_details, mock_session, mock_executor
-    ):
-        mock_step_details.step_template.let = ["region = 'us-west-2'"]
-        action = RunStepTaskAction(
-            id="action-123",
-            details=mock_step_details,
-            task_id="task-456",
-            task_parameter_values={},
-        )
-
-        action.start(session=mock_session, executor=mock_executor)
-
-        call_kwargs = mock_session.run_task.call_args.kwargs
-        assert call_kwargs["extra_let_bindings"] == ["region = 'us-west-2'"]
-
-    def test_start_passes_none_when_step_has_no_let_bindings(
-        self, mock_step_details, mock_session, mock_executor
-    ):
-        """A step without `let` must send None, not an empty list or a Mock."""
-        mock_step_details.step_template.let = None
-        action = RunStepTaskAction(
-            id="action-123",
-            details=mock_step_details,
-            task_parameter_values={},
-        )
-
-        action.start(session=mock_session, executor=mock_executor)
-
-        call_kwargs = mock_session.run_task.call_args.kwargs
-        assert call_kwargs["extra_let_bindings"] is None
-
-
 def _step_details_from_template(template: dict[str, Any], extensions: list[str]) -> StepDetails:
     """Parse a served step template the way BatchGetJobEntity delivers it."""
     payload: Any = {
@@ -165,16 +121,12 @@ class TestRunStepTaskActionSimpleActionSugar:
     ``resolve_syntax_sugar()`` produces, which a Mock cannot tell us.
     """
 
-    def test_start_de_sugars_a_bash_step_and_sends_no_extra_bindings(
-        self, mock_session, mock_executor
-    ):
-        """The folded script goes out, and ``extra_let_bindings`` is None.
+    def test_start_de_sugars_a_bash_step(self, mock_session, mock_executor):
+        """The folded script goes out, carrying both `let` scopes in order.
 
         ``resolve_syntax_sugar()`` folds step-scope ``let`` into the script's own
-        ``let`` as ``[*step lets, *simple-action lets]``, so sending the step's
-        bindings again would apply them twice. That is idempotent for a literal
-        but not for a self-referential binding (``n = n + 1`` twice yields 3),
-        so this path must send None.
+        ``let`` as ``[*step lets, *simple-action lets]``. Without that fold the
+        action would have no script at all to send.
         """
         details = _step_details_from_template(
             {
@@ -195,7 +147,6 @@ class TestRunStepTaskActionSimpleActionSugar:
         action.start(session=mock_session, executor=mock_executor)
 
         call_kwargs = mock_session.run_task.call_args.kwargs
-        assert call_kwargs["extra_let_bindings"] is None
         step_script = call_kwargs["step_script"]
         assert step_script is not None
         # Both scopes present exactly once, step bindings first.
@@ -225,12 +176,11 @@ class TestRunStepTaskActionSimpleActionSugar:
         assert details.step_template.bash is not None
 
     def test_start_forwards_a_plain_script_unchanged(self, mock_session, mock_executor):
-        """Control: a ``script:`` template still sends its own script and ``let``.
+        """Control: a ``script:`` template sends its own script object untouched.
 
-        Guards the other direction -- de-sugaring unconditionally would also
-        fold ``let`` into ``script.let``, so a plain step would resolve its
-        step-scope bindings through a different channel than the one
-        test_session.py pins.
+        Guards the other direction -- de-sugaring unconditionally would fold
+        the step's ``let`` into ``script.let`` and send a rebuilt script, so a
+        plain step's script must come through by identity.
         """
         details = _step_details_from_template(
             {
@@ -249,5 +199,8 @@ class TestRunStepTaskActionSimpleActionSugar:
         action.start(session=mock_session, executor=mock_executor)
 
         call_kwargs = mock_session.run_task.call_args.kwargs
-        assert call_kwargs["step_script"] is details.step_template.script
-        assert call_kwargs["extra_let_bindings"] == ["region = 'us-west-2'"]
+        script = details.step_template.script
+        assert script is not None
+        assert call_kwargs["step_script"] is script
+        # No fold happened: the step's own `let` stayed out of script.let.
+        assert script.let is None

--- a/test/unit/sessions/actions/test_run_step_task.py
+++ b/test/unit/sessions/actions/test_run_step_task.py
@@ -93,3 +93,47 @@ class TestRunStepTaskAction:
         assert env_vars["DEADLINE_STEP_ID"] == "step-123"
         assert env_vars["DEADLINE_SESSIONACTION_ID"] == "action-123"
         assert "DEADLINE_TASK_ID" not in env_vars
+
+
+class TestRunStepTaskActionStepScopeLetBindings:
+    """The action must hand the step's step-template-scope `let` to the session.
+
+    The service serves an un-instantiated StepTemplate: step-scope `let` lives
+    in StepTemplate.let and script-scope `let` in StepTemplate.script.let, as
+    separate fields. Nothing folds the former into the latter on the worker's
+    path, so if the action drops StepTemplate.let then a step-scope name is
+    simply absent from the Python session's symbol table and every reference to
+    it fails to resolve.
+    """
+
+    def test_start_passes_step_scope_let_bindings(
+        self, mock_step_details, mock_session, mock_executor
+    ):
+        mock_step_details.step_template.let = ["region = 'us-west-2'"]
+        action = RunStepTaskAction(
+            id="action-123",
+            details=mock_step_details,
+            task_id="task-456",
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        call_kwargs = mock_session.run_task.call_args.kwargs
+        assert call_kwargs["extra_let_bindings"] == ["region = 'us-west-2'"]
+
+    def test_start_passes_none_when_step_has_no_let_bindings(
+        self, mock_step_details, mock_session, mock_executor
+    ):
+        """A step without `let` must send None, not an empty list or a Mock."""
+        mock_step_details.step_template.let = None
+        action = RunStepTaskAction(
+            id="action-123",
+            details=mock_step_details,
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        call_kwargs = mock_session.run_task.call_args.kwargs
+        assert call_kwargs["extra_let_bindings"] is None

--- a/test/unit/sessions/actions/test_run_step_task.py
+++ b/test/unit/sessions/actions/test_run_step_task.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from typing import Any
 from unittest.mock import Mock
 import pytest
 
@@ -137,3 +138,116 @@ class TestRunStepTaskActionStepScopeLetBindings:
 
         call_kwargs = mock_session.run_task.call_args.kwargs
         assert call_kwargs["extra_let_bindings"] is None
+
+
+def _step_details_from_template(template: dict[str, Any], extensions: list[str]) -> StepDetails:
+    """Parse a served step template the way BatchGetJobEntity delivers it."""
+    payload: Any = {
+        "jobId": "job-123",
+        "stepId": "step-123",
+        "schemaVersion": "jobtemplate-2023-09",
+        "dependencies": [],
+        "extensions": extensions,
+        "template": template,
+    }
+    return StepDetails.from_boto(payload)
+
+
+class TestRunStepTaskActionSimpleActionSugar:
+    """A served FEATURE_BUNDLE_1 simple action has no ``script`` to forward.
+
+    Gap 25: the service serves the sugar as authored, so
+    ``StepTemplate.script`` is None. The action de-sugars it here, because
+    nothing else on the worker's path does -- ``create_job`` only de-sugars for
+    callers that instantiate a job.
+
+    Real templates rather than Mocks: the whole point is what the model's
+    ``resolve_syntax_sugar()`` produces, which a Mock cannot tell us.
+    """
+
+    def test_start_de_sugars_a_bash_step_and_sends_no_extra_bindings(
+        self, mock_session, mock_executor
+    ):
+        """The folded script goes out, and ``extra_let_bindings`` is None.
+
+        ``resolve_syntax_sugar()`` folds step-scope ``let`` into the script's own
+        ``let`` as ``[*step lets, *simple-action lets]``, so sending the step's
+        bindings again would apply them twice. That is idempotent for a literal
+        but not for a self-referential binding (``n = n + 1`` twice yields 3),
+        so this path must send None.
+        """
+        details = _step_details_from_template(
+            {
+                "name": "MyStep",
+                "let": ["base = 'from step'"],
+                "bash": {"let": ["msg = base"], "script": "echo hi"},
+            },
+            ["FEATURE_BUNDLE_1", "EXPR"],
+        )
+        assert details.step_template.script is None
+        action = RunStepTaskAction(
+            id="action-123",
+            details=details,
+            task_id="task-456",
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        call_kwargs = mock_session.run_task.call_args.kwargs
+        assert call_kwargs["extra_let_bindings"] is None
+        step_script = call_kwargs["step_script"]
+        assert step_script is not None
+        # Both scopes present exactly once, step bindings first.
+        assert step_script.let == ["base = 'from step'", "msg = base"]
+        assert step_script.actions.onRun.command == "bash"
+
+    def test_start_does_not_mutate_the_served_template(self, mock_session, mock_executor):
+        """De-sugaring returns a new template; the entity's own is untouched.
+
+        StepDetails is cached and re-used across the tasks of a step, so a
+        de-sugar that mutated in place would leave later reads of the same
+        entity looking at a different shape than the service sent.
+        """
+        details = _step_details_from_template(
+            {"name": "MyStep", "bash": {"script": "echo hi"}},
+            ["FEATURE_BUNDLE_1", "EXPR"],
+        )
+        action = RunStepTaskAction(
+            id="action-123",
+            details=details,
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        assert details.step_template.script is None
+        assert details.step_template.bash is not None
+
+    def test_start_forwards_a_plain_script_unchanged(self, mock_session, mock_executor):
+        """Control: a ``script:`` template still sends its own script and ``let``.
+
+        Guards the other direction -- de-sugaring unconditionally would also
+        fold ``let`` into ``script.let``, so a plain step would resolve its
+        step-scope bindings through a different channel than the one
+        test_session.py pins.
+        """
+        details = _step_details_from_template(
+            {
+                "name": "MyStep",
+                "let": ["region = 'us-west-2'"],
+                "script": {"actions": {"onRun": {"command": "echo", "args": ["hi"]}}},
+            },
+            ["EXPR"],
+        )
+        action = RunStepTaskAction(
+            id="action-123",
+            details=details,
+            task_parameter_values={},
+        )
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        call_kwargs = mock_session.run_task.call_args.kwargs
+        assert call_kwargs["step_script"] is details.step_template.script
+        assert call_kwargs["extra_let_bindings"] == ["region = 'us-west-2'"]

--- a/test/unit/sessions/runtime/conftest.py
+++ b/test/unit/sessions/runtime/conftest.py
@@ -41,7 +41,6 @@ def _make_stub_runtime_class() -> type[SessionRuntime]:
             os_env_vars: Optional[dict[str, str]] = None,
             resolved_symbol_table_json: str | None = None,
             step_name: str | None = None,
-            extra_let_bindings: list[str] | None = None,
         ) -> str:
             return "env-id"
 
@@ -64,7 +63,6 @@ def _make_stub_runtime_class() -> type[SessionRuntime]:
             log_task_banner: bool = True,
             step_name: str | None = None,
             resolved_symbol_table_json: str | None = None,
-            extra_let_bindings: list[str] | None = None,
         ) -> None:
             return None
 

--- a/test/unit/sessions/runtime/conftest.py
+++ b/test/unit/sessions/runtime/conftest.py
@@ -64,6 +64,7 @@ def _make_stub_runtime_class() -> type[SessionRuntime]:
             log_task_banner: bool = True,
             step_name: str | None = None,
             resolved_symbol_table_json: str | None = None,
+            extra_let_bindings: list[str] | None = None,
         ) -> None:
             return None
 

--- a/test/unit/sessions/runtime/test_import_purity.py
+++ b/test/unit/sessions/runtime/test_import_purity.py
@@ -1,0 +1,143 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""The Python runtime adapter must not load the native EXPR extension at import.
+
+``openjd.expr`` is a thin facade over the native ``openjd._openjd_rs``
+extension. python.py needs ``SerializedSymbolTable`` from it only when a
+session actually receives a resolved symbol table, so the import is
+function-local and behind a None guard. A module-level import would make the
+extension a load-time requirement of every worker process, including ones
+that only run non-EXPR templates.
+
+Each probe runs in a fresh interpreter, because by the time any given test
+runs the extension has usually been loaded by another test in the same worker
+(test_rust.py imports it at module level). Modeled on
+test/openjd/test_import_purity.py in openjd-sessions-for-python.
+
+Note for coverage readers: these probes run in child processes with no
+``COVERAGE_PROCESS_START``, so the lazy imports they exercise still report as
+uncovered. Do not "fix" that by making the imports module-level -- they are
+what these tests exist to protect.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+# Kept below the suite-wide timeout so a hung probe is reported as a probe
+# timeout with its output rather than being killed silently.
+_PROBE_TIMEOUT_SECONDS = 20
+
+# Injected ahead of every probe body. sys.path is handed over as a JSON
+# argument -- not embedded in the source -- so that a path which is not
+# encodable as UTF-8 source cannot break the probe.
+_PROBE_PREAMBLE = """\
+import json
+import sys
+
+sys.path[:] = json.loads(sys.argv[1])
+
+RS = "openjd._openjd_rs"
+"""
+
+
+def _probe_python() -> str:
+    """The interpreter to run a probe with.
+
+    Under Windows Session 0 ``sys.executable`` is ``pythonservice.exe``, which
+    cannot run a script.
+    """
+    if sys.platform == "win32" and "pythonservice.exe" in sys.executable.lower():
+        return sys.executable.lower().replace("pythonservice.exe", "python.exe")
+    return sys.executable
+
+
+def _run_probe(tmp_path: Path, body: str) -> str:
+    """Run ``body`` in a fresh interpreter and return its stdout, stripped."""
+    script = tmp_path / "probe.py"
+    script.write_text(_PROBE_PREAMBLE + textwrap.dedent(body), encoding="utf-8")
+    completed = subprocess.run(
+        [_probe_python(), str(script), json.dumps(sys.path)],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=_PROBE_TIMEOUT_SECONDS,
+    )
+    assert completed.returncode == 0, (
+        f"probe exited {completed.returncode}\n"
+        f"--- script ---\n{script.read_text(encoding='utf-8')}\n"
+        f"--- stdout ---\n{completed.stdout}\n--- stderr ---\n{completed.stderr}"
+    )
+    return completed.stdout.strip()
+
+
+def test_importing_python_runtime_does_not_load_native_extension(tmp_path: Path) -> None:
+    """Importing the Python runtime adapter must not load the extension.
+
+    Before this fix, python.py imported SerializedSymbolTable at module level,
+    which loaded the native extension in every worker process unconditionally.
+    """
+    # WHEN
+    loaded = _run_probe(
+        tmp_path,
+        """
+        import deadline_worker_agent.sessions.runtime.python
+
+        print(RS in sys.modules)
+        """,
+    )
+
+    # THEN
+    assert loaded == "False", (
+        "importing deadline_worker_agent.sessions.runtime.python loaded the "
+        "native extension. Something on its import path imports openjd.expr "
+        "(or openjd._openjd_rs) at module level; it must be imported lazily, "
+        "behind the None guards in _extract_job_name/_parse_resolved_symtab."
+    )
+
+
+def test_importing_python_runtime_does_not_resolve_openjd_expr(tmp_path: Path) -> None:
+    """``openjd.expr`` is the facade the extension gets pulled in through, so
+    it must not appear either -- this still fails on a module-level import if
+    some future build made the extension itself lazy."""
+    # WHEN
+    resolved = _run_probe(
+        tmp_path,
+        """
+        import deadline_worker_agent.sessions.runtime.python
+
+        print("openjd.expr" in sys.modules)
+        """,
+    )
+
+    # THEN
+    assert resolved == "False", (
+        "importing the Python runtime adapter resolved openjd.expr at import "
+        "time; it must only be imported from inside a function on the "
+        "resolved-table path."
+    )
+
+
+def test_native_extension_is_available(tmp_path: Path) -> None:
+    """Positive control: the extension really is installed here. Without this,
+    every "must not be loaded" test above would pass trivially in an
+    environment where it simply is not present."""
+    # WHEN
+    loaded = _run_probe(
+        tmp_path,
+        """
+        import openjd.expr
+
+        print(RS in sys.modules)
+        """,
+    )
+
+    # THEN
+    assert loaded == "True", (
+        "openjd.expr did not load the native extension, so the purity tests in "
+        "this file prove nothing. Check the openjd-model install."
+    )

--- a/test/unit/sessions/runtime/test_import_purity.py
+++ b/test/unit/sessions/runtime/test_import_purity.py
@@ -122,6 +122,67 @@ def test_importing_python_runtime_does_not_resolve_openjd_expr(tmp_path: Path) -
     )
 
 
+def test_constructing_runtime_without_table_does_not_load_native_extension(
+    tmp_path: Path,
+) -> None:
+    """Building a runtime with no resolved table must not load the extension.
+
+    The two probes above pin import time only. This one pins construction: the
+    ctor runs ``_extract_job_name(config.resolved_symbol_table_json)``, and the
+    None guard there is the thing that keeps the extension out of a worker
+    process that only ever runs non-EXPR templates. ``_parse_resolved_symtab``
+    is exercised too, since the same guard protects it on the action paths.
+
+    ``path_mapping_rules=None`` is load-bearing: real path mapping rules load
+    the extension themselves (a known open limitation in the sessions repo), so
+    a probe that passed rules would fail for a reason this test is not about.
+    """
+    # WHEN
+    loaded = _run_probe(
+        tmp_path,
+        """
+        import tempfile
+        from pathlib import Path
+
+        from deadline_worker_agent.sessions.runtime import SessionRuntimeConfig
+        from deadline_worker_agent.sessions.runtime.python import (
+            PythonSessionRuntime,
+            _parse_resolved_symtab,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            runtime = PythonSessionRuntime(
+                SessionRuntimeConfig(
+                    session_id="purity-probe",
+                    job_parameter_values={},
+                    path_mapping_rules=None,
+                    retain_working_dir=False,
+                    user=None,
+                    action_callback=lambda session_id, status: None,
+                    os_env_vars=None,
+                    session_root_directory=Path(td),
+                    resolved_symbol_table_json=None,
+                )
+            )
+            # Release the working directory before the tempdir is removed --
+            # Windows refuses to delete a directory that is still in use.
+            runtime.cleanup()
+            _parse_resolved_symtab(None)
+
+        print(RS in sys.modules)
+        """,
+    )
+
+    # THEN
+    assert loaded == "False", (
+        "constructing PythonSessionRuntime with resolved_symbol_table_json=None "
+        "loaded the native extension. The imports in _extract_job_name and "
+        "_parse_resolved_symtab must stay inside their functions, after the "
+        "None guard -- a session that never receives a resolved table must not "
+        "pay for the extension."
+    )
+
+
 def test_native_extension_is_available(tmp_path: Path) -> None:
     """Positive control: the extension really is installed here. Without this,
     every "must not be loaded" test above would pass trivially in an

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -11,7 +11,10 @@ import pytest
 
 from openjd.model import SpecificationRevision
 
-from deadline_worker_agent.sessions.runtime import SessionRuntimeConfig
+from deadline_worker_agent.sessions.runtime import (
+    ResolvedSymbolTableError,
+    SessionRuntimeConfig,
+)
 from deadline_worker_agent.sessions.runtime import python as python_module
 from deadline_worker_agent.sessions.runtime.python import PythonSessionRuntime
 
@@ -438,51 +441,86 @@ class TestResolvedSymbolTableForwarding:
         call_kwargs = mock_session_instance.exit_environment.call_args.kwargs
         assert call_kwargs["resolved_symtab"] is None
 
-    def test_enter_environment_graceful_degradation_on_malformed_json(
+    def test_enter_environment_raises_on_malformed_json(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        """Malformed JSON causes a warning log and proceeds with resolved_symtab=None."""
+        """An unparseable table fails the action instead of silently dropping it.
+
+        The table is the only channel for step-scope `let`, so degrading to None
+        would enter the environment with those symbols undefined and surface a
+        downstream "undefined symbol" error naming the symbol, not the cause.
+        """
         environment = MagicMock()
 
         with patch.object(python_module, "logger") as mock_logger:
-            adapter.enter_environment(
-                environment=environment,
-                identifier="env-1",
-                resolved_symbol_table_json="not valid json",
-            )
+            with pytest.raises(ResolvedSymbolTableError):
+                adapter.enter_environment(
+                    environment=environment,
+                    identifier="env-1",
+                    resolved_symbol_table_json="not valid json",
+                )
 
-        mock_logger.warning.assert_called_once()
-        assert "resolvedSymbolTable" in mock_logger.warning.call_args[0][0]
-        call_kwargs = mock_session_instance.enter_environment.call_args.kwargs
-        assert call_kwargs["resolved_symtab"] is None
+        # The environment must not be entered at all -- a half-entered
+        # environment would land on Session._active_envs and be exited later.
+        mock_session_instance.enter_environment.assert_not_called()
+        mock_logger.error.assert_called_once()
+        assert "resolvedSymbolTable" in mock_logger.error.call_args[0][0]
 
-    def test_run_task_graceful_degradation_on_malformed_json(
+    def test_run_task_raises_on_malformed_json(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        """Malformed JSON causes a warning log and proceeds with resolved_symtab=None."""
+        """An unparseable table fails the task instead of running it degraded."""
         with patch.object(python_module, "logger") as mock_logger:
+            with pytest.raises(ResolvedSymbolTableError):
+                adapter.run_task(
+                    step_script=MagicMock(),
+                    task_parameter_values={},
+                    resolved_symbol_table_json="{not json",
+                )
+
+        mock_session_instance.run_task.assert_not_called()
+        mock_logger.error.assert_called_once()
+        assert "resolvedSymbolTable" in mock_logger.error.call_args[0][0]
+
+    def test_exit_environment_raises_on_malformed_json(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """An unparseable table fails the exit action.
+
+        Session.exit_environment pops _active_envs only after the runtime call
+        returns, so the environment stays active and Session._cleanup retries the
+        exit with the enter-time table.
+        """
+        with patch.object(python_module, "logger") as mock_logger:
+            with pytest.raises(ResolvedSymbolTableError):
+                adapter.exit_environment(
+                    identifier="env-1",
+                    resolved_symbol_table_json="{not json",
+                )
+
+        mock_session_instance.exit_environment.assert_not_called()
+        mock_logger.error.assert_called_once()
+        assert "resolvedSymbolTable" in mock_logger.error.call_args[0][0]
+
+    def test_malformed_table_error_does_not_leak_payload_and_chains_cause(
+        self, adapter: PythonSessionRuntime
+    ) -> None:
+        """The fail message reaches the service, so it must not echo the payload.
+
+        Session._start_action reports str(e) as the action's fail message, which
+        the scheduler forwards as progressMessage. The underlying parse error is
+        preserved as __cause__ for the agent-side traceback instead.
+        """
+        payload = '{"UNIQUE_PAYLOAD_MARKER_9f3a": "should not be echoed"'
+
+        with pytest.raises(ResolvedSymbolTableError) as excinfo:
             adapter.run_task(
                 step_script=MagicMock(),
                 task_parameter_values={},
-                resolved_symbol_table_json="{not json",
+                resolved_symbol_table_json=payload,
             )
 
-        mock_logger.warning.assert_called_once()
-        assert "resolvedSymbolTable" in mock_logger.warning.call_args[0][0]
-        call_kwargs = mock_session_instance.run_task.call_args.kwargs
-        assert call_kwargs["resolved_symtab"] is None
-
-    def test_exit_environment_graceful_degradation_on_malformed_json(
-        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
-    ) -> None:
-        """Malformed JSON causes a warning log and proceeds with resolved_symtab=None."""
-        with patch.object(python_module, "logger") as mock_logger:
-            adapter.exit_environment(
-                identifier="env-1",
-                resolved_symbol_table_json="{not json",
-            )
-
-        mock_logger.warning.assert_called_once()
-        assert "resolvedSymbolTable" in mock_logger.warning.call_args[0][0]
-        call_kwargs = mock_session_instance.exit_environment.call_args.kwargs
-        assert call_kwargs["resolved_symtab"] is None
+        message = str(excinfo.value)
+        assert "UNIQUE_PAYLOAD_MARKER_9f3a" not in message
+        assert "resolvedSymbolTable" in message
+        assert excinfo.value.__cause__ is not None

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -188,6 +188,34 @@ class TestPythonSessionRuntimeDelegation:
             os_env_vars={"X": "Y"},
             log_task_banner=False,
             step_name=None,
+            extra_let_bindings=None,
+        )
+
+    def test_run_task_forwards_step_scope_let_bindings_to_wrapped_session(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """Step-template-scope `let` bindings reach the Python session.
+
+        The service serves an un-instantiated StepTemplate, so StepTemplate.let
+        is never folded into script.let on this path. This kwarg is the only way
+        those bindings reach the v0 session's task symbol table.
+        """
+        step_script = MagicMock()
+
+        adapter.run_task(
+            step_script=step_script,
+            task_parameter_values={},
+            step_name="MyStep",
+            extra_let_bindings=["region = 'us-west-2'"],
+        )
+
+        mock_session_instance.run_task.assert_called_once_with(
+            step_script=step_script,
+            task_parameter_values={},
+            os_env_vars=None,
+            log_task_banner=True,
+            step_name="MyStep",
+            extra_let_bindings=["region = 'us-west-2'"],
         )
 
     def test_run_task_without_session_env_when_called_delegates_to_private_method(

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -482,25 +482,52 @@ class TestResolvedSymbolTableForwarding:
         mock_logger.error.assert_called_once()
         assert "resolvedSymbolTable" in mock_logger.error.call_args[0][0]
 
-    def test_exit_environment_raises_on_malformed_json(
+    def test_exit_environment_degrades_on_malformed_json_so_teardown_runs(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        """An unparseable table fails the exit action.
+        """Exit must not be blocked by an unparseable table -- onExit still runs.
 
-        Session.exit_environment pops _active_envs only after the runtime call
-        returns, so the environment stays active and Session._cleanup retries the
-        exit with the enter-time table.
+        Deliberately the opposite of the enter and run paths. Session.exit_environment
+        pops _active_envs only after this returns, so raising would leave the
+        environment active and Session._cleanup would retry with the same stored
+        table and swallow the same failure -- onExit would never run, leaking
+        whatever the environment set up (licenses, daemons).
         """
         with patch.object(python_module, "logger") as mock_logger:
-            with pytest.raises(ResolvedSymbolTableError):
-                adapter.exit_environment(
-                    identifier="env-1",
-                    resolved_symbol_table_json="{not json",
-                )
+            adapter.exit_environment(
+                identifier="env-1",
+                resolved_symbol_table_json="{not json",
+            )
 
-        mock_session_instance.exit_environment.assert_not_called()
+        # Teardown proceeded, with the table dropped rather than the exit skipped.
+        mock_session_instance.exit_environment.assert_called_once()
+        assert mock_session_instance.exit_environment.call_args.kwargs["resolved_symtab"] is None
+        # Still loud in the agent log, just not fatal.
         mock_logger.error.assert_called_once()
         assert "resolvedSymbolTable" in mock_logger.error.call_args[0][0]
+
+    def test_enter_and_run_still_raise_while_exit_degrades(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """Negative control for the exit carve-out: it must not soften enter/run.
+
+        A single flag or a misplaced try/except that degraded everywhere would
+        pass the exit test above; this pins that the carve-out is exit-only.
+        """
+        bad = "{not json"
+
+        with pytest.raises(ResolvedSymbolTableError):
+            adapter.enter_environment(environment=MagicMock(), resolved_symbol_table_json=bad)
+        with pytest.raises(ResolvedSymbolTableError):
+            adapter.run_task(
+                step_script=MagicMock(), task_parameter_values={}, resolved_symbol_table_json=bad
+            )
+
+        adapter.exit_environment(identifier="env-1", resolved_symbol_table_json=bad)
+
+        mock_session_instance.enter_environment.assert_not_called()
+        mock_session_instance.run_task.assert_not_called()
+        mock_session_instance.exit_environment.assert_called_once()
 
     def test_malformed_table_error_does_not_leak_payload_and_chains_cause(
         self, adapter: PythonSessionRuntime

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 from datetime import timedelta
 from pathlib import Path
 from typing import Generator
@@ -528,6 +529,35 @@ class TestResolvedSymbolTableForwarding:
         mock_session_instance.enter_environment.assert_not_called()
         mock_session_instance.run_task.assert_not_called()
         mock_session_instance.exit_environment.assert_called_once()
+
+    def test_extension_load_failure_becomes_resolved_symbol_table_error(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """An unloadable native extension must not escape as a raw ImportError.
+
+        The openjd.expr import is lazy (function-local, to keep the extension off
+        the import path for sessions that never receive a table). That moved where
+        an unloadable extension is discovered: it no longer fails at adapter
+        construction, where _factory.create_session_runtime converts ImportError
+        into NotImplementedError. Left uncaught it would surface mid-session as a
+        raw ImportError reported as the task's fail message.
+        """
+        real_import = builtins.__import__
+
+        def fail_openjd_expr(name: str, *args: object, **kwargs: object) -> object:
+            if name == "openjd.expr":
+                raise ImportError("native extension unavailable on this platform")
+            return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(builtins, "__import__", side_effect=fail_openjd_expr):
+            with pytest.raises(ResolvedSymbolTableError):
+                adapter.run_task(
+                    step_script=MagicMock(),
+                    task_parameter_values={},
+                    resolved_symbol_table_json='[{"name":"X","type":"string","value":"1"}]',
+                )
+
+        mock_session_instance.run_task.assert_not_called()
 
     def test_malformed_table_error_does_not_leak_payload_and_chains_cause(
         self, adapter: PythonSessionRuntime

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -110,6 +110,7 @@ class TestPythonSessionRuntimeDelegation:
             os_env_vars=os_env,
             step_name=None,
             extra_let_bindings=None,
+            resolved_symtab=None,
         )
         # enter_environment is the only non-void method — verify the return value
         # (EnvironmentIdentifier) flows through the adapter.
@@ -138,6 +139,7 @@ class TestPythonSessionRuntimeDelegation:
             os_env_vars=os_env,
             step_name="MyStep",
             extra_let_bindings=["VAR=value"],
+            resolved_symtab=None,
         )
         assert result is mock_session_instance.enter_environment.return_value
 
@@ -151,22 +153,10 @@ class TestPythonSessionRuntimeDelegation:
         )
 
         mock_session_instance.exit_environment.assert_called_once_with(
-            identifier=identifier, os_env_vars={"A": "B"}, keep_session_running=True
-        )
-
-    def test_exit_environment_does_not_forward_resolved_symbol_table_json(
-        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
-    ) -> None:
-        """The v0 Python session has no resolved-table API; the kwarg is accepted but not forwarded."""
-        identifier = MagicMock()
-
-        adapter.exit_environment(
             identifier=identifier,
-            resolved_symbol_table_json='[{"name":"Job.Name","type":"string","value":"X"}]',
-        )
-
-        mock_session_instance.exit_environment.assert_called_once_with(
-            identifier=identifier, os_env_vars=None, keep_session_running=False
+            os_env_vars={"A": "B"},
+            keep_session_running=True,
+            resolved_symtab=None,
         )
 
     def test_run_task_when_called_delegates_to_wrapped_session(
@@ -189,6 +179,7 @@ class TestPythonSessionRuntimeDelegation:
             log_task_banner=False,
             step_name=None,
             extra_let_bindings=None,
+            resolved_symtab=None,
         )
 
     def test_run_task_forwards_step_scope_let_bindings_to_wrapped_session(
@@ -216,6 +207,7 @@ class TestPythonSessionRuntimeDelegation:
             log_task_banner=True,
             step_name="MyStep",
             extra_let_bindings=["region = 'us-west-2'"],
+            resolved_symtab=None,
         )
 
     def test_run_task_without_session_env_when_called_delegates_to_private_method(
@@ -375,3 +367,154 @@ class TestPythonSessionRuntimeJobName:
         mock_logger.warning.assert_called_once()
         call_kwargs = mock_openjd_session.call_args.kwargs
         assert call_kwargs["job_name"] is None
+
+
+class TestResolvedSymbolTableForwarding:
+    """Tests for resolved_symbol_table_json parsing and forwarding to the v0 session.
+
+    Mirrors TestResolvedSymbolTableForwarding in test_rust.py. python.py imports
+    SerializedSymbolTable lazily (extension purity), so the class is patched at
+    its source (openjd.expr) rather than as a module attribute of python.py.
+    """
+
+    @pytest.fixture()
+    def adapter(
+        self, runtime_config: SessionRuntimeConfig, mock_openjd_session: MagicMock
+    ) -> PythonSessionRuntime:
+        return PythonSessionRuntime(runtime_config)
+
+    @pytest.fixture()
+    def mock_session_instance(self, mock_openjd_session: MagicMock) -> MagicMock:
+        return mock_openjd_session.return_value
+
+    def test_enter_environment_forwards_resolved_symtab_when_json_present(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """When resolved_symbol_table_json is provided, it's parsed and forwarded."""
+        from openjd.expr import SerializedSymbolTable
+
+        environment = MagicMock()
+        symtab_json = '[{"name":"Job.Name","type":"string","value":"TestJob"}]'
+        fake_symtab = MagicMock()
+
+        with patch.object(
+            SerializedSymbolTable, "from_json_str", return_value=fake_symtab
+        ) as mock_from_json:
+            adapter.enter_environment(
+                environment=environment,
+                identifier="env-1",
+                resolved_symbol_table_json=symtab_json,
+            )
+
+        mock_from_json.assert_called_once_with(symtab_json)
+        call_kwargs = mock_session_instance.enter_environment.call_args.kwargs
+        assert call_kwargs["resolved_symtab"] is fake_symtab
+
+    def test_run_task_forwards_resolved_symtab_when_json_present(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """When resolved_symbol_table_json is provided, it's parsed and forwarded."""
+        from openjd.expr import SerializedSymbolTable
+
+        step_script = MagicMock()
+        symtab_json = '[{"name":"Job.Name","type":"string","value":"TestJob"}]'
+        fake_symtab = MagicMock()
+
+        with patch.object(
+            SerializedSymbolTable, "from_json_str", return_value=fake_symtab
+        ) as mock_from_json:
+            adapter.run_task(
+                step_script=step_script,
+                task_parameter_values={},
+                resolved_symbol_table_json=symtab_json,
+            )
+
+        mock_from_json.assert_called_once_with(symtab_json)
+        call_kwargs = mock_session_instance.run_task.call_args.kwargs
+        assert call_kwargs["resolved_symtab"] is fake_symtab
+
+    def test_exit_environment_forwards_resolved_symtab_when_json_present(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """When resolved_symbol_table_json is provided, it's parsed and forwarded."""
+        from openjd.expr import SerializedSymbolTable
+
+        symtab_json = '[{"name":"Job.Name","type":"string","value":"TestJob"}]'
+        fake_symtab = MagicMock()
+
+        with patch.object(
+            SerializedSymbolTable, "from_json_str", return_value=fake_symtab
+        ) as mock_from_json:
+            adapter.exit_environment(
+                identifier="env-1",
+                resolved_symbol_table_json=symtab_json,
+            )
+
+        mock_from_json.assert_called_once_with(symtab_json)
+        call_kwargs = mock_session_instance.exit_environment.call_args.kwargs
+        assert call_kwargs["resolved_symtab"] is fake_symtab
+
+    def test_exit_environment_passes_none_when_json_is_none(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """When resolved_symbol_table_json is None, the parser is not invoked."""
+        from openjd.expr import SerializedSymbolTable
+
+        with patch.object(SerializedSymbolTable, "from_json_str") as mock_from_json:
+            adapter.exit_environment(
+                identifier="env-1",
+                resolved_symbol_table_json=None,
+            )
+
+        mock_from_json.assert_not_called()
+        call_kwargs = mock_session_instance.exit_environment.call_args.kwargs
+        assert call_kwargs["resolved_symtab"] is None
+
+    def test_enter_environment_graceful_degradation_on_malformed_json(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """Malformed JSON causes a warning log and proceeds with resolved_symtab=None."""
+        environment = MagicMock()
+
+        with patch.object(python_module, "logger") as mock_logger:
+            adapter.enter_environment(
+                environment=environment,
+                identifier="env-1",
+                resolved_symbol_table_json="not valid json",
+            )
+
+        mock_logger.warning.assert_called_once()
+        assert "resolvedSymbolTable" in mock_logger.warning.call_args[0][0]
+        call_kwargs = mock_session_instance.enter_environment.call_args.kwargs
+        assert call_kwargs["resolved_symtab"] is None
+
+    def test_run_task_graceful_degradation_on_malformed_json(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """Malformed JSON causes a warning log and proceeds with resolved_symtab=None."""
+        with patch.object(python_module, "logger") as mock_logger:
+            adapter.run_task(
+                step_script=MagicMock(),
+                task_parameter_values={},
+                resolved_symbol_table_json="{not json",
+            )
+
+        mock_logger.warning.assert_called_once()
+        assert "resolvedSymbolTable" in mock_logger.warning.call_args[0][0]
+        call_kwargs = mock_session_instance.run_task.call_args.kwargs
+        assert call_kwargs["resolved_symtab"] is None
+
+    def test_exit_environment_graceful_degradation_on_malformed_json(
+        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """Malformed JSON causes a warning log and proceeds with resolved_symtab=None."""
+        with patch.object(python_module, "logger") as mock_logger:
+            adapter.exit_environment(
+                identifier="env-1",
+                resolved_symbol_table_json="{not json",
+            )
+
+        mock_logger.warning.assert_called_once()
+        assert "resolvedSymbolTable" in mock_logger.warning.call_args[0][0]
+        call_kwargs = mock_session_instance.exit_environment.call_args.kwargs
+        assert call_kwargs["resolved_symtab"] is None

--- a/test/unit/sessions/runtime/test_python.py
+++ b/test/unit/sessions/runtime/test_python.py
@@ -109,7 +109,6 @@ class TestPythonSessionRuntimeDelegation:
             identifier=identifier,
             os_env_vars=os_env,
             step_name=None,
-            extra_let_bindings=None,
             resolved_symtab=None,
         )
         # enter_environment is the only non-void method — verify the return value
@@ -119,8 +118,8 @@ class TestPythonSessionRuntimeDelegation:
     def test_enter_environment_forwards_step_context_to_wrapped_session(
         self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        """Non-None step_name and extra_let_bindings are forwarded to the
-        Python session, which uses them for wrap-action symbol resolution."""
+        """A non-None step_name is forwarded to the Python session, which uses
+        it for wrap-action symbol resolution."""
         env = MagicMock()
         identifier = "env-123"
         os_env = {"K": "V"}
@@ -130,7 +129,6 @@ class TestPythonSessionRuntimeDelegation:
             identifier=identifier,
             os_env_vars=os_env,
             step_name="MyStep",
-            extra_let_bindings=["VAR=value"],
         )
 
         mock_session_instance.enter_environment.assert_called_once_with(
@@ -138,7 +136,6 @@ class TestPythonSessionRuntimeDelegation:
             identifier=identifier,
             os_env_vars=os_env,
             step_name="MyStep",
-            extra_let_bindings=["VAR=value"],
             resolved_symtab=None,
         )
         assert result is mock_session_instance.enter_environment.return_value
@@ -178,35 +175,6 @@ class TestPythonSessionRuntimeDelegation:
             os_env_vars={"X": "Y"},
             log_task_banner=False,
             step_name=None,
-            extra_let_bindings=None,
-            resolved_symtab=None,
-        )
-
-    def test_run_task_forwards_step_scope_let_bindings_to_wrapped_session(
-        self, adapter: PythonSessionRuntime, mock_session_instance: MagicMock
-    ) -> None:
-        """Step-template-scope `let` bindings reach the Python session.
-
-        The service serves an un-instantiated StepTemplate, so StepTemplate.let
-        is never folded into script.let on this path. This kwarg is the only way
-        those bindings reach the v0 session's task symbol table.
-        """
-        step_script = MagicMock()
-
-        adapter.run_task(
-            step_script=step_script,
-            task_parameter_values={},
-            step_name="MyStep",
-            extra_let_bindings=["region = 'us-west-2'"],
-        )
-
-        mock_session_instance.run_task.assert_called_once_with(
-            step_script=step_script,
-            task_parameter_values={},
-            os_env_vars=None,
-            log_task_banner=True,
-            step_name="MyStep",
-            extra_let_bindings=["region = 'us-west-2'"],
             resolved_symtab=None,
         )
 

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -18,7 +18,10 @@ from openjd.model._v1.types import ModelProfile, SpecificationRevision
 
 from deadline_worker_agent.file_system_operations import FileSystemPermissionEnum
 from deadline_worker_agent.sessions.runtime import SessionRuntime, SessionRuntimeConfig
-from deadline_worker_agent.sessions.runtime._abc import SessionRuntimeCrashError
+from deadline_worker_agent.sessions.runtime._abc import (
+    ResolvedSymbolTableError,
+    SessionRuntimeCrashError,
+)
 from deadline_worker_agent.sessions.runtime import rust as rust_module
 from deadline_worker_agent.sessions.runtime.rust import RustSessionRuntime
 from deadline_worker_agent.sessions.runtime.rust import _to_rust_task_parameter_values
@@ -1414,10 +1417,14 @@ class TestResolvedSymbolTableForwarding:
         call_kwargs = mock_session_instance.run_task.call_args.kwargs
         assert call_kwargs["resolved_symtab"] is fake_symtab
 
-    def test_enter_environment_graceful_degradation_on_malformed_json(
+    def test_enter_environment_raises_on_malformed_json(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        """Malformed JSON causes a warning log and proceeds with resolved_symtab=None."""
+        """An unparseable table fails the action, matching the Python adapter.
+
+        The two adapters are kept in lockstep deliberately: the same malformed
+        payload must fail the same way whichever runtime the worker selects.
+        """
         environment = MagicMock()
 
         with (
@@ -1430,16 +1437,16 @@ class TestResolvedSymbolTableForwarding:
             ),
             patch.object(rust_module, "logger") as mock_logger,
         ):
-            adapter.enter_environment(
-                environment=environment,
-                identifier="env-1",
-                resolved_symbol_table_json="not valid json",
-            )
+            with pytest.raises(ResolvedSymbolTableError):
+                adapter.enter_environment(
+                    environment=environment,
+                    identifier="env-1",
+                    resolved_symbol_table_json="not valid json",
+                )
 
-        mock_logger.warning.assert_called_once()
-        assert "resolvedSymbolTable" in mock_logger.warning.call_args[0][0]
-        call_kwargs = mock_session_instance.enter_environment.call_args.kwargs
-        assert call_kwargs["resolved_symtab"] is None
+        mock_session_instance.enter_environment.assert_not_called()
+        mock_logger.error.assert_called_once()
+        assert "resolvedSymbolTable" in mock_logger.error.call_args[0][0]
 
     def test_exit_environment_forwards_resolved_symtab_when_json_present(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
@@ -1474,10 +1481,10 @@ class TestResolvedSymbolTableForwarding:
         call_kwargs = mock_session_instance.exit_environment.call_args.kwargs
         assert call_kwargs["resolved_symtab"] is None
 
-    def test_exit_environment_graceful_degradation_on_malformed_json(
+    def test_exit_environment_raises_on_malformed_json(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        """Malformed JSON causes a warning log and proceeds with resolved_symtab=None."""
+        """An unparseable table fails the exit action, matching the Python adapter."""
         with (
             patch.object(
                 rust_module.SerializedSymbolTable,
@@ -1486,12 +1493,12 @@ class TestResolvedSymbolTableForwarding:
             ),
             patch.object(rust_module, "logger") as mock_logger,
         ):
-            adapter.exit_environment(
-                identifier="env-1",
-                resolved_symbol_table_json="{not json",
-            )
+            with pytest.raises(ResolvedSymbolTableError):
+                adapter.exit_environment(
+                    identifier="env-1",
+                    resolved_symbol_table_json="{not json",
+                )
 
-        mock_logger.warning.assert_called_once()
-        assert "resolvedSymbolTable" in mock_logger.warning.call_args[0][0]
-        call_kwargs = mock_session_instance.exit_environment.call_args.kwargs
-        assert call_kwargs["resolved_symtab"] is None
+        mock_session_instance.exit_environment.assert_not_called()
+        mock_logger.error.assert_called_once()
+        assert "resolvedSymbolTable" in mock_logger.error.call_args[0][0]

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -1481,10 +1481,15 @@ class TestResolvedSymbolTableForwarding:
         call_kwargs = mock_session_instance.exit_environment.call_args.kwargs
         assert call_kwargs["resolved_symtab"] is None
 
-    def test_exit_environment_raises_on_malformed_json(
+    def test_exit_environment_degrades_on_malformed_json_so_teardown_runs(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        """An unparseable table fails the exit action, matching the Python adapter."""
+        """Exit degrades rather than raising, matching the Python adapter.
+
+        Raising here would leave the environment on Session._active_envs and
+        Session._cleanup would retry with the same stored table and swallow the
+        same failure, so onExit would never run.
+        """
         with (
             patch.object(
                 rust_module.SerializedSymbolTable,
@@ -1493,12 +1498,12 @@ class TestResolvedSymbolTableForwarding:
             ),
             patch.object(rust_module, "logger") as mock_logger,
         ):
-            with pytest.raises(ResolvedSymbolTableError):
-                adapter.exit_environment(
-                    identifier="env-1",
-                    resolved_symbol_table_json="{not json",
-                )
+            adapter.exit_environment(
+                identifier="env-1",
+                resolved_symbol_table_json="{not json",
+            )
 
-        mock_session_instance.exit_environment.assert_not_called()
+        mock_session_instance.exit_environment.assert_called_once()
+        assert mock_session_instance.exit_environment.call_args.kwargs["resolved_symtab"] is None
         mock_logger.error.assert_called_once()
         assert "resolvedSymbolTable" in mock_logger.error.call_args[0][0]

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -1415,6 +1415,25 @@ class TestResolvedSymbolTableForwarding:
         call_kwargs = mock_session_instance.run_task.call_args.kwargs
         assert call_kwargs["resolved_symtab"] is fake_symtab
 
+    def test_run_task_omits_extra_let_bindings_from_rust_session(
+        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
+    ) -> None:
+        """extra_let_bindings is accepted and not forwarded to the _v1 session.
+
+        The step-scope `let` values it carries are already inside
+        resolved_symtab, which create_job pre-resolved. Forwarding them too
+        would define the same names twice.
+        """
+        with patch.object(rust_module, "deserialize_step"):
+            adapter.run_task(
+                step_script=MagicMock(),
+                task_parameter_values={},
+                extra_let_bindings=["region = 'us-west-2'"],
+            )
+
+        call_kwargs = mock_session_instance.run_task.call_args.kwargs
+        assert "extra_let_bindings" not in call_kwargs
+
     def test_enter_environment_graceful_degradation_on_malformed_json(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:

--- a/test/unit/sessions/runtime/test_rust.py
+++ b/test/unit/sessions/runtime/test_rust.py
@@ -282,8 +282,8 @@ class TestRustSessionRuntimeDelegation:
     def test_enter_environment_omits_step_context_from_rust_session(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
     ) -> None:
-        """step_name and extra_let_bindings are not forwarded to the _v1
-        session — it receives equivalent context via resolved_symtab."""
+        """step_name is not forwarded to the _v1 session — it receives
+        equivalent context via resolved_symtab."""
         environment = MagicMock()
         identifier = "env-456"
         os_env = {"K": "V"}
@@ -297,7 +297,6 @@ class TestRustSessionRuntimeDelegation:
                 identifier=identifier,
                 os_env_vars=os_env,
                 step_name="MyStep",
-                extra_let_bindings=["X=1"],
             )
 
         mock_session_instance.enter_environment.assert_called_once_with(
@@ -1414,25 +1413,6 @@ class TestResolvedSymbolTableForwarding:
         mock_from_json.assert_called_once_with(symtab_json)
         call_kwargs = mock_session_instance.run_task.call_args.kwargs
         assert call_kwargs["resolved_symtab"] is fake_symtab
-
-    def test_run_task_omits_extra_let_bindings_from_rust_session(
-        self, adapter: RustSessionRuntime, mock_session_instance: MagicMock
-    ) -> None:
-        """extra_let_bindings is accepted and not forwarded to the _v1 session.
-
-        The step-scope `let` values it carries are already inside
-        resolved_symtab, which create_job pre-resolved. Forwarding them too
-        would define the same names twice.
-        """
-        with patch.object(rust_module, "deserialize_step"):
-            adapter.run_task(
-                step_script=MagicMock(),
-                task_parameter_values={},
-                extra_let_bindings=["region = 'us-west-2'"],
-            )
-
-        call_kwargs = mock_session_instance.run_task.call_args.kwargs
-        assert "extra_let_bindings" not in call_kwargs
 
     def test_enter_environment_graceful_degradation_on_malformed_json(
         self, adapter: RustSessionRuntime, mock_session_instance: MagicMock

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -2573,24 +2573,28 @@ class TestRunAttachmentSyncTask:
         )
 
 
-class TestRunTaskStepScopeLetBindings:
-    """Session.run_task must pass step-scope `let` bindings to the runtime.
+class TestRunTask:
+    """Session.run_task is a pass-through to the configured runtime.
 
-    Session.run_task is a pass-through to the configured runtime; this pins the
-    step-scope `let` channel so the Python runtime can seed those names into the
+    The resolved symbol table is the only channel carrying step-scope EXPR
+    `let` values, so its forwarding is what pins those names reaching the
     task's symbol table.
     """
 
     @pytest.mark.parametrize(
-        "extra_let_bindings",
-        [None, ["region = 'us-west-2'"], ["a = 1", "b = a + 1"]],
+        "resolved_symbol_table_json",
+        [
+            None,
+            '[{"name":"region","type":"string","value":"us-west-2"}]',
+            '[{"name":"a","type":"int","value":"1"},{"name":"b","type":"int","value":"2"}]',
+        ],
         ids=["none", "single", "multiple_dependent"],
     )
-    def test_forwards_extra_let_bindings_to_runtime(
+    def test_forwards_resolved_symbol_table_json_to_runtime(
         self,
         session: Session,
         mock_runtime: MagicMock,
-        extra_let_bindings: list[str] | None,
+        resolved_symbol_table_json: str | None,
     ) -> None:
         # GIVEN
         step_script_model = MagicMock()
@@ -2599,11 +2603,14 @@ class TestRunTaskStepScopeLetBindings:
         session.run_task(
             step_script=step_script_model,
             task_parameter_values=dict[str, ParameterValue](),
-            extra_let_bindings=extra_let_bindings,
+            resolved_symbol_table_json=resolved_symbol_table_json,
         )
 
         # THEN
-        assert mock_runtime.run_task.call_args.kwargs["extra_let_bindings"] is extra_let_bindings
+        assert (
+            mock_runtime.run_task.call_args.kwargs["resolved_symbol_table_json"]
+            is resolved_symbol_table_json
+        )
 
     def test_propagates_exception_from_openjd_session(
         self,

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -2572,6 +2572,25 @@ class TestRunAttachmentSyncTask:
             log_task_banner=log_task_banner,
         )
 
+    def test_propagates_exception_from_openjd_session(
+        self,
+        session: Session,
+        mock_runtime: MagicMock,
+    ) -> None:
+        """Tests that exceptions from the underlying Open Job Description session are propagated."""
+        # GIVEN
+        expected_exception = RuntimeError("Task execution failed")
+        mock_runtime._run_task_without_session_env.side_effect = expected_exception
+
+        # WHEN / THEN
+        with pytest.raises(RuntimeError) as exc_info:
+            session._run_attachment_sync_task(
+                step_script=MagicMock(),
+                task_parameter_values={},
+            )
+
+        assert exc_info.value is expected_exception
+
 
 class TestRunTask:
     """Session.run_task is a pass-through to the configured runtime.
@@ -2611,25 +2630,6 @@ class TestRunTask:
             mock_runtime.run_task.call_args.kwargs["resolved_symbol_table_json"]
             is resolved_symbol_table_json
         )
-
-    def test_propagates_exception_from_openjd_session(
-        self,
-        session: Session,
-        mock_runtime: MagicMock,
-    ) -> None:
-        """Tests that exceptions from the underlying Open Job Description session are propagated."""
-        # GIVEN
-        expected_exception = RuntimeError("Task execution failed")
-        mock_runtime._run_task_without_session_env.side_effect = expected_exception
-
-        # WHEN / THEN
-        with pytest.raises(RuntimeError) as exc_info:
-            session._run_attachment_sync_task(
-                step_script=MagicMock(),
-                task_parameter_values={},
-            )
-
-        assert exc_info.value is expected_exception
 
 
 class TestRuntimeCrashTelemetry:

--- a/test/unit/sessions/test_session.py
+++ b/test/unit/sessions/test_session.py
@@ -2572,6 +2572,39 @@ class TestRunAttachmentSyncTask:
             log_task_banner=log_task_banner,
         )
 
+
+class TestRunTaskStepScopeLetBindings:
+    """Session.run_task must pass step-scope `let` bindings to the runtime.
+
+    Session.run_task is a pass-through to the configured runtime; this pins the
+    step-scope `let` channel so the Python runtime can seed those names into the
+    task's symbol table.
+    """
+
+    @pytest.mark.parametrize(
+        "extra_let_bindings",
+        [None, ["region = 'us-west-2'"], ["a = 1", "b = a + 1"]],
+        ids=["none", "single", "multiple_dependent"],
+    )
+    def test_forwards_extra_let_bindings_to_runtime(
+        self,
+        session: Session,
+        mock_runtime: MagicMock,
+        extra_let_bindings: list[str] | None,
+    ) -> None:
+        # GIVEN
+        step_script_model = MagicMock()
+
+        # WHEN
+        session.run_task(
+            step_script=step_script_model,
+            task_parameter_values=dict[str, ParameterValue](),
+            extra_let_bindings=extra_let_bindings,
+        )
+
+        # THEN
+        assert mock_runtime.run_task.call_args.kwargs["extra_let_bindings"] is extra_let_bindings
+
     def test_propagates_exception_from_openjd_session(
         self,
         session: Session,

--- a/test/unit/sessions/test_step_scope_let_end_to_end.py
+++ b/test/unit/sessions/test_step_scope_let_end_to_end.py
@@ -27,6 +27,7 @@ names are simply absent from the task's symbol table.
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 import uuid
@@ -37,6 +38,7 @@ from unittest.mock import Mock
 import pytest
 from openjd.sessions import ActionState
 
+from deadline_worker_agent.api_models import StepDetailsData
 from deadline_worker_agent.sessions.actions.run_step_task import RunStepTaskAction
 from deadline_worker_agent.sessions.job_entities.step_details import StepDetails
 from deadline_worker_agent.sessions.runtime import SessionRuntimeConfig
@@ -72,11 +74,16 @@ def _step_details(
     step_let: list[str] | None,
     script_let: list[str] | None,
     args: list[str],
+    resolved_symbol_table: list[dict[str, str]] | None = None,
 ) -> StepDetails:
     """Build a StepDetails from the shape the service actually serves.
 
     Note ``let`` and ``script.let`` are siblings here, never folded together --
     that is the served shape, and the reason this defect exists.
+
+    ``resolved_symbol_table`` is a list of ``{"name", "type", "value"}`` entries
+    serialized into the payload's ``resolvedSymbolTable`` field -- the JSON
+    string ``create_job`` pre-resolves and ``BatchGetJobEntity`` serves.
     """
     template: dict[str, Any] = {
         "name": "MyStep",
@@ -87,16 +94,18 @@ def _step_details(
     if script_let is not None:
         template["script"]["let"] = script_let
 
-    return StepDetails.from_boto(
-        {
-            "jobId": "job-123",
-            "stepId": "step-123",
-            "schemaVersion": "jobtemplate-2023-09",
-            "dependencies": [],
-            "extensions": ["EXPR"],
-            "template": template,
-        }
-    )
+    payload: StepDetailsData = {
+        "jobId": "job-123",
+        "stepId": "step-123",
+        "schemaVersion": "jobtemplate-2023-09",
+        "dependencies": [],
+        "extensions": ["EXPR"],
+        "template": template,
+    }
+    if resolved_symbol_table is not None:
+        payload["resolvedSymbolTable"] = json.dumps(resolved_symbol_table)
+
+    return StepDetails.from_boto(payload)
 
 
 def _run_action_to_completion(
@@ -260,3 +269,54 @@ class TestStepScopeLetEndToEnd:
         state, _ = _run_action_to_completion(details, tmp_path)
 
         assert state == ActionState.FAILED
+
+
+class TestResolvedSymbolTableEndToEnd:
+    """The served ``resolvedSymbolTable`` reaches the v0 session's symbol table.
+
+    Same real chain as TestStepScopeLetEndToEnd, but the symbol under test
+    arrives via the entity's pre-resolved symbol table rather than the
+    template's ``let`` -- the channel this fix adds for the Python runtime.
+    """
+
+    def test_symbol_from_resolved_table_resolves_in_the_task_command(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A symbol the template's ``let`` does NOT define resolves from the
+        served table.
+
+        This is the regression. Before the fix the Python runtime dropped
+        ``resolvedSymbolTable``, so ``{{ from_base }}`` had no definition and
+        the action failed to resolve it.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=None,
+            script_let=None,
+            args=["BASE:{{ from_base }}"],
+            resolved_symbol_table=[
+                {"name": "from_base", "type": "string", "value": "served value"}
+            ],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("BASE:served value" in m for m in caplog.messages)
+
+    def test_a_step_without_resolved_table_still_runs(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Negative control: no table and no ``let`` is today's common case.
+
+        Guards against over-correction -- a fix that only works when a table is
+        served, or that breaks when ``resolvedSymbolTable`` is absent.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(step_let=None, script_let=None, args=["NOTABLE:ok"])
+        assert details.resolved_symbol_table_json is None
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("NOTABLE:ok" in m for m in caplog.messages)

--- a/test/unit/sessions/test_step_scope_let_end_to_end.py
+++ b/test/unit/sessions/test_step_scope_let_end_to_end.py
@@ -1,0 +1,262 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""End-to-end coverage for step-template-scope ``let`` delivery (RFC 0005 §3.6).
+
+This drives the worker's real chain for a task run --
+
+    BatchGetJobEntity payload
+      -> StepDetails.from_boto        (real parse, real extension gating)
+      -> RunStepTaskAction.start      (real action)
+      -> Session.run_task             (stood in for; see _RunTaskOnlySession)
+      -> PythonSessionRuntime.run_task(real adapter)
+      -> openjd.sessions.Session      (real v0 session, real subprocess)
+
+-- and asserts on the *actual* text the task's command emitted, not on mock
+call arguments. The plumbing-level assertions live in test_python.py,
+test_rust.py, test_session.py and actions/test_run_step_task.py; this file
+exists to prove the whole path resolves a real step-scope name.
+
+Why the defect is invisible to most callers: step-scope ``let`` resolves at job
+instantiation, and ``create_job`` folds ``StepTemplate.let`` into
+``script.let``. Anyone instantiating a job locally (openjd-cli) therefore never
+sees a problem. The worker is handed a service-resolved, *un-instantiated*
+``StepTemplate`` whose ``let`` and ``script.let`` are separate fields, and it
+never calls ``resolve_syntax_sugar``. Without an explicit channel the step-scope
+names are simply absent from the task's symbol table.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from openjd.sessions import ActionState
+
+from deadline_worker_agent.sessions.actions.run_step_task import RunStepTaskAction
+from deadline_worker_agent.sessions.job_entities.step_details import StepDetails
+from deadline_worker_agent.sessions.runtime import SessionRuntimeConfig
+from deadline_worker_agent.sessions.runtime.python import PythonSessionRuntime
+
+# Bound on how long a single `echo` task may take before the test gives up.
+# Generous: this waits on a real subprocess, and a hang is a test bug worth
+# failing loudly rather than blocking the suite forever.
+_ACTION_TIMEOUT = 30.0
+
+
+class _RunTaskOnlySession:
+    """Stands in for ``deadline_worker_agent.sessions.Session``.
+
+    The real class is a scheduler-facing orchestrator (queue, asset sync,
+    telemetry, action reporting) whose construction pulls in far more than this
+    test needs. Its ``run_task`` is a verbatim pass-through to the runtime, and
+    that pass-through -- including ``extra_let_bindings`` -- is pinned
+    independently by ``TestRunTaskStepScopeLetBindings`` in test_session.py. So
+    this reproduces just that one hop and lets the real runtime and the real
+    openjd session do the work.
+    """
+
+    def __init__(self, runtime: PythonSessionRuntime) -> None:
+        self._runtime = runtime
+
+    def run_task(self, **kwargs: Any) -> None:
+        self._runtime.run_task(**kwargs)
+
+
+def _step_details(
+    *,
+    step_let: list[str] | None,
+    script_let: list[str] | None,
+    args: list[str],
+) -> StepDetails:
+    """Build a StepDetails from the shape the service actually serves.
+
+    Note ``let`` and ``script.let`` are siblings here, never folded together --
+    that is the served shape, and the reason this defect exists.
+    """
+    template: dict[str, Any] = {
+        "name": "MyStep",
+        "script": {"actions": {"onRun": {"command": "echo", "args": args}}},
+    }
+    if step_let is not None:
+        template["let"] = step_let
+    if script_let is not None:
+        template["script"]["let"] = script_let
+
+    return StepDetails.from_boto(
+        {
+            "jobId": "job-123",
+            "stepId": "step-123",
+            "schemaVersion": "jobtemplate-2023-09",
+            "dependencies": [],
+            "extensions": ["EXPR"],
+            "template": template,
+        }
+    )
+
+
+def _run_action_to_completion(
+    details: StepDetails, session_root: Path
+) -> tuple[ActionState, PythonSessionRuntime]:
+    """Run the step's task through the real chain and return its final state."""
+    runtime = PythonSessionRuntime(
+        SessionRuntimeConfig(
+            session_id=f"session-{uuid.uuid4().hex}",
+            job_parameter_values={},
+            path_mapping_rules=None,
+            retain_working_dir=False,
+            user=None,
+            action_callback=lambda session_id, status: None,
+            os_env_vars=None,
+            session_root_directory=session_root,
+            supported_extensions=("EXPR",),
+        )
+    )
+    try:
+        action = RunStepTaskAction(
+            id="sessionaction-123",
+            details=details,
+            task_id="task-456",
+            task_parameter_values={},
+        )
+
+        action.start(session=_RunTaskOnlySession(runtime), executor=Mock())  # type: ignore[arg-type]
+
+        # run_task is asynchronous -- it spawns the subprocess on its own
+        # thread. Poll the real status rather than sleeping a fixed amount.
+        deadline = time.monotonic() + _ACTION_TIMEOUT
+        while True:
+            status = runtime.action_status
+            if status is not None and status.state != ActionState.RUNNING:
+                return status.state, runtime
+            if time.monotonic() > deadline:
+                pytest.fail(
+                    f"task action did not finish within {_ACTION_TIMEOUT}s (last status: {status})"
+                )
+            time.sleep(0.05)
+    finally:
+        runtime.cleanup()
+
+
+class TestStepScopeLetEndToEnd:
+    def test_step_scope_let_resolves_in_the_task_command(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A step-scope ``let`` name resolves in the command the task runs.
+
+        This is the regression. Before the fix the action dropped
+        ``StepTemplate.let``, so ``{{ from_step }}`` had no definition and the
+        action failed to resolve it.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=["from_step = 'step value'"],
+            script_let=None,
+            args=["STEP:{{ from_step }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("STEP:step value" in m for m in caplog.messages)
+
+    def test_both_scopes_resolve_and_script_scope_shadows_step_scope(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Both scopes reach the task, and script scope wins on a name clash.
+
+        RFC 0005 orders step-scope bindings before script-scope ones, so a
+        script-scope binding of the same name shadows the step's, and a
+        script-scope binding may reference a step-scope one.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=["shared = 'from step'", "base = 'step base'"],
+            script_let=["shared = 'from script'", "derived = base + ' + script'"],
+            args=["SHARED:{{ shared }} DERIVED:{{ derived }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("SHARED:from script" in m for m in caplog.messages)
+        assert any("DERIVED:step base + script" in m for m in caplog.messages)
+
+    def test_step_scope_let_can_reference_step_name(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Step-scope bindings evaluate after ``Step.Name`` is seeded.
+
+        Pins the seeding order through the whole worker chain: the action passes
+        ``step_name`` and ``extra_let_bindings`` together, and the session must
+        place ``Step.Name`` in the table before evaluating the bindings.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=["msg = 'step is ' + Step.Name"],
+            script_let=None,
+            args=["NAME:{{ msg }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("NAME:step is MyStep" in m for m in caplog.messages)
+
+    def test_a_step_without_let_bindings_still_runs(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Negative control: the common no-``let`` step is unaffected.
+
+        Guards against over-correction -- a fix that only works when bindings
+        are present, or that breaks when ``StepTemplate.let`` is None.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(step_let=None, script_let=None, args=["PLAIN:ok"])
+        assert details.step_template.let is None
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("PLAIN:ok" in m for m in caplog.messages)
+
+    def test_script_scope_let_alone_still_resolves(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Negative control: script-scope ``let`` was never broken.
+
+        It travels inside the StepScript the action already forwards. If a
+        change to the step-scope channel were to disturb it, this fails.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=None,
+            script_let=["from_script = 'script value'"],
+            args=["SCRIPT:{{ from_script }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("SCRIPT:script value" in m for m in caplog.messages)
+
+    def test_a_broken_step_scope_binding_fails_the_action_cleanly(self, tmp_path: Path) -> None:
+        """An unresolvable step-scope binding fails the action, not the worker.
+
+        The binding references an undefined symbol. The session must fail the
+        action before starting the subprocess rather than raising out through
+        the worker's action layer.
+        """
+        details = _step_details(
+            step_let=["msg = NoSuchSymbol"],
+            script_let=None,
+            args=["NEVER:{{ msg }}"],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.FAILED

--- a/test/unit/sessions/test_step_scope_let_end_to_end.py
+++ b/test/unit/sessions/test_step_scope_let_end_to_end.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -100,6 +101,43 @@ def _step_details(
         "schemaVersion": "jobtemplate-2023-09",
         "dependencies": [],
         "extensions": ["EXPR"],
+        "template": template,
+    }
+    if resolved_symbol_table is not None:
+        payload["resolvedSymbolTable"] = json.dumps(resolved_symbol_table)
+
+    return StepDetails.from_boto(payload)
+
+
+def _bash_sugar_step_details(
+    *,
+    step_let: list[str] | None,
+    sugar_let: list[str] | None,
+    script_body: str,
+    resolved_symbol_table: list[dict[str, str]] | None = None,
+) -> StepDetails:
+    """Build a StepDetails for a FEATURE_BUNDLE_1 ``bash:`` simple action.
+
+    A sibling of ``_step_details`` rather than a parameter on it: the served
+    shape is genuinely different. There is no ``script`` field at all, the
+    command and embedded file do not exist yet, and the simple action carries
+    its own ``let`` alongside the step's. ``FEATURE_BUNDLE_1`` has to be in the
+    payload's ``extensions`` or the parse rejects the sugar.
+    """
+    bash: dict[str, Any] = {"script": script_body}
+    if sugar_let is not None:
+        bash["let"] = sugar_let
+
+    template: dict[str, Any] = {"name": "MyStep", "bash": bash}
+    if step_let is not None:
+        template["let"] = step_let
+
+    payload: StepDetailsData = {
+        "jobId": "job-123",
+        "stepId": "step-123",
+        "schemaVersion": "jobtemplate-2023-09",
+        "dependencies": [],
+        "extensions": ["FEATURE_BUNDLE_1", "EXPR"],
         "template": template,
     }
     if resolved_symbol_table is not None:
@@ -320,3 +358,95 @@ class TestResolvedSymbolTableEndToEnd:
 
         assert state == ActionState.SUCCESS
         assert any("NOTABLE:ok" in m for m in caplog.messages)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the de-sugared bash: action spawns `bash`, which stock Windows lacks. "
+    "The de-sugar branch itself is pinned on every platform by "
+    "TestRunStepTaskActionSimpleActionSugar in actions/test_run_step_task.py.",
+)
+class TestSimpleActionSugarEndToEnd:
+    """A served FEATURE_BUNDLE_1 simple action runs, and its ``let`` resolves once.
+
+    Gap 25: the service serves simple-action sugar as authored, so
+    ``StepTemplate.script`` is None and ``StepTemplate.bash`` holds the body.
+    ``create_job`` de-sugars during instantiation, so a caller that instantiates
+    a job locally (openjd-cli) never sees this -- the worker is handed the
+    un-instantiated template and has to de-sugar it itself.
+    """
+
+    def test_a_bash_sugar_step_runs_and_resolves_its_own_let(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """This is the regression.
+
+        Before the fix the action forwarded ``step_template.script`` -- None for
+        a sugar template -- under a comment claiming the service had already
+        resolved the sugar, and the task failed before its command ran.
+        """
+        caplog.set_level(logging.INFO)
+        details = _bash_sugar_step_details(
+            step_let=None,
+            sugar_let=["msg = 'hello from bash'"],
+            script_body='echo "BASH:{{ msg }}"',
+        )
+        assert details.step_template.script is None
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("BASH:hello from bash" in m for m in caplog.messages)
+
+    def test_step_and_sugar_scope_let_each_resolve_exactly_once(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The no-double-apply pin for the de-sugared path.
+
+        ``resolve_syntax_sugar()`` folds step-scope ``let`` into the script's own
+        ``let``, so the de-sugared path must send ``extra_let_bindings=None``.
+        Sending the step's bindings as well would apply them twice, which is
+        invisible for a literal but not for a self-referential binding: ``n``
+        arrives as ``"a"`` from the served table, ``n = n + 'b'`` yields ``"ab"``
+        applied once and ``"abb"`` applied twice.
+        """
+        caplog.set_level(logging.INFO)
+        details = _bash_sugar_step_details(
+            step_let=["n = n + 'b'"],
+            sugar_let=["out = n + '|sugar'"],
+            script_body='echo "OUT:{{ out }}"',
+            resolved_symbol_table=[{"name": "n", "type": "string", "value": "a"}],
+        )
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("OUT:ab|sugar" in m for m in caplog.messages)
+        assert not any("OUT:abb|sugar" in m for m in caplog.messages), (
+            "the step-scope binding was applied twice -- the de-sugared path must send no extra bindings"
+        )
+
+    def test_a_plain_script_step_applies_step_scope_let_exactly_once(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Control: the ``script:`` branch is unchanged, and also applies once.
+
+        The other direction of over-correction -- de-sugaring every template
+        *and* still sending ``extra_let_bindings`` -- resolves to the same values
+        for the literal bindings the rest of this file uses. It shows up only
+        against a self-referential binding, so this control carries one.
+        """
+        caplog.set_level(logging.INFO)
+        details = _step_details(
+            step_let=["n = n + 'b'"],
+            script_let=["out = n + '|script'"],
+            args=["OUT:{{ out }}"],
+            resolved_symbol_table=[{"name": "n", "type": "string", "value": "a"}],
+        )
+        assert details.step_template.script is not None
+
+        state, _ = _run_action_to_completion(details, tmp_path)
+
+        assert state == ActionState.SUCCESS
+        assert any("OUT:ab|script" in m for m in caplog.messages)
+        assert not any("OUT:abb|script" in m for m in caplog.messages)

--- a/test/unit/sessions/test_step_scope_let_end_to_end.py
+++ b/test/unit/sessions/test_step_scope_let_end_to_end.py
@@ -16,13 +16,13 @@ call arguments. The plumbing-level assertions live in test_python.py,
 test_rust.py, test_session.py and actions/test_run_step_task.py; this file
 exists to prove the whole path resolves a real step-scope name.
 
-Why the defect is invisible to most callers: step-scope ``let`` resolves at job
-instantiation, and ``create_job`` folds ``StepTemplate.let`` into
-``script.let``. Anyone instantiating a job locally (openjd-cli) therefore never
-sees a problem. The worker is handed a service-resolved, *un-instantiated*
-``StepTemplate`` whose ``let`` and ``script.let`` are separate fields, and it
-never calls ``resolve_syntax_sugar``. Without an explicit channel the step-scope
-names are simply absent from the task's symbol table.
+Step-scope ``let`` resolves at job instantiation, and the worker never
+instantiates a job: it is handed an *un-instantiated* ``StepTemplate`` whose
+``let`` and ``script.let`` are separate fields. The service resolves that scope
+and serves the result in the entity's ``resolvedSymbolTable``, which is the
+single authoritative channel for those values -- the worker reads the table and
+does not re-evaluate ``StepTemplate.let``. These tests therefore seed step-scope
+names through the served table, exactly as production does.
 """
 
 from __future__ import annotations
@@ -57,10 +57,10 @@ class _RunTaskOnlySession:
     The real class is a scheduler-facing orchestrator (queue, asset sync,
     telemetry, action reporting) whose construction pulls in far more than this
     test needs. Its ``run_task`` is a verbatim pass-through to the runtime, and
-    that pass-through -- including ``extra_let_bindings`` -- is pinned
-    independently by ``TestRunTaskStepScopeLetBindings`` in test_session.py. So
-    this reproduces just that one hop and lets the real runtime and the real
-    openjd session do the work.
+    that pass-through -- including ``resolved_symbol_table_json`` -- is pinned
+    independently by ``TestRunTask`` in test_session.py. So this reproduces just
+    that one hop and lets the real runtime and the real openjd session do the
+    work.
     """
 
     def __init__(self, runtime: PythonSessionRuntime) -> None:
@@ -195,15 +195,16 @@ class TestStepScopeLetEndToEnd:
     ) -> None:
         """A step-scope ``let`` name resolves in the command the task runs.
 
-        This is the regression. Before the fix the action dropped
-        ``StepTemplate.let``, so ``{{ from_step }}`` had no definition and the
-        action failed to resolve it.
+        The served shape production sends: the un-instantiated template still
+        carries ``let``, and the table carries that scope already resolved. The
+        table is authoritative, so ``{{ from_step }}`` resolves from it.
         """
         caplog.set_level(logging.INFO)
         details = _step_details(
             step_let=["from_step = 'step value'"],
             script_let=None,
             args=["STEP:{{ from_step }}"],
+            resolved_symbol_table=[{"name": "from_step", "type": "string", "value": "step value"}],
         )
 
         state, _ = _run_action_to_completion(details, tmp_path)
@@ -218,13 +219,19 @@ class TestStepScopeLetEndToEnd:
 
         RFC 0005 orders step-scope bindings before script-scope ones, so a
         script-scope binding of the same name shadows the step's, and a
-        script-scope binding may reference a step-scope one.
+        script-scope binding may reference a step-scope one. The step's scope
+        arrives resolved in the served table; the script's is evaluated on top
+        of it by the session.
         """
         caplog.set_level(logging.INFO)
         details = _step_details(
             step_let=["shared = 'from step'", "base = 'step base'"],
             script_let=["shared = 'from script'", "derived = base + ' + script'"],
             args=["SHARED:{{ shared }} DERIVED:{{ derived }}"],
+            resolved_symbol_table=[
+                {"name": "shared", "type": "string", "value": "from step"},
+                {"name": "base", "type": "string", "value": "step base"},
+            ],
         )
 
         state, _ = _run_action_to_completion(details, tmp_path)
@@ -233,19 +240,19 @@ class TestStepScopeLetEndToEnd:
         assert any("SHARED:from script" in m for m in caplog.messages)
         assert any("DERIVED:step base + script" in m for m in caplog.messages)
 
-    def test_step_scope_let_can_reference_step_name(
+    def test_script_scope_let_can_reference_step_name(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Step-scope bindings evaluate after ``Step.Name`` is seeded.
+        """Script-scope bindings evaluate after ``Step.Name`` is seeded.
 
         Pins the seeding order through the whole worker chain: the action passes
-        ``step_name`` and ``extra_let_bindings`` together, and the session must
-        place ``Step.Name`` in the table before evaluating the bindings.
+        ``step_name``, and the session must place ``Step.Name`` in the table
+        before evaluating the script's own bindings.
         """
         caplog.set_level(logging.INFO)
         details = _step_details(
-            step_let=["msg = 'step is ' + Step.Name"],
-            script_let=None,
+            step_let=None,
+            script_let=["msg = 'step is ' + Step.Name"],
             args=["NAME:{{ msg }}"],
         )
 
@@ -274,10 +281,11 @@ class TestStepScopeLetEndToEnd:
     def test_script_scope_let_alone_still_resolves(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Negative control: script-scope ``let`` was never broken.
+        """Negative control: script-scope ``let`` resolves on its own.
 
-        It travels inside the StepScript the action already forwards. If a
-        change to the step-scope channel were to disturb it, this fails.
+        It travels inside the StepScript the action forwards, with no served
+        table involved. If a change to the table channel were to disturb it,
+        this fails.
         """
         caplog.set_level(logging.INFO)
         details = _step_details(
@@ -291,16 +299,16 @@ class TestStepScopeLetEndToEnd:
         assert state == ActionState.SUCCESS
         assert any("SCRIPT:script value" in m for m in caplog.messages)
 
-    def test_a_broken_step_scope_binding_fails_the_action_cleanly(self, tmp_path: Path) -> None:
-        """An unresolvable step-scope binding fails the action, not the worker.
+    def test_a_broken_script_scope_binding_fails_the_action_cleanly(self, tmp_path: Path) -> None:
+        """An unresolvable binding fails the action, not the worker.
 
         The binding references an undefined symbol. The session must fail the
         action before starting the subprocess rather than raising out through
         the worker's action layer.
         """
         details = _step_details(
-            step_let=["msg = NoSuchSymbol"],
-            script_let=None,
+            step_let=None,
+            script_let=["msg = NoSuchSymbol"],
             args=["NEVER:{{ msg }}"],
         )
 
@@ -367,7 +375,7 @@ class TestResolvedSymbolTableEndToEnd:
     "TestRunStepTaskActionSimpleActionSugar in actions/test_run_step_task.py.",
 )
 class TestSimpleActionSugarEndToEnd:
-    """A served FEATURE_BUNDLE_1 simple action runs, and its ``let`` resolves once.
+    """A served FEATURE_BUNDLE_1 simple action runs, and its ``let`` resolves.
 
     Gap 25: the service serves simple-action sugar as authored, so
     ``StepTemplate.script`` is None and ``StepTemplate.bash`` holds the body.
@@ -398,55 +406,26 @@ class TestSimpleActionSugarEndToEnd:
         assert state == ActionState.SUCCESS
         assert any("BASH:hello from bash" in m for m in caplog.messages)
 
-    def test_step_and_sugar_scope_let_each_resolve_exactly_once(
+    def test_step_and_sugar_scope_let_both_resolve_through_the_fold(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """The no-double-apply pin for the de-sugared path.
+        """Both scopes of a sugar template resolve, via the fold alone.
 
-        ``resolve_syntax_sugar()`` folds step-scope ``let`` into the script's own
-        ``let``, so the de-sugared path must send ``extra_let_bindings=None``.
-        Sending the step's bindings as well would apply them twice, which is
-        invisible for a literal but not for a self-referential binding: ``n``
-        arrives as ``"a"`` from the served table, ``n = n + 'b'`` yields ``"ab"``
-        applied once and ``"abb"`` applied twice.
+        ``resolve_syntax_sugar()`` folds the step's ``let`` into the script's own
+        as ``[*step lets, *simple-action lets]``, so the de-sugared script
+        carries both scopes in RFC 0005 order and a sugar-scope binding can
+        reference a step-scope one. This is the only thing that resolves the
+        step's scope on this path -- nothing else re-applies it.
         """
         caplog.set_level(logging.INFO)
         details = _bash_sugar_step_details(
-            step_let=["n = n + 'b'"],
-            sugar_let=["out = n + '|sugar'"],
+            step_let=["base = 'from step'"],
+            sugar_let=["out = base + '|sugar'"],
             script_body='echo "OUT:{{ out }}"',
-            resolved_symbol_table=[{"name": "n", "type": "string", "value": "a"}],
         )
+        assert details.step_template.script is None
 
         state, _ = _run_action_to_completion(details, tmp_path)
 
         assert state == ActionState.SUCCESS
-        assert any("OUT:ab|sugar" in m for m in caplog.messages)
-        assert not any("OUT:abb|sugar" in m for m in caplog.messages), (
-            "the step-scope binding was applied twice -- the de-sugared path must send no extra bindings"
-        )
-
-    def test_a_plain_script_step_applies_step_scope_let_exactly_once(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Control: the ``script:`` branch is unchanged, and also applies once.
-
-        The other direction of over-correction -- de-sugaring every template
-        *and* still sending ``extra_let_bindings`` -- resolves to the same values
-        for the literal bindings the rest of this file uses. It shows up only
-        against a self-referential binding, so this control carries one.
-        """
-        caplog.set_level(logging.INFO)
-        details = _step_details(
-            step_let=["n = n + 'b'"],
-            script_let=["out = n + '|script'"],
-            args=["OUT:{{ out }}"],
-            resolved_symbol_table=[{"name": "n", "type": "string", "value": "a"}],
-        )
-        assert details.step_template.script is not None
-
-        state, _ = _run_action_to_completion(details, tmp_path)
-
-        assert state == ActionState.SUCCESS
-        assert any("OUT:ab|script" in m for m in caplog.messages)
-        assert not any("OUT:abb|script" in m for m in caplog.messages)
+        assert any("OUT:from step|sugar" in m for m in caplog.messages)


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked on a dependency release.** Needs
> OpenJobDescription/openjd-sessions-for-python#357 merged and released; CI
> cannot install until then.
>
> Supersedes #1076, which is closed. That PR passed step-scope `let` as source
> strings; the decision is that the service's resolved symbol table is the
> single authoritative source, so this PR removes that channel. The history
> contains the add and the removal; the net diff is the table work plus two
> fixes.

## What changed

The Python session runtime now forwards the service's `resolvedSymbolTable` to
the v0 session on all three entry points, instead of reading one symbol out of it
and discarding the rest.

Also, two fixes found while testing this on a fleet:

- The native EXPR extension is no longer imported at module load. It is imported
  inside the two functions that need it, behind their `None` guards, so a worker
  that never receives a resolved table never loads it.
- A served FEATURE_BUNDLE_1 simple-action step template is now de-sugared. See
  the second section below; this one is an independent defect.

## Why the forwarding

`create_job` resolves a symbol table per step and environment. The service
serves it, this agent stores it, and the Rust runtime uses it as the base of its
per-action table. On the Python runtime — the default — `_extract_job_name`
deserialized the whole table, kept `Job.Name`, and dropped everything else,
because the v0 session had no parameter to accept a table. #357 adds that
parameter; this forwards to it.

`_extract_job_name` and the constructor `job_name` stay: the attachment-sync path
builds a symbol table through `_run_task_without_session_env`, which never sees a
per-action table.

`extra_let_bindings` is removed everywhere — the runtime signatures, the
`ENV_ENTER` extraction in the scheduler, and `EnterEnvironmentAction`. The table
is the only channel. This is safe for step-scoped environments because the
service stores them with the owning step's table (`activities/jobs.py:2387`,
citing RFC 0007), so an `ENV_ENTER` receives `Step.Name` and the step's
template-scope `let` values in its own table.

`step_name` stays on both paths: `run_task` needs it for RFC 0008's
`WrappedStep.Name`, which the table does not carry.

## De-sugaring simple actions

Independent pre-existing defect, found by the conformance run for the above.

A step authored as a FEATURE_BUNDLE_1 simple action arrives with `bash` (or
`cmd`, `node`, `powershell`, `python`) populated and `script` set to `None`,
because the service serves the template as authored and this agent never
instantiates a job. `RunStepTaskAction` did:

```python
# The service resolves step template syntax sugar, so script is always present.
step_script=cast("StepScript", self._details.step_template.script),
```

The comment is wrong and `cast` converts nothing, so the session was handed
`None` and the task failed before its command ran. `openjd-cli` never hits this
because `create_job` de-sugars during instantiation.

`_resolve_step_script` now calls `resolve_syntax_sugar()` when `script` is
absent and returns the folded script. The fold produces
`script.let == [*step lets, *simple-action lets]`, so both scopes reach the task
through the script body.

## Tests

The net is 14 new tests less the ones the channel removal retired.

`test_python.py` covers forwarding a parsed table on enter, exit and run_task,
`None` for absent JSON, and a warning plus `None` for malformed JSON.
`test_import_purity.py` gains a fresh-interpreter probe that constructs the
runtime with no table and asserts the extension is absent from `sys.modules`.
`test_step_scope_let_end_to_end.py` and `actions/test_run_step_task.py` cover the
end-to-end chain for a table-only symbol and for both simple-action cases,
including one that pins each `let` scope resolving exactly once.

Verification:

- **Mutation-checked.** Reverting each behaviour fails a named test: dropping the
  forwarding, sending `None` instead of the table, hoisting the lazy import above
  its guard, reverting the de-sugar, de-sugaring unconditionally, and
  double-applying the step bindings on the de-sugared path. The double-apply
  mutant was confirmed by running it while both channels still existed: the task
  emitted `OUT:abb|sugar` instead of `OUT:ab|sugar`. After the channel removal
  that mutant is unreachable, and reverting the de-sugar fails three named tests.
- **Full unit suite: 3175 passed / 47 skipped, no failures.** Five tests whose
  only subject was `extra_let_bindings` were deleted; the ones that used it to
  set up step context were rewritten to use a served table, so their properties
  are still pinned.
- `ruff format`, `ruff check` and `mypy` clean over 218 files.
- **Exercised on a real Deadline Cloud fleet.** 31 of 32 `EXPR/jobs` conformance
  cases pass, including all five step-scope `let` cases. The one failure was the
  simple-action defect above, now fixed here and not yet re-run on a fleet.

Not verified: the end-to-end simple-action tests skip on Windows, since a
de-sugared `bash:` action spawns `bash`; the branch is covered there by the
platform-independent unit tests. Only `bash:` was exercised of the five sugar
forms. The Rust runtime's behaviour with a `None` script is unchanged and still
untested.
