### PR TITLE
fix: track openjd-model 0.11.9's step-scope let resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,26 @@ dependencies = [
     # StepTemplate.resolve_syntax_sugar() (run_step_task.py, for FEATURE_BUNDLE_1
     # simple-action steps) and openjd.expr.SerializedSymbolTable (the runtime
     # adapters). resolve_syntax_sugar() first shipped in openjd-model 0.9.0, well
-    # below the floor here, so no floor change is needed for it to exist. It is
-    # recorded because the fold order it produces,
-    # [*step lets, *simple-action lets], is model behaviour this package's tests
-    # assert rather than behaviour this package controls.
-    "openjd-model >= 0.11.4, < 0.12",
+    # below the floor here, so no floor change is needed for it to exist.
+    #
+    # Floored at 0.11.9 (openjd-model#341), where a step's template-scope `let`
+    # stopped being folded into the script's `let` because it is now resolved once
+    # at job creation instead, its values travelling in
+    # `create_job_with_symbol_tables().step_symbol_tables`. That matches how this
+    # package already receives those bindings -- via the service-resolved symtab
+    # passed to openjd-sessions, per the note above -- so only the simple-action
+    # scope is folded on the worker.
+    #
+    # The floor is not a test-shape preference. 0.11.8 and earlier fold both
+    # scopes, which re-declares every step-scope binding in `script.let` and has
+    # the session re-evaluate it in host scope on top of the value the service
+    # already resolved -- re-rendering PATH values over the correctly formatted
+    # seeded one. The pinned openjd-sessions 0.12.0 evaluates exactly one `let`
+    # scope, a script's own, in `apply_let_bindings`; it has no template-scope
+    # pass for the fold's output to feed. So this floor cannot be relaxed to
+    # widen resolution; below it, sugar steps with a step-scope `let` resolve
+    # those names twice, from two sources that can disagree.
+    "openjd-model >= 0.11.9, < 0.12",
     # tomli became tomllib in standard library in Python 3.11
     "tomli == 2.0.* ; python_version<'3.11'",
     "tomlkit >= 0.13,< 0.16",

--- a/src/deadline_worker_agent/sessions/actions/run_step_task.py
+++ b/src/deadline_worker_agent/sessions/actions/run_step_task.py
@@ -28,20 +28,50 @@ def _resolve_step_script(step_template: StepTemplate) -> StepScript:
     `powershell:`, `python:`) has no `script` at all. The service serves the
     sugar as authored and the worker never instantiates a job, so nothing
     de-sugars it. `resolve_syntax_sugar()` does that here, returning a new
-    template whose script carries `[*step lets, *simple-action lets]`.
+    template whose script carries the simple action's own `let` and nothing
+    else.
 
     Step-scope `let` values reach the session through the resolved symbol table
-    the service serves. For a `script:` template that is the only channel, and
-    the source expressions are never re-evaluated here.
+    the service serves, on both shapes alike. That is the only channel: the
+    step's own `let` is evaluated once in template scope at job creation and its
+    values travel in `create_job_with_symbol_tables().step_symbol_tables[name]`,
+    which the service serves as the entity's `resolvedSymbolTable`. Neither
+    branch above re-declares those names, so their source expressions are never
+    re-evaluated on the worker.
 
