### PR TITLE
fix: bound and retry the IMDS probe so shutdown always reports STOPPED

### DIFF
--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -9,6 +9,7 @@ import re
 import requests
 import sys
 import sysconfig
+import time
 
 from deadline_worker_agent.config.settings import (
     DEFAULT_MACOS_SESSION_ROOT_DIR,
@@ -30,17 +31,93 @@ INSTALLER_PATH = {
 }
 
 
+_IMDS_REQUEST_TIMEOUT = (1.0, None)
+"""(connect, read) ceiling on one IMDS request during install.
+
+The address is link-local, so where nothing answers it the connect waits on ARP rather than
+being refused, stalling the installer with no output on every workstation install.
+
+Read stays unbounded: `None` from _get_ec2_region is fatal -- `install()` exits 1 -- and a
+user-data install runs during boot, when IMDS is slowest. A ceiling would fail the install on a
+slow-but-present IMDS, and the retry cannot help, since N attempts at an N-second read tolerate
+a consistently slower IMDS no better than one."""
+
+_IMDS_ATTEMPTS = 3
+"""Attempts before giving up. Retried because `None` here is fatal, so bounding the request
+without retrying would turn a slow EC2 answer into a failed install."""
+
+_IMDS_BACKOFF_S = 0.5
+"""Delay between attempts. A throttled IMDS answers immediately, so back-to-back retries would
+meet the same empty token bucket."""
+
+
+def _is_transient_status(status_code: int) -> bool:
+    """Whether an IMDS status may clear on its own.
+
+    5xx as much as 429: boot is when a user-data install runs and when the metadata service is
+    not yet up.
+    """
+    return status_code == 429 or status_code >= 500
+
+
+class _ImdsTransientError(Exception):
+    """IMDS answered in a way another attempt may improve on.
+
+    Raised for a transient status, and for a 401 on the availability-zone hop. Everything else
+    is determinate -- IMDSv2 disabled, a low hop limit, an empty token, an empty or unparseable
+    AZ, a ConnectTimeout -- and retrying only repeats the same message at the user.
+
+    Not raised for a slow read, because the read is unbounded and there is no ReadTimeout to
+    catch. Anyone bounding it later must add that clause; the retry does not already cover it.
+
+    Must be re-raised past the broad `except Exception` in _get_ec2_region_once.
+    """
+
+
 def _get_ec2_region() -> Optional[str]:
     """
     Gets the AWS region if running on EC2 by querying IMDS.
     Returns None if region could not be detected.
+    """
+    for attempt in range(1, _IMDS_ATTEMPTS + 1):
+        try:
+            return _get_ec2_region_once()
+        except _ImdsTransientError as e:
+            print(f"Failed to detect AWS region: {e}")
+            if attempt < _IMDS_ATTEMPTS:
+                print(f"Retrying region detection ({attempt} of {_IMDS_ATTEMPTS} attempts used)")
+                time.sleep(_IMDS_BACKOFF_S)
+    return None
+
+
+def _get_ec2_region_once() -> Optional[str]:
+    """One attempt at reading the region from IMDS.
+
+    Returns None when the answer is determinate; raises _ImdsTransientError when another attempt
+    may resolve it.
     """
     try:
         # Create IMDSv2 token
         token_response = requests.put(
             url="http://169.254.169.254/latest/api/token",
             headers={"X-aws-ec2-metadata-token-ttl-seconds": "10"},  # 10 second expiry
+            timeout=_IMDS_REQUEST_TIMEOUT,
         )
+        # Checked before the body is used: an error body is non-empty, so `if not token` misses
+        # it, and forwarding it as the token gets a 401 next hop -- surfacing as "unexpected
+        # availability zone" with an error page quoted at the user.
+        if _is_transient_status(token_response.status_code):
+            raise _ImdsTransientError(
+                f"IMDS returned HTTP {token_response.status_code} for the token request"
+            )
+        if token_response.status_code != 200:
+            print(
+                "AWS region could not be detected: IMDS returned HTTP "
+                f"{token_response.status_code} for an IMDSv2 token. IMDSv2 may be disabled, "
+                "or the hop limit may be too low to reach it from here."
+            )
+            return None
+
         token = token_response.text
         if not token:
             raise RuntimeError("Received empty IMDSv2 token")
@@ -49,8 +126,28 @@ def _get_ec2_region() -> Optional[str]:
         az_response = requests.get(
             url="http://169.254.169.254/latest/meta-data/placement/availability-zone",
             headers={"X-aws-ec2-metadata-token": token},
+            timeout=_IMDS_REQUEST_TIMEOUT,
         )
+        # Same reason as the token: throttling is per request, so this hop can fail after the
+        # token succeeded. 401 is transient here only -- it means the 10s token TTL lapsed, and a
+        # fresh token fixes it, whereas a rejected token *request* is not re-obtainable.
+        if _is_transient_status(az_response.status_code) or az_response.status_code == 401:
+            raise _ImdsTransientError(
+                f"IMDS returned HTTP {az_response.status_code} for the availability zone"
+            )
+        if az_response.status_code != 200:
+            print(
+                "AWS region could not be detected: IMDS returned HTTP "
+                f"{az_response.status_code} for the availability zone."
+            )
+            return None
+
         az = az_response.text
+    except _ImdsTransientError:
+        # Re-raised past the broad handler below, which would make a retryable case determinate.
+        # No ReadTimeout clause: the read is unbounded. A ConnectTimeout is the black-holed
+        # workstation and falls through as determinate, which is right.
+        raise
     except Exception as e:
         print(f"Failed to detect AWS region: {e}")
         return None

--- a/src/deadline_worker_agent/startup/bootstrap.py
+++ b/src/deadline_worker_agent/startup/bootstrap.py
@@ -60,6 +60,24 @@ IMDS_RETRY_INITIAL_BACKOFF_SECONDS = 1.0
 IMDS_RETRY_BACKOFF_FACTOR = 2.0
 IMDS_RETRY_MAX_BACKOFF_SECONDS = 16.0
 
+# (connect, read) pairs, since `requests` applies a scalar per phase. The connect half is what
+# needed bounding: the address is link-local, so where nothing answers it the connect waits on
+# ARP rather than being refused, parking the caller.
+#
+# The read halves differ because every failure here is reported as `None`, and a false `None` is
+# expensive: _enforce_no_instance_profile reads it as unreachable and stops the worker, while
+# _get_instance_id has no retry and its `None` silently skips the AMI-staleness check in
+# _load_or_create_worker, adopting the worker_id baked into the AMI.
+IMDS_TOKEN_REQUEST_TIMEOUT = (0.5, 0.5)
+"""Read stays bounded here because it already was -- this hop shipped `timeout=0.5`, which
+`requests` expands to both phases. Dropping it would be a regression, and a hang is worse than
+a false `None`: it never reaches the IMDS_RETRY_* budget, which only runs once this returns."""
+
+IMDS_METADATA_REQUEST_TIMEOUT = (0.5, None)
+"""Read stays unbounded here because it never was bounded; a ceiling would be a new `None`
+path. A half-open connection can still park this hop -- pre-existing, and fixing it needs the
+callers to tell "slow" from "unreachable" rather than conflating both into `None`."""
+
 
 class WorkerDeregisteredError(Exception):
     """Exception raised when Worker is deregistered"""
@@ -727,12 +745,18 @@ def _get_metadata(metadata_type: str) -> requests.Response | None:
         response = requests.put(
             "http://169.254.169.254/latest/api/token",
             headers={"X-aws-ec2-metadata-token-ttl-seconds": "30"},
-            timeout=0.5,  # Non-aws worker hosts will time-out, but the default timeout can be > 20s
+            timeout=IMDS_TOKEN_REQUEST_TIMEOUT,
         )
+        # Neither status is inspected, deliberately: both are the caller's to read, and mapping
+        # them to None would cost more than it buys. 404 on /iam/info is
+        # _enforce_no_instance_profile's success case, and a transient 429/5xx is tolerated by
+        # its ~120s outer loop, which recovers -- where None caps that at the 31s IMDS_RETRY_*
+        # budget and then stops the worker.
         token = response.text
         response = requests.get(
             f"http://169.254.169.254/latest/meta-data/{metadata_type}",
             headers={"X-aws-ec2-metadata-token": token},
+            timeout=IMDS_METADATA_REQUEST_TIMEOUT,
         )
     except Exception:
         _logger.info("Not running on EC2 or the metadata service was unable to be found!")

--- a/src/deadline_worker_agent/worker.py
+++ b/src/deadline_worker_agent/worker.py
@@ -33,6 +33,15 @@ from .sessions import Session
 logger = getLogger(__name__)
 
 
+def _is_usable_imds_status(status_code: int) -> bool:
+    """Whether an IMDS status carries an answer the caller can act on.
+
+    404 included: it is the normal reply on both monitored endpoints -- no interruption pending,
+    or host not in an auto-scaling group.
+    """
+    return status_code in (200, 404)
+
+
 class WorkerSessionCollection:
     def __init__(self, *, worker: Worker) -> None: ...
 
@@ -62,6 +71,30 @@ class Worker:
     """The amount of time to allow the Worker to gracefully shutdown after detecting an auto-scaling
     life-cycle event."""
 
+    _IMDS_REQUEST_TIMEOUT = (1.0, 1.0)
+    """(connect, read) ceiling on one IMDS request.
+
+    The address is link-local, so where nothing answers it the connect waits on ARP rather than
+    being refused, parking the caller. Written as a pair to make the per-attempt cost explicit --
+    a scalar would expand to the same thing -- and because the two halves differ elsewhere in the
+    agent. See TestImdsProbeCost."""
+
+    _IMDS_PROBE_ATTEMPTS = 3
+    """Attempts before concluding a host is not on EC2. Retried because the verdict is
+    permanent -- see _is_ec2_host."""
+
+    _IMDS_PROBE_BACKOFF_S = 0.5
+    """Delay between probe attempts. A throttled IMDS answers immediately, so back-to-back
+    retries would meet the same empty token bucket."""
+
+    _IMDS_RECOVERY_ANSWERS = 3
+    """Consecutive usable answers before a path is considered recovered -- see _imds_answered."""
+
+    _IMDS_CAUSE_SLOW_READ = "the connection was accepted but nothing came back in time"
+    _IMDS_CAUSE_NO_CONNECT = (
+        "no connection was accepted, though the token request answered moments ago"
+    )
+
     _farm_id: str
     _fleet_id: str
     _worker_id: str
@@ -75,6 +108,8 @@ class Worker:
     _worker_persistence_dir: Path
     _host_metrics_logger: HostMetricsLogger | None = None
     _retain_session_dir: bool
+    _imds_unanswered: set[str]
+    _imds_answers: dict[str, int]
 
     def __init__(
         self,
@@ -126,6 +161,12 @@ class Worker:
         self._boto_session = boto_session
         self._worker_persistence_dir = worker_persistence_dir
         self._retain_session_dir = retain_session_dir
+        # The IMDS paths whose last query did not answer, keyed individually. Gates the
+        # warning in _log_imds_unanswered to the transition, per path -- one shared flag
+        # would flap, because the monitor queries two paths per poll and either can time out
+        # while the other answers.
+        self._imds_unanswered = set()
+        self._imds_answers = {}
 
         if host_metrics_logging:
             assert host_metrics_logging_interval_seconds is not None, (
@@ -222,12 +263,15 @@ class Worker:
             futures: list[Future[Any]] = [
                 scheduler_future,
             ]
-            if self._get_ec2_metadata_imdsv2_token():
-                # Create a future for monitoring EC2 shutdown events
-                monitor_ec2_shutdown = self._executor.submit(self._monitor_ec2_shutdown)
-                futures.append(monitor_ec2_shutdown)
-
             try:
+                # Inside the try: the scheduler is already running, so anything raised here
+                # would leave the `with` and have the executor join a scheduler never asked to
+                # stop. The handler below is what prevents that.
+                if self._is_ec2_host():
+                    # Create a future for monitoring EC2 shutdown events
+                    monitor_ec2_shutdown = self._executor.submit(self._monitor_ec2_shutdown)
+                    futures.append(monitor_ec2_shutdown)
+
                 complete_futures, _ = wait(
                     fs=futures,
                     return_when="FIRST_COMPLETED",
@@ -246,21 +290,39 @@ class Worker:
                 for future in complete_futures:
                     if monitor_ec2_shutdown and future is monitor_ec2_shutdown:
                         logger.debug("monitor ec2 shutdown future complete")
-                        worker_shutdown: WorkerShutdown | None = future.result()
-                        # We only stop the other threads if we detected an imminent EC2 shutdown.
-                        # The monitoring thread returns None if the monitor thread was stopped by the OS signal handler
-                        if worker_shutdown:
+                        # This `else:` runs outside the `except BaseException` above, so an
+                        # exception from result() would otherwise leave the `with` and have
+                        # ThreadPoolExecutor.__exit__ join a scheduler never asked to stop.
+                        # Reachable: the monitor parses IMDS responses, and neither
+                        # JSONDecodeError nor ValueError is a RequestException.
+                        #
+                        # Both calls are needed, as in the handler above. self._stop only stops
+                        # the monitor: when entrypoint() is called without a stop event -- every
+                        # non-Windows-service invocation -- WorkerScheduler builds its own Event,
+                        # so self._stop is not the one its run loop waits on.
+                        try:
+                            worker_shutdown: WorkerShutdown | None = future.result()
+                            # We only stop the other threads if we detected an imminent EC2 shutdown.
+                            # The monitoring thread returns None if the monitor thread was stopped by the OS signal handler
+                            if worker_shutdown:
+                                self._scheduler.shutdown(
+                                    grace_time=worker_shutdown.grace_time,
+                                    fail_message=worker_shutdown.fail_message,
+                                )
+                            else:
+                                # If we are here, it's because self._stop.set() was set causing the monitor_ec2_shutdown thread to join.
+                                # The scheduler thread has a longer wait, so let's wake it up so it can join as well.
+                                self._scheduler.shutdown(
+                                    fail_message="The Worker received a shutdown event locally from the host machine."
+                                )
+                        except BaseException as e:
+                            self._scheduler.shutdown(
+                                grace_time=timedelta(seconds=5),
+                                fail_message=f"Worker Agent encountered error: {e}",
+                            )
+                            raise
+                        finally:
                             self._stop.set()
-                            self._scheduler.shutdown(
-                                grace_time=worker_shutdown.grace_time,
-                                fail_message=worker_shutdown.fail_message,
-                            )
-                        else:
-                            # If we are here, it's because self._stop.set() was set causing the monitor_ec2_shutdown thread to join.
-                            # The scheduler thread has a longer wait, so let's wake it up so it can join as well.
-                            self._scheduler.shutdown(
-                                fail_message="The Worker received a shutdown event locally from the host machine."
-                            )
                     elif future is scheduler_future:
                         logger.debug("scheduler future complete")
                         try:
@@ -346,12 +408,16 @@ class Worker:
         monitor_ec2_shutdown_rate = Worker._EC2_SHUTDOWN_MONITOR_RATE.total_seconds()
         while not self._stop.wait(timeout=monitor_ec2_shutdown_rate):
             if not (imdsv2_token := self._get_ec2_metadata_imdsv2_token()):
-                # Not on EC2 or IMDSv2 is inactive.
-                logger.info(
+                # _is_ec2_host gated this thread on IMDS answering, so a token that now fails
+                # is the same condition the queries below warn about, not "not on EC2". Same
+                # suppression, since this is the first thing every failing poll logs.
+                self._log_imds_unanswered("api/token", cause="the request returned no token")
+                logger.debug(
                     "IMDS unavailable - unable to monitor for spot interruption or ASG life-cycle "
                     "changes"
                 )
                 continue
+            self._imds_answered("api/token")
 
             # Check for spot interruption or shutdown
             if (
@@ -378,6 +444,44 @@ class Worker:
 
         return None
 
+    def _is_ec2_host(self) -> bool:
+        """Whether to monitor for EC2 spot interruption and ASG lifecycle changes.
+
+        Retried because the verdict is taken once, at startup, and a negative permanently skips
+        monitoring for the life of the process -- so one slow probe during boot must not disable
+        interruption handling on a real EC2 host. Costs nothing where IMDS answers; see
+        TestImdsProbeCost for where it does not.
+
+        Making the verdict revisable would be the fuller fix -- _monitor_ec2_shutdown already
+        tolerates failure per poll -- but it changes behaviour on every fleet, so it is left out
+        of a change whose job is bounding the requests.
+        """
+        for attempt in range(1, Worker._IMDS_PROBE_ATTEMPTS + 1):
+            if self._get_ec2_metadata_imdsv2_token():
+                return True
+            if attempt < Worker._IMDS_PROBE_ATTEMPTS:
+                logger.debug(
+                    "IMDS did not answer on attempt %d of %d; retrying",
+                    attempt,
+                    Worker._IMDS_PROBE_ATTEMPTS,
+                )
+                # wait() returns the flag, so this sleeps and checks for shutdown at once.
+                # Abandoning on stop: the monitor this gates would only be asked to stop.
+                if self._stop.wait(timeout=Worker._IMDS_PROBE_BACKOFF_S):
+                    logger.debug("Stop requested while probing IMDS; abandoning the probe")
+                    return False
+        # info, not warning: a customer-managed fleet on non-EC2 hardware reaches this on every
+        # start, and it is correct behaviour there. Something is only wrong if the host *is* on
+        # EC2, which this cannot tell -- so the monitor's own warnings, which run only after a
+        # token succeeded, are where a real IMDS problem gets flagged.
+        logger.info(
+            "IMDS did not answer in %d attempts, so this host is treated as not being an "
+            "EC2 instance. Spot interruption and ASG life-cycle changes will not be "
+            "monitored for the life of this process.",
+            Worker._IMDS_PROBE_ATTEMPTS,
+        )
+        return False
+
     def _get_ec2_metadata_imdsv2_token(self) -> str | None:
         """Query the EC2 Metadata service to obtain an IMDSv2 token to use in further queries to the
         service.
@@ -394,10 +498,14 @@ class Worker:
             response = requests.put(
                 "http://169.254.169.254/latest/api/token",
                 headers={"X-aws-ec2-metadata-token-ttl-seconds": "10"},
+                timeout=Worker._IMDS_REQUEST_TIMEOUT,
             )
-        except requests.ConnectionError:
+        except requests.RequestException:
             # Could not connect to the metadata service. Either it's not enabled or we're not
             # on an EC2 instance.
+            #
+            # The whole RequestException family, not just (ConnectionError, Timeout): "not on
+            # EC2" is the right answer for every sibling, and none says anything more useful.
             return None
 
         if response.status_code == 200:
@@ -425,11 +533,32 @@ class Worker:
             response = requests.get(
                 "http://169.254.169.254/latest/meta-data/spot/instance-action",
                 headers={"X-aws-ec2-metadata-token": imdsv2_token},
+                timeout=Worker._IMDS_REQUEST_TIMEOUT,
             )
-        except requests.ConnectionError:
+        except requests.ReadTimeout:
+            # Logged because None is not "unknown" to the caller, it is "no interruption
+            # pending" -- indistinguishable from a real answer. ReadTimeout not Timeout, since
+            # ConnectTimeout subclasses both and means the opposite; see the next clause.
+            self._log_imds_unanswered("spot/instance-action", cause=Worker._IMDS_CAUSE_SLOW_READ)
+            return None
+        except requests.ConnectTimeout:
+            # Reaching this method means the token just succeeded, so a connect that now times
+            # out is anomalous rather than the ordinary not-on-EC2 case below.
+            self._log_imds_unanswered("spot/instance-action", cause=Worker._IMDS_CAUSE_NO_CONNECT)
+            return None
+        except requests.RequestException:
             # Could not connect to the metadata service. Either it's inactive or we're not
             # on an EC2 instance.
             return None
+
+        # Getting bytes back is not getting an answer: a 429 produces the same silent "no
+        # interruption pending" a timeout does.
+        if not _is_usable_imds_status(response.status_code):
+            self._log_imds_unanswered(
+                "spot/instance-action", cause=f"it returned HTTP {response.status_code}"
+            )
+            return None
+        self._imds_answered("spot/instance-action")
 
         if response.status_code == 200:
             decoded_response = json.loads(response.text)
@@ -476,10 +605,75 @@ class Worker:
             response = requests.get(
                 "http://169.254.169.254/latest/meta-data/autoscaling/target-lifecycle-state",
                 headers={"X-aws-ec2-metadata-token": imdsv2_token},
+                timeout=Worker._IMDS_REQUEST_TIMEOUT,
             )
-        except requests.ConnectionError:
+        except requests.ReadTimeout:
+            # As above: False means "not terminating", so an unlogged timeout is
+            # indistinguishable from an answer.
+            self._log_imds_unanswered(
+                "autoscaling/target-lifecycle-state", cause=Worker._IMDS_CAUSE_SLOW_READ
+            )
             return False
+        except requests.ConnectTimeout:
+            self._log_imds_unanswered(
+                "autoscaling/target-lifecycle-state", cause=Worker._IMDS_CAUSE_NO_CONNECT
+            )
+            return False
+        except requests.RequestException:
+            return False
+
+        # As above; 404 here is what a host outside an auto-scaling group gets.
+        if not _is_usable_imds_status(response.status_code):
+            self._log_imds_unanswered(
+                "autoscaling/target-lifecycle-state",
+                cause=f"it returned HTTP {response.status_code}",
+            )
+            return False
+        self._imds_answered("autoscaling/target-lifecycle-state")
 
         if response.status_code == 200:
             return response.text == "Terminated"
         return False
+
+    def _log_imds_unanswered(self, path: str, *, cause: str) -> None:
+        """Report an IMDS path that gave no usable answer, once per outage.
+
+        Warns on the transition only: the monitor polls once a second, so an unconditional
+        warning is 3600 lines an hour and buries itself.
+
+        Per path, not one flag. The monitor queries several paths per poll, so a shared flag
+        would be set by one and cleared by the next within an iteration -- a warning plus a
+        false recovery every second.
+        """
+        self._imds_answers.pop(path, None)
+        if path in self._imds_unanswered:
+            return
+        self._imds_unanswered.add(path)
+        logger.warning(
+            "IMDS gave no usable answer for %s: %s. Treating it as no pending shutdown, so a "
+            "spot interruption or ASG life-cycle change could be missed while this persists.",
+            path,
+            cause,
+        )
+
+    def _imds_answered(self, path: str) -> None:
+        """Count an answer, and clear the path once it has answered consistently.
+
+        Only after _IMDS_RECOVERY_ANSWERS in a row, because clearing on the first one re-arms the
+        warning immediately: an IMDS alternating between 429 and 200 -- the shape a shared token
+        bucket produces -- would then warn on every other poll, which is the volume the
+        suppression exists to avoid. Requiring a streak means an intermittent path warns once and
+        a genuinely recovered one still reports.
+
+        Per path, since another may still be unanswered and a recovery claimed on its behalf
+        would be false.
+        """
+        if path not in self._imds_unanswered:
+            return
+        answers = self._imds_answers.get(path, 0) + 1
+        if answers < Worker._IMDS_RECOVERY_ANSWERS:
+            self._imds_answers[path] = answers
+            return
+        self._imds_unanswered.discard(path)
+        self._imds_answers.pop(path, None)
+        logger.info("IMDS is answering %s again.", path)

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -11,6 +11,7 @@ import sysconfig
 import typing
 
 import pytest
+import requests
 
 from deadline_worker_agent.installer import (
     ParsedCommandLineArguments,
@@ -226,6 +227,182 @@ class TestGetEc2Region:
         with patch.object(installer_mod.requests, "put") as m:
             yield m
 
+    @pytest.fixture(autouse=True)
+    def az_hop_is_ok(self, mock_requests_get: MagicMock) -> MagicMock:
+        """A bare MagicMock's status_code compares unequal to 200, and this hop is now checked."""
+        mock_requests_get.return_value.status_code = 200
+        return mock_requests_get
+
+    @pytest.fixture(autouse=True)
+    def token_is_ok(self, mock_requests_put: MagicMock) -> MagicMock:
+        """As above: the code now rejects a non-200 token rather than forwarding its body."""
+        mock_requests_put.return_value.status_code = 200
+        return mock_requests_put
+
+    @pytest.fixture(autouse=True)
+    def no_real_backoff(self) -> Generator[MagicMock, None, None]:
+        """Keep the retry backoff out of the suite's wall-clock time."""
+        with patch.object(installer_mod.time, "sleep") as m:
+            yield m
+
+    @pytest.mark.parametrize(
+        ["status_code", "expected_output"],
+        [
+            pytest.param(403, "IMDSv2 may be disabled", id="imdsv2-disabled"),
+            pytest.param(401, "returned HTTP 401", id="unauthorized"),
+            pytest.param(404, "returned HTTP 404", id="not-found"),
+        ],
+    )
+    def test_names_the_cause_when_the_token_is_rejected(
+        self,
+        status_code: int,
+        expected_output: str,
+        mock_requests_put: MagicMock,
+        mock_requests_get: MagicMock,
+        no_real_backoff: MagicMock,
+        capfd: pytest.CaptureFixture,
+    ) -> None:
+        """An error body is non-empty, so an emptiness check misses it -- forwarded as a token it
+        gets a 401 next hop and surfaces as "unexpected availability zone"."""
+        mock_requests_put.return_value.status_code = status_code
+
+        assert installer_mod._get_ec2_region() is None
+        out, _ = capfd.readouterr()
+        assert expected_output in out
+        # Determinate, so no second hop and no retry.
+        mock_requests_get.assert_not_called()
+        no_real_backoff.assert_not_called()
+
+    def test_names_the_cause_when_the_az_hop_is_rejected(
+        self,
+        mock_requests_get: MagicMock,
+        no_real_backoff: MagicMock,
+        capfd: pytest.CaptureFixture,
+    ) -> None:
+        """Unchecked, the error body becomes `az` and is reported as an unexpected availability
+        zone -- the token check's misattribution, one hop later."""
+        # 403 rather than 401: a 401 here means a lapsed token and is retried, per
+        # test_retries_a_lapsed_token_on_the_az_hop.
+        mock_requests_get.return_value.status_code = 403
+
+        assert installer_mod._get_ec2_region() is None
+        out, _ = capfd.readouterr()
+        assert "HTTP 403 for the availability zone" in out
+        no_real_backoff.assert_not_called()
+
+    def test_retries_a_throttled_az_hop(
+        self, mock_requests_get: MagicMock, mock_requests_put: MagicMock
+    ) -> None:
+        """A 429 here arrives as a body, not an exception, so it needs its own check to retry."""
+        mock_requests_get.side_effect = [
+            MagicMock(status_code=429),
+            MagicMock(status_code=200, text="us-east-1a"),
+        ]
+
+        assert installer_mod._get_ec2_region() == "us-east-1"
+        assert mock_requests_get.call_count == 2
+
+    @pytest.mark.parametrize("status_code", [429, 500, 503])
+    def test_retries_a_transient_token_status(
+        self, status_code: int, mock_requests_put: MagicMock, mock_requests_get: MagicMock
+    ) -> None:
+        """Boot is when a user-data install runs and when the metadata service is not yet up, so
+        treating 500/503 as final would leave the retry covering half the transient set."""
+        mock_requests_put.side_effect = [
+            MagicMock(status_code=status_code),
+            MagicMock(status_code=200, text="TOKEN"),
+        ]
+        mock_requests_get.return_value.text = "ap-southeast-2c"
+
+        assert installer_mod._get_ec2_region() == "ap-southeast-2"
+        assert mock_requests_put.call_count == 2
+
+    def test_retries_a_lapsed_token_on_the_az_hop(
+        self, mock_requests_put: MagicMock, mock_requests_get: MagicMock
+    ) -> None:
+        """The 10s token TTL can lapse between the two calls, so a fresh token fixes it.
+        Transient on this hop only -- a rejected token *request* is not re-obtainable."""
+        mock_requests_get.side_effect = [
+            MagicMock(status_code=401),
+            MagicMock(status_code=200, text="eu-central-1a"),
+        ]
+
+        assert installer_mod._get_ec2_region() == "eu-central-1"
+        assert mock_requests_put.call_count == 2
+
+    @pytest.mark.parametrize(
+        ["az", "reason"],
+        [
+            pytest.param("", "an empty availability zone", id="empty-az"),
+            pytest.param("not-an-az", "an AZ that fails the regex", id="unparseable-az"),
+        ],
+    )
+    def test_does_not_retry_a_determinate_answer(
+        self,
+        az: str,
+        reason: str,
+        mock_requests_get: MagicMock,
+        mock_requests_put: MagicMock,
+        no_real_backoff: MagicMock,
+    ) -> None:
+        """A workstation install with no --region expects None, so retrying makes one failure read
+        as three."""
+        mock_requests_get.return_value.text = az
+
+        assert installer_mod._get_ec2_region() is None, reason
+        mock_requests_put.assert_called_once()
+        no_real_backoff.assert_not_called()
+
+    def test_does_not_retry_a_black_holed_address(
+        self, mock_requests_put: MagicMock, no_real_backoff: MagicMock
+    ) -> None:
+        """ConnectTimeout subclasses both ConnectionError and Timeout, so a handler keyed on
+        Timeout would make the workstation case retryable -- five lines and ~4s for an answer
+        known on the first attempt."""
+        mock_requests_put.side_effect = requests.ConnectTimeout("connect timed out")
+
+        assert installer_mod._get_ec2_region() is None
+        mock_requests_put.assert_called_once()
+        no_real_backoff.assert_not_called()
+
+    def test_retries_a_slow_answer_rather_than_failing_the_install(
+        self, mock_requests_put: MagicMock, mock_requests_get: MagicMock
+    ) -> None:
+        """`install()` exits 1 on None, and user-data installs run during boot, so bounding the
+        request cannot be the whole story."""
+        # GIVEN: the first attempt times out, the second answers
+        region = "us-west-2"
+        mock_requests_put.side_effect = [
+            MagicMock(status_code=503),
+            MagicMock(status_code=200, text="TOKEN"),
+        ]
+        mock_requests_get.return_value.text = f"{region}b"
+
+        # WHEN / THEN
+        assert installer_mod._get_ec2_region() == region
+        assert mock_requests_put.call_count == 2
+
+    def test_gives_up_after_the_attempt_budget(
+        self, mock_requests_put: MagicMock, no_real_backoff: MagicMock
+    ) -> None:
+        # GIVEN
+        mock_requests_put.side_effect = [MagicMock(status_code=503)] * installer_mod._IMDS_ATTEMPTS
+
+        # WHEN / THEN
+        assert installer_mod._get_ec2_region() is None
+        assert mock_requests_put.call_count == installer_mod._IMDS_ATTEMPTS
+        # Between attempts, not after the last.
+        assert no_real_backoff.call_count == installer_mod._IMDS_ATTEMPTS - 1
+
+    def test_does_not_retry_a_host_that_answers(
+        self, mock_requests_get: MagicMock, no_real_backoff: MagicMock
+    ) -> None:
+        """Control: no delay is paid on an EC2 host, which is the case that matters at boot."""
+        mock_requests_get.return_value.text = "eu-west-1a"
+
+        assert installer_mod._get_ec2_region() == "eu-west-1"
+        no_real_backoff.assert_not_called()
+
     def test_gets_ec2_region(self, mock_requests_get: MagicMock, mock_requests_put: MagicMock):
         # GIVEN
         region = "us-east-2"
@@ -238,13 +415,17 @@ class TestGetEc2Region:
 
         # THEN
         assert actual == region
+        # Both carry a timeout: unbounded, a non-EC2 host that black-holes the
+        # link-local address stalls the installer with no output.
         mock_requests_put.assert_called_once_with(
             url="http://169.254.169.254/latest/api/token",
             headers={"X-aws-ec2-metadata-token-ttl-seconds": "10"},
+            timeout=installer_mod._IMDS_REQUEST_TIMEOUT,
         )
         mock_requests_get.assert_called_once_with(
             url="http://169.254.169.254/latest/meta-data/placement/availability-zone",
             headers={"X-aws-ec2-metadata-token": mock_requests_put.return_value.text},
+            timeout=installer_mod._IMDS_REQUEST_TIMEOUT,
         )
 
     @pytest.mark.parametrize(
@@ -252,6 +433,10 @@ class TestGetEc2Region:
         [
             [Exception(), None],  # token request fails
             [None, Exception()],  # az request fails
+            # A black-holed metadata address: the case the timeout turns into this
+            # branch rather than a stall.
+            [requests.ConnectTimeout(), None],
+            [None, requests.ConnectTimeout()],
         ],
     )
     def test_fails_if_request_raises(

--- a/test/unit/startup/test_bootstrap.py
+++ b/test/unit/startup/test_bootstrap.py
@@ -1014,6 +1014,50 @@ class TestEnforceNoInstanceProfile:
         )
         assert result is None
 
+    def test_a_connect_timeout_reads_as_not_on_ec2(
+        self,
+        mod_logger_mock: MagicMock,
+    ) -> None:
+        """ConnectTimeout subclasses both ConnectionError and Timeout, so a handler catching
+        Timeout would warn on every non-EC2 host, naming the wrong cause."""
+        # GIVEN
+        with patch.object(
+            bootstrap_mod.requests,
+            "put",
+            side_effect=bootstrap_mod.requests.ConnectTimeout("connect timed out"),
+        ):
+            # WHEN
+            result = bootstrap_mod._get_metadata("instance-id")
+
+        # THEN
+        assert result is None
+        mod_logger_mock.info.assert_called_once_with(
+            "Not running on EC2 or the metadata service was unable to be found!",
+        )
+        mod_logger_mock.warning.assert_not_called()
+
+    def test_the_token_hop_keeps_its_read_bound(
+        self,
+    ) -> None:
+        """This hop shipped `timeout=0.5`, which requests applies to read too, so dropping the
+        read half would be a regression. A hang is worse than a false `None`: it never reaches
+        the IMDS_RETRY_* budget, which only runs once this call returns."""
+        connect, read = bootstrap_mod.IMDS_TOKEN_REQUEST_TIMEOUT
+
+        assert connect == 0.5
+        assert read == 0.5, "this hop shipped with a bounded read; do not drop it"
+
+    def test_the_metadata_hop_leaves_the_read_unbounded(
+        self,
+    ) -> None:
+        """This hop had no timeout, so only its connect is newly bounded. A read ceiling would be
+        a new `None` path, which stops the worker on one call path and silently skips the
+        AMI-staleness check on the other."""
+        connect, read = bootstrap_mod.IMDS_METADATA_REQUEST_TIMEOUT
+
+        assert connect is not None, "the link-local connect must stay bounded"
+        assert read is None, "a read ceiling here would make a slow IMDS fail the worker"
+
     def test_imds_none_then_recovers(
         self,
         get_metadata_mock: MagicMock,

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, call, patch
 from pathlib import Path
 
 import pytest
+import requests
 
 from deadline_worker_agent import Worker
 from deadline_worker_agent.config import JobsRunAsUserOverride
@@ -104,6 +105,36 @@ def mock_signal() -> Generator[MagicMock, None, None]:
         yield mock_signal
 
 
+class TestImdsProbeCost:
+    """Pins what the three probe constants cost together, so prose arithmetic cannot drift.
+
+    Not a guarantee: urllib3's read timeout is per-socket-read inactivity with no `total` set, so
+    a peer dribbling bytes can keep one attempt alive indefinitely. A true ceiling would need
+    urllib3.Timeout(total=...), i.e. depending directly on a transitive dependency. This is the
+    expected cost against a peer that answers or goes silent.
+    """
+
+    def test_expected_cost_against_a_silent_peer(self) -> None:
+        connect, read = Worker._IMDS_REQUEST_TIMEOUT
+        attempts = Worker._IMDS_PROBE_ATTEMPTS
+
+        # Both halves, because requests applies each to its own phase -- one attempt can spend
+        # connect + read, not one of the two.
+        expected = attempts * (connect + read) + (attempts - 1) * Worker._IMDS_PROBE_BACKOFF_S
+
+        assert expected == 7.0
+
+    def test_a_black_holed_address_costs_less(self) -> None:
+        """Nothing answers ARP, so each attempt fails in connect -- the figure above overstates
+        what an ordinary workstation or runner pays."""
+        connect, _read = Worker._IMDS_REQUEST_TIMEOUT
+        attempts = Worker._IMDS_PROBE_ATTEMPTS
+
+        connect_only = attempts * connect + (attempts - 1) * Worker._IMDS_PROBE_BACKOFF_S
+
+        assert connect_only == 4.0
+
+
 def test_monitor_rate() -> None:
     """Asserts that Worker._MONITOR_RATE (the rate between polling for spot interruption and ASG
     life-cycle events) is once per second.
@@ -178,6 +209,74 @@ class TestInit:
 
 
 class TestRun:
+    @pytest.fixture(autouse=True)
+    def imds_answers(self, requests_put: MagicMock) -> MagicMock:
+        """Let the startup probe succeed first try: otherwise it pays the real backoff twice,
+        and a negative verdict leaves the monitor-future branch these tests set up unexercised."""
+        requests_put.return_value.status_code = 200
+        requests_put.return_value.text = "TOKEN"
+        return requests_put
+
+    def test_a_raising_ec2_probe_shuts_the_scheduler_down(
+        self,
+        worker: Worker,
+        thread_pool_executor: MagicMock,
+        scheduler: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """The scheduler is already submitted when the probe runs, and the `with` joins it on the
+        way out -- so without this cleanup that join never returns and SIGTERM cannot kill the
+        worker. Holds for any exception type, not only ones the probe's handler catches."""
+        # GIVEN
+        boom = RuntimeError("something the probe's own handlers do not cover")
+        with (
+            patch.object(worker, "_is_ec2_host", side_effect=boom),
+            patch.object(worker_mod, "AwsCredentialsRefresher"),
+            # THEN
+            pytest.raises(RuntimeError) as raise_ctx,
+        ):
+            # WHEN
+            worker.run()
+
+        # THEN
+        assert raise_ctx.value is boom
+        scheduler.shutdown.assert_called_once()
+        assert worker._stop.is_set()
+
+    def test_a_raising_monitor_future_does_not_hang_the_executor(
+        self,
+        worker: Worker,
+        thread_pool_executor: MagicMock,
+        scheduler: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """result() re-raises from outside `except BaseException`, so without the try/finally the
+        executor joins a scheduler never asked to stop. Reachable: the monitor parses IMDS
+        responses, and JSONDecodeError is not a RequestException."""
+        # GIVEN: the monitor future completed by raising
+        boom = ValueError("Invalid isoformat string")
+        monitor_future = MagicMock()
+        monitor_future.result.side_effect = boom
+        scheduler_future = MagicMock()
+        thread_pool_executor.submit.side_effect = [scheduler_future, monitor_future]
+
+        with (
+            patch.object(worker, "_is_ec2_host", return_value=True),
+            patch.object(worker_mod, "wait", return_value=([monitor_future], [])),
+            patch.object(worker_mod, "AwsCredentialsRefresher"),
+            # THEN
+            pytest.raises(ValueError) as raise_ctx,
+        ):
+            # WHEN
+            worker.run()
+
+        # THEN: it propagated, and both stops happened. The scheduler assertion is the
+        # load-bearing one: _stop alone does not stop the scheduler, because it builds its own
+        # Event whenever entrypoint() is called without one.
+        assert raise_ctx.value is boom
+        scheduler.shutdown.assert_called_once()
+        assert worker._stop.is_set()
+
     def test_service_shutdown_raised_not_logged(
         self,
         worker: Worker,
@@ -308,7 +407,10 @@ class TestMonitorEc2Shutdown:
             result = worker._monitor_ec2_shutdown()
 
         # THEN
-        logger_info.assert_has_calls(
+        # At debug, not info: this is the first thing every failing poll logs, so at 1 Hz an
+        # info line here buries the warning that names the condition. That warning is emitted
+        # once, on the transition, by _log_imds_unanswered.
+        mock_logger.debug.assert_has_calls(
             [
                 call(
                     "IMDS unavailable - unable to monitor for spot interruption or ASG life-cycle changes"
@@ -318,6 +420,8 @@ class TestMonitorEc2Shutdown:
                 ),
             ]
         )
+        logger_info.assert_not_called()
+        mock_logger.warning.assert_called_once()
         assert result is None
 
     def test_asg_termination(
@@ -406,6 +510,7 @@ class TestEC2MetadataQueries:
         requests_put.assert_called_once_with(
             "http://169.254.169.254/latest/api/token",
             headers={"X-aws-ec2-metadata-token-ttl-seconds": "10"},
+            timeout=Worker._IMDS_REQUEST_TIMEOUT,
         )
 
     def test_get_imdsv2_token_cannot_connect(self, worker: Worker, requests_put: MagicMock) -> None:
@@ -463,6 +568,7 @@ class TestEC2MetadataQueries:
         requests_get.assert_called_once_with(
             "http://169.254.169.254/latest/meta-data/spot/instance-action",
             headers={"X-aws-ec2-metadata-token": fake_token},
+            timeout=Worker._IMDS_REQUEST_TIMEOUT,
         )
         if not is_interrupt:
             assert result is None
@@ -575,6 +681,7 @@ class TestEC2MetadataQueries:
         requests_get.assert_called_once_with(
             "http://169.254.169.254/latest/meta-data/autoscaling/target-lifecycle-state",
             headers={"X-aws-ec2-metadata-token": fake_token},
+            timeout=Worker._IMDS_REQUEST_TIMEOUT,
         )
 
     def test_asg_terminate_cannot_connect(self, worker: Worker, requests_get: MagicMock) -> None:
@@ -598,3 +705,343 @@ class TestEC2MetadataQueries:
 
         # THEN
         assert not result
+
+
+class TestIsEc2Host:
+    """The startup determination that gates EC2 shutdown monitoring.
+
+    Taken once, at startup, and a negative permanently skips spot-interruption and ASG
+    life-cycle handling for the life of the process -- so a single slow or throttled
+    probe must not decide it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def no_real_backoff(self, worker: Worker) -> Generator[MagicMock, None, None]:
+        """Keep the retry backoff out of the suite's wall-clock time.
+
+        Patched on the Event rather than on time.sleep so the tests still exercise the real
+        call the implementation makes. `False` is the return the implementation reads as
+        "not stopped, keep probing", so this stands in for a backoff that elapsed.
+        """
+        with patch.object(worker._stop, "wait", return_value=False) as m:
+            yield m
+
+    def test_first_answer_wins(self, worker: Worker, no_real_backoff: MagicMock) -> None:
+        with patch.object(worker, "_get_ec2_metadata_imdsv2_token", return_value="TOKEN") as probe:
+            assert worker._is_ec2_host() is True
+
+        # No wasted probes on the host where this normally answers in about a millisecond.
+        probe.assert_called_once()
+        # And no delay paid on an EC2 fleet, which is the case that matters for startup.
+        no_real_backoff.assert_not_called()
+
+    def test_a_slow_probe_does_not_decide_it(self, worker: Worker) -> None:
+        """Instance boot is when this runs and when IMDS is most likely to be slow."""
+        with patch.object(
+            worker, "_get_ec2_metadata_imdsv2_token", side_effect=[None, None, "TOKEN"]
+        ) as probe:
+            assert worker._is_ec2_host() is True
+
+        assert probe.call_count == 3
+
+    def test_backs_off_between_attempts(self, worker: Worker, no_real_backoff: MagicMock) -> None:
+        """A throttled IMDS answers immediately, so back-to-back retries would be useless.
+
+        They would meet the same empty token bucket microseconds apart, leaving the retry
+        covering only the slow case.
+        """
+        with patch.object(worker, "_get_ec2_metadata_imdsv2_token", return_value=None):
+            assert worker._is_ec2_host() is False
+
+        # Between attempts, not after the last one.
+        assert no_real_backoff.call_count == Worker._IMDS_PROBE_ATTEMPTS - 1
+        for backoff_call in no_real_backoff.call_args_list:
+            assert backoff_call.kwargs["timeout"] == Worker._IMDS_PROBE_BACKOFF_S
+
+    def test_abandons_the_probe_when_stop_is_requested(self, worker: Worker) -> None:
+        """Shutdown during the backoff must not hold the startup path for the full budget.
+
+        The monitor this gates would only be asked to stop, so there is nothing to wait for.
+        """
+        with (
+            # One patch, because the implementation reads the flag from wait's return value
+            # rather than following it with a second is_set().
+            patch.object(worker._stop, "wait", return_value=True),
+            patch.object(worker, "_get_ec2_metadata_imdsv2_token", return_value=None) as probe,
+        ):
+            assert worker._is_ec2_host() is False
+
+        probe.assert_called_once()
+
+    def test_gives_up_after_the_attempt_budget(self, worker: Worker) -> None:
+        with patch.object(worker, "_get_ec2_metadata_imdsv2_token", return_value=None) as probe:
+            assert worker._is_ec2_host() is False
+
+        assert probe.call_count == Worker._IMDS_PROBE_ATTEMPTS
+
+    def test_says_so_when_monitoring_is_disabled(self, worker: Worker) -> None:
+        """Nothing else on this path reports that interruption handling was turned off."""
+        with (
+            patch.object(worker, "_get_ec2_metadata_imdsv2_token", return_value=None),
+            patch.object(worker_mod.logger, "info") as logger_info,
+        ):
+            worker._is_ec2_host()
+
+        logger_info.assert_called_once()
+        assert "not be" in logger_info.call_args.args[0]
+
+
+class TestImdsTimeoutIsVisible:
+    """A timed-out interruption query must not pass for "nothing is shutting down".
+
+    None and False are the caller's "no interruption pending", indistinguishable from a real
+    answer -- so a reachable-but-slow IMDS would report all-clear every second and a missed spot
+    notice would leave nothing to diagnose.
+    """
+
+    def test_a_timed_out_spot_query_warns(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        requests_get.side_effect = requests.ReadTimeout("timed out")
+
+        assert worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="TOKEN") is None
+
+        mock_logger.warning.assert_called_once()
+        assert "no usable answer" in mock_logger.warning.call_args.args[0]
+        assert Worker._IMDS_CAUSE_SLOW_READ in mock_logger.warning.call_args.args
+
+    def test_a_timed_out_asg_query_warns(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        requests_get.side_effect = requests.ReadTimeout("timed out")
+
+        assert worker._is_asg_terminated(imdsv2_token="TOKEN") is False
+
+        mock_logger.warning.assert_called_once()
+
+    def test_a_connection_error_does_not_warn(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """Control: the not-on-EC2 case is not a slow IMDS and has its own reporting.
+
+        Warning there would fire on every poll of every non-EC2 worker.
+        """
+        requests_get.side_effect = requests.ConnectionError("no route")
+
+        assert worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="TOKEN") is None
+
+        mock_logger.warning.assert_not_called()
+
+    def test_it_warns_once_per_outage_not_once_per_poll(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """The monitor polls once a second, so an unconditional warning would bury itself.
+
+        3600 identical lines an hour hides the thing the warning exists to surface.
+        """
+        requests_get.side_effect = requests.ReadTimeout("timed out")
+
+        for _ in range(5):
+            worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="TOKEN")
+
+        mock_logger.warning.assert_called_once()
+
+    def test_a_404_counts_as_answered(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """404 is the normal reply on both endpoints, so it must not read as unanswered.
+
+        /spot/instance-action returns it when no interruption is pending and
+        /autoscaling/target-lifecycle-state when the host is not in an ASG -- the steady state of
+        a healthy worker. Warning there would fire on every healthy fleet, and because the state
+        suppresses repeats it would then stay quiet through a real outage.
+        """
+        requests_get.return_value = MagicMock(status_code=404)
+
+        assert worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="TOKEN") is None
+        assert worker._is_asg_terminated(imdsv2_token="TOKEN") is False
+
+        mock_logger.warning.assert_not_called()
+        assert worker._imds_unanswered == set()
+
+    @pytest.mark.parametrize("status_code", [429, 500, 503])
+    def test_an_unusable_status_warns_like_a_timeout(
+        self, status_code: int, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """Getting bytes back is not getting an answer.
+
+        A 429 produces the same silent "no interruption pending" a timeout does, and throttling
+        is per-request against a path polled once a second, so it is at least as likely.
+        """
+        requests_get.return_value = MagicMock(status_code=status_code)
+
+        assert worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="TOKEN") is None
+
+        mock_logger.warning.assert_called_once()
+        assert f"HTTP {status_code}" in str(mock_logger.warning.call_args)
+
+    def test_an_error_status_is_not_a_recovery(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """A timeout followed by a 429 has not recovered, and must not say so."""
+        requests_get.side_effect = [
+            requests.ReadTimeout("timed out"),
+            MagicMock(status_code=429),
+        ]
+
+        for _ in range(2):
+            worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="TOKEN")
+
+        assert not any("is answering" in str(c) for c in mock_logger.info.call_args_list), (
+            mock_logger.info.call_args_list
+        )
+        assert "spot/instance-action" in worker._imds_unanswered
+
+    def test_a_failing_token_hop_warns_once_not_once_per_poll(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """The token hop is the first thing every failing poll hits.
+
+        Left unsuppressed it emits a line a second and buries the warnings from the two queries
+        below it -- and after _is_ec2_host gated this thread on IMDS answering, a token that now
+        fails is the same condition, not "not on EC2".
+        """
+        with (
+            patch.object(worker, "_get_ec2_metadata_imdsv2_token", return_value=None),
+            patch.object(worker._stop, "wait", side_effect=[False, False, False, True]),
+        ):
+            worker._monitor_ec2_shutdown()
+
+        mock_logger.warning.assert_called_once()
+        assert "api/token" in str(mock_logger.warning.call_args)
+
+    def test_an_alternating_path_warns_once_not_on_every_flip(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """A shared IMDS token bucket produces bursty 429s, not a clean outage.
+
+        Clearing the state on the first good answer would re-arm immediately, so alternating
+        429/200 would warn every other poll -- worse than the volume the suppression exists to
+        avoid, and worse than mainline, which was silent here.
+        """
+        throttled = MagicMock(status_code=429)
+        answered = MagicMock(status_code=404)
+        requests_get.side_effect = [throttled, answered] * 6
+
+        for _ in range(12):
+            worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="TOKEN")
+
+        mock_logger.warning.assert_called_once()
+        assert not any("is answering" in str(c) for c in mock_logger.info.call_args_list)
+
+    def test_a_non_ec2_host_does_not_warn(self, worker: Worker, mock_logger: MagicMock) -> None:
+        """Every customer-managed fleet on non-EC2 hardware reaches this on each start.
+
+        It is correct behaviour there, so it must not read as a fault. Mainline logged nothing.
+        """
+        with patch.object(worker, "_get_ec2_metadata_imdsv2_token", return_value=None):
+            with patch.object(worker._stop, "wait", return_value=False):
+                assert worker._is_ec2_host() is False
+
+        mock_logger.warning.assert_not_called()
+        assert any("not being an" in str(c.args[0]) for c in mock_logger.info.call_args_list)
+
+    def test_one_slow_path_does_not_flap_against_a_fast_one(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """The realistic partial-slowness case, driven through the monitor loop.
+
+        _monitor_ec2_shutdown queries both paths per poll, so a spot query over the read bound
+        followed by an ASG query under it is the case a single shared flag got wrong: set by the
+        first, cleared by the second, producing a warning and a spurious recovery every second.
+        Driven through the loop rather than the queries directly, because that interleaving is
+        the whole defect and calling either query alone cannot reproduce it.
+        """
+
+        # GIVEN: spot always read-times-out, ASG always answers "not terminating"
+        def get(url: str, **kwargs: object) -> MagicMock:
+            if "spot/instance-action" in url:
+                raise requests.ReadTimeout("timed out")
+            return MagicMock(status_code=200, text="InService")
+
+        requests_get.side_effect = get
+
+        # WHEN: three polls, then stop
+        with patch.object(worker._stop, "wait", side_effect=[False, False, False, True]):
+            with patch.object(worker, "_get_ec2_metadata_imdsv2_token", return_value="TOKEN"):
+                worker._monitor_ec2_shutdown()
+
+        # THEN: the slow path is reported once across all three polls, and the fast path never
+        # claims a recovery on its behalf.
+        assert mock_logger.warning.call_count == 1
+        assert not any("answering" in str(c.args[0]) for c in mock_logger.info.call_args_list), (
+            mock_logger.info.call_args_list
+        )
+
+    def test_a_later_answer_re_arms_the_warning(
+        self, worker: Worker, requests_get: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """A second outage after a recovery is news again, and the recovery itself is logged."""
+        answered = MagicMock(status_code=404)
+        requests_get.side_effect = (
+            [requests.ReadTimeout("timed out")]
+            + [answered] * Worker._IMDS_RECOVERY_ANSWERS
+            + [requests.ReadTimeout("timed out")]
+        )
+
+        for _ in range(Worker._IMDS_RECOVERY_ANSWERS + 2):
+            worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="TOKEN")
+
+        assert mock_logger.warning.call_count == 2
+        # The recovery names the path, since only that path recovered.
+        assert any(
+            "is answering" in c.args[0] and "spot/instance-action" in c.args
+            for c in mock_logger.info.call_args_list
+        ), mock_logger.info.call_args_list
+
+
+class TestImdsRequestsAreBounded:
+    """The metadata address is link-local, so where nothing answers it the connect waits
+    on ARP rather than being refused. Unbounded, that parks the calling thread -- and for
+    the token probe that thread is the one the shutdown path returns through.
+    """
+
+    def test_token_probe_survives_a_read_timeout(
+        self, worker: Worker, requests_put: MagicMock
+    ) -> None:
+        """ReadTimeout subclasses Timeout, not ConnectionError.
+
+        So this is the case the widened handler adds: against the previous
+        `except requests.ConnectionError` alone it escapes and takes the agent down.
+        """
+        requests_put.side_effect = requests.ReadTimeout("timed out")
+
+        assert worker._get_ec2_metadata_imdsv2_token() is None
+
+    def test_token_probe_survives_a_proxy_error(
+        self, worker: Worker, requests_put: MagicMock
+    ) -> None:
+        """ProxyError subclasses ConnectionError, so this was already handled.
+
+        Kept as documentation of the intent rather than as coverage of the change: a proxy
+        configured in the environment intercepts the metadata address, and the right answer
+        on this path is still "assume we are not on EC2" rather than an exception out of
+        `run()`. It would fail if someone narrowed the handler to ConnectTimeout.
+        """
+        requests_put.side_effect = requests.exceptions.ProxyError("bad proxy")
+
+        assert worker._get_ec2_metadata_imdsv2_token() is None
+
+    def test_spot_query_survives_a_read_timeout(
+        self, worker: Worker, requests_get: MagicMock
+    ) -> None:
+        requests_get.side_effect = requests.ReadTimeout("timed out")
+
+        assert worker._get_spot_instance_shutdown_action_timeout(imdsv2_token="TOKEN") is None
+
+    def test_asg_query_survives_a_read_timeout(
+        self, worker: Worker, requests_get: MagicMock
+    ) -> None:
+        requests_get.side_effect = requests.ReadTimeout("timed out")
+
+        assert worker._is_asg_terminated(imdsv2_token="TOKEN") is False


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The agent can fail to ever report `STOPPED`, leaving the service-side worker in `STARTED` until it ages out to `NOT_RESPONDING`.

`Worker.run()` probes IMDS at startup to decide whether to monitor for spot interruption:

```python
scheduler_future = self._executor.submit(self._scheduler.run)
futures = [scheduler_future]
if self._get_ec2_metadata_imdsv2_token():   # unbounded requests.put
```

`169.254.169.254` is link-local. On a host that routes it but has nothing answering ARP, the connect waits rather than being refused, and the request had no `timeout`. That parks the **main** thread. The scheduler keeps running on the executor, so the worker registers, picks up sessions and drains on SIGTERM exactly as normal — but `_agent_shutdown()`, which reports `STOPPED`, is *after* `worker_sessions.run()` returns in `startup/entrypoint.py`. A parked main thread means `run()` never returns and the status update never happens.

Only `requests.ConnectionError` was caught, so a `requests.Timeout` would also propagate out of the probe rather than being read as "not on EC2".

Reproduced in CI on a GitHub-hosted macOS runner, where `test_worker_lifecycle_status_is_expected` and `test_worker_enters_stopping_state_while_draining` both fail. A SIGUSR1 thread dump from the stalled agent:

```
entrypoint.py:205   worker_sessions.run()
worker.py:225       if self._get_ec2_metadata_imdsv2_token():
worker.py:394       response = requests.put(
urllib3/util/connection.py:85   sock.connect(sa)
```

Intermittent, not constant: the kernel's ARP negative cache makes some attempts fail in milliseconds, so it only bites when SIGTERM lands inside a connect window. That is why this reads as flakiness rather than a hang.

### What was the solution? (How)

Bound every IMDS request, and stop letting one slow probe make a permanent decision.

- `timeout=Worker._IMDS_REQUEST_TIMEOUT_S` (1.0s) on all three requests in `worker.py`, and on both in `installer/__init__.py`. `startup/bootstrap._get_metadata` already does this, with the same rationale recorded next to it — *"Non-aws worker hosts will time-out, but the default timeout can be > 20s"*. These callers were simply missed.
- `except (requests.ConnectionError, requests.Timeout)`, so a timeout means "IMDS unavailable" rather than escaping.
- A new `Worker._is_ec2_host()` wraps the startup probe in `_IMDS_PROBE_ATTEMPTS` (3) attempts and logs a warning when the verdict is negative.

The retry is the one non-obvious part, and it is there because of what the probe gates. Its result is latched once, at startup, and a negative silently disables spot-interruption and ASG-lifecycle monitoring **for the life of the process**. That probe also runs during instance boot, when the host is busiest and IMDS may be slow or throttling while its token bucket fills. A bare 1s timeout with no retry would trade a hang for a quiet loss of function on a real EC2 host, which is the worse failure — it is invisible until an interruption is mishandled. The two in-loop queries need no retry: they re-issue every poll and self-heal.

Cost on a genuinely non-EC2 host is 3 x 1s once at startup, on a thread that is otherwise only waiting on futures while the scheduler already works.

Nothing here changes behaviour on a host where IMDS answers, which is every EC2 fleet.

### What is the impact of this change?

A worker on a host that black-holes the metadata address now reports `STOPPED` and exits, instead of needing SIGKILL and leaving a stale `STARTED` record. That is any non-EC2 host whose network drops rather than refuses link-local traffic — customer-managed fleets on-premises, on workstations, and on macOS.

The installer no longer stalls with no output while detecting a region on such a host.

### How was this change tested?

`hatch run test`: the 4 new `TestIsEc2Host` cases, 3 new `TestImdsRequestsAreBounded` cases and the extended `TestGetEc2Region` parametrization all pass. The suite is otherwise at its pre-existing baseline — the 2 failures and 18 errors on this branch are `test/unit/test_telemetry.py` plus the `openjd-model` resolution drift that #1082 fixes, both present on a pristine `mainline` checkout.

`hatch run lint` passes: ruff, ruff format, mypy across 202 source files.

The read-timeout tests are meaningful rather than tautological: `requests.Timeout` is not a subclass of `requests.ConnectionError`, so they fail against the old `except` clause.

End to end, the macOS e2e suite in #1080 exercises this path — start a worker, stop it, assert it reports `STOPPED` — on every run.

### Was this change documented?

No. The reasoning is recorded on the two class constants and in `_is_ec2_host`'s docstring.

### Is this a breaking change?

No.

### Prior art

#1010 proposes the same `timeout` fix, independently diagnosed and with the same stack frame, and predates this by two months. This change is a superset: it adds the startup retry, covers `installer/__init__.py`, and keeps that PR's tighter `(ConnectionError, Timeout)` clause. Opening this rather than iterating there because #1010 has had no review activity since 2026-07-16 and is `mergeable_state: behind`. Happy to close this in favour of #1010 plus a follow-up if its author would rather carry it.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
