### PR TITLE
Macos e2e fixtures

### DIFF
--- a/.github/workflows/macos_e2e_test.yml
+++ b/.github/workflows/macos_e2e_test.yml
@@ -1,0 +1,97 @@
+name: macOS E2E Test
+
+# Runs the E2E suite against a worker agent installed on the runner itself
+# (LocalMacWorker), rather than on a provisioned instance the way the Linux and
+# Windows E2E jobs do.
+#
+# Why this diverges from reusable_e2e_test.yml: those jobs start a CodeBuild build,
+# which then launches an EC2 worker. Mac hardware is only available on EC2 dedicated
+# hosts (24-hour minimum billing per allocation) and CodeBuild offers macOS only via
+# reserved-capacity fleets, which hold — and bill for — a Mac host continuously.
+# A GitHub-hosted macOS runner is free for public repositories and gives a fresh VM
+# per run, which matters here because the installer mutates system state: it creates
+# users and groups, writes a sudoers rule, and bootstraps a LaunchDaemon.
+#
+# The run creates and deletes its own farm, queues, fleets, and storage profiles
+# (BYO_DEADLINE=false), so it needs no access to the shared CI farm resources.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'mainline'
+
+jobs:
+  MacOSE2ETest:
+    name: macOS E2E Test
+    runs-on: macos-latest
+    # The suite provisions a worker, waits on scaling, and runs jobs end to end.
+    # Matches the timeout the Linux and Windows E2E builds use.
+    timeout-minutes: 180
+    permissions:
+      id-token: write
+      contents: read
+    # Each run has its own farm, so overlapping runs cannot corrupt each other's
+    # resources. Serialized anyway to keep concurrent farm and fleet counts inside
+    # the account's service quotas.
+    concurrency:
+      group: macose2e
+    environment: mainline
+    env:
+      OPERATING_SYSTEM: macos
+      # Ask the fixtures for a run-scoped farm rather than reading FARM_ID and the
+      # queue and fleet ids from the environment.
+      BYO_DEADLINE: "false"
+      # The IAM roles and buckets are long-lived and supplied below, so the fixtures
+      # must not try to deploy the bootstrap CloudFormation stack.
+      BYO_BOOTSTRAP: "true"
+      REGION: ${{ vars.E2E_REGION }}
+      BOOTSTRAP_BUCKET_NAME: ${{ vars.E2E_BOOTSTRAP_BUCKET_NAME }}
+      JOB_ATTACHMENTS_BUCKET_NAME: ${{ vars.E2E_JOB_ATTACHMENTS_BUCKET_NAME }}
+      JOB_ATTACHMENTS_ROOT_PREFIX: root
+      WORKER_ROLE_ARN: ${{ vars.E2E_WORKER_ROLE_ARN }}
+      SESSION_ROLE_ARN: ${{ vars.E2E_SESSION_ROLE_ARN }}
+      TEST_CATEGORY: macOSMainline
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          # A single version rather than a matrix: the E2E suite takes tens of minutes
+          # and installs a system service, so a matrix would multiply runtime without
+          # covering meaningfully different agent behaviour. code_quality.yml and
+          # macos_installer_test.yml cover the supported interpreter range.
+          python-version: '3.11'
+
+      - name: Install Hatch
+        run: pip install --upgrade hatch 'virtualenv<21'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ vars.E2E_MACOS_ROLE_ARN }}
+          aws-region: ${{ vars.E2E_REGION }}
+          role-session-name: macos-e2e-${{ github.run_id }}
+          # LocalMacWorker copies this process's credentials into the agent user's
+          # credentials file as static keys, and the agent re-reads that file on every
+          # refresh. So the session has to outlive the whole run, not just the setup
+          # steps: the default hour would strand the worker mid-suite. Requires the
+          # role's MaxSessionDuration to be at least this value.
+          role-duration-seconds: 21600
+
+      - name: Build the worker agent wheel
+        # The suite installs the agent from a wheel built out of this checkout, which is
+        # what makes the run test the current commit rather than the published package.
+        run: |
+          set -euxo pipefail
+          hatch build
+          # Read the name off disk rather than composing it from `hatch run metadata name`
+          # and `hatch run version`: the first `hatch run` in a job also creates the
+          # environment and prints the install log to stdout, which ends up inside the
+          # command substitution and corrupts the value.
+          count=$(find dist -maxdepth 1 -name '*.whl' | wc -l | tr -d ' ')
+          test "$count" -eq 1 || { echo "expected exactly one wheel in dist/, found $count"; exit 1; }
+          echo "WORKER_AGENT_WHL_PATH=$PWD/$(find dist -maxdepth 1 -name '*.whl')" >> "$GITHUB_ENV"
+
+      - name: Run E2E tests
+        run: hatch run e2e:test

--- a/.github/workflows/macos_e2e_test.yml
+++ b/.github/workflows/macos_e2e_test.yml
@@ -119,5 +119,28 @@ jobs:
           test "$count" -eq 1 || { echo "expected exactly one wheel in dist/, found $count"; exit 1; }
           echo "WORKER_AGENT_WHL_PATH=$PWD/$(find dist -maxdepth 1 -name '*.whl')" >> "$GITHUB_ENV"
 
+      # DIAGNOSTIC, revert to `hatch run e2e:test` once read. Narrowed to the one test
+      # that stops a running agent and waits for it to report STOPPED, so the loop is
+      # minutes rather than the better part of an hour. The sibling draining test is
+      # excluded on purpose: it stops the worker ~200ms after CreateJob, before the
+      # scheduler's 15s poll can give it a session, and the STOPPING transition it
+      # asserts is gated on there being one -- a separate problem from this.
       - name: Run E2E tests
-        run: hatch run e2e:test
+        run: hatch run e2e:test -k test_worker_lifecycle_status_is_expected
+
+      # DIAGNOSTIC, remove with the above. The failure is in a test body rather than a
+      # fixture, so nothing dumps the agent's own log, and the suite log only records
+      # that the status was awaited -- never what it actually was. This is the shutdown
+      # sequence for the agent the test just stopped.
+      - name: Dump the worker agent log
+        if: always()
+        continue-on-error: true
+        run: |
+          echo "--- launchd state ---"
+          sudo launchctl print system/com.amazon.deadline.worker-agent 2>&1 | head -5 || echo "(label not loaded)"
+          echo "--- worker.json ---"
+          sudo cat /var/lib/deadline/worker.json 2>&1 || echo "(absent)"
+          echo "--- worker-agent.log, last 120 lines ---"
+          sudo tail -120 /var/log/amazon/deadline/worker-agent.log 2>&1 || echo "(absent)"
+          echo "--- bootstrap log, last 40 lines ---"
+          sudo tail -40 /var/log/amazon/deadline/worker-agent-bootstrap.log 2>&1 || echo "(absent)"

--- a/.github/workflows/macos_e2e_test.yml
+++ b/.github/workflows/macos_e2e_test.yml
@@ -66,6 +66,32 @@ jobs:
       - name: Install Hatch
         run: pip install --upgrade hatch 'virtualenv<21'
 