-    That is not true of the sugar path: the fold above re-declares every
-    step-scope binding in the produced `script.let`, so on a sugar template
-    those names arrive twice -- once resolved by the service in the table, and
-    once as a source expression the session re-evaluates on top of it. No test
-    covers a sugar template together with a populated resolvedSymbolTable, so
-    whether the two channels can disagree (a binding that re-evaluates to a
-    different value, or fails to re-evaluate against the per-action table) is
-    currently unverified rather than known-safe.
+    Deliberately so, as of the `openjd-model` floor in `pyproject.toml`: folding
+    step scope into `script.let` had the session re-evaluate those bindings in
+    host scope, re-rendering PATH values over the correctly formatted seeded
+    value.
+
+    A step whose `let` the service serves no table for therefore has no binding
+    for those names -- a service-side condition, from the table being dropped over
+    a size cap or gated on a minimum worker version.
+    `_warn_if_step_let_has_no_table` reports it so the log names that cause rather
+    than only the symbol.
+
+    On the sugar path that is a change in outcome, and worth being explicit about.
+    Before the model stopped folding, a tableless sugar step still resolved: the
+    fold re-declared the step's `let` in `script.let` and `apply_let_bindings`
+    evaluated it. A tableless `script:` step never had that and failed then as it
+    fails now. So the sugar path lost a route that did work, and the size cap in
+    particular is not monotone in worker version -- it fires on payload size, so it
+    can reach a job that ran yesterday.
+
+    Not restored here, and the reason is not that it is impossible -- a fold
+    conditional on no table being served would work. It is that the value it
+    produces is the wrong kind of wrong. Host-scope evaluation is what the model
+    withdrew the fold to stop: it re-renders a PATH binding in the host's format
+    rather than the format job creation resolved it to. With no table there is no
+    seeded value to clobber, so nothing detects the difference, and the step runs
+    with a plausible but differently-formatted path -- writing output somewhere
+    slightly wrong instead of failing. A conditional fold would also make the same
+    template resolve or not depending on whether it was authored as `bash:` or
+    `script:`, and would mean rebuilding the script here, since the model exposes no
+    "fold anyway" mode.
+
+    A clear failure is the better outcome, which is what an undefined symbol
+    produces, with the warning above naming the missing table as its cause.
     """
     script = step_template.script
     if script is not None:
@@ -52,6 +82,48 @@ def _resolve_step_script(step_template: StepTemplate) -> StepScript:
     # invariant for the type checker; it is not a runtime conversion.
     folded = step_template.resolve_syntax_sugar()
     return cast("StepScript", folded.script)
+
+
+def _warn_if_step_let_has_no_table(session: Session, details: StepDetails) -> None:
+    """Log when a step declares a template-scope `let` but no table was served.
+
+    Those two facts are only visible together here, which is why this sits on the
+    action rather than in `_resolve_step_script`.
+
+    Emitted on `session.logger`, the session log, rather than the module logger.
+    The reader this is written for is whoever opens the failed task's log and sees
+    an undefined-symbol error; the agent log is on the host and is not theirs to
+    read at all on a service-managed fleet. Same reason the attachment actions
+    build their own adapter over OPENJD_LOG.
+
+    Once per task, deliberately. The condition belongs to the step rather than the
+    task, so this repeats across a step's tasks -- but so does the failure it
+    explains, and each task's log is read on its own. A reader who opens one failed
+    task finds exactly one warning; suppressing all but the first would leave most
+    failed tasks unexplained.
+
+    A warning rather than a raise. `_parse_resolved_symtab` raises on a table that
+    is present but unparseable, because there the served bytes are evidence the
+    service meant to supply symbols and something corrupted them. An absent table
+    is not that: a step may declare `let` bindings its script never references, and
+    such a step runs correctly with no table at all. Failing it would turn a
+    dropped table into a job failure for work that would otherwise succeed.
+
+    Scope: this detects an absent table, not a served table that lacks the step's
+    names. Checking the latter would mean parsing the table here and deciding which
+    names the script needs -- work the session already does, and the place its
+    result is already reported. So the message says what was observed, a table that
+    was not served, rather than claiming every route to an undefined symbol.
+    """
+    if details.step_template.let and details.resolved_symbol_table_json is None:
+        session.logger.warning(
+            "Step %s declares template-scope `let` bindings but the service served no "
+            "resolved symbol table, so those names are undefined for this task. The "
+            "table is the only channel for them; the worker does not evaluate the "
+            "step's `let` itself. Expect an undefined-symbol failure if the script "
+            "references one.",
+            details.step_id,
+        )
 
 
 class RunStepTaskAction(OpenjdAction):
@@ -118,6 +190,7 @@ class RunStepTaskAction(OpenjdAction):
             env_vars["DEADLINE_TASK_ID"] = self.task_id
 
         step_template = self._details.step_template
+        _warn_if_step_let_has_no_table(session, self._details)
         step_script = _resolve_step_script(step_template)
 
         session.run_task(

--- a/test/unit/sessions/actions/test_run_step_task.py
+++ b/test/unit/sessions/actions/test_run_step_task.py
@@ -1,5 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from __future__ import annotations
+
+import json
 from typing import Any
 from unittest.mock import Mock
 import pytest
@@ -96,7 +99,11 @@ class TestRunStepTaskAction:
         assert "DEADLINE_TASK_ID" not in env_vars
 
 
-def _step_details_from_template(template: dict[str, Any], extensions: list[str]) -> StepDetails:
+def _step_details_from_template(
+    template: dict[str, Any],
+    extensions: list[str],
+    resolved_symbol_table: str | None = None,
+) -> StepDetails:
     """Parse a served step template the way BatchGetJobEntity delivers it."""
     payload: Any = {
         "jobId": "job-123",
@@ -106,7 +113,115 @@ def _step_details_from_template(template: dict[str, Any], extensions: list[str])
         "extensions": extensions,
         "template": template,
     }
+    if resolved_symbol_table is not None:
+        payload["resolvedSymbolTable"] = resolved_symbol_table
     return StepDetails.from_boto(payload)
+
+
+def _warned(mock_session: Mock) -> bool:
+    """Whether the action warned on the *session* logger.
+
+    Asserted through `session.logger` rather than caplog on purpose: routing this
+    to the session log is the point -- the agent log is on the host, and a job owner
+    on a service-managed fleet cannot read it. A caplog assertion would pass just as
+    happily against the module logger and so would not pin that.
+    """
+    return any(
+        "served no resolved symbol table" in str(call.args[0])
+        for call in mock_session.logger.warning.call_args_list
+    )
+
+
+class TestStepLetWithoutAServedTable:
+    """A step declaring template-scope ``let`` with no table served is reported.
+
+    The table is the only channel for those names -- the worker does not evaluate
+    the step's ``let`` itself -- so this combination leaves them undefined. The
+    service can produce it: it drops a table over a size cap, and gates serving
+    one on a minimum worker version.
+
+    The action warns rather than raising. A step may declare bindings its script
+    never references, and such a step runs correctly with no table; failing it
+    would turn a dropped table into a job failure for work that would otherwise
+    succeed. The warning exists so the log names the missing channel instead of
+    leaving an undefined-symbol error to point at a binding that is plainly
+    declared in the template.
+    """
+
+    def test_warns_when_a_step_let_has_no_table(self, mock_session, mock_executor) -> None:
+        details = _step_details_from_template(
+            {
+                "name": "MyStep",
+                "let": ["base = 'from step'"],
+                "script": {"actions": {"onRun": {"command": "echo", "args": ["hi"]}}},
+            },
+            ["EXPR"],
+        )
+        assert details.resolved_symbol_table_json is None
+        action = RunStepTaskAction(id="action-123", details=details, task_parameter_values={})
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        assert _warned(mock_session)
+        # Warned, not raised: the task still goes out.
+        mock_session.run_task.assert_called_once()
+
+    def test_warns_for_a_sugar_step_too(self, mock_session, mock_executor) -> None:
+        """The sugar path reaches the same check.
+
+        Worth pinning separately: before openjd-model 0.11.9 a sugar step in this
+        state still resolved, because ``resolve_syntax_sugar()`` re-declared the
+        step's ``let`` in ``script.let`` and the session re-evaluated it. That
+        fold is gone, so the sugar path now depends on the table exactly as the
+        ``script:`` path does.
+        """
+        details = _step_details_from_template(
+            {
+                "name": "MyStep",
+                "let": ["base = 'from step'"],
+                "bash": {"let": ["msg = base"], "script": "echo hi"},
+            },
+            ["FEATURE_BUNDLE_1", "EXPR"],
+        )
+        action = RunStepTaskAction(id="action-123", details=details, task_parameter_values={})
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        assert _warned(mock_session)
+
+    def test_is_silent_when_a_table_is_served(self, mock_session, mock_executor) -> None:
+        """Control: the normal case must not warn."""
+        details = _step_details_from_template(
+            {
+                "name": "MyStep",
+                "let": ["base = 'from step'"],
+                "script": {"actions": {"onRun": {"command": "echo", "args": ["hi"]}}},
+            },
+            ["EXPR"],
+            resolved_symbol_table=json.dumps(
+                [{"name": "base", "type": "string", "value": "from step"}]
+            ),
+        )
+        action = RunStepTaskAction(id="action-123", details=details, task_parameter_values={})
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        assert not _warned(mock_session)
+
+    def test_is_silent_for_a_step_with_no_let(self, mock_session, mock_executor) -> None:
+        """Control: no ``let`` and no table is the common case, and is fine."""
+        details = _step_details_from_template(
+            {
+                "name": "MyStep",
+                "script": {"actions": {"onRun": {"command": "echo", "args": ["hi"]}}},
+            },
+            ["EXPR"],
+        )
+        action = RunStepTaskAction(id="action-123", details=details, task_parameter_values={})
+
+        action.start(session=mock_session, executor=mock_executor)
+
+        assert not _warned(mock_session)
 
 
 class TestRunStepTaskActionSimpleActionSugar:
@@ -122,11 +237,18 @@ class TestRunStepTaskActionSimpleActionSugar:
     """
 
     def test_start_de_sugars_a_bash_step(self, mock_session, mock_executor):
