### PR TITLE
fix: bound IMDS requests so shutdown always reports STOPPED

### DIFF
--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -62,6 +62,18 @@ class Worker:
     """The amount of time to allow the Worker to gracefully shutdown after detecting an auto-scaling
     life-cycle event."""
 
+    _IMDS_REQUEST_TIMEOUT_S = 1.0
+    """Timeout applied to every IMDS request.
+
+    IMDS is a link-local endpoint that answers in single-digit milliseconds when it is present, so a
+    one second bound is generous for hosts that are on EC2. It exists for the hosts that are not:
+    169.254.169.254 is typically black-holed rather than refused off EC2, so an unbounded request
+    blocks for the OS TCP connect timeout (75s on macOS, ~130s on Linux). The first of these
+    requests is issued from the thread that runs the Worker, ahead of the wait that the shutdown
+    path returns through, so an unbounded request there stops the Worker from ever reporting STOPPED
+    to the service after a SIGTERM/service stop and leaves it stuck in IDLE until the service
+    manager escalates to SIGKILL."""
+
     _farm_id: str
     _fleet_id: str
     _worker_id: str
@@ -394,9 +406,10 @@ class Worker:
             response = requests.put(
                 "http://169.254.169.254/latest/api/token",
                 headers={"X-aws-ec2-metadata-token-ttl-seconds": "10"},
+                timeout=Worker._IMDS_REQUEST_TIMEOUT_S,
             )
-        except requests.ConnectionError:
-            # Could not connect to the metadata service. Either it's not enabled or we're not
+        except (requests.ConnectionError, requests.Timeout):
+            # Could not reach the metadata service. Either it's not enabled or we're not
             # on an EC2 instance.
             return None
 
@@ -425,9 +438,10 @@ class Worker:
             response = requests.get(
                 "http://169.254.169.254/latest/meta-data/spot/instance-action",
                 headers={"X-aws-ec2-metadata-token": imdsv2_token},
+                timeout=Worker._IMDS_REQUEST_TIMEOUT_S,
             )
-        except requests.ConnectionError:
-            # Could not connect to the metadata service. Either it's inactive or we're not
+        except (requests.ConnectionError, requests.Timeout):
+            # Could not reach the metadata service. Either it's inactive or we're not
             # on an EC2 instance.
             return None
 
@@ -476,8 +490,9 @@ class Worker:
             response = requests.get(
                 "http://169.254.169.254/latest/meta-data/autoscaling/target-lifecycle-state",
                 headers={"X-aws-ec2-metadata-token": imdsv2_token},
+                timeout=Worker._IMDS_REQUEST_TIMEOUT_S,
             )
-        except requests.ConnectionError:
+        except (requests.ConnectionError, requests.Timeout):
             return False
 
         if response.status_code == 200:

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -208,6 +208,45 @@ class TestRun:
         assert raise_ctx.value is service_shutdown
         logger_exception.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "timeout_exception_cls",
+        [
+            pytest.param(worker_mod.requests.ConnectTimeout, id="ConnectTimeout"),
+            pytest.param(worker_mod.requests.ReadTimeout, id="ReadTimeout"),
+        ],
+    )
+    def test_completes_when_startup_imds_probe_times_out(
+        self,
+        worker: Worker,
+        thread_pool_executor: MagicMock,
+        mock_logger: MagicMock,
+        requests_put: MagicMock,
+        timeout_exception_cls: type[Exception],
+    ) -> None:
+        """Tests that run() still returns when the IMDS probe it makes on startup times out.
+
+        run() makes that probe on the calling thread, before the wait() that the shutdown path
+        returns through. If the probe does not complete then the caller never gets to report status
+        STOPPED to the service, so the Worker is left in IDLE until the service manager escalates
+        to SIGKILL.
+        """
+
+        # GIVEN
+        requests_put.side_effect = timeout_exception_cls("Timed out")
+        scheduler_future = MagicMock()
+        thread_pool_executor.submit.return_value = scheduler_future
+        with (
+            patch.object(worker_mod, "wait", return_value=([scheduler_future], [])),
+            patch.object(worker_mod, "AwsCredentialsRefresher"),
+        ):
+            # WHEN
+            worker.run()
+
+        # THEN
+        # No EC2 shutdown monitor is started, since we could not determine that we are on EC2.
+        thread_pool_executor.submit.assert_called_once_with(worker._scheduler.run)
+        mock_logger.info.assert_any_call("Worker shutdown complete")
+
 
 class TestMonitorEc2Shutdown:
     @pytest.fixture