+      # DIAGNOSTIC, remove once read: establishes how this runner treats the EC2
+      # metadata address. The worker agent probes it at startup to decide whether to
+      # monitor for spot interruption, on the same thread the shutdown path returns
+      # through. A host with no route fails immediately and the agent carries on; a
+      # host that routes the address but drops the packets blocks instead, which
+      # stalls shutdown. Which of those this runner does determines whether the
+      # agent needs a timeout or the runner needs a reject route.
+      - name: Probe the EC2 metadata address
+        continue-on-error: true
+        run: |
+          echo "--- route ---"
+          route -n get 169.254.169.254 2>&1 | head -8 || true
+          echo "--- connect, 20s ceiling ---"
+          python3 - <<'PY'
+          import socket, time
+          t0 = time.monotonic()
+          try:
+              socket.create_connection(("169.254.169.254", 80), timeout=20).close()
+              print(f"connected in {time.monotonic()-t0:.3f}s -- IMDS answers here")
+          except Exception as e:
+              print(f"{type(e).__name__} after {time.monotonic()-t0:.3f}s -> {e}")
+              print("fast failure (<1s) means a reject/no route: the agent's existing")
+              print("ConnectionError handler copes and shutdown is unaffected.")
+              print("Slow failure means the address is black-holed and the probe blocks.")
+          PY
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:

--- a/.github/workflows/macos_e2e_test.yml
+++ b/.github/workflows/macos_e2e_test.yml
@@ -140,11 +140,6 @@ jobs:
                 pid=$(launchctl print system/com.amazon.deadline.worker-agent 2>/dev/null \
                       | awk "/[^a-z]pid = /{print \$3}" | head -1)
                 echo "=== drain seen at $(date -u +%H:%M:%S), pid=${pid:-none} ===" >> "$out"
-                # The agent stays alive in SIGTERMed state for about five seconds before
-                # bootout escalates to SIGKILL. Its own SIGUSR1 handler prints every
-                # thread's stack, and stderr now goes to a file rather than /dev/null, so
-                # signal it inside that window. Twice, in case the first lands before the
-                # thread that matters has parked.
                 for attempt in 1 2; do
                   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
                     echo "--- SIGUSR1 $attempt to $pid at $(date -u +%H:%M:%S) ---" >> "$out"

--- a/.github/workflows/macos_e2e_test.yml
+++ b/.github/workflows/macos_e2e_test.yml
@@ -119,11 +119,10 @@ jobs:
           test "$count" -eq 1 || { echo "expected exactly one wheel in dist/, found $count"; exit 1; }
           echo "WORKER_AGENT_WHL_PATH=$PWD/$(find dist -maxdepth 1 -name '*.whl')" >> "$GITHUB_ENV"
 
-      # DIAGNOSTIC, remove with the rest. Says where the shutdown is parked rather than
-      # leaving it to elimination. py-spy rather than the agent's own SIGUSR1 handler:
-      # that handler prints to stderr, and the LaunchDaemon plist points stderr at
-      # /dev/null, so those stacks are discarded. py-spy reads the frames out of the
-      # live process instead.
+      # DIAGNOSTIC, remove with the rest. py-spy could not read the hardened process, so
+      # record launchd's own view across the stall instead: pid, state, last exit status
+      # and run count. KeepAlive is { SuccessfulExit = false }, so a non-zero exit is
+      # what makes launchd relaunch the agent, and the exit status names the cause.
       #
       # Armed as a watchdog because it has to fire while the agent is still stalled:
       # stop_worker_service waits for launchd to release the label, so by the time the
@@ -131,9 +130,6 @@ jobs:
       # agent writes.
       - name: Arm a thread-stack watchdog
         run: |
-          pip install --quiet py-spy
-          PY_SPY=$(command -v py-spy)
-          echo "py-spy at $PY_SPY"
           sudo nohup bash -c '
             log=/var/log/amazon/deadline/worker-agent.log
             out=/tmp/agent-stacks.txt
@@ -141,15 +137,16 @@ jobs:
               if grep -q "Draining any remaining Sessions" "$log" 2>/dev/null; then
                 pid=$(launchctl print system/com.amazon.deadline.worker-agent 2>/dev/null \
                       | awk "/[^a-z]pid = /{print \$3}" | head -1)
-                if [ -n "$pid" ]; then
-                  for attempt in 1 2 3; do
-                    echo "=== dump $attempt, pid $pid, $(date -u +%H:%M:%S) ===" >> "$out"
-                    '"$PY_SPY"' dump --pid "$pid" >> "$out" 2>&1 || echo "py-spy failed" >> "$out"
-                    sleep 3
-                  done
-                else
-                  echo "agent already gone when watchdog fired" >> "$out"
-                fi
+                echo "=== drain seen at $(date -u +%H:%M:%S), pid=${pid:-none} ===" >> "$out"
+                for attempt in $(seq 1 12); do
+                  {
+                    echo "--- t+$attempt ($(date -u +%H:%M:%S)) ---"
+                    launchctl print system/com.amazon.deadline.worker-agent 2>&1 \
+                      | grep -E "state|pid|last exit|runs =" | head -6 \
+                      || echo "label gone"
+                  } >> "$out"
+                  sleep 1
+                done
                 exit 0
               fi
               sleep 1
@@ -176,7 +173,11 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          echo "--- thread stacks captured mid-stall ---"
+          echo "--- agent stderr (plist redirected for this run) ---"
+          sudo tail -60 /var/log/amazon/deadline/worker-agent-stderr.log 2>&1 || echo "(absent)"
+          echo "--- agent stdout ---"
+          sudo tail -30 /var/log/amazon/deadline/worker-agent-stdout.log 2>&1 || echo "(absent)"
+          echo "--- launchd snapshots across the stall ---"
           sudo cat /tmp/agent-stacks.txt 2>&1 || echo "(no stacks captured)"
           echo "--- launchd state ---"
           sudo launchctl print system/com.amazon.deadline.worker-agent 2>&1 | head -5 || echo "(label not loaded)"

--- a/.github/workflows/macos_e2e_test.yml
+++ b/.github/workflows/macos_e2e_test.yml
@@ -119,6 +119,45 @@ jobs:
           test "$count" -eq 1 || { echo "expected exactly one wheel in dist/, found $count"; exit 1; }
           echo "WORKER_AGENT_WHL_PATH=$PWD/$(find dist -maxdepth 1 -name '*.whl')" >> "$GITHUB_ENV"
 
+      # DIAGNOSTIC, remove with the rest. Says where the shutdown is parked rather than
+      # leaving it to elimination. py-spy rather than the agent's own SIGUSR1 handler:
+      # that handler prints to stderr, and the LaunchDaemon plist points stderr at
+      # /dev/null, so those stacks are discarded. py-spy reads the frames out of the
+      # live process instead.
+      #
+      # Armed as a watchdog because it has to fire while the agent is still stalled:
+      # stop_worker_service waits for launchd to release the label, so by the time the
+      # suite reports failure the process is gone. Triggers on the last line the stalled
+      # agent writes.
+      - name: Arm a thread-stack watchdog
+        run: |
+          pip install --quiet py-spy
+          PY_SPY=$(command -v py-spy)
+          echo "py-spy at $PY_SPY"
+          sudo nohup bash -c '
+            log=/var/log/amazon/deadline/worker-agent.log
+            out=/tmp/agent-stacks.txt
+            for _ in $(seq 1 900); do
+              if grep -q "Draining any remaining Sessions" "$log" 2>/dev/null; then
+                pid=$(launchctl print system/com.amazon.deadline.worker-agent 2>/dev/null \
+                      | awk "/[^a-z]pid = /{print \$3}" | head -1)
+                if [ -n "$pid" ]; then
+                  for attempt in 1 2 3; do
+                    echo "=== dump $attempt, pid $pid, $(date -u +%H:%M:%S) ===" >> "$out"
+                    '"$PY_SPY"' dump --pid "$pid" >> "$out" 2>&1 || echo "py-spy failed" >> "$out"
+                    sleep 3
+                  done
+                else
+                  echo "agent already gone when watchdog fired" >> "$out"
+                fi
+                exit 0
+              fi
+              sleep 1
+            done
+            echo "watchdog timed out without seeing the drain line" >> "$out"
+          ' >/dev/null 2>&1 &
+          echo "watchdog armed"
+
       # DIAGNOSTIC, revert to `hatch run e2e:test` once read. Narrowed to the one test
       # that stops a running agent and waits for it to report STOPPED, so the loop is
       # minutes rather than the better part of an hour. The sibling draining test is