-        """The folded script goes out, carrying both `let` scopes in order.
+        """The folded script goes out, carrying the simple action's own `let`.
 
-        ``resolve_syntax_sugar()`` folds step-scope ``let`` into the script's own
-        ``let`` as ``[*step lets, *simple-action lets]``. Without that fold the
-        action would have no script at all to send.
+        ``resolve_syntax_sugar()`` folds the simple action's ``let`` into the script
+        it produces. Without that fold the action would have no script at all to
+        send.
+
+        The step's template-scope ``let`` is deliberately absent from that list. As
+        of openjd-model 0.11.9 the model resolves template scope once at job
+        creation rather than folding it here, and this package receives those
+        bindings by a different route anyway: the service-resolved symtab it passes
+        to ``openjd-sessions``. Asserting them here would test a shape no worker
+        sees, since the worker de-sugars a template the service already created.
         """
         details = _step_details_from_template(
             {
@@ -149,8 +271,8 @@ class TestRunStepTaskActionSimpleActionSugar:
         call_kwargs = mock_session.run_task.call_args.kwargs
         step_script = call_kwargs["step_script"]
         assert step_script is not None
-        # Both scopes present exactly once, step bindings first.
-        assert step_script.let == ["base = 'from step'", "msg = base"]
+        # Simple-action scope only; template scope arrives via the resolved symtab.
+        assert step_script.let == ["msg = base"]
         assert step_script.actions.onRun.command == "bash"
 
     def test_start_does_not_mutate_the_served_template(self, mock_session, mock_executor):
@@ -178,9 +300,11 @@ class TestRunStepTaskActionSimpleActionSugar:
     def test_start_forwards_a_plain_script_unchanged(self, mock_session, mock_executor):
         """Control: a ``script:`` template sends its own script object untouched.
 
