### PR TITLE
chore: pin GitPython for release bump

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,7 @@
 python-semantic-release == 10.6.*
+# GitPython 3.1.60 dropped Actor.name_email_regex, which python-semantic-release
+# 10.6.1 still references; the release bump dies with
+# "type object 'Actor' has no attribute 'name_email_regex'" before it does any
+# git work. PSR depends on `gitpython~=3.0`, so the bad version floats in on a
+# fresh install. Unpin once PSR ships a release compatible with 3.1.60+.
+GitPython == 3.1.59


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `Release: Bump` workflow is broken. [Run 32998180130](https://github.com/aws-deadline/deadline-cloud-worker-agent/actions/runs/32998180130)
(dispatched today, no forced bump) died in the `NextSemver` step:

```
INFO     Loading configuration from pyproject.toml
INFO     Using group 'release' options, as ...
##[error] type object 'Actor' has no attribute 'name_email_regex'
##[error]Process completed with exit code 1.
```

It fails immediately after config load, before any git or version work.

GitPython 3.1.60 dropped `Actor.name_email_regex`, which python-semantic-release
10.6.1 still references. `requirements-release.txt` pins PSR (`== 10.6.*`) but not
GitPython, and PSR depends on `gitpython~=3.0` — so the job's fresh
`pip install -r requirements-release.txt` resolved **gitpython-3.1.60** and broke.
That is visible in the run's own install line:

```
Successfully installed ... gitpython-3.1.60 ... python-semantic-release-10.6.1 ...
```

Nothing in this repo changed; the transitive dependency floated underneath it.

### What was the solution? (How)

Pin `GitPython == 3.1.59` in `requirements-release.txt`, matching the fix
openjd-model landed in
[`12816ad`](https://github.com/OpenJobDescription/openjd-model-for-python/commit/12816ada0c8e1db5620959bf0e75fc2f447cf902)
and openjd-sessions-for-python landed in
[`3d5feb5`](https://github.com/OpenJobDescription/openjd-sessions-for-python/commit/3d5feb5e85e9b610107e34fd49ba2275130d6d15).
Same pin, same reason, so the repos stay consistent.

The comment records why the pin exists and when it can go away — a bare pin on a
transitive dependency is the kind of line that gets "cleaned up" a year later and
silently reintroduces this failure.

### What is the impact of this change?

The release bump works again. Release tooling only: `requirements-release.txt` is
not part of `dependencies` in `pyproject.toml`, so the published package and its
consumers are unaffected. It is consumed by the reusable bump workflow's
`pip install -r requirements-release.txt` step and by `hatch run release:deps`.

### How was this change tested?

A/B against the workflow's own command, in a clean venv at this commit's parent
(`08a5878`), on a branch name matching `[tool.semantic_release.branches.release]`
(`(mainline|release|patch_.*)` — on any other branch PSR exits earlier with "isn't
in any release groups" and never reaches the failure):

```
semantic-release -v --strict version --no-commit --no-push --no-tag [--minor]
```

| GitPython | Result |
| --- | --- |
| 3.1.59 (this PR) | exit 0 — next version `0.33.1`, or `0.34.0` with forced minor |
| 3.1.60 (what CI resolved) | `::ERROR:: type object 'Actor' has no attribute 'name_email_regex'`, exit 1 — reproduced verbatim, with and without `--minor` |

So the floated dependency is confirmed to be both the cause and the fix, rather
than assumed. With the pin in the file, a fresh
`pip install -r requirements-release.txt` resolves 3.1.59 and both bump paths exit
0, with no resolver conflicts.

- Have you run the unit tests? Not applicable to this change — it touches only the
  release requirements file, which no test imports and no runtime code reads.

### Was this change documented?

- Are relevant docstrings in the code base updated? N/A. The pin carries an inline
  comment explaining the incompatibility and the removal condition (unpin once PSR
  ships a release compatible with GitPython 3.1.60+).

### Is this a breaking change?

No. Release tooling only; no public contract is touched.

### Does this change impact security?

No. It pins a build-time dependency to a slightly older patch release. No files,
directories, or permissions are affected.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
