### PR TITLE
fix: Standardized OS username defaults to deadline-worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ command performs all worker host setup activities, such as:
 
 *   creates an operating system user account (specified by the `--user` argument) on the worker
     host that the worker will run as. `install-deadline-worker` accepts a previously created user.
-    The user defaults to `deadline-worker-agent` on Linux and `deadline-worker` on Windows.
+    The user defaults to `deadline-worker`.
 *   creates a job user group (specified by `--group`, defaults to `deadline-job-users`) if required. The
     `install-deadline-worker` accepts an existing group.
 *   creates cache, log, and config directories, and an example config file

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -139,7 +139,7 @@ The `install-deadline-worker` program:
 
 -   **Agent User**:
     -   Dedicated system user that the worker agent process runs as
-    -   Defaults to `deadline-worker-agent` on Linux and `deadline-worker` on Windows
+    -   Defaults to `deadline-worker`
     -   Limited privileges following the principle of least privilege
     -   No login shell access for security
 

--- a/src/deadline_worker_agent/installer/__init__.py
+++ b/src/deadline_worker_agent/installer/__init__.py
@@ -132,8 +132,6 @@ def install() -> None:
             args.fleet_id,
             "--region",
             args.region,
-            "--user",
-            args.user,
             "--scripts-path",
             str(scripts_path),
             "--python-interpreter-path",
@@ -143,6 +141,8 @@ def install() -> None:
         ]
         if args.vfs_install_path:
             cmd += ["--vfs-install-path", args.vfs_install_path]
+        if args.user:
+            cmd += ["--user", args.user]
         if args.group:
             cmd += ["--group", args.group]
         if args.confirmed:
@@ -173,7 +173,7 @@ class ParsedCommandLineArguments(Namespace):
     farm_id: str
     fleet_id: str
     region: Optional[str] = None
-    user: str
+    user: Optional[str] = None
     password: Optional[str] = None
     group: Optional[str] = None
     confirmed: bool
@@ -214,12 +214,9 @@ def get_argument_parser() -> ArgumentParser:  # pragma: no cover
         default=None,
     )
 
-    # Windows local usernames are restricted to 20 characters in length.
-    default_username = "deadline-worker-agent" if sys.platform != "win32" else "deadline-worker"
     parser.add_argument(
         "--user",
-        help=f'The username of the AWS Deadline Cloud Worker Agent user. Defaults to "{default_username}".',
-        default=default_username,
+        help='The username of the AWS Deadline Cloud Worker Agent user. Defaults to "deadline-worker".',
     )
 
     parser.add_argument(

--- a/test/unit/install/test_install.py
+++ b/test/unit/install/test_install.py
@@ -61,8 +61,6 @@ def expected_cmd(
         parsed_args.fleet_id,
         "--region",
         parsed_args.region,
-        "--user",
-        parsed_args.user,
         "--scripts-path",
         sysconfig.get_path("scripts"),
         "--python-interpreter-path",
@@ -72,6 +70,8 @@ def expected_cmd(
         "--vfs-install-path",
         parsed_args.vfs_install_path,
     ]
+    if parsed_args.user is not None:
+        expected_cmd.extend(("--user", parsed_args.user))
     if parsed_args.group is not None:
         expected_cmd.extend(("--group", parsed_args.group))
     if parsed_args.confirmed:
@@ -374,8 +374,6 @@ class TestMacOSInstall:
             "fleet-1",
             "--region",
             "us-west-2",
-            "--user",
-            "wa-user",
             "--scripts-path",
             sysconfig.get_path("scripts"),
             "--python-interpreter-path",
@@ -384,6 +382,8 @@ class TestMacOSInstall:
             # install() passes str(args.session_root_dir); a Path stringifies with the host
             # separator, so build the expected value the same way rather than hard-coding it.
             str(Path("/var/lib/deadline/sessions")),
+            "--user",
+            "wa-user",
             "--group",
             "job-group",
             "-y",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

\_\_init\_\_.py was overwriting defaults set in the install scripts (`install.sh`, `install_macos.sh`, and `win_installer.py`). The install scripts set `deadline-worker` as the default OS user, but \_\_init\_\_.py made it so the username was `deadline-worker-agent` on Linux and Mac. This divergence in default usernames was documented, but still caused some confusion and doesn't seem to serve a purpose.

### What was the solution? (How)

Removed the default override from \_\_init\_\_.py and forwarded the `--user` flag only when it is set,
so each platform installer's own default applies. This matches how `--group` is already
handled. All three platform installers already used `deadline-worker`, so it is now the
default everywhere.

I also updated all docs, code comments, and unit tests to match.

### What is the impact of this change?

New runs of the install command will default to `deadline-worker` on Linux and Mac if no user is provided. This won't affect existing worker agents (unless you run the installer again) and users can still provide custom usernames if they don't like the new (old?) default.

### How was this change tested?

I tested on my local macOS laptop and spun up a Linux and Windows EC2 to make sure that the changes worked properly on all 3 operating systems. I also ran the test suite an make sure all of the changes passed.

### Was this change documented?

Yes. The readmes, code comments, and the CLI `--help` menu have been updated.

### Is this a breaking change?

No. Existing worker agents will run like normal even after updating. This only affects new runs of the installer when no `--user` flag is provided.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*