-        Guards the other direction -- de-sugaring unconditionally would fold
-        the step's ``let`` into ``script.let`` and send a rebuilt script, so a
-        plain step's script must come through by identity.
+        Guards the other direction -- de-sugaring unconditionally would send a
+        rebuilt script in place of the served one, so a plain step's script must
+        come through by identity. The step's own ``let`` stays out of
+        ``script.let`` on this path as it does on the sugar path, since neither
+        re-declares template scope.
         """
         details = _step_details_from_template(
             {

--- a/test/unit/sessions/test_step_scope_let_end_to_end.py
+++ b/test/unit/sessions/test_step_scope_let_end_to_end.py
@@ -406,22 +406,35 @@ class TestSimpleActionSugarEndToEnd:
         assert state == ActionState.SUCCESS
         assert any("BASH:hello from bash" in m for m in caplog.messages)
 
-    def test_step_and_sugar_scope_let_both_resolve_through_the_fold(
+    def test_step_and_sugar_scope_let_both_resolve(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Both scopes of a sugar template resolve, via the fold alone.
+        """A sugar-scope binding resolves against a step-scope name.
 
-        ``resolve_syntax_sugar()`` folds the step's ``let`` into the script's own
-        as ``[*step lets, *simple-action lets]``, so the de-sugared script
-        carries both scopes in RFC 0005 order and a sugar-scope binding can
-        reference a step-scope one. This is the only thing that resolves the
-        step's scope on this path -- nothing else re-applies it.
+        Step scope arrives through the served ``resolvedSymbolTable``, which this
+        module's header describes as the single authoritative channel for it, and
+        the sugar's own ``let`` is folded into the script that
+        ``resolve_syntax_sugar()`` produces. The two together are what let
+        ``out`` reference ``base``.
+
+        Seeded through the table rather than left to the fold, and the seeded
+        value is not an assumption about the service: as of openjd-model 0.11.9
+        the model resolves template scope once at job creation into
+        ``create_job_with_symbol_tables().step_symbol_tables[step name]`` -- job
+        scope plus ``Step.Name`` plus the step's evaluated ``let`` -- and that is
+        what the service serves as ``resolvedSymbolTable``. The table is built
+        from the step's name, its ``let`` and the job-scope table alone, so a
+        sugar step gets the same one a ``script:`` step does; the sugar changes
+        the script's shape, not the table's contents.
+
+        Which is why relying on the fold tested a path production does not take.
         """
         caplog.set_level(logging.INFO)
         details = _bash_sugar_step_details(
             step_let=["base = 'from step'"],
             sugar_let=["out = base + '|sugar'"],
             script_body='echo "OUT:{{ out }}"',
+            resolved_symbol_table=[{"name": "base", "type": "string", "value": "from step"}],
         )
         assert details.step_template.script is None
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`Code Quality`'s `Unit Tests` job fails on any pull request that triggers it, regardless of that PR's contents:

```
assert ['msg = base'] == ["base = 'from step'", 'msg = base']
```

`Mainline Canary` stays green and is not evidence to the contrary: `mainline_e2e_canary.yml` runs `hatch run integ-test` plus the Linux and Windows e2e jobs, and no unit tests. `Code Quality` last ran on `mainline` on 2026-09-01, before 0.11.9 reached the index, so nothing has re-resolved the dependency there since.

openjd-model 0.11.9 stops folding a step's template-scope `let` into the script's `let`, resolving that scope once at job instantiation instead. Two tests asserted the fold, so a fresh dependency resolve under the existing `openjd-model >= 0.11.4, < 0.12` turned mainline red with no commit to this repository. Nothing here changed; the resolution drifted.

### What was the solution? (How)

Move the assertions to the 0.11.9 shape, and floor the pin there.

The 0.11.9 behaviour is what this package already assumes. `test_step_scope_let_end_to_end`'s own module header states it: the worker never instantiates a job, so the service resolves template scope and serves it in the entity's `resolvedSymbolTable`, "the single authoritative channel for those values — the worker reads the table and does not re-evaluate `StepTemplate.let`". The `pyproject.toml` note on `openjd-sessions == 0.12.0` says the same thing from the other side, describing `resolved_symtab` as what "this package now passes to deliver step-scope `let` and the rest of the service-resolved table".

The fold was a second, redundant route to the same values, and the model has now withdrawn it.

- `test_start_de_sugars_a_bash_step` expects the simple action's own `let` only.
- `test_step_and_sugar_scope_let_both_resolve_through_the_fold` seeds its step-scope name through the served table, as every other test in that module already does. It still proves a sugar-scope binding can reference a step-scope one, now over the path production actually takes — that test was the one place in the module relying on the fold instead of the table, contradicting its own header.

The floor rises to `>= 0.11.9` so a single behaviour is pinned in both directions: 0.11.6 through 0.11.8 fold both scopes and would fail these assertions. Capping below 0.11.9 instead was considered and rejected — it would hold the package on withdrawn behaviour and leave a cap for someone to remember to lift.

### What is the impact of this change?

`mainline` goes green, unblocking open pull requests. Callers resolve openjd-model 0.11.9 or later within 0.11.x. `openjd-sessions == 0.12.0` already requires `>= 0.11.6`, so the new floor conflicts with nothing.

No runtime behaviour change in this package: step-scope `let` was already arriving through the resolved symbol table.

### How was this change tested?

Bisected the model change: `TestRunStepTaskActionSimpleActionSugar` is 5 passed on openjd-model 0.11.8 and 1 failed on 0.11.9.

With this change, `hatch run test` gives `1 failed, 3162 passed, 47 skipped, 18 errors`. The remaining failure and all 18 errors are in `test/unit/test_telemetry.py` and are pre-existing on `mainline` — the identical counts appear on a pristine checkout at `f1a88f2`, which I verified in a separate worktree.

`hatch run lint` passes: ruff, ruff format, and mypy across 202 source files.

### Was this change documented?

No. The reasoning is recorded beside the pin and in both test docstrings.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