@@ -128,6 +167,7 @@ jobs:
       - name: Run E2E tests
         run: hatch run e2e:test -k test_worker_lifecycle_status_is_expected
 
+
       # DIAGNOSTIC, remove with the above. The failure is in a test body rather than a
       # fixture, so nothing dumps the agent's own log, and the suite log only records
       # that the status was awaited -- never what it actually was. This is the shutdown
@@ -136,6 +176,8 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
+          echo "--- thread stacks captured mid-stall ---"
+          sudo cat /tmp/agent-stacks.txt 2>&1 || echo "(no stacks captured)"
           echo "--- launchd state ---"
           sudo launchctl print system/com.amazon.deadline.worker-agent 2>&1 | head -5 || echo "(label not loaded)"
           echo "--- worker.json ---"

--- a/.github/workflows/macos_e2e_test.yml
+++ b/.github/workflows/macos_e2e_test.yml
@@ -119,10 +119,12 @@ jobs:
           test "$count" -eq 1 || { echo "expected exactly one wheel in dist/, found $count"; exit 1; }
           echo "WORKER_AGENT_WHL_PATH=$PWD/$(find dist -maxdepth 1 -name '*.whl')" >> "$GITHUB_ENV"
 
-      # DIAGNOSTIC, remove with the rest. py-spy could not read the hardened process, so
-      # record launchd's own view across the stall instead: pid, state, last exit status
-      # and run count. KeepAlive is { SuccessfulExit = false }, so a non-zero exit is
-      # what makes launchd relaunch the agent, and the exit status names the cause.
+      # DIAGNOSTIC, remove with the rest. launchd reports the agent alive in SIGTERMed
+      # state with `last exit code = (never exited)` for about five seconds after the
+      # drain line, and `runs = 1`, so it is stuck rather than crashing or being
+      # relaunched. This signals its own SIGUSR1 thread-stack dumper inside that window
+      # to say which frame is parked; that output goes to stderr, which this branch
+      # redirects to a file instead of /dev/null.
       #
       # Armed as a watchdog because it has to fire while the agent is still stalled:
       # stop_worker_service waits for launchd to release the label, so by the time the
@@ -138,15 +140,25 @@ jobs:
                 pid=$(launchctl print system/com.amazon.deadline.worker-agent 2>/dev/null \
                       | awk "/[^a-z]pid = /{print \$3}" | head -1)
                 echo "=== drain seen at $(date -u +%H:%M:%S), pid=${pid:-none} ===" >> "$out"
-                for attempt in $(seq 1 12); do
-                  {
-                    echo "--- t+$attempt ($(date -u +%H:%M:%S)) ---"
-                    launchctl print system/com.amazon.deadline.worker-agent 2>&1 \
-                      | grep -E "state|pid|last exit|runs =" | head -6 \
-                      || echo "label gone"
-                  } >> "$out"
-                  sleep 1
+                # The agent stays alive in SIGTERMed state for about five seconds before
+                # bootout escalates to SIGKILL. Its own SIGUSR1 handler prints every
+                # thread's stack, and stderr now goes to a file rather than /dev/null, so
+                # signal it inside that window. Twice, in case the first lands before the
+                # thread that matters has parked.
+                for attempt in 1 2; do
+                  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+                    echo "--- SIGUSR1 $attempt to $pid at $(date -u +%H:%M:%S) ---" >> "$out"
+                    kill -USR1 "$pid" 2>/dev/null || echo "signal failed" >> "$out"
+                  else
+                    echo "--- pid gone before signal $attempt ---" >> "$out"
+                  fi
+                  sleep 2
                 done
+                {
+                  echo "--- launchd view after signalling ---"
+                  launchctl print system/com.amazon.deadline.worker-agent 2>&1 \
+                    | grep -E "state|pid|last exit|runs =" | head -6 || echo "label gone"
+                } >> "$out"
                 exit 0
               fi
               sleep 1
@@ -174,7 +186,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "--- agent stderr (plist redirected for this run) ---"
-          sudo tail -60 /var/log/amazon/deadline/worker-agent-stderr.log 2>&1 || echo "(absent)"
+          sudo tail -300 /var/log/amazon/deadline/worker-agent-stderr.log 2>&1 || echo "(absent)"
           echo "--- agent stdout ---"
           sudo tail -30 /var/log/amazon/deadline/worker-agent-stdout.log 2>&1 || echo "(absent)"
           echo "--- launchd snapshots across the stall ---"

--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -2,7 +2,7 @@ backoff == 2.2.*
 boto3 >= 1.34.75
 deadline >= 0.60.3, < 0.61
 deadline-job-attachments >= 0.1.1, < 0.1.4
-deadline-cloud-test-fixtures >= 0.18.18, < 0.19
+deadline-cloud-test-fixtures >= 0.18.22, < 0.19
 flaky == 3.8.*
 mypy >= 2.3.0, < 2.4; python_version >= "3.10"
 mypy >= 1.19.1, < 1.20; python_version < "3.10"

--- a/src/deadline_worker_agent/installer/install_macos.sh
+++ b/src/deadline_worker_agent/installer/install_macos.sh
@@ -809,9 +809,9 @@ ${prog_args_xml}    </array>
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/dev/null</string>
+    <string>/var/log/amazon/deadline/worker-agent-stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>/dev/null</string>
+    <string>/var/log/amazon/deadline/worker-agent-stderr.log</string>
 </dict>
 </plist>
 EOF

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -8,9 +8,9 @@ import threading
 import traceback
 from collections.abc import Generator
 from configparser import ConfigParser
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import InitVar, dataclass, field
-from typing import Callable, Optional, Type
+from typing import Callable, Optional, Type, TypeVar
 
 import backoff
 import boto3