@@ -406,11 +445,39 @@ class TestEC2MetadataQueries:
         requests_put.assert_called_once_with(
             "http://169.254.169.254/latest/api/token",
             headers={"X-aws-ec2-metadata-token-ttl-seconds": "10"},
+            timeout=Worker._IMDS_REQUEST_TIMEOUT_S,
         )
 
     def test_get_imdsv2_token_cannot_connect(self, worker: Worker, requests_put: MagicMock) -> None:
         # GIVEN
         requests_put.side_effect = worker_mod.requests.ConnectionError("Error")
+
+        # WHEN
+        result = worker._get_ec2_metadata_imdsv2_token()
+
+        # THEN
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "timeout_exception_cls",
+        [
+            pytest.param(worker_mod.requests.ConnectTimeout, id="ConnectTimeout"),
+            pytest.param(worker_mod.requests.ReadTimeout, id="ReadTimeout"),
+        ],
+    )
+    def test_get_imdsv2_token_times_out(
+        self,
+        worker: Worker,
+        requests_put: MagicMock,
+        timeout_exception_cls: type[Exception],
+    ) -> None:
+        """A timed-out IMDS token request must be treated as "not on EC2" rather than propagating.
+
+        requests.ReadTimeout is not a subclass of requests.ConnectionError, so it would otherwise
+        escape Worker.run() and abort the agent instead of letting it shut down cleanly.
+        """
+        # GIVEN
+        requests_put.side_effect = timeout_exception_cls("Timed out")
 
         # WHEN
         result = worker._get_ec2_metadata_imdsv2_token()
@@ -463,6 +530,7 @@ class TestEC2MetadataQueries:
         requests_get.assert_called_once_with(
             "http://169.254.169.254/latest/meta-data/spot/instance-action",
             headers={"X-aws-ec2-metadata-token": fake_token},
+            timeout=Worker._IMDS_REQUEST_TIMEOUT_S,
         )
         if not is_interrupt:
             assert result is None
@@ -575,6 +643,7 @@ class TestEC2MetadataQueries:
         requests_get.assert_called_once_with(
             "http://169.254.169.254/latest/meta-data/autoscaling/target-lifecycle-state",
             headers={"X-aws-ec2-metadata-token": fake_token},
+            timeout=Worker._IMDS_REQUEST_TIMEOUT_S,
         )
 
     def test_asg_terminate_cannot_connect(self, worker: Worker, requests_get: MagicMock) -> None:
@@ -586,6 +655,32 @@ class TestEC2MetadataQueries:
 
         # THEN
         assert not result
+
+    @pytest.mark.parametrize(
+        "timeout_exception_cls",
+        [
+            pytest.param(worker_mod.requests.ConnectTimeout, id="ConnectTimeout"),
+            pytest.param(worker_mod.requests.ReadTimeout, id="ReadTimeout"),
+        ],
+    )
+    def test_imds_metadata_queries_time_out(
+        self,
+        worker: Worker,
+        requests_get: MagicMock,
+        timeout_exception_cls: type[Exception],
+    ) -> None:
+        """A timed-out IMDS metadata request must report "no shutdown pending" rather than
+        propagating out of the EC2 shutdown monitoring thread."""
+        # GIVEN
+        requests_get.side_effect = timeout_exception_cls("Timed out")
+
+        # WHEN
+        spot_result = worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="token")
+        asg_result = worker._is_asg_terminated(imdsv2_token="token")
+
+        # THEN
+        assert spot_result is None
+        assert asg_result is False
 
     def test_asg_terminate_imds_inactive(self, worker: Worker, requests_get: MagicMock) -> None:
         # GIVEN


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The agent intermittently never reports `STOPPED` after a SIGTERM or service stop, leaving the worker `IDLE` from the service's point of view until the service manager escalates to `SIGKILL`.

