### PR TITLE
feat: default session_runtime to service-selected

### DIFF
--- a/src/deadline_worker_agent/config/settings.py
+++ b/src/deadline_worker_agent/config/settings.py
@@ -95,7 +95,7 @@ class WorkerSettings(BaseSettings):
         If true, then the Worker Agent's logs are structured.
     session_runtime : SessionRuntimeKind
         The session runtime implementation to use. One of 'python', 'rust', or
-        'service-selected'. Defaults to 'python'.
+        'service-selected'. Defaults to 'service-selected'.
     """
 
     farm_id: str = Field(regex=r"^farm-[a-z0-9]{32}$")
@@ -130,7 +130,7 @@ class WorkerSettings(BaseSettings):
     retain_session_dir: bool = False
     structured_logs: bool = False
     # No env var mapping — runtime selection is via config file or CLI only.
-    session_runtime: SessionRuntimeKind = SessionRuntimeKind.PYTHON
+    session_runtime: SessionRuntimeKind = SessionRuntimeKind.SERVICE_SELECTED
     telemetry_opt_out: bool = False
     session_root_dir: Path = (
         DEFAULT_WINDOWS_SESSION_ROOT_DIR

--- a/src/deadline_worker_agent/installer/worker.toml.example
+++ b/src/deadline_worker_agent/installer/worker.toml.example
@@ -51,17 +51,17 @@
 # The session runtime implementation to use. This controls which backend runs OpenJD session
 # actions. Available values:
 #
-#   "python"           - Use the Python OpenJD session implementation (default)
+#   "python"           - Use the Python OpenJD session implementation
 #   "rust"             - Use the Rust OpenJD session implementation
-#   "service-selected" - Let the service determine the runtime per-session
+#   "service-selected" - Let the service determine the runtime per-session (default)
 #                       (follows the service's per-session runtimeHint; defaults to python when
 #                       no hint is provided)
 #
 # This value is overridden when the --session-runtime command-line argument is specified.
 #
-# By default, the Python runtime is used. To change the session runtime, uncomment the line below:
+# By default, the service selects the runtime. To change the session runtime, uncomment the line below:
 #
-# session_runtime = "python"
+# session_runtime = "service-selected"
 
 [aws]
 

--- a/test/unit/config/test_settings.py
+++ b/test/unit/config/test_settings.py
@@ -185,7 +185,7 @@ FIELD_TEST_CASES: list[FieldTestCaseParams] = [
         field_name="session_runtime",
         expected_type=SessionRuntimeKind,
         expected_required=False,
-        expected_default=SessionRuntimeKind.PYTHON,
+        expected_default=SessionRuntimeKind.SERVICE_SELECTED,
         expected_default_factory_return_value=None,
     ),
     FieldTestCaseParams(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
All fleets currently default to the Python session runtime. After a successful six-week canary bake of service-selected routing, the default should flip so all fleets defer runtime selection to the service by default.

### What was the solution? (How)
Changed the `WorkerSettings.session_runtime` default from `PYTHON` to `SERVICE_SELECTED`, updated the installer config example, and updated the corresponding unit test.

### What is the impact of this change?
Workers with no explicit `session_runtime` config now default to service-selected routing. The service resolves to Python when no runtime hint is provided, so behavior is unchanged for fleets without service-side routing configured. Operators can pin `session_runtime = "python"` to opt out.

### How was this change tested?
- Red-before-green: flipped test expectation, observed failure, then applied source change
- Unit test matrix (Python 3.9/3.10/3.11): 3187 pass per version
- Lint (ruff + mypy + format): clean
- Package build: clean

### Was this change documented?
Updated the installer config example (`worker.toml.example`) to reflect the new default.

### Is this a breaking change?
No. Workers upgrade to service-selected routing, but the runtime resolves to Python when no hint is provided. Reverting is a single config change (`session_runtime = "python"`).