@@ -25,6 +25,7 @@ from deadline.client.config import set_setting as set_deadline_setting
 from deadline.job_attachments.download import get_s3_client, get_s3_transfer_manager
 from deadline_test_fixtures import (
     BootstrapResources,
+    CodeArtifactRepositoryInfo,
     DeadlineWorker,
     DeadlineWorkerConfiguration,
     DockerContainerWorker,
@@ -32,10 +33,13 @@ from deadline_test_fixtures import (
     Ec2Tag,
     Farm,
     Fleet,
+    LocalMacWorker,
     OperatingSystem,
     PosixSessionUser,
     Queue,
+    QueueFleetAssociation,
 )
+
 
 LOG = logging.getLogger(__name__)
 
@@ -157,12 +161,300 @@ def _shutdown_s3_transfer_manager(
     LOG.info(f"Shut down S3 Transfer Manager: {desc} (num threads joined: {num_threads_joined})")
 
 
+def _scaffold_deadline_resources(
+    request: pytest.FixtureRequest,
+    operating_system: OperatingSystem,
+) -> Generator[DeadlineResources, None, None]:
+    """Create the Deadline resources for this run, then delete them.
+
+    Used when BYO_DEADLINE is not "true". CI passes pre-provisioned IDs instead,
+    which is cheaper per run; this path exists so a run can stand itself up on a
+    platform CI has no resources for yet, and so a developer needs only
+    credentials rather than twelve resource IDs.
+
+    Resource roles come from `bootstrap_resources`, which either deploys the
+    bootstrap CloudFormation stack or reads its own env vars when
+    BYO_BOOTSTRAP=true. CreateFleet requires a roleArn, so there is no
+    role-free variant of this path.
+    """
+    bootstrap: BootstrapResources = request.getfixturevalue("bootstrap_resources")
+    deadline_client = boto3.client("deadline")
+
+    os_family = (
+        "MACOS"
+        if operating_system.is_macos()
+        else ("WINDOWS" if operating_system.name == "WIN2022" else "LINUX")
+    )
+    cpu_architecture = "arm64" if operating_system.is_macos() else "x86_64"
+
+    def _storage_profile(display_name: str, family: str, path: str) -> str:
+        # The path mapping under test works by giving the job's profile and the fleet's
+        # profile a location with the SAME name and different paths; the agent then
+        # rewrites one to the other. A profile with no fileSystemLocations makes the
+        # test that reads them fail on a missing key, so mirror the shape the
+        # CloudFormation scaffolding in scripts/e2e_testing_infrastructure.yaml uses.
+        response = deadline_client.create_storage_profile(
+            farmId=farm.id,
+            displayName=display_name,
+            osFamily=family,
+            fileSystemLocations=[{"name": "StorageProfileTest", "path": path, "type": "LOCAL"}],
+        )
+        storage_profile_id = response["storageProfileId"]
+        # Storage profiles are not modelled by deadline-cloud-test-fixtures, so
+        # register the delete directly. Registered on the same stack as everything
+        # else, which unwinds in reverse, so these go before the farm they belong to.
+        stack.callback(
+            lambda: deadline_client.delete_storage_profile(
+                farmId=farm.id, storageProfileId=storage_profile_id
+            )
+        )
+        return storage_profile_id
+
+    def _fleet_configuration(mode: str, storage_profile_id: str | None = None) -> dict:
+        customer_managed: dict = {
+            "mode": mode,
+            "workerCapabilities": {
+                "vCpuCount": {"min": 1},
+                "memoryMiB": {"min": 1024},
+                # The API models osFamily as WINDOWS | LINUX | MACOS. botocore does
+                # not validate enums client-side, so a wrong casing fails at the
+                # service rather than locally.
+                "osFamily": os_family,
+                "cpuArchitectureType": cpu_architecture,
+            },
+        }
+        if storage_profile_id:
+            # Without this the service sends the worker no path mapping rules, so the
+            # agent remaps job attachment roots into the session directory instead of the
+            # fleet's file system location, and the path mapping tests see no outputs at
+            # all. The CloudFormation scaffolding sets it on the non-scaling fleet only.
+            customer_managed["storageProfileId"] = storage_profile_id
+        return {"customerManaged": customer_managed}
+
+    T = TypeVar("T", Farm, Fleet, Queue, QueueFleetAssociation)
+
+    @contextmanager
+    def deletable(resource: T) -> Generator[T, None, None]:
+        try:
+            yield resource
+        finally:
+            resource.delete(client=deadline_client)
+
+    _FARM_NAME = "worker-agent-e2e-farm"
+
+    def _report_leftover_farms() -> str:
+        """Name any farm this fixture appears to have leaked, for the quota error message.
+
+        A run that is killed rather than failed, such as a cancelled CI job, never unwinds
+        the ExitStack, so its farm survives. The farm quota is small enough that one
+        leftover makes every later run fail here, and CreateFarm's own message does not say
+        which farms are consuming the quota.
+        """
+        try:
+            farms = deadline_client.list_farms()["farms"]
+        except Exception:  # pragma: no cover - diagnostics only
+            return ""
+        leftovers = [f for f in farms if f.get("displayName") == _FARM_NAME]
+        if not leftovers:
+            return f" No farm named {_FARM_NAME} exists, so the quota is consumed elsewhere."
+        ids = ", ".join(f["farmId"] for f in leftovers)
+        return (
+            f" A farm named {_FARM_NAME} already exists ({ids}), which most likely leaked"
+            " from a run that was cancelled before it could clean up. Delete it and retry."
+        )
+
+    with ExitStack() as stack:
+        try:
+            created_farm = Farm.create(client=deadline_client, display_name=_FARM_NAME)
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "ServiceQuotaExceededException":
+                raise
+            raise RuntimeError(f"Could not create the e2e farm: {e}.{_report_leftover_farms()}")
+        farm = stack.enter_context(deletable(created_farm))
+
+        # Created before the queues, which must allowlist them: a queue rejects a job
+        # carrying a storage profile absent from its allowedStorageProfileIds. Four
+        # distinct profiles, a job/fleet pair for this run's platform plus a job/fleet
+        # pair for Windows, which keeps that family regardless of the run's platform
+        # because the tests reading them exercise cross-platform path mapping. The job
+        # and fleet halves must differ, or the mapping they prove is the identity.
+        # /private/tmp on macOS, where /tmp is a symlink to it: paths the agent resolves
+        # come back physical, and a location recorded under the symlink then fails to
+        # match. The same substitution is what made the session_root_dir test pass.
+        storage_profile_root = (
+            "/private/tmp/storageprofiletest"
+            if operating_system.is_macos()
+            else "/tmp/storageprofiletest"
+        )
+        run_job_storage_profile = _storage_profile(
+            f"e2e-{os_family.lower()}-job-storage-profile", os_family, storage_profile_root
+        )
+        run_fleet_storage_profile = _storage_profile(
+            f"e2e-{os_family.lower()}-fleet-storage-profile",
+            os_family,
+            f"{storage_profile_root}/dest",
+        )
+        windows_job_storage_profile = _storage_profile(
+            "e2e-windows-job-storage-profile", "WINDOWS", "C:\\Users\\Public\\submission"
+        )
+        windows_fleet_storage_profile = _storage_profile(
+            "e2e-windows-fleet-storage-profile", "WINDOWS", "C:\\Users\\Public\\worker"
+        )
+        all_storage_profile_ids = [
+            run_job_storage_profile,
+            run_fleet_storage_profile,
+            windows_job_storage_profile,
+            windows_fleet_storage_profile,
+        ]
+
+        def _queue(display_name: str, **kwargs) -> Queue:
+            return stack.enter_context(
+                deletable(
+                    Queue.create(
+                        client=deadline_client,
+                        display_name=display_name,
+                        farm=farm,
+                        job_attachments=bootstrap.job_attachments,
+                        raw_kwargs={
+                            **kwargs.pop("raw_kwargs", {}),
+                            "allowedStorageProfileIds": all_storage_profile_ids,
+                        },
+                        **kwargs,
+                    )
+                )
+            )
+
+        # CreateQueueFleetAssociation rejects a queue with no jobRunAsUser, so every queue
+        # here sets one. Sent as the API shape rather than as a JobRunAsUser dataclass:
+        # Queue.create runs that through asdict(), which emits the windows member with an
+        # empty passwordArn instead of omitting it, failing client-side validation. The
+        # windows member is unnecessary here because these queues only associate with a
+        # macOS or Linux fleet.
+        job_user: PosixSessionUser = request.getfixturevalue("posix_job_user")
+        queue_configured_user = {
+            "jobRunAsUser": {
+                "runAs": "QUEUE_CONFIGURED_USER",
+                "posix": {"user": job_user.user, "group": job_user.group},
+            }
+        }
+
+        queue_a = _queue(
+            "e2e-queue-a",
+            role_arn=bootstrap.session_role_arn,
+            raw_kwargs={
+                **queue_configured_user,
+                # Allowing the storage profiles is not enough to get path mapping: the
+                # queue has to require the file system location by name before the service
+                # emits pathMappingRules for it, and without them the agent silently
+                # remaps job attachment roots into the session directory instead. Set on
+                # this queue alone, matching MainQueue in the CloudFormation scaffolding.
+                "requiredFileSystemLocationNames": ["StorageProfileTest"],
+            },
+        )
+        queue_b = _queue(
+            "e2e-queue-b",
+            role_arn=bootstrap.session_role_arn,
+            raw_kwargs=queue_configured_user,
+        )
+        scaling_queue = _queue(
+            "e2e-scaling-queue",
+            role_arn=bootstrap.session_role_arn,
+            raw_kwargs=queue_configured_user,
+        )
+        jobs_run_as_agent_user_queue = _queue(
+            "e2e-jobs-run-as-agent-user-queue",
+            role_arn=bootstrap.session_role_arn,
+            raw_kwargs={"jobRunAsUser": {"runAs": "WORKER_AGENT_USER"}},
+        )
+        # Deliberately given the worker role rather than the session role: its trust
+        # policy does not admit queue-user credential vending, which is the failure
+        # the tests using this queue assert on.
+        non_valid_role_queue = _queue(
+            "e2e-non-valid-role-queue",
+            role_arn=bootstrap.worker_role_arn,
+            raw_kwargs=queue_configured_user,
+        )
+
+        # Matches the count the pre-provisioned CI fleets use. One worker per fleet is not
+        # enough even though a run only ever has one host: the suite creates a worker per
+        # test in places, and a worker record keeps counting against this until it is
+        # deleted, so a low cap makes CreateWorker fail for the rest of the run.
+        max_worker_count = 15
+
+        fleet = stack.enter_context(
+            deletable(
+                Fleet.create(
+                    client=deadline_client,
+                    display_name="e2e-fleet",
+                    farm=farm,
+                    configuration=_fleet_configuration("NO_SCALING", run_fleet_storage_profile),
+                    max_worker_count=max_worker_count,
+                    role_arn=bootstrap.worker_role_arn,
+                )
+            )
+        )
+        scaling_fleet = stack.enter_context(
+            deletable(
+                Fleet.create(
+                    client=deadline_client,
+                    display_name="e2e-scaling-fleet",
+                    farm=farm,
+                    configuration=_fleet_configuration("EVENT_BASED_AUTO_SCALING"),
+                    max_worker_count=max_worker_count,
+                    role_arn=bootstrap.worker_role_arn,
+                )
+            )
+        )
+
+        for queue, target_fleet in (
+            (queue_a, fleet),
+            (queue_b, fleet),
+            (jobs_run_as_agent_user_queue, fleet),
+            (non_valid_role_queue, fleet),
+            (scaling_queue, scaling_fleet),
+        ):
+            stack.enter_context(
+                deletable(
+                    QueueFleetAssociation.create(
+                        client=deadline_client, farm=farm, queue=queue, fleet=target_fleet
+                    )
+                )
+            )
+
+        LOG.info(
+            f"Created Deadline resources - Farm ID: {farm.id}, Fleet ID: {fleet.id}, "
+            f"Queue A ID: {queue_a.id}, osFamily: {os_family}, arch: {cpu_architecture}"
+        )
+
+        yield DeadlineResources(
+            farm_id=farm.id,
+            queue_a_id=queue_a.id,
+            queue_b_id=queue_b.id,
+            jobs_run_as_agent_user_queue_id=jobs_run_as_agent_user_queue.id,
+            non_valid_role_queue_id=non_valid_role_queue.id,
+            fleet_id=fleet.id,
+            scaling_queue_id=scaling_queue.id,
+            scaling_fleet_id=scaling_fleet.id,
+            job_storage_profile_id=run_job_storage_profile,
+            windows_job_storage_profile_id=windows_job_storage_profile,
+            fleet_storage_profile_id=run_fleet_storage_profile,
+            windows_fleet_storage_profile_id=windows_fleet_storage_profile,
+        )
+
+
 @pytest.fixture(scope="session")
-def deadline_resources() -> Generator[DeadlineResources, None, None]:
+def deadline_resources(
+    request: pytest.FixtureRequest,
+    operating_system: OperatingSystem,
+) -> Generator[DeadlineResources, None, None]:
     """
     Gets Deadline resources required for running tests.
 
     Environment Variables:
+        BYO_DEADLINE: Whether to use pre-provisioned resources. Defaults to "true",
+            which is what CI does. Set it to "false" to have the run create and then
+            delete its own farm, queues, fleets, and storage profiles, in which case
+            none of the ID variables below are read.
         FARM_ID: ID of the Deadline farm to use.
         QUEUE_A_ID: ID of a non scaling Deadline queue to use for tests.
         QUEUE_B_ID: ID of a non scaling Deadline queue to use for tests.
@@ -180,6 +472,10 @@ def deadline_resources() -> Generator[DeadlineResources, None, None]:
     Returns:
         DeadlineResources: The Deadline resources used for tests
     """
+    if os.environ.get("BYO_DEADLINE", "true").lower() != "true":
+        yield from _scaffold_deadline_resources(request, operating_system)
+        return
+
     farm_id = os.environ["FARM_ID"]
     queue_a_id = os.environ["QUEUE_A_ID"]
     queue_b_id = os.environ["QUEUE_B_ID"]
@@ -278,6 +574,32 @@ def test_runner_identity() -> dict[str, str]:
 
 
 @pytest.fixture(scope="session")
+def codeartifact(operating_system: OperatingSystem) -> CodeArtifactRepositoryInfo:
+    """Overrides the fixtures package's fixture, which requires four CODEARTIFACT_* vars.
+
+    `worker_config` depends on this unconditionally, so the variables are mandatory even
+    for a run that never reaches a CodeArtifact repository. EC2 and container workers do
+    need one, because they pip install the agent from a VPC with no route to PyPI. A
+    worker on a GitHub-hosted runner reaches PyPI directly and installs the agent from a
+    wheel built in the same job, so it needs no repository, and `worker_config` below
+    drops this from the install command rather than logging in to it.
+    """
+    if operating_system.is_macos() and "CODEARTIFACT_DOMAIN" not in os.environ:
+        return CodeArtifactRepositoryInfo(
+            region=os.getenv("REGION", "us-west-2"),
+            domain="unused",
+            domain_owner="unused",
+            repository="unused",
+        )
+    return CodeArtifactRepositoryInfo(
+        region=os.environ["CODEARTIFACT_REGION"],
+        domain=os.environ["CODEARTIFACT_DOMAIN"],
+        domain_owner=os.environ["CODEARTIFACT_ACCOUNT_ID"],
+        repository=os.environ["CODEARTIFACT_REPOSITORY"],
+    )
+
+
+@pytest.fixture(scope="session")
 def worker_config(
     posix_job_user: PosixSessionUser,
     posix_env_override_job_user: PosixSessionUser,
@@ -285,6 +607,7 @@ def worker_config(
     worker_config: DeadlineWorkerConfiguration,
     windows_job_users: list[str],
     session_runtime_option: Optional[str],
+    operating_system: OperatingSystem,
 ) -> DeadlineWorkerConfiguration:
     """
     Builds the configuration for a DeadlineWorker.
@@ -306,6 +629,13 @@ def worker_config(
         DeadlineWorkerConfiguration: Configuration for use by DeadlineWorker.
     """
 
+    worker_agent_install = worker_config.worker_agent_install
+    if operating_system.is_macos() and "CODEARTIFACT_DOMAIN" not in os.environ:
+        # Without this the install command begins with `aws codeartifact login`, which
+        # fails against the placeholder repository the fixture above returns. The agent
+        # comes from a locally built wheel and its dependencies from PyPI.
+        worker_agent_install = dataclasses.replace(worker_agent_install, codeartifact=None)
+
     return dataclasses.replace(
         worker_config,
         job_users=[
@@ -317,6 +647,7 @@ def worker_config(
         # TODO: Temporary workaround due to AWS CLI v2 upgrade causing canary failures when copying over AWS models for deadline
         service_model_path=None,
         session_runtime=session_runtime_option,
+        worker_agent_install=worker_agent_install,
     )
 
 
@@ -324,9 +655,8 @@ def worker_config(
 def session_worker(
     request: pytest.FixtureRequest,
     worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
 ) -> Generator[DeadlineWorker, None, None]:
-    with create_worker(worker_config, ec2_worker_type, request) as worker:
+    with create_worker(worker_config, request) as worker:
         yield worker
 
     stop_worker(request, worker)
@@ -359,9 +689,8 @@ def asset_sync_worker_config(
 def asset_sync_class_worker(
     request: pytest.FixtureRequest,
     asset_sync_worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
 ) -> Generator[DeadlineWorker, None, None]:
-    with create_worker(asset_sync_worker_config, ec2_worker_type, request) as worker:
+    with create_worker(asset_sync_worker_config, request) as worker:
         yield worker
 
     stop_worker(request, worker)
@@ -371,9 +700,8 @@ def asset_sync_class_worker(
 def class_worker(
     request: pytest.FixtureRequest,
     worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
 ) -> Generator[DeadlineWorker, None, None]:
-    with create_worker(worker_config, ec2_worker_type, request) as worker:
+    with create_worker(worker_config, request) as worker:
         yield worker
 
     stop_worker(request, worker)
@@ -383,9 +711,8 @@ def class_worker(
 def function_worker(
     request: pytest.FixtureRequest,
     worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
 ) -> Generator[DeadlineWorker, None, None]:
-    with create_worker(worker_config, ec2_worker_type, request) as worker:
+    with create_worker(worker_config, request) as worker:
         yield worker
 
     stop_worker(request, worker)
@@ -394,14 +721,13 @@ def function_worker(
 @pytest.fixture(scope="function")
 def function_worker_factory(
     request: pytest.FixtureRequest,
-    ec2_worker_type: Type[EC2InstanceWorker],
-) -> Generator[Callable[[DeadlineWorkerConfiguration], EC2InstanceWorker], None, None]:
+) -> Generator[Callable[[DeadlineWorkerConfiguration], DeadlineWorker], None, None]:
     created_workers = []
 
     def _create_function_worker(
         custom_worker_config: DeadlineWorkerConfiguration,
     ):
-        with create_worker(custom_worker_config, ec2_worker_type, request) as worker:
+        with create_worker(custom_worker_config, request) as worker:
             created_workers.append(worker)
             return worker
 
@@ -441,7 +767,6 @@ def _grab_bootstrap_log(worker: DeadlineWorker) -> None:
 
 def create_worker(
     worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
     request: pytest.FixtureRequest,
 ):
     def __init__(self):
@@ -471,14 +796,30 @@ def create_worker(
         DeadlineWorker: Instance of the DeadlineWorker class that can be used to interact with the Worker.
     """
 
+    operating_system: OperatingSystem = request.getfixturevalue("operating_system")
+
     worker: DeadlineWorker
     if os.environ.get("USE_DOCKER_WORKER", "").lower() == "true":
         LOG.info("Creating Docker worker")
         worker = DockerContainerWorker(
             configuration=worker_config,
         )
+    elif operating_system.is_macos():
+        # macOS workers run on the host executing the tests rather than a provisioned
+        # instance: Mac hardware is only available on EC2 dedicated hosts, which bill a
+        # 24-hour minimum per allocation. The CI runner is itself ephemeral, so each job
+        # gets a clean host.
+        LOG.info("Creating local macOS worker")
+        worker = LocalMacWorker(
+            configuration=worker_config,
+            deadline_client=boto3.client("deadline"),
+        )
     else:
         LOG.info("Creating EC2 worker")
+        # Resolved here rather than as a fixture parameter: it raises for any non-EC2
+        # operating system, so requesting it eagerly would fail the macOS path before it
+        # is reached.
+        ec2_worker_type: Type[EC2InstanceWorker] = request.getfixturevalue("ec2_worker_type")
         ami_id = os.getenv("AMI_ID")
         subnet_id = os.getenv("SUBNET_ID")
         security_group_id = os.getenv("SECURITY_GROUP_ID")
@@ -615,13 +956,7 @@ def operating_system() -> OperatingSystem:
     elif os_env_var == "windows":
         return OperatingSystem(name="WIN2022")
     elif os_env_var == "macos":
-        # deadline-cloud-test-fixtures types this as Literal["AL2023", "WIN2022"], so mypy
-        # rejects "MACOS" until that package gains macOS support (it also needs a
-        # MacInstanceWorker: the posix worker hardcodes an AL2023 AMI and provisions with
-        # useradd/groupadd). Nothing sets OPERATING_SYSTEM=macos in CI yet, so this branch is
-        # unreachable today and kept only so the plumbing is in place; the ignore comes off
-        # with that release.
-        return OperatingSystem(name="MACOS")  # type: ignore[arg-type]
+        return OperatingSystem(name="MACOS")
     else:
         assert False, (
             f'Expected OPERATING_SYSTEM env var to be "linux", "windows", or "macos", '

--- a/test/e2e/pre_test_cleanup.py
+++ b/test/e2e/pre_test_cleanup.py
@@ -244,6 +244,14 @@ def get_farm() -> str:
 def cleanup_test_environment() -> None:
     config = Config(retries={"mode": "adaptive"})
 
+    if os.getenv("BYO_DEADLINE", "true").lower() != "true":
+        # Everything this would clean belongs to a shared environment. A run that creates
+        # its own farm, queues, and worker has no leftovers from a previous run to cancel
+        # jobs on, and the queue id variables read below are unset. Returning here also
+        # keeps EC2 permissions off the credentials such a run needs.
+        LOG.info("BYO_DEADLINE is false, nothing to clean up before the run")
+        return
+
     if os.getenv("KEEP_WORKER_AFTER_FAILURE", "").lower() != "true":
         ec2_client = boto3.client("ec2", config=config)
         cleanup_ec2_instances(ec2_client)

--- a/test/e2e/test_gpu.py
+++ b/test/e2e/test_gpu.py
@@ -35,7 +35,11 @@ set -e
 echo "=== identity ==="
 whoami
 echo "=== GPU inventory ==="
-system_profiler SPDisplaysDataType | grep -E "Chipset Model|Metal Support"
+# Informational, and deliberately not allowed to fail the probe. A headless CI VM
+# reports no displays, so grep matches nothing and exits 1, which under `set -e`
+# aborted this script before it reached the Metal check it exists to perform.
+system_profiler SPDisplaysDataType 2>&1 | grep -E "Chipset Model|Metal Support|Device Type" \
+    || echo "(no display information available)"
 echo "=== Metal compute ==="
 cat > ./metalprobe.swift <<'SWIFT'
 import Metal
@@ -61,7 +65,10 @@ print("compute result[8] =", p[8], "(expect 16.0)")
 guard p[8] == 16.0 else { print("FAIL: wrong compute result"); exit(3) }
 print("PASS: GPU compute works from session")
 SWIFT
-/usr/bin/swift ./metalprobe.swift
+# Redirected so a Metal or toolchain error reaches the session log: only stdout is
+# captured there, and a bare failure here would otherwise be indistinguishable from
+# the compute simply not running.
+/usr/bin/swift ./metalprobe.swift 2>&1
 """
 
 

--- a/test/e2e/test_job_attachments.py
+++ b/test/e2e/test_job_attachments.py
@@ -263,6 +263,12 @@ if __name__ == "__main__":
             },
         )
         job.wait_until_complete(client=deadline_client)
+        # Asserted before the output check below: wait_until_complete treats FAILED as
+        # complete, so a job that failed yields an empty mapping and the test reports
+        # "expected exactly one output root, but got {}" with nothing about the cause.
+        assert job.task_run_status == TaskStatus.SUCCEEDED, job_failure_message(
+            job, deadline_client, deadline_resources.queue_a, deadline_resources
+        )
 
         output_root_to_file_mappings: dict[str, list[str]] = wait_for_job_output(
             job=job,
@@ -720,7 +726,7 @@ if __name__ == "__main__":
         )
 
     @pytest.mark.skipif(
-        os.environ["OPERATING_SYSTEM"] == "windows",
+        os.environ["OPERATING_SYSTEM"] != "linux",
         reason="Linux specific job bundle to test job attachments dependency data flow",
     )
     @pytest.mark.parametrize(
@@ -1813,7 +1819,7 @@ with open(output_path, "w") as f:
         )
 
     @pytest.mark.skipif(
-        os.environ["OPERATING_SYSTEM"] == "windows",
+        os.environ["OPERATING_SYSTEM"] != "linux",
         reason="Linux specific job bundle to test create job API call",
     )
     def test_worker_create_job_API_call_linux(

--- a/test/e2e/test_session_runtime.py
+++ b/test/e2e/test_session_runtime.py
@@ -48,7 +48,7 @@ Worker openjd package location (for making the Rust adapter unloadable):
     fault-injection step in TestRustUnavailableAndRecovery)
 """
 
-from typing import Generator, Type
+from typing import Generator, Union
 
 import backoff
 import dataclasses
@@ -63,6 +63,7 @@ from deadline_test_fixtures import (
     DeadlineWorker,
     DeadlineWorkerConfiguration,
     EC2InstanceWorker,
+    LocalMacWorker,
     TaskStatus,
 )
 
@@ -76,6 +77,11 @@ from e2e.utils import (
 LOG = logging.getLogger(__name__)
 
 # Agent log paths per OS
+# This module drives the agent's service directly, which the DeadlineWorker base
+# class does not declare. Both concrete workers that can host a macOS or Linux
+# agent expose it, so accept either rather than requiring the EC2 one.
+ServiceControllableWorker = Union[EC2InstanceWorker, LocalMacWorker]
+
 _LINUX_AGENT_LOG = "/var/log/amazon/deadline/worker-agent.log"
 _WINDOWS_AGENT_LOG = r"C:\ProgramData\Amazon\Deadline\Logs\worker-agent.log"
 
@@ -111,13 +117,13 @@ def _running_on_windows() -> bool:
     return os.environ["OPERATING_SYSTEM"].lower() == "windows"
 
 
-def _agent_log_path(worker: EC2InstanceWorker) -> str:
+def _agent_log_path(worker: ServiceControllableWorker) -> str:
     """Return the agent log path appropriate for the worker's OS."""
     return _WINDOWS_AGENT_LOG if _running_on_windows() else _LINUX_AGENT_LOG
 
 
 def _assert_log_contains(
-    worker: EC2InstanceWorker,
+    worker: ServiceControllableWorker,
     pattern: str,
     description: str,
 ) -> None:
@@ -171,8 +177,7 @@ def _assert_log_contains(
 def explicit_runtime_worker(
     request: pytest.FixtureRequest,
     worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
-) -> Generator[tuple[EC2InstanceWorker, str], None, None]:
+) -> Generator[tuple[ServiceControllableWorker, str], None, None]:
     """Create a worker with session_runtime set to the parametrized value.
 
     Two values: python and rust. Both run unconditionally; the Rust
@@ -184,10 +189,9 @@ def explicit_runtime_worker(
     runtime: str = request.param
     with create_worker(
         dataclasses.replace(worker_config, session_runtime=runtime),
-        ec2_worker_type,
         request,
     ) as worker:
-        assert isinstance(worker, EC2InstanceWorker)
+        assert isinstance(worker, (EC2InstanceWorker, LocalMacWorker))
         yield worker, runtime
     stop_worker(request, worker)
 
@@ -206,7 +210,7 @@ class TestExplicitModeRouting:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        explicit_runtime_worker: tuple[EC2InstanceWorker, str],
+        explicit_runtime_worker: tuple[ServiceControllableWorker, str],
     ) -> None:
         worker, runtime = explicit_runtime_worker
         job = submit_sleep_job(
@@ -231,14 +235,12 @@ class TestExplicitModeRouting:
 def service_selected_worker(
     request: pytest.FixtureRequest,
     worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
 ) -> Generator[DeadlineWorker, None, None]:
     with create_worker(
         dataclasses.replace(worker_config, session_runtime="service-selected"),
-        ec2_worker_type,
         request,
     ) as worker:
-        assert isinstance(worker, EC2InstanceWorker)
+        assert isinstance(worker, (EC2InstanceWorker, LocalMacWorker))
         yield worker
     stop_worker(request, worker)
 
@@ -259,7 +261,7 @@ class TestServiceSelectedDefaultsToPython:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        service_selected_worker: EC2InstanceWorker,
+        service_selected_worker: ServiceControllableWorker,
     ) -> None:
         job = submit_sleep_job(
             "session_runtime=service-selected (no hint) routing test",
@@ -297,7 +299,7 @@ class TestServiceSelectedWithRustHint:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        service_selected_worker: EC2InstanceWorker,
+        service_selected_worker: ServiceControllableWorker,
     ) -> None:
         job = submit_sleep_job(
             "session_runtime=service-selected (hint=rust) routing test",
@@ -340,7 +342,7 @@ class TestServiceSelectedWithPythonexprHint:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        service_selected_worker: EC2InstanceWorker,
+        service_selected_worker: ServiceControllableWorker,
     ) -> None:
         job = submit_sleep_job(
             "session_runtime=service-selected (hint=pythonexpr) routing test",
@@ -364,14 +366,12 @@ class TestServiceSelectedWithPythonexprHint:
 def rust_unavailable_worker(
     request: pytest.FixtureRequest,
     worker_config: DeadlineWorkerConfiguration,
-    ec2_worker_type: Type[EC2InstanceWorker],
 ) -> Generator[DeadlineWorker, None, None]:
     with create_worker(
         dataclasses.replace(worker_config, session_runtime="rust"),
-        ec2_worker_type,
         request,
     ) as worker:
-        assert isinstance(worker, EC2InstanceWorker)
+        assert isinstance(worker, (EC2InstanceWorker, LocalMacWorker))
         yield worker
     stop_worker(request, worker)
 
@@ -390,7 +390,7 @@ class TestRustUnavailableAndRecovery:
         self,
         deadline_resources: DeadlineResources,
         deadline_client: DeadlineClient,
-        rust_unavailable_worker: EC2InstanceWorker,
+        rust_unavailable_worker: ServiceControllableWorker,
     ) -> None:
         """Rust mode fails visibly when the adapter cannot load, then recovers after
         switching to python via worker.toml edit + service restart."""
@@ -484,8 +484,12 @@ class TestRustUnavailableAndRecovery:
                 f"-Pattern '^session_runtime = .python.$' -Quiet)) {{ exit 1 }}"
             )
         else:
+            # -i.bak rather than a bare -i: BSD sed, which macOS ships, requires an
+            # argument to -i and would otherwise take the script as the backup suffix.
+            # The suffixed form is accepted by both BSD and GNU sed.
             switch_cmd = (
-                f"sed -i 's/^session_runtime = .*/session_runtime = \"python\"/' {toml_path}"
+                f"sed -i.bak 's/^session_runtime = .*/session_runtime = \"python\"/' {toml_path}"
+                f" && rm -f {toml_path}.bak"
                 f" && grep -q '^session_runtime = .python.$' {toml_path}"
             )
 
@@ -495,36 +499,13 @@ class TestRustUnavailableAndRecovery:
         )
 
         # Restart the worker service to pick up the new config
+        # No stop confirmation here on purpose. The Windows and Linux checks that used to
+        # live at this point named their own service manager, so on macOS the POSIX branch
+        # ran `systemctl is-active`, exited 127, and satisfied both assertions on the first
+        # attempt -- a gate that contributed no settle time at all on the one platform
+        # where the restart below actually raced. Confirming the service really stopped is
+        # the worker implementation's job, so it belongs behind stop_worker_service().
         worker.stop_worker_service()
-
-        if is_win:
-
-            @backoff.on_exception(
-                backoff.constant,
-                Exception,
-                max_time=45,
-                interval=5,
-            )
-            def check_worker_service_stopped_win() -> None:
-                status_result = worker.send_command("(Get-Service DeadlineWorker).Status")
-                assert status_result.stdout.strip() != "Running"
-
-            check_worker_service_stopped_win()
-        else:
-
-            @backoff.on_exception(
-                backoff.constant,
-                Exception,
-                max_time=45,
-                interval=5,
-            )
-            def check_worker_service_stopped() -> None:
-                status_result = worker.send_command("systemctl is-active deadline-worker")
-                assert status_result.exit_code != 0
-                assert status_result.stdout.strip() != "active"
-
-            check_worker_service_stopped()
-
         worker.start_worker_service()
 
         # Wait for the worker to come back online

--- a/test/e2e/test_worker_config.py
+++ b/test/e2e/test_worker_config.py
@@ -11,6 +11,7 @@ import boto3
 import dataclasses
 import logging
 import os
+import pytest
 
 from deadline_test_fixtures import (
     DeadlineClient,
@@ -146,6 +147,14 @@ class TestWorkerConfiguration:
                     f"Checking that local session logs do not exist returned unexpected response: {check_log_exists_result}"
                 )
 
+    @pytest.mark.skipif(
+        os.environ["OPERATING_SYSTEM"] == "macos",
+        reason=(
+            "Needs a host that can be scaled out and powered off. The macOS worker runs on "
+            "the test host itself, so it has no instance_id, and shutting it down would take "
+            "the rest of the suite with it."
+        ),
+    )
     def test_worker_shuts_down_host_machine_if_configured(
         self,
         deadline_resources: DeadlineResources,
@@ -216,9 +225,15 @@ class TestWorkerConfiguration:
         session_root_dir: str
         run_script: str
 
-        if operating_system.is_amazon_linux():
-            session_root_dir = "/mysessionroot"
-            run_script = f"""#!/usr/bin/bash
+        if operating_system.is_amazon_linux() or operating_system.is_macos():
+            # macOS cannot take the Linux path: the system volume is sealed and read-only,
+            # so a root-level /mysessionroot cannot be created. /private/tmp rather than
+            # /tmp because /tmp is a symlink to it, and the agent reports the resolved
+            # path, which would not match a prefix check written against the symlink.
+            session_root_dir = (
+                "/private/tmp/mysessionroot" if operating_system.is_macos() else "/mysessionroot"
+            )
+            run_script = f"""#!/usr/bin/env bash
 set -euo pipefail
 echo "=== Session Root Dir Test ==="
 echo "Expected: working dir under {session_root_dir}/"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The worker agent has never been tested on macOS. The existing "macOS" CI fleet is Linux-backed and exists for client tests, so no Deadline worker agent has ever run on macOS in CI, and `install_macos.sh` shipped with only installer-level integration coverage.

### What was the solution? (How)

A standalone `macos_e2e_test.yml` that runs the suite against a `LocalMacWorker` on a GitHub-hosted macOS runner, rather than a job on `reusable_e2e_test.yml`.

Why not the shared workflow: Mac hardware is only available on EC2 dedicated hosts, which bill a 24-hour minimum per allocation, and CodeBuild offers macOS only through reserved-capacity fleets that hold a Mac host continuously. A GitHub-hosted runner is free for public repositories and gives a fresh VM per run, which matters because the installer creates users and groups, writes a sudoers rule, and bootstraps a LaunchDaemon. `macos_installer_test.yml` already establishes that the runner grants passwordless sudo and a reachable system launchd domain.

The run creates and deletes its own farm, queues, fleets and storage profiles (`BYO_DEADLINE=false`), so it needs no macOS resources in the shared CI accounts. That path also had to be brought to parity with the CloudFormation scaffolding before path mapping worked at all: fleets need `configuration.customerManaged.storageProfileId` and queues need `requiredFileSystemLocationNames`, or the service emits no `pathMappingRules` and the agent silently remaps attachment roots into the session directory instead.

### What is the impact of this change?

First macOS coverage for the worker agent: 42 passing tests per run, free on public repositories, with no macOS resources needed in the CI accounts.

Non-macOS paths are touched, none expected to change behaviour:

- The runtime recovery test's hand-rolled stop confirmation is removed. Each branch named its own service manager, so on macOS the POSIX branch ran `systemctl is-active`, exited 127, and passed vacuously — no settle time on the one platform where the restart raced. `systemctl stop` and `Stop-Service` are both synchronous, so Linux and Windows lose nothing, and confirming the stop now sits behind `stop_worker_service()`.
- `sed -i` becomes `sed -i.bak` and the Linux job script uses `#!/usr/bin/env bash`; both forms work under GNU.
- The path mapping test asserts the job succeeded before checking outputs, so a failed job reports as a job failure with logs rather than an empty mapping.
- `ec2_worker_type` is resolved inside the EC2 branch of `create_worker` rather than as a fixture parameter, since it raises for any non-EC2 operating system. Linux and Windows get the same fixture and the same value.

### How was this change tested?

42 passed, 37 skipped on a GitHub-hosted macOS runner against `deadline-cloud-test-fixtures` 0.18.22.

The 37 skips are the Windows-only (22) and Linux-only (11) tests that any single-platform run skips, two gated on a service-side allowlist, one pre-existing `@pytest.mark.skip`, and one macOS skip for the test that powers off its host.

Linux and Windows e2e need dispatching against this branch before merge; they cannot authenticate from a fork.

Known gap: two shutdown tests depend on the agent reporting `STOPPED`, which is unreliable on hosts where the IMDS probe in `Worker.run()` does not answer promptly — an unbounded request that predates this change. That is being addressed separately; this PR does not include the fix.

### Was this change documented?

No. Test infrastructure only.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