`Worker.run()` probes IMDS on the calling thread to decide whether to start the EC2 shutdown monitor, and that probe has no request timeout. Where the address does not answer promptly — routed but silently dropped, as on some VM networks — the request blocks for however long the OS allows. The probe has been unbounded since the initial commit.

That probe sits ahead of the `wait()` the shutdown path returns through. The signal itself is handled fine — the scheduler drains and logs — but the thread resumes the blocked connect and never returns from `run()`, so the entrypoint never reaches the `UpdateWorker(STOPPED)` call. The apparent intermittency is only whether the stop lands inside that fixed startup window, which is why the logs stop between "Draining any remaining Sessions." and "Worker shutdown complete".

The affected set is narrow, which is likely why this has not been reported before. On EC2 the probe returns in about a millisecond. A host with no route to link-local fails immediately with a connection error and never blocks either — measured at 0.01s on a non-EC2 macOS host. What is left is hosts where the address is routed but unanswered, which is the case on GitHub-hosted macOS runners. The symptom there also looks like the service manager killing the worker rather than anything the agent did.

### What was the solution? (How)

A 1s timeout on all three IMDS requests, with the handlers widened to `requests.Timeout`.

`bootstrap.py` already passes `timeout=0.5` to the identical request, with a comment noting the default can exceed 20s; this brings the call sites into line rather than restructuring startup. The spot-interruption and ASG-lifecycle requests get the same bound because they run on the monitor thread that `run()` joins during shutdown, so an unbounded request there blocks shutdown the same way on hosts that do have IMDS.

`requests.ReadTimeout` is not a subclass of `requests.ConnectionError`, so widening the handlers is load-bearing: adding a timeout alone would trade the hang for an unhandled exception out of `Worker.run()`.

### What is the impact of this change?

Worker stop is reliable on hosts without IMDS, so a stopped worker reports `STOPPED` rather than sitting `IDLE` until it is force-killed. Costs at most 1s of extra shutdown latency, and nothing on EC2.

Platform-independent in principle: the probe has no platform guard, so Linux `systemctl stop` and the Windows service (same stop event via `SvcStop`) reach it the same way. Whether it manifests depends on the host's network behaviour rather than its OS.

### How was this change tested?

14 unit tests in `test/unit/test_worker.py` fail without the source change and pass with it, including one asserting `run()` returns and logs "Worker shutdown complete" when the startup probe times out — the exact sentinel missing from the failing logs.

Also confirmed end to end: `test_worker_lifecycle_status_is_expected` in the macOS e2e suite is what surfaced this. It failed consistently without the fix and has passed on every run since, which is the main evidence that the probe is what stalls the shutdown.

For the record on what is not established: the exact block duration in the failing environment was not isolated. The agent logs show shutdown reaching "Draining any remaining Sessions." and the process being replaced 1.6s to 6.1s later without ever logging "Worker shutdown complete", against 1ms for a healthy stop. The causal link rests on the behaviour changing when the timeout is added, not on a measured stall matching a known OS timeout.

`hatch run lint` and `hatch run test` pass. The one failure and 18 errors in `test/unit/test_telemetry.py` are pre-existing on `mainline`, verified by running that file against a pristine checkout.

### Was this change documented?

No. Behavioural fix with no API or configuration surface.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
